### PR TITLE
Change Network methods names

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -13,21 +13,37 @@ var current;
  * that will be used by this process for the purposes of generating signatures
  *
  * The public network is the default, but you can also override the default by using the `use`,
- * `usePublicNet` and `useTestNet` helper methods
+ * `usePublicNetwork` and `useTestNetwork` helper methods
  *
  */
 export class Network {
 
 	static useDefault() {
-		this.useTestNet();
+		this.useTestNetwork();
 	}
 
-	static usePublicNet() {
+	static usePublicNetwork() {
 		this.use(new Network(Networks.PUBLIC));
 	}
 
-	static useTestNet() {
+	/**
+	 * Alias for `usePublicNetwork`.
+	 * @deprecated Use `usePublicNetwork` method
+	 */
+	static usePublicNet() {
+		this.usePublicNetwork();
+	}
+
+	static useTestNetwork() {
 		this.use(new Network(Networks.TESTNET));
+	}
+
+	/**
+	 * Alias for `useTestNetwork`.
+	 * @deprecated Use `useTestNetwork` method
+	 */
+	static useTestNet() {
+		this.useTestNetwork();
 	}
 
 	static use(network) {

--- a/test/unit/network_test.js
+++ b/test/unit/network_test.js
@@ -7,3 +7,16 @@ describe("Network.current()", function() {
   })
 
 });
+
+describe("Network.usePublicNetwork()", function() {
+
+  beforeEach(function() {
+    StellarBase.Network.useDefault();
+  });
+
+  it("switches to the public network", function() {
+    StellarBase.Network.usePublicNetwork();
+    expect(StellarBase.Network.current().networkPassphrase()).to.equal(StellarBase.Networks.PUBLIC)
+  });
+
+});


### PR DESCRIPTION
This PR:
* Changes `usePublicNet` to `usePublicNetwork`,
* Changes `useTestNet` to `useTestNetwork`,
* Depreciates previous methods: `usePublicNet`, `useTestNet`.
