### PR TITLE
Improve Keypair class

### DIFF
--- a/src/keypair.js
+++ b/src/keypair.js
@@ -28,13 +28,16 @@ export class Keypair {
       throw new Error("Invalid keys type");
     }
 
+    this.type = keys.type;
+
     if (keys.secretKey) {
       keys.secretKey = new Buffer(keys.secretKey);
 
       let secretKeyUint8 = new Uint8Array(keys.secretKey);
       let naclKeys = nacl.sign.keyPair.fromSeed(secretKeyUint8);
 
-      this._secretKey = keys.secretKey;
+      this._secretSeed = keys.secretKey;
+      this._secretKey = new Buffer(naclKeys.secretKey);
       this._publicKey = new Buffer(naclKeys.publicKey);
 
       if (keys.publicKey && !this._publicKey.equals(new Buffer(keys.publicKey))) {
@@ -145,10 +148,15 @@ export class Keypair {
    * @returns {string}
    */
   secret() {
-    if (!this._secretKey) {
+    if (!this._secretSeed) {
       throw new Error("no secret key available");
     }
-    return StrKey.encodeEd25519SecretSeed(this._secretKey);
+
+    if (this.type == 'ed25519') {
+      return StrKey.encodeEd25519SecretSeed(this._secretSeed);
+    }
+
+    throw new Error("Invalid Keypair type");
   }
 
   /**
@@ -156,7 +164,7 @@ export class Keypair {
    * @returns {Buffer}
    */
   rawSecretKey() {
-    return this._secretKey;
+    return this._secretSeed;
   }
 
   /**

--- a/src/keypair.js
+++ b/src/keypair.js
@@ -33,6 +33,10 @@ export class Keypair {
     if (keys.secretKey) {
       keys.secretKey = new Buffer(keys.secretKey);
 
+      if (keys.secretKey.length != 32) {
+        throw new Error("secretKey length is invalid");
+      }
+
       let secretKeyUint8 = new Uint8Array(keys.secretKey);
       let naclKeys = nacl.sign.keyPair.fromSeed(secretKeyUint8);
 
@@ -45,6 +49,10 @@ export class Keypair {
       }
     } else {
       this._publicKey = new Buffer(keys.publicKey);
+
+      if (this._publicKey.length != 32) {
+        throw new Error("publicKey length is invalid");
+      }
     }
   }
 

--- a/test/unit/keypair_test.js
+++ b/test/unit/keypair_test.js
@@ -1,4 +1,16 @@
 
+describe('Keypair.fromSecret', function() {
+  it("fails when passes secret key does not match public key", function() {
+    let secret = "SD7X7LEHBNMUIKQGKPARG5TDJNBHKC346OUARHGZL5ITC6IJPXHILY36";
+    let kp = StellarBase.Keypair.fromSecret(secret);
+
+    let secretKey = kp.rawSecretKey();
+    let publicKey = StellarBase.StrKey.decodeEd25519PublicKey(kp.publicKey());
+    publicKey[0] = 0; // Make public key invalid
+
+    expect(() => new StellarBase.Keypair({type: 'ed25519', secretKey, publicKey})).to.throw()
+  });
+});
 
 describe('Keypair.fromSecret', function() {
 
@@ -72,11 +84,11 @@ describe('Keypair.fromBase58Seed', function() {
 
 });
 
-describe('Keypair.fromRawSeed', function() {
+describe('Keypair.fromRawEd25519Seed', function() {
 
   it("creates a keypair correctly", function() {
     let seed = "masterpassphrasemasterpassphrase";
-    let kp = StellarBase.Keypair.fromRawSeed(seed);
+    let kp = StellarBase.Keypair.fromRawEd25519Seed(seed);
 
     expect(kp).to.be.instanceof(StellarBase.Keypair);
     expect(kp.publicKey()).to.eql("GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH");
@@ -85,10 +97,10 @@ describe('Keypair.fromRawSeed', function() {
   });
 
   it("throws an error if the arg isn't 32 bytes", function() {
-    expect(() => StellarBase.Keypair.fromRawSeed("masterpassphrasemasterpassphras")).to.throw()
-    expect(() => StellarBase.Keypair.fromRawSeed("masterpassphrasemasterpassphrase1")).to.throw()
-    expect(() => StellarBase.Keypair.fromRawSeed(null)).to.throw()
-    expect(() => StellarBase.Keypair.fromRawSeed()).to.throw()
+    expect(() => StellarBase.Keypair.fromRawEd25519Seed("masterpassphrasemasterpassphras")).to.throw()
+    expect(() => StellarBase.Keypair.fromRawEd25519Seed("masterpassphrasemasterpassphrase1")).to.throw()
+    expect(() => StellarBase.Keypair.fromRawEd25519Seed(null)).to.throw()
+    expect(() => StellarBase.Keypair.fromRawEd25519Seed()).to.throw()
   });
 
 });

--- a/test/unit/keypair_test.js
+++ b/test/unit/keypair_test.js
@@ -1,5 +1,5 @@
 
-describe('Keypair.fromSecret', function() {
+describe('Keypair.contructor', function() {
   it("fails when passes secret key does not match public key", function() {
     let secret = "SD7X7LEHBNMUIKQGKPARG5TDJNBHKC346OUARHGZL5ITC6IJPXHILY36";
     let kp = StellarBase.Keypair.fromSecret(secret);
@@ -8,7 +8,17 @@ describe('Keypair.fromSecret', function() {
     let publicKey = StellarBase.StrKey.decodeEd25519PublicKey(kp.publicKey());
     publicKey[0] = 0; // Make public key invalid
 
-    expect(() => new StellarBase.Keypair({type: 'ed25519', secretKey, publicKey})).to.throw()
+    expect(() => new StellarBase.Keypair({type: 'ed25519', secretKey, publicKey})).to.throw(/secretKey does not match publicKey/)
+  });
+
+  it("fails when secretKey length is invalid", function() {
+    let secretKey = new Buffer(33);
+    expect(() => new StellarBase.Keypair({type: 'ed25519', secretKey})).to.throw(/secretKey length is invalid/)
+  });
+
+  it("fails when publicKey length is invalid", function() {
+    let publicKey = new Buffer(33);
+    expect(() => new StellarBase.Keypair({type: 'ed25519', publicKey})).to.throw(/publicKey length is invalid/)
   });
 });
 


### PR DESCRIPTION
In https://github.com/stellar/js-stellar-base/issues/101 @pakokrew noticed that `Keypair.constructor` usage is not clear. I realized that this class can be further improved (see https://github.com/stellar/js-stellar-base/pull/96).
* `Keypair.constructor` now requires `type` field to define public-key signature system used in this instance (so `Keypair` can support other systems in a future). It also checks if public key and secret key match if both are passed (to prevent nasty bugs).
* `Keypair.fromRawSeed` has been renamed to `Keypair.fromRawEd25519Seed` to make it clear that the seed must be Ed25519 seed.