### PR TITLE
Throw Error when the best rational approximation cannot be found

### DIFF
--- a/src/operation.js
+++ b/src/operation.js
@@ -310,6 +310,7 @@ export class Operation {
     * @param {number|string|BigNumber} opts.price - The exchange rate ratio (selling / buying).
     * @param {number|string} [opts.offerId ]- If `0`, will create a new offer (default). Otherwise, edits an exisiting offer.
     * @param {string} [opts.source] - The source account (defaults to transaction source).
+    * @throws {Error} Throws `Error` when the best rational approximation of `price` cannot be found.
     * @returns {xdr.ManageOfferOp}
     */
     static manageOffer(opts) {
@@ -351,6 +352,7 @@ export class Operation {
     * @param {string} opts.amount - The total amount you're selling. If 0, deletes the offer.
     * @param {number|string|BigNumber} opts.price - The exchange rate ratio (selling / buying)
     * @param {string} [opts.source] - The source account (defaults to transaction source).
+    * @throws {Error} Throws `Error` when the best rational approximation of `price` cannot be found.
     * @returns {xdr.CreatePassiveOfferOp}
     */
     static createPassiveOffer(opts) {

--- a/src/util/continued_fraction.js
+++ b/src/util/continued_fraction.js
@@ -6,6 +6,7 @@ const MAX_INT = (1 << 31 >>> 0) - 1;
  * Calculates and returns the best rational approximation of the given real number.
  * @private
  * @param {string|number|BigNumber} number
+ * @throws Error Throws `Error` when the best rational approximation cannot be found.
  * @returns {array} first element is n (numerator), second element is d (denominator)
  */
 export function best_r(number) {
@@ -33,8 +34,13 @@ export function best_r(number) {
       break;
     }
     number = new BigNumber(1).div(f);
-    i = i + 1;
+    i++;
   }
   let [n, d] = fractions[fractions.length - 1];
+
+  if (n.isZero() || d.isZero()) {
+    throw new Error("Couldn't find approximation");
+  }
+
   return [n.toNumber(), d.toNumber()];
 }

--- a/test/unit/util/continued_fraction_test.js
+++ b/test/unit/util/continued_fraction_test.js
@@ -8,7 +8,6 @@ describe('best_r', function() {
       ['1,100', '0.01'],
       ['1,1000', '0.001'],
       ['54301793,100000', '543.017930'],
-      ['0,1', '0.0'],
       ['31969983,100000', '319.69983'],
       ['93,100', '0.93'],
       ['1,2', '0.5'],
@@ -30,5 +29,10 @@ describe('best_r', function() {
     for (var i in tests) {
       expect(best_r(tests[i][1]).toString()).to.be.equal(tests[i][0]);
     }
+  });
+
+  it("throws an error when best rational approximation cannot be found", function() {
+    expect(() => best_r("0.0000000003")).to.throw(/Couldn't find approximation/);
+    expect(() => best_r("2147483648")).to.throw(/Couldn't find approximation/);
   });
 });


### PR DESCRIPTION
Throw `Error` in `best_r` when the best rational approximation cannot be found. Operations that contain such approximations would be [rejected](https://github.com/stellar/stellar-core/blob/eed89649c2060b8e9dacffe2cec4e8b258b32416/src/transactions/ManageOfferOpFrame.cpp#L390) by stellar-core anyway so it's better to reject them early.