### PR TITLE
Version 0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: node_js
 sudo: required # to install newer g++ :(
 matrix:
   include:
-    - node_js: "4.2"
-    - node_js: "0.12"
-    - node_js: "0.11"
-    - node_js: "0.10"
-    - node_js: "0.12"
+    - node_js: "4"
+    - node_js: "6.9.4"
+    - node_js: "6.9.4"
       env: SAUCE=true
 before_install:
 - npm install -g npm@'>=2.13.5'
@@ -28,7 +26,7 @@ script:
 after_success:
 - |
   # Send report to coveralls but only once
-  if [ -z "${SAUCE}" ] && [ "${TRAVIS_NODE_VERSION}" = "0.12" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
+  if [ -z "${SAUCE}" ] && [ "${TRAVIS_NODE_VERSION}" = "6.9.4" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
     gulp submit-coverage
   fi
 notifications:
@@ -56,11 +54,11 @@ deploy:
     on:
       tags: true
       repo: stellar/js-stellar-base
-      node: "4.2" # Deploy only once, no matter which node
+      node: "6.9.4" # Deploy only once, no matter which node
   - provider: script
     script: ./bower_publish.sh
     skip_cleanup: true
     on:
       tags: true
       repo: stellar/js-stellar-base
-      node: "4.2" # Deploy only once, no matter which node
+      node: "6.9.4" # Deploy only once, no matter which node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 As this project is pre 1.0, breaking changes may happen for minor version bumps. A breaking change will get clearly notified in this log.
 
+## 0.7.0
+
+* Support for new signer types: `sha256Hash`, `preAuthTx`.
+* `StrKey` helper class with `strkey` encoding related methods.
+* Removed deprecated methods: `Keypair.isValidPublicKey` (use `StrKey`), `Keypair.isValidSecretKey` (use `StrKey`), `Keypair.fromSeed`, `Keypair.seed`, `Keypair.rawSeed`.
+* **Breaking changes**:
+  * `Network` must be explicitly selected. Previously testnet was a default network.
+  * `Operation.setOptions()` method `signer` param changed.
+  * `Keypair.fromAccountId()` renamed to `Keypair.fromPublicKey()`.
+  * `Keypair.accountId()` renamed to `Keypair.publicKey()`.
+  * Dropping support for `End-of-Life` node versions.
+
 ## 0.6.0
 
 * **Breaking change** `ed25519` package is now optional dependency.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "stellar"
   ],
   "engines": {
-    "node": ">=0.10 <=4"
+    "node": ">=4"
   },
   "author": "Scott Fleckenstein <scott@stellar.org>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gulp-webpack": "^1.3.1",
     "isparta": "^3.1.0",
     "istanbul": "~0.3.2",
+    "jsdoc": "^3.4.1",
     "jshint-stylish": "^1.0.1",
     "karma": "^0.13.9",
     "karma-chrome-launcher": "^0.1.7",

--- a/src/account.js
+++ b/src/account.js
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import isString from 'lodash/isString';
 import {Keypair} from './keypair';
-import {decodeCheck} from "./strkey";
+import {StrKey} from "./strkey";
 
 export class Account {
     /**
@@ -16,7 +16,7 @@ export class Account {
      * @param {string} sequence current sequence number of the account
      */
     constructor(accountId, sequence) {
-        if (!Keypair.isValidPublicKey(accountId)) {
+        if (!StrKey.isValidEd25519PublicKey(accountId)) {
             throw new Error('accountId is invalid');
         }
         if (!isString(sequence)) {
@@ -24,25 +24,6 @@ export class Account {
         }
         this._accountId = accountId;
         this.sequence = new BigNumber(sequence);
-    }
-
-    /**
-     * Returns true if the given accountId is a valid Stellar account ID.
-     * @param {string} accountId account ID to check
-     * @returns {boolean}
-     * @deprecated Use {@link Keypair.isValidPublicKey}
-     */
-    static isValidAccountId(accountId) {
-        console.warn('Account.isValidAccountId is deprecated. Use Keypair.isValidPublicKey.');
-        try {
-            let decoded = decodeCheck("accountId", accountId);
-            if (decoded.length !== 32) {
-                return false;
-            }
-        } catch (err) {
-            return false;
-        }
-        return true;
     }
 
     /**

--- a/src/asset.js
+++ b/src/asset.js
@@ -1,6 +1,6 @@
 import {default as xdr} from "./generated/stellar-xdr_generated";
 import {Keypair} from "./keypair";
-import {encodeCheck} from "./strkey";
+import {StrKey} from "./strkey";
 import clone from 'lodash/clone';
 import padEnd from 'lodash/padEnd';
 import trimEnd from 'lodash/trimEnd';
@@ -24,7 +24,7 @@ export class Asset {
       if (String(code).toLowerCase() !== "xlm" && !issuer) {
         throw new Error("Issuer cannot be null");
       }
-      if (issuer && !Keypair.isValidPublicKey(issuer)) {
+      if (issuer && !StrKey.isValidEd25519PublicKey(issuer)) {
         throw new Error("Issuer is invalid");
       }
 
@@ -52,12 +52,12 @@ export class Asset {
           return this.native();
         case xdr.AssetType.assetTypeCreditAlphanum4():
           anum = assetXdr.alphaNum4();
-          issuer = encodeCheck("accountId", anum.issuer().ed25519());
+          issuer = StrKey.encodeEd25519PublicKey(anum.issuer().ed25519());
           code = trimEnd(anum.assetCode(), '\0');
           return new this(code, issuer);
         case xdr.AssetType.assetTypeCreditAlphanum12():
           anum = assetXdr.alphaNum12();
-          issuer = encodeCheck("accountId", anum.issuer().ed25519());
+          issuer = StrKey.encodeEd25519PublicKey(anum.issuer().ed25519());
           code = trimEnd(anum.assetCode(), '\0');
           return new this(code, issuer);
         default:
@@ -88,7 +88,7 @@ export class Asset {
 
             var assetType = new xdrType({
                 assetCode: paddedCode,
-                issuer: Keypair.fromAccountId(this.issuer).xdrAccountId()
+                issuer: Keypair.fromPublicKey(this.issuer).xdrAccountId()
             });
 
             return new xdr.Asset(xdrTypeString, assetType);

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,6 @@ export {Operation, AuthRequiredFlag, AuthRevocableFlag, AuthImmutableFlag} from 
 export {Memo} from "./memo";
 export {Account} from "./account";
 export {Network, Networks} from "./network";
-
-export * from "./strkey";
+export {StrKey} from "./strkey";
 
 export default module.exports;

--- a/src/keypair.js
+++ b/src/keypair.js
@@ -1,7 +1,7 @@
 import {Network} from "./network";
 import {sign, verify} from "./signing";
 import * as base58 from "./base58";
-import * as strkey from "./strkey";
+import {StrKey} from "./strkey";
 import {default as xdr} from "./generated/stellar-xdr_generated";
 
 let nacl = require("tweetnacl");
@@ -11,7 +11,7 @@ export class Keypair {
    * `Keypair` represents public (and secret) keys of the account.
    *
    * Use more convenient methods to create `Keypair` object:
-   * * `{@link Keypair.fromAccountId}`
+   * * `{@link Keypair.fromPublicKey}`
    * * `{@link Keypair.fromSecret}`
    * * `{@link Keypair.random}`
    *
@@ -30,22 +30,12 @@ export class Keypair {
   }
 
   /**
-   * @param {string} seed Secret key seed
-   * @deprecated Use {@link Keypair.fromSecret}
-   * @returns {Keypair}
-   */
-  static fromSeed(seed) {
-    console.log('Keypair.fromSeed() is deprecated. Use Keypair.fromSecret().');
-    return Keypair.fromSecret(seed);
-  }
-
-  /**
    * Creates a new `Keypair` instance from secret key.
    * @param {string} secretKey Secret key
    * @returns {Keypair}
    */
   static fromSecret(secretKey) {
-    let rawSeed = strkey.decodeCheck("seed", secretKey);
+    let rawSeed = StrKey.decodeEd25519SecretSeed(secretKey);
     return this.fromRawSeed(rawSeed);
   }
 
@@ -87,14 +77,14 @@ export class Keypair {
   }
 
   /**
-   * Creates a new `Keypair` object from account ID.
-   * @param {string} accountId account ID (ex. `GB3KJPLFUYN5VL6R3GU3EGCGVCKFDSD7BEDX42HWG5BWFKB3KQGJJRMA`)
+   * Creates a new `Keypair` object from public key.
+   * @param {string} publicKey public key (ex. `GB3KJPLFUYN5VL6R3GU3EGCGVCKFDSD7BEDX42HWG5BWFKB3KQGJJRMA`)
    * @returns {Keypair}
    */
-  static fromAccountId(accountId) {
-    let publicKey = strkey.decodeCheck("accountId", accountId);
+  static fromPublicKey(publicKey) {
+    publicKey = StrKey.decodeEd25519PublicKey(publicKey);
     if (publicKey.length !== 32) {
-      throw new Error('Invalid Stellar accountId');
+      throw new Error('Invalid Stellar public key');
     }
     return new this({publicKey});
   }
@@ -108,54 +98,12 @@ export class Keypair {
     return this.fromRawSeed(seed);
   }
 
-  /**
-   * Returns true if the given Stellar public key is valid.
-   * @param {string} publicKey public key to check
-   * @returns {boolean}
-   */
-  static isValidPublicKey(publicKey) {
-    if (publicKey && publicKey.length != 56) {
-      return false;
-    }
-
-    try {
-      let decoded = strkey.decodeCheck("accountId", publicKey);
-      if (decoded.length !== 32) {
-        return false;
-      }
-    } catch (err) {
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Returns true if the given Stellar secret key is valid.
-   * @param {string} secretKey secret key to check
-   * @returns {boolean}
-   */
-  static isValidSecretKey(secretKey) {
-    if (secretKey && secretKey.length != 56) {
-      return false;
-    }
-
-    try {
-      let decoded = strkey.decodeCheck("seed", secretKey);
-      if (decoded.length !== 32) {
-        return false;
-      }
-    } catch (err) {
-      return false;
-    }
-    return true;
-  }
-
   xdrAccountId() {
-    return new xdr.AccountId.keyTypeEd25519(this._publicKey);
+    return new xdr.AccountId.publicKeyTypeEd25519(this._publicKey);
   }
 
   xdrPublicKey() {
-    return new xdr.PublicKey.keyTypeEd25519(this._publicKey);
+    return new xdr.PublicKey.publicKeyTypeEd25519(this._publicKey);
   }
 
   /**
@@ -173,20 +121,11 @@ export class Keypair {
   }
 
   /**
-   * Returns account ID associated with this `Keypair` object.
+   * Returns public key associated with this `Keypair` object.
    * @returns {string}
    */
-  accountId() {
-    return strkey.encodeCheck("accountId", this._publicKey);
-  }
-
-  /**
-   * @deprecated Use {@link Keypair.secret}
-   * @returns {string}
-   */
-  seed() {
-    console.log('Keypair.seed() is deprecated. Use Keypair.secret().');
-    return this.secret();
+  publicKey() {
+    return StrKey.encodeEd25519PublicKey(this._publicKey);
   }
 
   /**
@@ -194,17 +133,7 @@ export class Keypair {
    * @returns {string}
    */
   secret() {
-    return strkey.encodeCheck("seed", this._secretSeed);
-  }
-
-  /**
-   * Returns raw secret key seed.
-   * @deprecated
-   * @returns {Buffer}
-   */
-  rawSeed() {
-    console.log('Keypair.rawSeed() is deprecated.');
-    return this._secretSeed;
+    return StrKey.encodeEd25519SecretSeed(this._secretSeed);
   }
 
   /**

--- a/src/keypair.js
+++ b/src/keypair.js
@@ -80,6 +80,9 @@ export class Keypair {
    * @returns {Keypair}
    */
   static master() {
+    if (Network.current() === null) {
+      throw new Error("No network selected. Use `Network.use`, `Network.usePublicNetwork` or `Network.useTestNetwork` helper methods to select network.");
+    }
     return this.fromRawSeed(Network.current().networkId());
   }
 

--- a/src/network.js
+++ b/src/network.js
@@ -11,7 +11,7 @@ export const Networks = {
 	TESTNET: "Test SDF Network ; September 2015"
 };
 
-var current;
+var current = null;
 
 export class Network {
 	/**
@@ -19,7 +19,7 @@ export class Network {
    * stellar networks.  It also provides the {@link Network.current} class method that returns the network
    * that will be used by this process for the purposes of generating signatures.
    *
-   * The test network is the default, but you can also override the default by using the `use`,
+   * You should select network your app will use before adding the first signature. You can use the `use`,
    * `usePublicNetwork` and `useTestNetwork` helper methods.
    *
 	 * Creates a new `Network` object.
@@ -28,13 +28,6 @@ export class Network {
 	 */
 	constructor(networkPassphrase) {
 		this._networkPassphrase = networkPassphrase;
-	}
-
-	/**
-	 * Use default network (right now default network is `testnet`).
-	 */
-	static useDefault() {
-		this.useTestNetwork();
 	}
 
 	/**
@@ -83,5 +76,3 @@ export class Network {
 		return hash(this.networkPassphrase());
 	}
 }
-
-Network.useDefault();

--- a/src/strkey.js
+++ b/src/strkey.js
@@ -6,9 +6,122 @@ import isNull from "lodash/isNull";
 import isString from "lodash/isString";
 
 const versionBytes = {
-  accountId: 0x30,
-  seed:      0x90
+  ed25519PublicKey:  6 << 3, // G
+  ed25519SecretSeed: 18 << 3, // S
+  preAuthTx:         19 << 3, // T
+  sha256Hash:        23 << 3  // X
 };
+
+/**
+ * StrKey is a helper class that allows encoding and decoding strkey.
+ */
+export class StrKey {
+  /**
+   * Encodes data to strkey ed25519 public key.
+   * @param {Buffer} data data to encode
+   * @returns {string}
+   */
+  static encodeEd25519PublicKey(data) {
+    return encodeCheck("ed25519PublicKey", data);
+  }
+
+  /**
+   * Decodes strkey ed25519 public key to raw data.
+   * @param {string} data data to decode
+   * @returns {Buffer}
+   */
+  static decodeEd25519PublicKey(data) {
+    return decodeCheck("ed25519PublicKey", data);
+  }
+
+  /**
+   * Returns true if the given Stellar public key is a valid ed25519 public key.
+   * @param {string} publicKey public key to check
+   * @returns {boolean}
+   */
+  static isValidEd25519PublicKey(publicKey) {
+    return isValid("ed25519PublicKey", publicKey);
+  }
+
+  /**
+   * Encodes data to strkey ed25519 seed.
+   * @param {Buffer} data data to encode
+   * @returns {string}
+   */
+  static encodeEd25519SecretSeed(data) {
+    return encodeCheck("ed25519SecretSeed", data);
+  }
+
+  /**
+   * Decodes strkey ed25519 seed to raw data.
+   * @param {string} data data to decode
+   * @returns {Buffer}
+   */
+  static decodeEd25519SecretSeed(data) {
+    return decodeCheck("ed25519SecretSeed", data);
+  }
+
+  /**
+   * Returns true if the given Stellar secret key is a valid ed25519 secret seed.
+   * @param {string} seed seed to check
+   * @returns {boolean}
+   */
+  static isValidEd25519SecretSeed(seed) {
+    return isValid("ed25519SecretSeed", seed);
+  }
+
+  /**
+   * Encodes data to strkey preAuthTx.
+   * @param {Buffer} data data to encode
+   * @returns {string}
+   */
+  static encodePreAuthTx(data) {
+    return encodeCheck("preAuthTx", data);
+  }
+
+  /**
+   * Decodes strkey PreAuthTx to raw data.
+   * @param {string} data data to decode
+   * @returns {Buffer}
+   */
+  static decodePreAuthTx(data) {
+    return decodeCheck("preAuthTx", data);
+  }
+
+  /**
+   * Encodes data to strkey sha256 hash.
+   * @param {Buffer} data data to encode
+   * @returns {string}
+   */
+  static encodeSha256Hash(data) {
+    return encodeCheck("sha256Hash", data);
+  }
+
+  /**
+   * Decodes strkey sha256 hash to raw data.
+   * @param {string} data data to decode
+   * @returns {Buffer}
+   */
+  static decodeSha256Hash(data) {
+    return decodeCheck("sha256Hash", data);
+  }
+}
+
+function isValid(versionByteName, encoded) {
+  if (encoded && encoded.length != 56) {
+    return false;
+  }
+
+  try {
+    let decoded = decodeCheck(versionByteName, encoded);
+    if (decoded.length !== 32) {
+      return false;
+    }
+  } catch (err) {
+    return false;
+  }
+  return true;
+}
 
 export function decodeCheck(versionByteName, encoded) {
   if (!isString(encoded)) {
@@ -52,7 +165,7 @@ export function encodeCheck(versionByteName, data) {
   let versionByte = versionBytes[versionByteName];
 
   if (isUndefined(versionByte)) {
-    throw new Error(`${versionByteName} is not a valid version byte name.  expected one of "accountId" or "seed"`);
+    throw new Error(`${versionByteName} is not a valid version byte name.  expected one of "ed25519PublicKey", "ed25519SecretSeed", "preAuthTx", "sha256Hash"`);
   }
 
   data              = new Buffer(data);

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -78,6 +78,10 @@ export class Transaction {
      * @returns {Buffer}
      */
     signatureBase() {
+        if (Network.current() === null) {
+            throw new Error("No network selected. Use `Network.use`, `Network.usePublicNetwork` or `Network.useTestNetwork` helper methods to select network.");
+        }
+
         return Buffer.concat([
             Network.current().networkId(),
             xdr.EnvelopeType.envelopeTypeTx().toXDR(),

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -1,10 +1,11 @@
 import {xdr, hash} from "./index";
 
-import {encodeCheck} from "./strkey";
+import {StrKey} from "./strkey";
 import {Operation} from "./operation";
 import {Network} from "./network";
 import map from "lodash/map";
 import each from "lodash/each";
+import crypto from "crypto";
 
 let MIN_LEDGER   = 0;
 let MAX_LEDGER   = 0xFFFFFFFF; // max uint32
@@ -25,7 +26,7 @@ export class Transaction {
         }
         // since this transaction is immutable, save the tx
         this.tx       = envelope.tx();
-        this.source   = encodeCheck("accountId", envelope.tx().sourceAccount().ed25519());
+        this.source   = StrKey.encodeEd25519PublicKey(envelope.tx().sourceAccount().ed25519());
         this.fee      = this.tx.fee();
         this.memo     = this.tx.memo();
         this.sequence = this.tx.seqNum().toString();
@@ -58,6 +59,18 @@ export class Transaction {
           let sig = kp.signDecorated(txHash);
           this.signatures.push(sig);
         });
+    }
+
+    /**
+     * Add `hashX` signer preimage as signature.
+     * @param {Buffer|String} preimage Preimage of hash used as signer
+     * @returns {void}
+     */
+    signHashX(preimage) {
+        let signature = preimage;
+        let hash = crypto.createHash('sha256').update(preimage).digest();
+        let hint = hash.slice(hash.length - 4);
+        this.signatures.push(new xdr.DecoratedSignature({hint, signature}));
     }
 
     /**

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -105,7 +105,7 @@ export class TransactionBuilder {
         let sequenceNumber = new BigNumber(this.source.sequenceNumber()).add(1);
 
         var attrs = {
-          sourceAccount: Keypair.fromAccountId(this.source.accountId()).xdrAccountId(),
+          sourceAccount: Keypair.fromPublicKey(this.source.accountId()).xdrAccountId(),
           fee:           this.baseFee * this.operations.length,
           seqNum:        xdr.SequenceNumber.fromString(sequenceNumber.toString()),
           memo:          this.memo,

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -65,7 +65,6 @@ export class TransactionBuilder {
         }
         this.source        = sourceAccount;
         this.operations    = [];
-        this.signers       = [];
 
         this.baseFee    = (isUndefined(opts.fee) ? BASE_FEE : opts.fee);
 
@@ -122,7 +121,6 @@ export class TransactionBuilder {
         let xenv = new xdr.TransactionEnvelope({tx:xtx});
 
         let tx = new Transaction(xenv);
-        tx.sign(...this.signers);
 
         this.source.incrementSequenceNumber();
         return tx;

--- a/test/unit/keypair_test.js
+++ b/test/unit/keypair_test.js
@@ -7,7 +7,7 @@ describe('Keypair.fromSecret', function() {
     let kp = StellarBase.Keypair.fromSecret(secret);
 
     expect(kp).to.be.instanceof(StellarBase.Keypair);
-    expect(kp.accountId()).to.eql("GDFQVQCYYB7GKCGSCUSIQYXTPLV5YJ3XWDMWGQMDNM4EAXAL7LITIBQ7");
+    expect(kp.publicKey()).to.eql("GDFQVQCYYB7GKCGSCUSIQYXTPLV5YJ3XWDMWGQMDNM4EAXAL7LITIBQ7");
     expect(kp.secret()).to.eql(secret);
   });
 
@@ -58,7 +58,7 @@ describe('Keypair.fromBase58Seed', function() {
       let key = keys[i];
       let keyPair = StellarBase.Keypair.fromBase58Seed(key.oldSeed);
       expect(keyPair.secret()).to.equal(key.newSeed);
-      expect(keyPair.accountId()).to.equal(key.newAddress);
+      expect(keyPair.publicKey()).to.equal(key.newAddress);
     }
   });
 
@@ -79,7 +79,7 @@ describe('Keypair.fromRawSeed', function() {
     let kp = StellarBase.Keypair.fromRawSeed(seed);
 
     expect(kp).to.be.instanceof(StellarBase.Keypair);
-    expect(kp.accountId()).to.eql("GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH");
+    expect(kp.publicKey()).to.eql("GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH");
     expect(kp.secret()).to.eql("SBWWC43UMVZHAYLTONYGQ4TBONSW2YLTORSXE4DBONZXA2DSMFZWLP2R");
     expect(kp.rawPublicKey().toString("hex")).to.eql("2e3c35010749c1de3d9a5bdd6a31c12458768da5ce87cca6aad63ebbaaef7432");
   });
@@ -94,26 +94,26 @@ describe('Keypair.fromRawSeed', function() {
 });
 
 
-describe('Keypair.fromAccountId', function() {
+describe('Keypair.fromPublicKey', function() {
 
   it("creates a keypair correctly", function() {
-    let kp = StellarBase.Keypair.fromAccountId("GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH");
+    let kp = StellarBase.Keypair.fromPublicKey("GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH");
     expect(kp).to.be.instanceof(StellarBase.Keypair);
-    expect(kp.accountId()).to.eql("GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH");
+    expect(kp.publicKey()).to.eql("GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH");
     expect(kp.rawPublicKey().toString("hex")).to.eql("2e3c35010749c1de3d9a5bdd6a31c12458768da5ce87cca6aad63ebbaaef7432");
   });
 
   it("throw an error if the arg isn't strkey encoded as a accountid", function() {
-    expect(() => StellarBase.Keypair.fromAccountId("hel0")).to.throw()
-    expect(() => StellarBase.Keypair.fromAccountId("masterpassphrasemasterpassphrase")).to.throw()
-    expect(() => StellarBase.Keypair.fromAccountId("sfyjodTxbwLtRToZvi6yQ1KnpZriwTJ7n6nrASFR6goRviCU3Ff")).to.throw()
+    expect(() => StellarBase.Keypair.fromPublicKey("hel0")).to.throw()
+    expect(() => StellarBase.Keypair.fromPublicKey("masterpassphrasemasterpassphrase")).to.throw()
+    expect(() => StellarBase.Keypair.fromPublicKey("sfyjodTxbwLtRToZvi6yQ1KnpZriwTJ7n6nrASFR6goRviCU3Ff")).to.throw()
   });
 
   it("throws an error if the address isn't 32 bytes", function() {
-    expect(() => StellarBase.Keypair.fromAccountId("masterpassphrasemasterpassphrase")).to.throw()
-    expect(() => StellarBase.Keypair.fromAccountId("masterpassphrasemasterpassphrase")).to.throw()
-    expect(() => StellarBase.Keypair.fromAccountId(null)).to.throw()
-    expect(() => StellarBase.Keypair.fromAccountId()).to.throw()
+    expect(() => StellarBase.Keypair.fromPublicKey("masterpassphrasemasterpassphrase")).to.throw()
+    expect(() => StellarBase.Keypair.fromPublicKey("masterpassphrasemasterpassphrase")).to.throw()
+    expect(() => StellarBase.Keypair.fromPublicKey(null)).to.throw()
+    expect(() => StellarBase.Keypair.fromPublicKey()).to.throw()
   });
 
 });
@@ -124,83 +124,6 @@ describe('Keypair.random', function() {
   it("creates a keypair correctly", function() {
     let kp = StellarBase.Keypair.random();
     expect(kp).to.be.instanceof(StellarBase.Keypair);
-  });
-
-});
-
-describe('Keypair.isValidPublicKey', function() {
-
-  it("returns true for valid public key", function() {
-    var keys = [
-      'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
-      'GB7KKHHVYLDIZEKYJPAJUOTBE5E3NJAXPSDZK7O6O44WR3EBRO5HRPVT',
-      'GD6WVYRVID442Y4JVWFWKWCZKB45UGHJAABBJRS22TUSTWGJYXIUR7N2',
-      'GBCG42WTVWPO4Q6OZCYI3D6ZSTFSJIXIS6INCIUF23L6VN3ADE4337AP',
-      'GDFX463YPLCO2EY7NGFMI7SXWWDQAMASGYZXCG2LATOF3PP5NQIUKBPT',
-      'GBXEODUMM3SJ3QSX2VYUWFU3NRP7BQRC2ERWS7E2LZXDJXL2N66ZQ5PT',
-      'GAJHORKJKDDEPYCD6URDFODV7CVLJ5AAOJKR6PG2VQOLWFQOF3X7XLOG',
-      'GACXQEAXYBEZLBMQ2XETOBRO4P66FZAJENDHOQRYPUIXZIIXLKMZEXBJ',
-      'GDD3XRXU3G4DXHVRUDH7LJM4CD4PDZTVP4QHOO4Q6DELKXUATR657OZV',
-      'GDTYVCTAUQVPKEDZIBWEJGKBQHB4UGGXI2SXXUEW7LXMD4B7MK37CWLJ'
-    ];
-
-    for (var i in keys) {
-      expect(StellarBase.Keypair.isValidPublicKey(keys[i])).to.be.true;
-    }
-  });
-
-  it("returns false for invalid public key", function() {
-    var keys = [
-      'GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL',
-      'GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++',
-      'GADE5QJ2TY7S5ZB65Q43DFGWYWCPHIYDJ2326KZGAGBN7AE5UY6JVDRRA',
-      'GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2',
-      'GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T',
-      'GDXIIZTKTLVYCBHURXL2UPMTYXOVNI7BRAEFQCP6EZCY4JLKY4VKFNLT',
-      'SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY',
-      'gWRYUerEKuz53tstxEuR3NCkiQDcV4wzFHmvLnZmj7PUqxW2wt',
-      'test',
-      null,
-      'g4VPBPrHZkfE8CsjuG2S4yBQNd455UWmk' // Old network key
-    ];
-
-    for (var i in keys) {
-      expect(StellarBase.Keypair.isValidPublicKey(keys[i])).to.be.false;
-    }
-  });
-
-});
-
-describe('Keypair.isValidSecretKey', function() {
-
-  it("returns true for valid secret key", function() {
-    var keys = [
-      'SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY',
-      'SCZTUEKSEH2VYZQC6VLOTOM4ZDLMAGV4LUMH4AASZ4ORF27V2X64F2S2',
-      'SCGNLQKTZ4XCDUGVIADRVOD4DEVNYZ5A7PGLIIZQGH7QEHK6DYODTFEH',
-      'SDH6R7PMU4WIUEXSM66LFE4JCUHGYRTLTOXVUV5GUEPITQEO3INRLHER',
-      'SC2RDTRNSHXJNCWEUVO7VGUSPNRAWFCQDPP6BGN4JFMWDSEZBRAPANYW',
-      'SCEMFYOSFZ5MUXDKTLZ2GC5RTOJO6FGTAJCF3CCPZXSLXA2GX6QUYOA7'
-    ];
-
-    for (var i in keys) {
-      expect(StellarBase.Keypair.isValidSecretKey(keys[i])).to.be.true;
-    }
-  });
-
-  it("returns false for invalid secret key", function() {
-    var keys = [
-      'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
-      'SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDYT', // Too long
-      'SAFGAMN5Z6IHVI3IVEPIILS7ITZDYSCEPLN4FN5Z3IY63DRH4CIYEV', // To short
-      'SAFGAMN5Z6IHVI3IVEPIILS7ITZDYSCEPLN4FN5Z3IY63DRH4CIYEVIT', // Checksum
-      'test',
-      null
-    ];
-
-    for (var i in keys) {
-      expect(StellarBase.Keypair.isValidSecretKey(keys[i])).to.be.false;
-    }
   });
 
 });

--- a/test/unit/network_test.js
+++ b/test/unit/network_test.js
@@ -1,22 +1,19 @@
-
-
 describe("Network.current()", function() {
+  it("defaults network is null", function() {
+    expect(StellarBase.Network.current()).to.be.null;
+  });
+});
 
-  it("defaults to the public network", function() {
+describe("Network.useTestNetwork()", function() {
+  it("switches to the test network", function() {
+    StellarBase.Network.useTestNetwork();
     expect(StellarBase.Network.current().networkPassphrase()).to.equal(StellarBase.Networks.TESTNET)
-  })
-
+  });
 });
 
 describe("Network.usePublicNetwork()", function() {
-
-  beforeEach(function() {
-    StellarBase.Network.useDefault();
-  });
-
   it("switches to the public network", function() {
     StellarBase.Network.usePublicNetwork();
     expect(StellarBase.Network.current().networkPassphrase()).to.equal(StellarBase.Networks.PUBLIC)
   });
-
 });

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -1,76 +1,84 @@
-var keypair          = StellarBase.Keypair.master();
-let unencodedBuffer  = keypair.rawPublicKey();
-let unencoded        = unencodedBuffer.toString();
-let accountIdEncoded = keypair.accountId();
-let seedEncoded      = StellarBase.encodeCheck("seed", unencodedBuffer);
+describe("Strkey encoding", function() {
+  before(function() {
+    StellarBase.Network.useTestNetwork();
+    var keypair           = StellarBase.Keypair.master();
+    this.unencodedBuffer  = keypair.rawPublicKey();
+    this.unencoded        = this.unencodedBuffer.toString();
+    this.accountIdEncoded = keypair.accountId();
+    this.seedEncoded      = StellarBase.encodeCheck("seed", this.unencodedBuffer);
+  })
 
-describe('StellarBase#decodeCheck', function() {
+  after(function() {
+    StellarBase.Network.use(null);
+  })
 
-  it("decodes correctly", function() {
-    expectBuffersToBeEqual(StellarBase.decodeCheck("accountId", accountIdEncoded), unencodedBuffer);
-    expectBuffersToBeEqual(StellarBase.decodeCheck("seed", seedEncoded), unencodedBuffer);
+  describe('StellarBase#decodeCheck', function() {
+    it("decodes correctly", function() {
+      expectBuffersToBeEqual(StellarBase.decodeCheck("accountId", this.accountIdEncoded), this.unencodedBuffer);
+      expectBuffersToBeEqual(StellarBase.decodeCheck("seed", this.seedEncoded), this.unencodedBuffer);
+    });
+
+    it("throws an error when the version byte is not defined", function() {
+      expect(() => StellarBase.decodeCheck("notreal", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/notreal is not a valid/);
+      expect(() => StellarBase.decodeCheck("broken", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/broken is not a valid/);
+    });
+
+    it("throws an error when the version byte is wrong", function() {
+      expect(() => StellarBase.decodeCheck("seed", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid version/);
+      expect(() => StellarBase.decodeCheck("accountId", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/invalid version/);
+    });
+
+    it("throws an error when decoded data encodes to other string", function() {
+      // accountId
+      expect(() => StellarBase.decodeCheck("accountId", "GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("accountId", "GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("accountId", "GADE5QJ2TY7S5ZB65Q43DFGWYWCPHIYDJ2326KZGAGBN7AE5UY6JVDRRA")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("accountId", "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("accountId", "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T")).to.throw(/invalid encoded string/);
+      // seed
+      expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYW")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2T")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("seed", "SCMB30FQCIQAWZ4WQTS6SVK37LGMAFJGXOZIHTH2PY6EXLP37G46H6DT")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.decodeCheck("seed", "SAYC2LQ322EEHZYWNSKBEW6N66IRTDREEBUXXU5HPVZGMAXKLIZNM45H++")).to.throw(/invalid encoded string/);
+    });
+
+    it("throws an error when the checksum is wrong", function() {
+      expect(() => StellarBase.decodeCheck("accountId", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVT")).to.throw(/invalid checksum/);
+      expect(() => StellarBase.decodeCheck("seed", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCX")).to.throw(/invalid checksum/);
+    });
   });
 
-  it("throws an error when the version byte is not defined", function() {
-    expect(() => StellarBase.decodeCheck("notreal", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/notreal is not a valid/);
-    expect(() => StellarBase.decodeCheck("broken", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/broken is not a valid/);
+
+  describe('StellarBase#encodeCheck', function() {
+
+    it("encodes a buffer correctly", function() {
+      expect(StellarBase.encodeCheck("accountId", this.unencodedBuffer)).to.eql(this.accountIdEncoded);
+      expect(StellarBase.encodeCheck("seed", this.unencodedBuffer)).to.eql(this.seedEncoded);
+    });
+
+    it("encodes a buffer correctly", function() {
+      expect(StellarBase.encodeCheck("accountId", this.unencodedBuffer)).to.eql(this.accountIdEncoded);
+      expect(StellarBase.encodeCheck("seed", this.unencodedBuffer)).to.eql(this.seedEncoded);
+    });
+
+
+    it("throws an error when the data is null", function() {
+      expect(() => StellarBase.encodeCheck("seed", null)).to.throw(/null data/);
+      expect(() => StellarBase.encodeCheck("accountId", null)).to.throw(/null data/);
+    });
+
+    it("throws an error when the version byte is not defined", function() {
+      expect(() => StellarBase.encodeCheck("notreal", this.unencoded)).to.throw(/notreal is not a valid/);
+      expect(() => StellarBase.encodeCheck("broken", this.unencoded)).to.throw(/broken is not a valid/);
+    });
   });
 
-  it("throws an error when the version byte is wrong", function() {
-    expect(() => StellarBase.decodeCheck("seed", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid version/);
-    expect(() => StellarBase.decodeCheck("accountId", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/invalid version/);
-  });
 
-  it("throws an error when decoded data encodes to other string", function() {
-    // accountId
-    expect(() => StellarBase.decodeCheck("accountId", "GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("accountId", "GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("accountId", "GADE5QJ2TY7S5ZB65Q43DFGWYWCPHIYDJ2326KZGAGBN7AE5UY6JVDRRA")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("accountId", "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("accountId", "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T")).to.throw(/invalid encoded string/);
-    // seed
-    expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYW")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2T")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("seed", "SCMB30FQCIQAWZ4WQTS6SVK37LGMAFJGXOZIHTH2PY6EXLP37G46H6DT")).to.throw(/invalid encoded string/);
-    expect(() => StellarBase.decodeCheck("seed", "SAYC2LQ322EEHZYWNSKBEW6N66IRTDREEBUXXU5HPVZGMAXKLIZNM45H++")).to.throw(/invalid encoded string/);
-  });
+  function expectBuffersToBeEqual(left, right) {
+    let leftHex = left.toString('hex');
+    let rightHex = right.toString('hex');
 
-  it("throws an error when the checksum is wrong", function() {
-    expect(() => StellarBase.decodeCheck("accountId", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVT")).to.throw(/invalid checksum/);
-    expect(() => StellarBase.decodeCheck("seed", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCX")).to.throw(/invalid checksum/);
-  });
+    expect(leftHex).to.eql(rightHex);
+  }
 });
-
-
-describe('StellarBase#encodeCheck', function() {
-
-  it("encodes a buffer correctly", function() {
-    expect(StellarBase.encodeCheck("accountId", unencodedBuffer)).to.eql(accountIdEncoded);
-    expect(StellarBase.encodeCheck("seed", unencodedBuffer)).to.eql(seedEncoded);
-  });
-
-  it("encodes a buffer correctly", function() {
-    expect(StellarBase.encodeCheck("accountId", unencodedBuffer)).to.eql(accountIdEncoded);
-    expect(StellarBase.encodeCheck("seed", unencodedBuffer)).to.eql(seedEncoded);
-  });
-
-
-  it("throws an error when the data is null", function() {
-    expect(() => StellarBase.encodeCheck("seed", null)).to.throw(/null data/);
-    expect(() => StellarBase.encodeCheck("accountId", null)).to.throw(/null data/);
-  });
-
-  it("throws an error when the version byte is not defined", function() {
-    expect(() => StellarBase.encodeCheck("notreal", unencoded)).to.throw(/notreal is not a valid/);
-    expect(() => StellarBase.encodeCheck("broken", unencoded)).to.throw(/broken is not a valid/);
-  });
-});
-
-
-function expectBuffersToBeEqual(left, right) {
-  let leftHex = left.toString('hex');
-  let rightHex = right.toString('hex');
-
-  expect(leftHex).to.eql(rightHex);
-}

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -1,84 +1,152 @@
-describe("Strkey encoding", function() {
+describe('StrKey', function() {
   before(function() {
     StellarBase.Network.useTestNetwork();
     var keypair           = StellarBase.Keypair.master();
     this.unencodedBuffer  = keypair.rawPublicKey();
     this.unencoded        = this.unencodedBuffer.toString();
-    this.accountIdEncoded = keypair.accountId();
-    this.seedEncoded      = StellarBase.encodeCheck("seed", this.unencodedBuffer);
+    this.accountIdEncoded = keypair.publicKey();
+    this.seedEncoded      = StellarBase.StrKey.encodeEd25519SecretSeed(this.unencodedBuffer);
   })
 
   after(function() {
     StellarBase.Network.use(null);
   })
 
-  describe('StellarBase#decodeCheck', function() {
+  describe('#decodeCheck', function() {
     it("decodes correctly", function() {
-      expectBuffersToBeEqual(StellarBase.decodeCheck("accountId", this.accountIdEncoded), this.unencodedBuffer);
-      expectBuffersToBeEqual(StellarBase.decodeCheck("seed", this.seedEncoded), this.unencodedBuffer);
-    });
-
-    it("throws an error when the version byte is not defined", function() {
-      expect(() => StellarBase.decodeCheck("notreal", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/notreal is not a valid/);
-      expect(() => StellarBase.decodeCheck("broken", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/broken is not a valid/);
+      expect(StellarBase.StrKey.decodeEd25519PublicKey(this.accountIdEncoded)).to.eql(this.unencodedBuffer);
+      expect(StellarBase.StrKey.decodeEd25519SecretSeed(this.seedEncoded)).to.eql(this.unencodedBuffer);
     });
 
     it("throws an error when the version byte is wrong", function() {
-      expect(() => StellarBase.decodeCheck("seed", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid version/);
-      expect(() => StellarBase.decodeCheck("accountId", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/invalid version/);
+      expect(() => StellarBase.StrKey.decodeEd25519SecretSeed("GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid version/);
+      expect(() => StellarBase.StrKey.decodeEd25519PublicKey("SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU")).to.throw(/invalid version/);
     });
 
     it("throws an error when decoded data encodes to other string", function() {
       // accountId
-      expect(() => StellarBase.decodeCheck("accountId", "GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid encoded string/);
-      expect(() => StellarBase.decodeCheck("accountId", "GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++")).to.throw(/invalid encoded string/);
-      expect(() => StellarBase.decodeCheck("accountId", "GADE5QJ2TY7S5ZB65Q43DFGWYWCPHIYDJ2326KZGAGBN7AE5UY6JVDRRA")).to.throw(/invalid encoded string/);
-      expect(() => StellarBase.decodeCheck("accountId", "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2")).to.throw(/invalid encoded string/);
-      expect(() => StellarBase.decodeCheck("accountId", "GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.StrKey.decodeEd25519PublicKey("GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.StrKey.decodeEd25519PublicKey("GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.StrKey.decodeEd25519PublicKey("GADE5QJ2TY7S5ZB65Q43DFGWYWCPHIYDJ2326KZGAGBN7AE5UY6JVDRRA")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.StrKey.decodeEd25519PublicKey("GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.StrKey.decodeEd25519PublicKey("GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T")).to.throw(/invalid encoded string/);
       // seed
-      expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYW")).to.throw(/invalid encoded string/);
-      expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2")).to.throw(/invalid encoded string/);
-      expect(() => StellarBase.decodeCheck("seed", "SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2T")).to.throw(/invalid encoded string/);
-      expect(() => StellarBase.decodeCheck("seed", "SCMB30FQCIQAWZ4WQTS6SVK37LGMAFJGXOZIHTH2PY6EXLP37G46H6DT")).to.throw(/invalid encoded string/);
-      expect(() => StellarBase.decodeCheck("seed", "SAYC2LQ322EEHZYWNSKBEW6N66IRTDREEBUXXU5HPVZGMAXKLIZNM45H++")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.StrKey.decodeEd25519SecretSeed("SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYW")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.StrKey.decodeEd25519SecretSeed("SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.StrKey.decodeEd25519SecretSeed("SB7OJNF5727F3RJUG5ASQJ3LUM44ELLNKW35ZZQDHMVUUQNGYWMEGB2W2T")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.StrKey.decodeEd25519SecretSeed("SCMB30FQCIQAWZ4WQTS6SVK37LGMAFJGXOZIHTH2PY6EXLP37G46H6DT")).to.throw(/invalid encoded string/);
+      expect(() => StellarBase.StrKey.decodeEd25519SecretSeed("SAYC2LQ322EEHZYWNSKBEW6N66IRTDREEBUXXU5HPVZGMAXKLIZNM45H++")).to.throw(/invalid encoded string/);
     });
 
     it("throws an error when the checksum is wrong", function() {
-      expect(() => StellarBase.decodeCheck("accountId", "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVT")).to.throw(/invalid checksum/);
-      expect(() => StellarBase.decodeCheck("seed", "SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCX")).to.throw(/invalid checksum/);
+      expect(() => StellarBase.StrKey.decodeEd25519PublicKey("GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVT")).to.throw(/invalid checksum/);
+      expect(() => StellarBase.StrKey.decodeEd25519SecretSeed("SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCX")).to.throw(/invalid checksum/);
     });
   });
 
-
-  describe('StellarBase#encodeCheck', function() {
-
+  describe('#encodeCheck', function() {
     it("encodes a buffer correctly", function() {
-      expect(StellarBase.encodeCheck("accountId", this.unencodedBuffer)).to.eql(this.accountIdEncoded);
-      expect(StellarBase.encodeCheck("seed", this.unencodedBuffer)).to.eql(this.seedEncoded);
+      expect(StellarBase.StrKey.encodeEd25519PublicKey(this.unencodedBuffer)).to.eql(this.accountIdEncoded);
+      expect(StellarBase.StrKey.encodeEd25519PublicKey(this.unencodedBuffer)).to.match(/^G/);
+      expect(StellarBase.StrKey.encodeEd25519SecretSeed(this.unencodedBuffer)).to.eql(this.seedEncoded);
+      expect(StellarBase.StrKey.encodeEd25519SecretSeed(this.unencodedBuffer)).to.match(/^S/);
+
+      var strkeyEncoded;
+
+      strkeyEncoded = StellarBase.StrKey.encodePreAuthTx(this.unencodedBuffer);
+      expect(strkeyEncoded).to.match(/^T/);
+      expect(StellarBase.StrKey.decodePreAuthTx(strkeyEncoded)).to.eql(this.unencodedBuffer);
+
+      strkeyEncoded = StellarBase.StrKey.encodeSha256Hash(this.unencodedBuffer);
+      expect(strkeyEncoded).to.match(/^X/);
+      expect(StellarBase.StrKey.decodeSha256Hash(strkeyEncoded)).to.eql(this.unencodedBuffer);
     });
 
     it("encodes a buffer correctly", function() {
-      expect(StellarBase.encodeCheck("accountId", this.unencodedBuffer)).to.eql(this.accountIdEncoded);
-      expect(StellarBase.encodeCheck("seed", this.unencodedBuffer)).to.eql(this.seedEncoded);
+      expect(StellarBase.StrKey.encodeEd25519PublicKey(this.unencodedBuffer)).to.eql(this.accountIdEncoded);
+      expect(StellarBase.StrKey.encodeEd25519SecretSeed(this.unencodedBuffer)).to.eql(this.seedEncoded);
     });
 
 
     it("throws an error when the data is null", function() {
-      expect(() => StellarBase.encodeCheck("seed", null)).to.throw(/null data/);
-      expect(() => StellarBase.encodeCheck("accountId", null)).to.throw(/null data/);
-    });
-
-    it("throws an error when the version byte is not defined", function() {
-      expect(() => StellarBase.encodeCheck("notreal", this.unencoded)).to.throw(/notreal is not a valid/);
-      expect(() => StellarBase.encodeCheck("broken", this.unencoded)).to.throw(/broken is not a valid/);
+      expect(() => StellarBase.StrKey.encodeEd25519SecretSeed(null)).to.throw(/null data/);
+      expect(() => StellarBase.StrKey.encodeEd25519PublicKey(null)).to.throw(/null data/);
     });
   });
 
+  describe('#isValidEd25519PublicKey', function() {
+    it("returns true for valid public key", function() {
+      var keys = [
+        'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
+        'GB7KKHHVYLDIZEKYJPAJUOTBE5E3NJAXPSDZK7O6O44WR3EBRO5HRPVT',
+        'GD6WVYRVID442Y4JVWFWKWCZKB45UGHJAABBJRS22TUSTWGJYXIUR7N2',
+        'GBCG42WTVWPO4Q6OZCYI3D6ZSTFSJIXIS6INCIUF23L6VN3ADE4337AP',
+        'GDFX463YPLCO2EY7NGFMI7SXWWDQAMASGYZXCG2LATOF3PP5NQIUKBPT',
+        'GBXEODUMM3SJ3QSX2VYUWFU3NRP7BQRC2ERWS7E2LZXDJXL2N66ZQ5PT',
+        'GAJHORKJKDDEPYCD6URDFODV7CVLJ5AAOJKR6PG2VQOLWFQOF3X7XLOG',
+        'GACXQEAXYBEZLBMQ2XETOBRO4P66FZAJENDHOQRYPUIXZIIXLKMZEXBJ',
+        'GDD3XRXU3G4DXHVRUDH7LJM4CD4PDZTVP4QHOO4Q6DELKXUATR657OZV',
+        'GDTYVCTAUQVPKEDZIBWEJGKBQHB4UGGXI2SXXUEW7LXMD4B7MK37CWLJ'
+      ];
 
-  function expectBuffersToBeEqual(left, right) {
-    let leftHex = left.toString('hex');
-    let rightHex = right.toString('hex');
+      for (var i in keys) {
+        expect(StellarBase.StrKey.isValidEd25519PublicKey(keys[i])).to.be.true;
+      }
+    });
 
-    expect(leftHex).to.eql(rightHex);
-  }
+    it("returns false for invalid public key", function() {
+      var keys = [
+        'GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL',
+        'GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++',
+        'GADE5QJ2TY7S5ZB65Q43DFGWYWCPHIYDJ2326KZGAGBN7AE5UY6JVDRRA',
+        'GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2',
+        'GB6OWYST45X57HCJY5XWOHDEBULB6XUROWPIKW77L5DSNANBEQGUPADT2T',
+        'GDXIIZTKTLVYCBHURXL2UPMTYXOVNI7BRAEFQCP6EZCY4JLKY4VKFNLT',
+        'SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY',
+        'gWRYUerEKuz53tstxEuR3NCkiQDcV4wzFHmvLnZmj7PUqxW2wt',
+        'test',
+        null,
+        'g4VPBPrHZkfE8CsjuG2S4yBQNd455UWmk' // Old network key
+      ];
+
+      for (var i in keys) {
+        expect(StellarBase.StrKey.isValidEd25519PublicKey(keys[i])).to.be.false;
+      }
+    });
+
+  });
+
+  describe('#isValidSecretKey', function() {
+    it("returns true for valid secret key", function() {
+      var keys = [
+        'SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY',
+        'SCZTUEKSEH2VYZQC6VLOTOM4ZDLMAGV4LUMH4AASZ4ORF27V2X64F2S2',
+        'SCGNLQKTZ4XCDUGVIADRVOD4DEVNYZ5A7PGLIIZQGH7QEHK6DYODTFEH',
+        'SDH6R7PMU4WIUEXSM66LFE4JCUHGYRTLTOXVUV5GUEPITQEO3INRLHER',
+        'SC2RDTRNSHXJNCWEUVO7VGUSPNRAWFCQDPP6BGN4JFMWDSEZBRAPANYW',
+        'SCEMFYOSFZ5MUXDKTLZ2GC5RTOJO6FGTAJCF3CCPZXSLXA2GX6QUYOA7'
+      ];
+
+      for (var i in keys) {
+        expect(StellarBase.StrKey.isValidEd25519SecretSeed(keys[i])).to.be.true;
+      }
+    });
+
+    it("returns false for invalid secret key", function() {
+      var keys = [
+        'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
+        'SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDYT', // Too long
+        'SAFGAMN5Z6IHVI3IVEPIILS7ITZDYSCEPLN4FN5Z3IY63DRH4CIYEV', // To short
+        'SAFGAMN5Z6IHVI3IVEPIILS7ITZDYSCEPLN4FN5Z3IY63DRH4CIYEVIT', // Checksum
+        'test',
+        null
+      ];
+
+      for (var i in keys) {
+        expect(StellarBase.StrKey.isValidEd25519SecretSeed(keys[i])).to.be.false;
+      }
+    });
+
+  });
+
 });

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -27,6 +27,27 @@ describe('Transaction', function() {
     done();
   });
 
+  beforeEach(function() {
+    StellarBase.Network.useTestNetwork();
+  })
+
+  afterEach(function() {
+    StellarBase.Network.use(null);
+  })
+
+  it("does not sign when no Network selected", function() {
+    StellarBase.Network.use(null);
+    let source      = new StellarBase.Account("GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB", "0");
+    let destination = "GDJJRRMBK4IWLEPJGIE6SXD2LP7REGZODU7WDC3I2D6MR37F4XSHBKX2";
+    let asset       = StellarBase.Asset.native();
+    let amount      = "2000";
+    let signer      = StellarBase.Keypair.random();
+
+    let tx = new StellarBase.TransactionBuilder(source)
+                .addOperation(StellarBase.Operation.payment({destination, asset, amount}))
+                .build();
+    expect(() => tx.sign(signer)).to.throw(/No network selected/);
+  });
 
   it("signs correctly", function() {
     let source      = new StellarBase.Account("GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB", "0");

--- a/xdr/Stellar-ledger-entries.x
+++ b/xdr/Stellar-ledger-entries.x
@@ -70,7 +70,7 @@ enum LedgerEntryType
 
 struct Signer
 {
-    AccountID pubKey;
+    SignerKey key;
     uint32 weight; // really only need 1byte
 };
 

--- a/xdr/Stellar-ledger.x
+++ b/xdr/Stellar-ledger.x
@@ -144,11 +144,10 @@ case DEADENTRY:
 
 // Transaction sets are the unit used by SCP to decide on transitions
 // between ledgers
-const MAX_TX_PER_LEDGER = 5000;
 struct TransactionSet
 {
     Hash previousLedgerHash;
-    TransactionEnvelope txs<MAX_TX_PER_LEDGER>;
+    TransactionEnvelope txs<>;
 };
 
 struct TransactionResultPair
@@ -160,7 +159,7 @@ struct TransactionResultPair
 // TransactionResultSet is used to recover results between ledgers
 struct TransactionResultSet
 {
-    TransactionResultPair results<MAX_TX_PER_LEDGER>;
+    TransactionResultPair results<>;
 };
 
 // Entries below are used in the historical subsystem

--- a/xdr/Stellar-types.x
+++ b/xdr/Stellar-types.x
@@ -16,13 +16,39 @@ typedef hyper int64;
 
 enum CryptoKeyType
 {
-    KEY_TYPE_ED25519 = 0
+    KEY_TYPE_ED25519 = 0,
+    KEY_TYPE_HASH_TX = 1,
+    KEY_TYPE_HASH_X = 2
 };
 
-union PublicKey switch (CryptoKeyType type)
+enum PublicKeyType
 {
-case KEY_TYPE_ED25519:
+    PUBLIC_KEY_TYPE_ED25519 = KEY_TYPE_ED25519
+};
+
+enum SignerKeyType
+{
+    SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
+    SIGNER_KEY_TYPE_HASH_TX = KEY_TYPE_HASH_TX,
+    SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X
+};
+
+union PublicKey switch (PublicKeyType type)
+{
+case PUBLIC_KEY_TYPE_ED25519:
     uint256 ed25519;
+};
+
+union SignerKey switch (SignerKeyType type)
+{
+case SIGNER_KEY_TYPE_ED25519:
+    uint256 ed25519;
+case SIGNER_KEY_TYPE_HASH_TX:
+    /* Hash of Transaction structure */
+    uint256 hashTx;
+case SIGNER_KEY_TYPE_HASH_X:
+    /* Hash of random 256 bit preimage X */
+    uint256 hashX;
 };
 
 // variable size as the size depends on the signature scheme used


### PR DESCRIPTION
* Support for new signer types: `sha256Hash`, `preAuthTx`.
* `StrKey` helper class with `strkey` encoding related methods.
* Removed deprecated methods: `Keypair.isValidPublicKey` (use `StrKey`), `Keypair.isValidSecretKey` (use `StrKey`), `Keypair.fromSeed`, `Keypair.seed`, `Keypair.rawSeed`.
* **Breaking changes**:
  * `Network` must be explicitly selected. Previously testnet was a default network.
  * `Operation.setOptions()` method `signer` param changed.
  * `Keypair.fromAccountId()` renamed to `Keypair.fromPublicKey()`.
  * `Keypair.accountId()` renamed to `Keypair.publicKey()`.
  * Dropping support for `End-of-Life` node versions.