### PR TITLE
price fraction in Operation.managerOffer and Operation.createPassiveOffer

### DIFF
--- a/src/operation.js
+++ b/src/operation.js
@@ -597,20 +597,22 @@ export class Operation {
      * @private
      */
     static _toXDRPrice(price) {
-        if(price.n && price.d){
-          if ((price.n < 0) || (price.d < 0)) {
-            throw new Error('price numerator and denominator must be positive');
-          }
-          return new xdr.Price(price);
+        let xdrObject;
+        if (price.n && price.d) {
+            xdrObject = new xdr.Price(price);
+        } else {
+            price = new BigNumber(price);
+            let approx = best_r(price);
+            xdrObject = new xdr.Price({
+                n: parseInt(approx[0]),
+                d: parseInt(approx[1])
+            });
         }
-        price = new BigNumber(price);
-        if (price.lte(0)) {
+
+        if (xdrObject.n() < 0 || xdrObject.d() < 0) {
             throw new Error('price must be positive');
         }
-        let approx = best_r(price);
-        return new xdr.Price({
-            n: parseInt(approx[0]),
-            d: parseInt(approx[1])
-        });
+
+        return xdrObject;
     }
 }

--- a/src/operation.js
+++ b/src/operation.js
@@ -307,7 +307,9 @@ export class Operation {
     * @param {Asset} opts.selling - What you're selling.
     * @param {Asset} opts.buying - What you're buying.
     * @param {string} opts.amount - The total amount you're selling. If 0, deletes the offer.
-    * @param {number|string|BigNumber} opts.price - The exchange rate ratio (selling / buying).
+    * @param {number|string|BigNumber|Object} opts.price - The exchange rate ratio (selling / buying)
+    * @param {number} opts.price.n - The price numerator
+    * @param {number} opts.price.d - The price denominator
     * @param {number|string} [opts.offerId ]- If `0`, will create a new offer (default). Otherwise, edits an exisiting offer.
     * @param {string} [opts.source] - The source account (defaults to transaction source).
     * @throws {Error} Throws `Error` when the best rational approximation of `price` cannot be found.
@@ -350,7 +352,9 @@ export class Operation {
     * @param {Asset} opts.selling - What you're selling.
     * @param {Asset} opts.buying - What you're buying.
     * @param {string} opts.amount - The total amount you're selling. If 0, deletes the offer.
-    * @param {number|string|BigNumber} opts.price - The exchange rate ratio (selling / buying)
+    * @param {number|string|BigNumber|Object} opts.price - The exchange rate ratio (selling / buying)
+    * @param {number} opts.price.n - The price numerator
+    * @param {number} opts.price.d - The price denominator
     * @param {string} [opts.source] - The source account (defaults to transaction source).
     * @throws {Error} Throws `Error` when the best rational approximation of `price` cannot be found.
     * @returns {xdr.CreatePassiveOfferOp}
@@ -593,6 +597,12 @@ export class Operation {
      * @private
      */
     static _toXDRPrice(price) {
+        if(price.n && price.d){
+          if ((price.n < 0) || (price.d < 0)) {
+            throw new Error('price numerator and denominator must be positive');
+          }
+          return new xdr.Price(price);
+        }
         price = new BigNumber(price);
         if (price.lte(0)) {
             throw new Error('price must be positive');

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -347,7 +347,7 @@ describe('Operation', function() {
                 d: -1
             }
             opts.offerId = '1';
-            expect(() => StellarBase.Operation.manageOffer(opts)).to.throw(/price numerator and denominator must be positive/)
+            expect(() => StellarBase.Operation.manageOffer(opts)).to.throw(/price must be positive/)
         });
         it("creates a manageOfferOp (number price)", function () {
             var opts = {};

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -320,7 +320,35 @@ describe('Operation', function() {
             expect(obj.price).to.be.equal(opts.price);
             expect(obj.offerId).to.be.equal(opts.offerId);
         });
+        it("creates a manageOfferOp (price fraction)", function () {
+            var opts = {};
+            opts.selling = new StellarBase.Asset("USD", "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7");
+            opts.buying = new StellarBase.Asset("USD", "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7");
+            opts.amount = '3.123456';
+            opts.price = {
+                n: 11,
+                d: 10
+            }
+            opts.offerId = '1';
+            let op = StellarBase.Operation.manageOffer(opts);
+            var xdr = op.toXDR("hex");
+            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var obj = StellarBase.Operation.operationToObject(operation);
+            expect(obj.price).to.be.equal(new BigNumber(opts.price.n).div(opts.price.d).toString());
+        });
 
+        it("creates an invalid manageOfferOp (price fraction)", function () {
+            var opts = {};
+            opts.selling = new StellarBase.Asset("USD", "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7");
+            opts.buying = new StellarBase.Asset("USD", "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7");
+            opts.amount = '3.123456';
+            opts.price = {
+                n: 11,
+                d: -1
+            }
+            opts.offerId = '1';
+            expect(() => StellarBase.Operation.manageOffer(opts)).to.throw(/price numerator and denominator must be positive/)
+        });
         it("creates a manageOfferOp (number price)", function () {
             var opts = {};
             opts.selling = new StellarBase.Asset("USD", "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7");


### PR DESCRIPTION
The PR allows the price to be an object with numerator and denominator in Operation.managerOffer and Operation.createPassiveOffer. Otherwise, precision is lost, for instance, `1000` becomes `999.99999`.
