### PR TITLE
Make 0 a valid number for transaction fee

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -9,6 +9,7 @@ import {Memo} from "./memo";
 import BigNumber from 'bignumber.js';
 import clone from "lodash/clone";
 import map from "lodash/map";
+import isUndefined from "lodash/isUndefined";
 
 let BASE_FEE     = 100; // Stroops
 let MIN_LEDGER   = 0;
@@ -66,7 +67,7 @@ export class TransactionBuilder {
         this.operations    = [];
         this.signers       = [];
 
-        this.baseFee    = (isNaN(opts.fee) ? BASE_FEE : opts.fee);
+        this.baseFee    = (isUndefined(opts.fee) ? BASE_FEE : opts.fee);
 
         this.timebounds = clone(opts.timebounds);
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -66,7 +66,8 @@ export class TransactionBuilder {
         this.operations    = [];
         this.signers       = [];
 
-        this.baseFee    = opts.fee || BASE_FEE;
+        this.baseFee    = (isNaN(opts.fee) ? BASE_FEE : opts.fee);
+
         this.timebounds = clone(opts.timebounds);
 
         this.memo       = opts.memo || Memo.none();

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -47,4 +47,28 @@ describe('Transaction', function() {
     expect(verified).to.equal(true);
   });
 
+
+  it("accepts 0 as a valid transaction fee", function(done) {
+    let source      = new StellarBase.Account("GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB", "0");
+    let destination = "GDJJRRMBK4IWLEPJGIE6SXD2LP7REGZODU7WDC3I2D6MR37F4XSHBKX2";
+    let asset       = StellarBase.Asset.native();
+    let amount      = "2000";
+    let fee         = 0;
+
+    let input = new StellarBase.TransactionBuilder(source, {fee: 0})
+                .addOperation(StellarBase.Operation.payment({destination, asset, amount}))
+                .addMemo(StellarBase.Memo.text('Happy birthday!'))
+                .build()
+                .toEnvelope()
+                .toXDR('base64');
+
+
+    var transaction = new StellarBase.Transaction(input);
+    var operation = transaction.operations[0];
+
+    expect(transaction.fee).to.be.equal(0);
+
+    done();
+  });
+
 });


### PR DESCRIPTION
The way the base sdk checks for a submitted fee rules 0 out. Since having 0 as transaction fee is actually fine in the core config, I see no reason why it can't be set in this SDK.

I've also taken the liberty of adding a test for this, but I'm not sure if this is the right way to implement this test or not. 

If this pull request fails to meet any of the contributing requirements, please let me know and I will fix them.