### PR TITLE
Change default network to testnet

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -19,7 +19,7 @@ var current;
 export class Network {
 
 	static useDefault() {
-		this.usePublicNet();
+		this.useTestNet();
 	}
 
 	static usePublicNet() {

--- a/test/unit/network_test.js
+++ b/test/unit/network_test.js
@@ -3,7 +3,7 @@
 describe("Network.current()", function() {
 
   it("defaults to the public network", function() {
-    expect(StellarBase.Network.current().networkPassphrase()).to.equal(StellarBase.Networks.PUBLIC)
+    expect(StellarBase.Network.current().networkPassphrase()).to.equal(StellarBase.Networks.TESTNET)
   })
 
 });


### PR DESCRIPTION
This PR changes default network to testnet. Reasoning:
* Testnet is, in most cases, the first network developers are interacting with,
* With default Public Network developers can send real funds by accident. They should explicitly state they want to use Public Network (by calling `usePublicNet()`).