### PR TITLE
Network helper functions

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -30,6 +30,14 @@ export class Network {
 		this.use(new Network(Networks.TESTNET));
 	}
 
+	static usePublicnet() {
+		this.usePublicNet();
+	}
+
+	static useTestnet() {
+		this.useTestNet();
+	}
+
 	static use(network) {
 		current = network;
 	}

--- a/test/unit/network_test.js
+++ b/test/unit/network_test.js
@@ -7,3 +7,21 @@ describe("Network.current()", function() {
   })
 
 });
+
+describe("Network.useTestNet()", function() {
+
+  beforeEach(function() {
+    StellarBase.Network.useDefault();
+  });
+
+  it("switches to the test network", function() {
+    StellarBase.Network.useTestNet();
+    expect(StellarBase.Network.current().networkPassphrase()).to.equal(StellarBase.Networks.TESTNET)
+  })
+
+  it("switches to the test network using helper function", function() {
+    StellarBase.Network.useTestnet();
+    expect(StellarBase.Network.current().networkPassphrase()).to.equal(StellarBase.Networks.TESTNET)
+  })
+
+});


### PR DESCRIPTION
Helper function for `Network`:
- `usePublicnet()` (lower case `n`)
- `useTestnet()` (lower case `n`)