### PR TITLE
Optional ed25519

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This is an implementation in JavaScript that can be used on either Node.js or we
 
 * **[API Reference](https://stellar.github.io/js-stellar-base/)**
 
+> **Warning!** Node version of this package is using [`ed25519`](https://www.npmjs.com/package/ed25519) package, a native implementation of [Ed25519](https://ed25519.cr.yp.to/) in Node.js, as an [optional dependency](https://docs.npmjs.com/files/package.json#optionaldependencies). This means that if for any reason installation of this package fails, `stellar-base` will fallback to the much slower implementation contained in [`tweetnacl`](https://www.npmjs.com/package/tweetnacl).
+>
+> If you are using `stellar-base` in a browser you can ignore this. However, for production backend deployments you should definitely be using `ed25519`. If `ed25519` is successfully installed and working `StellarBase.fastSigning` variable will be equal `true`. Otherwise it will be `false`.
+
 ## Quick start
 
 Using npm to include js-stellar-base in your own project:

--- a/package.json
+++ b/package.json
@@ -69,10 +69,12 @@
     "base32.js": "~0.1.0",
     "bignumber.js": "^2.0.7",
     "crc": "^3.3.0",
-    "ed25519": "0.0.4",
     "js-xdr": "^1.0.0",
     "lodash": "^4.0.1",
     "sha.js": "^2.3.6",
     "tweetnacl": "^0.13.0"
+  },
+  "optionalDependencies": {
+     "ed25519": "0.0.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import {default as xdr} from "./generated/stellar-xdr_generated";
 
 export {xdr};
 export {hash} from "./hashing";
-export {sign, verify} from "./signing";
+export {sign, verify, fastSigning} from "./signing";
 export {Keypair} from "./keypair";
 export {UnsignedHyper,Hyper} from "js-xdr";
 export {Transaction} from "./transaction";

--- a/src/signing.js
+++ b/src/signing.js
@@ -17,7 +17,6 @@ export function verify(data, signature, publicKey) {
   return actualMethods.verify(data, signature, publicKey);
 }
 
-var useNacl;
 // if in node
 if (typeof window === 'undefined') {
   // NOTE: we use commonjs style require here because es6 imports
@@ -25,12 +24,12 @@ if (typeof window === 'undefined') {
   let ed25519;
   try {
     ed25519 = require("ed25519");
-    useNacl = false;
+    fastSigning = true;
   } catch (err) {
-    useNacl = true;
+    fastSigning = false;
   }
 
-  if (!useNacl) {
+  if (fastSigning) {
     actualMethods.sign = function(data, secretKey) {
       data = new Buffer(data);
       return ed25519.Sign(data, secretKey);
@@ -44,18 +43,15 @@ if (typeof window === 'undefined') {
         return false;
       }
     };
-    fastSigning = true;
   }
 } else {
-  useNacl = true;
+  fastSigning = false;
 }
 
-if (useNacl) {
+if (!fastSigning) {
   // fallback to tweetnacl.js if we're in the browser or
   // if there was a failure installing ed25519
   let nacl = require("tweetnacl");
-
-  fastSigning = false;
 
   actualMethods.sign = function(data, secretKey) {
     data      = new Buffer(data);

--- a/src/signing.js
+++ b/src/signing.js
@@ -7,7 +7,7 @@
 
 var actualMethods = {};
 
-export var fastSigning;
+export const fastSigning = checkFastSigning();
 
 export function sign(data, secretKey) {
   return actualMethods.sign(data, secretKey);
@@ -17,58 +17,63 @@ export function verify(data, signature, publicKey) {
   return actualMethods.verify(data, signature, publicKey);
 }
 
-// if in node
-if (typeof window === 'undefined') {
-  // NOTE: we use commonjs style require here because es6 imports
-  // can only occur at the top level.  thanks, obama.
-  let ed25519;
-  try {
-    ed25519 = require("ed25519");
-    fastSigning = true;
-  } catch (err) {
-    fastSigning = false;
+function checkFastSigning() {
+  var ed25519Used;
+  // if in node
+  if (typeof window === 'undefined') {
+    // NOTE: we use commonjs style require here because es6 imports
+    // can only occur at the top level.  thanks, obama.
+    let ed25519;
+    try {
+      ed25519 = require("ed25519");
+      ed25519Used = true;
+    } catch (err) {
+      ed25519Used = false;
+    }
+
+    if (ed25519Used) {
+      actualMethods.sign = function(data, secretKey) {
+        data = new Buffer(data);
+        return ed25519.Sign(data, secretKey);
+      };
+
+      actualMethods.verify = function(data, signature, publicKey) {
+        data = new Buffer(data);
+        try {
+          return ed25519.Verify(data, signature, publicKey);
+        } catch(e) {
+          return false;
+        }
+      };
+    }
+  } else {
+    ed25519Used = false;
   }
 
-  if (fastSigning) {
+  if (!ed25519Used) {
+    // fallback to tweetnacl.js if we're in the browser or
+    // if there was a failure installing ed25519
+    let nacl = require("tweetnacl");
+
     actualMethods.sign = function(data, secretKey) {
-      data = new Buffer(data);
-      return ed25519.Sign(data, secretKey);
+      data      = new Buffer(data);
+      data      = new Uint8Array(data.toJSON().data);
+      secretKey = new Uint8Array(secretKey.toJSON().data);
+
+      let signature = nacl.sign.detached(data, secretKey);
+
+      return new Buffer(signature);
     };
 
     actualMethods.verify = function(data, signature, publicKey) {
-      data = new Buffer(data);
-      try {
-        return ed25519.Verify(data, signature, publicKey);
-      } catch(e) {
-        return false;
-      }
+      data      = new Buffer(data);
+      data      = new Uint8Array(data.toJSON().data);
+      signature = new Uint8Array(signature.toJSON().data);
+      publicKey = new Uint8Array(publicKey.toJSON().data);
+
+      return nacl.sign.detached.verify(data, signature, publicKey);
     };
   }
-} else {
-  fastSigning = false;
-}
 
-if (!fastSigning) {
-  // fallback to tweetnacl.js if we're in the browser or
-  // if there was a failure installing ed25519
-  let nacl = require("tweetnacl");
-
-  actualMethods.sign = function(data, secretKey) {
-    data      = new Buffer(data);
-    data      = new Uint8Array(data.toJSON().data);
-    secretKey = new Uint8Array(secretKey.toJSON().data);
-
-    let signature = nacl.sign.detached(data, secretKey);
-
-    return new Buffer(signature);
-  };
-
-  actualMethods.verify = function(data, signature, publicKey) {
-    data      = new Buffer(data);
-    data      = new Uint8Array(data.toJSON().data);
-    signature = new Uint8Array(signature.toJSON().data);
-    publicKey = new Uint8Array(publicKey.toJSON().data);
-
-    return nacl.sign.detached.verify(data, signature, publicKey);
-  };
+  return ed25519Used;
 }


### PR DESCRIPTION
Move `ed25519` to `optionalDependencies` and fallback to `tweetnacl` if `ed25519` installation failed. Confirmed working as expected in the clean (git, node, npm, no compilation tools) Windows virtual machine.

Developers can check if native Ed25519 package is used by examining `StellarBase.fastSigning` variable.

This is a breaking change and will be published in `0.6.0`.

Close #68.