### PR TITLE
add repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "test": "gulp test",
     "docs": "./node_modules/.bin/jsdoc ./src/ -d docs/"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stellar/js-stellar-base.git"
+  },
   "keywords": [
     "stellar"
   ],


### PR DESCRIPTION
This should fix the warnings when installing something:
```
npm WARN package.json js-stellar-lib@0.0.7 No repository field.
```