### PR TITLE
No default network

### DIFF
--- a/src/keypair.js
+++ b/src/keypair.js
@@ -80,6 +80,9 @@ export class Keypair {
    * @returns {Keypair}
    */
   static master() {
+    if (Network.current() === null) {
+      throw new Error("No network selected. Use `Network.use`, `Network.usePublicNetwork` or `Network.useTestNetwork` helper methods to select network.");
+    }
     return this.fromRawSeed(Network.current().networkId());
   }
 

--- a/src/network.js
+++ b/src/network.js
@@ -11,7 +11,7 @@ export const Networks = {
 	TESTNET: "Test SDF Network ; September 2015"
 };
 
-var current;
+var current = null;
 
 export class Network {
 	/**
@@ -19,7 +19,7 @@ export class Network {
    * stellar networks.  It also provides the {@link Network.current} class method that returns the network
    * that will be used by this process for the purposes of generating signatures.
    *
-   * The test network is the default, but you can also override the default by using the `use`,
+   * You should select network your app will use before adding the first signature. You can use the `use`,
    * `usePublicNetwork` and `useTestNetwork` helper methods.
    *
 	 * Creates a new `Network` object.
@@ -28,13 +28,6 @@ export class Network {
 	 */
 	constructor(networkPassphrase) {
 		this._networkPassphrase = networkPassphrase;
-	}
-
-	/**
-	 * Use default network (right now default network is `testnet`).
-	 */
-	static useDefault() {
-		this.useTestNetwork();
 	}
 
 	/**
@@ -83,5 +76,3 @@ export class Network {
 		return hash(this.networkPassphrase());
 	}
 }
-
-Network.useDefault();

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -78,6 +78,10 @@ export class Transaction {
      * @returns {Buffer}
      */
     signatureBase() {
+        if (Network.current() === null) {
+            throw new Error("No network selected. Use `Network.use`, `Network.usePublicNetwork` or `Network.useTestNetwork` helper methods to select network.");
+        }
+
         return Buffer.concat([
             Network.current().networkId(),
             xdr.EnvelopeType.envelopeTypeTx().toXDR(),

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -65,7 +65,6 @@ export class TransactionBuilder {
         }
         this.source        = sourceAccount;
         this.operations    = [];
-        this.signers       = [];
 
         this.baseFee    = (isUndefined(opts.fee) ? BASE_FEE : opts.fee);
 
@@ -122,7 +121,6 @@ export class TransactionBuilder {
         let xenv = new xdr.TransactionEnvelope({tx:xtx});
 
         let tx = new Transaction(xenv);
-        tx.sign(...this.signers);
 
         this.source.incrementSequenceNumber();
         return tx;

--- a/test/unit/network_test.js
+++ b/test/unit/network_test.js
@@ -1,22 +1,19 @@
-
-
 describe("Network.current()", function() {
+  it("defaults network is null", function() {
+    expect(StellarBase.Network.current()).to.be.null;
+  });
+});
 
-  it("defaults to the public network", function() {
+describe("Network.useTestNetwork()", function() {
+  it("switches to the test network", function() {
+    StellarBase.Network.useTestNetwork();
     expect(StellarBase.Network.current().networkPassphrase()).to.equal(StellarBase.Networks.TESTNET)
-  })
-
+  });
 });
 
 describe("Network.usePublicNetwork()", function() {
-
-  beforeEach(function() {
-    StellarBase.Network.useDefault();
-  });
-
   it("switches to the public network", function() {
     StellarBase.Network.usePublicNetwork();
     expect(StellarBase.Network.current().networkPassphrase()).to.equal(StellarBase.Networks.PUBLIC)
   });
-
 });

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -1,76 +1,84 @@
-var keypair          = StellarBase.Keypair.master();
-let unencodedBuffer  = keypair.rawPublicKey();
-let unencoded        = unencodedBuffer.toString();
-let accountIdEncoded = keypair.accountId();
-let seedEncoded      = StellarBase.encodeCheck("seed", unencodedBuffer);
+describe("Strkey encoding", function() {
+  before(function() {
+    StellarBase.Network.useTestNetwork();
+    var keypair           = StellarBase.Keypair.master();
+    this.unencodedBuffer  = keypair.rawPublicKey();
+    this.unencoded        = this.unencodedBuffer.toString();
+    this.accountIdEncoded = keypair.accountId();
+    this.seedEncoded      = StellarBase.encodeCheck("seed", this.unencodedBuffer);
+  })
 
-describe('StellarBase#decodeCheck', function() {
+  after(function() {
+    StellarBase.Network.use(null);
+  })
 
-  it("decodes correctly", function() {
-    expectBuffersToBeEqual(StellarBase.decodeCheck("accountId", accountIdEncoded), unencodedBuffer);
-    expectBuffersToBeEqual(StellarBase.decodeCheck("seed", seedEncoded), unencodedBuffer);
+  describe('StellarBase#decodeCheck', function() {
+    it("decodes correctly", function() {
+      expectBuffersToBeEqual(StellarBase.decodeCheck("accountId", this.accountIdEncoded), this.unencodedBuffer);
+      expectBuffersToBeEqual(StellarBase.decodeCheck("seed", this.seedEncoded), this.unencodedBuffer);
+    });
+
+    it("throws an error when the version byte is not defined", function() {
+      expect(() => StellarBase.decodeCheck("notreal", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/notreal is not a valid/);
+      expect(() => StellarBase.decodeCheck("broken", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/broken is not a valid/);
+    });
+
+    it("throws an error when the version byte is wrong", function() {
+      expect(() => StellarBase.decodeCheck("seed", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid version/);
+      expect(() => StellarBase.decodeCheck("accountId", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/invalid version/);
+    });
+
+    it("throws an error when decoded data encodes to other string", function() {
+      // accountId
+      expect(() => StellarBase.decodeCheck("accountId", "GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("accountId", "GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("accountId", "GADE5QJ2TY7S5ZB65Q43DFGWYWCPHIYDJ2326KZGAGBN7AE5UY6JVDRRA")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("accountId", "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("accountId", "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T")).to.throw(/invalid encoded string/);
+      // seed
+      expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYW")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2T")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("seed", "SCMB30FQCIQAWZ4WQTS6SVK37LGMAFJGXOZIHTH2PY6EXLP37G46H6DT")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("seed", "SAYC2LQ322EEHZYWNSKBEW6N66IRTDREEBUXXU5HPVZGMAXKLIZNM45H++")).to.throw(/invalid encoded string/);
+    });
+
+    it("throws an error when the checksum is wrong", function() {
+      expect(() => StellarBase.decodeCheck("accountId", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVT")).to.throw(/invalid checksum/);
+      expect(() => StellarBase.decodeCheck("seed", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCX")).to.throw(/invalid checksum/);
+    });
   });
 
-  it("throws an error when the version byte is not defined", function() {
-    expect(() => StellarBase.decodeCheck("notreal", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/notreal is not a valid/);
-    expect(() => StellarBase.decodeCheck("broken", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/broken is not a valid/);
+
+  describe('StellarBase#encodeCheck', function() {
+
+    it("encodes a buffer correctly", function() {
+      expect(StellarBase.encodeCheck("accountId", this.unencodedBuffer)).to.eql(this.accountIdEncoded);
+      expect(StellarBase.encodeCheck("seed", this.unencodedBuffer)).to.eql(this.seedEncoded);
+    });
+
+    it("encodes a buffer correctly", function() {
+      expect(StellarBase.encodeCheck("accountId", this.unencodedBuffer)).to.eql(this.accountIdEncoded);
+      expect(StellarBase.encodeCheck("seed", this.unencodedBuffer)).to.eql(this.seedEncoded);
+    });
+
+
+    it("throws an error when the data is null", function() {
+      expect(() => StellarBase.encodeCheck("seed", null)).to.throw(/null data/);
+      expect(() => StellarBase.encodeCheck("accountId", null)).to.throw(/null data/);
+    });
+
+    it("throws an error when the version byte is not defined", function() {
+      expect(() => StellarBase.encodeCheck("notreal", this.unencoded)).to.throw(/notreal is not a valid/);
+      expect(() => StellarBase.encodeCheck("broken", this.unencoded)).to.throw(/broken is not a valid/);
+    });
   });
 
-  it("throws an error when the version byte is wrong", function() {
-    expect(() => StellarBase.decodeCheck("seed", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid version/);
-    expect(() => StellarBase.decodeCheck("accountId", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/invalid version/);
-  });
 
-  it("throws an error when decoded data encodes to other string", function() {
-    // accountId
-    expect(() => StellarBase.decodeCheck("accountId", "GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("accountId", "GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("accountId", "GADE5QJ2TY7S5ZB65Q43DFGWYWCPHIYDJ2326KZGAGBN7AE5UY6JVDRRA")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("accountId", "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("accountId", "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T")).to.throw(/invalid encoded string/);
-    // seed
-    expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYW")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2T")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("seed", "SCMB30FQCIQAWZ4WQTS6SVK37LGMAFJGXOZIHTH2PY6EXLP37G46H6DT")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("seed", "SAYC2LQ322EEHZYWNSKBEW6N66IRTDREEBUXXU5HPVZGMAXKLIZNM45H++")).to.throw(/invalid encoded string/);
-  });
+  function expectBuffersToBeEqual(left, right) {
+    let leftHex = left.toString('hex');
+    let rightHex = right.toString('hex');
 
-  it("throws an error when the checksum is wrong", function() {
-    expect(() => StellarBase.decodeCheck("accountId", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVT")).to.throw(/invalid checksum/);
-    expect(() => StellarBase.decodeCheck("seed", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCX")).to.throw(/invalid checksum/);
-  });
+    expect(leftHex).to.eql(rightHex);
+  }
 });
-
-
-describe('StellarBase#encodeCheck', function() {
-
-  it("encodes a buffer correctly", function() {
-    expect(StellarBase.encodeCheck("accountId", unencodedBuffer)).to.eql(accountIdEncoded);
-    expect(StellarBase.encodeCheck("seed", unencodedBuffer)).to.eql(seedEncoded);
-  });
-
-  it("encodes a buffer correctly", function() {
-    expect(StellarBase.encodeCheck("accountId", unencodedBuffer)).to.eql(accountIdEncoded);
-    expect(StellarBase.encodeCheck("seed", unencodedBuffer)).to.eql(seedEncoded);
-  });
-
-
-  it("throws an error when the data is null", function() {
-    expect(() => StellarBase.encodeCheck("seed", null)).to.throw(/null data/);
-    expect(() => StellarBase.encodeCheck("accountId", null)).to.throw(/null data/);
-  });
-
-  it("throws an error when the version byte is not defined", function() {
-    expect(() => StellarBase.encodeCheck("notreal", unencoded)).to.throw(/notreal is not a valid/);
-    expect(() => StellarBase.encodeCheck("broken", unencoded)).to.throw(/broken is not a valid/);
-  });
-});
-
-
-function expectBuffersToBeEqual(left, right) {
-  let leftHex = left.toString('hex');
-  let rightHex = right.toString('hex');
-
-  expect(leftHex).to.eql(rightHex);
-}

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -27,6 +27,27 @@ describe('Transaction', function() {
     done();
   });
 
+  beforeEach(function() {
+    StellarBase.Network.useTestNetwork();
+  })
+
+  afterEach(function() {
+    StellarBase.Network.use(null);
+  })
+
+  it("does not sign when no Network selected", function() {
+    StellarBase.Network.use(null);
+    let source      = new StellarBase.Account("GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB", "0");
+    let destination = "GDJJRRMBK4IWLEPJGIE6SXD2LP7REGZODU7WDC3I2D6MR37F4XSHBKX2";
+    let asset       = StellarBase.Asset.native();
+    let amount      = "2000";
+    let signer      = StellarBase.Keypair.random();
+
+    let tx = new StellarBase.TransactionBuilder(source)
+                .addOperation(StellarBase.Operation.payment({destination, asset, amount}))
+                .build();
+    expect(() => tx.sign(signer)).to.throw(/No network selected/);
+  });
 
   it("signs correctly", function() {
     let source      = new StellarBase.Account("GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB", "0");


### PR DESCRIPTION
Some users forget to switch to public network (by executing `Network.usePublicNetwork()`) before deploying apps because right now test network is a default choice, selected automatically. This PR changes `Network` module to not select a default network.

Merging into `0.7.0` branch because it's a breaking change.
