### PR TITLE
Memo instance

### DIFF
--- a/src/asset.js
+++ b/src/asset.js
@@ -69,7 +69,7 @@ export class Asset {
    * Returns the xdr object for this asset.
    * @returns {xdr.Asset}
    */
-  toXdrObject() {
+  toXDRObject() {
     if (this.isNative()) {
       return xdr.Asset.assetTypeNative();
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export {Transaction} from "./transaction";
 export {TransactionBuilder} from "./transaction_builder";
 export {Asset} from "./asset";
 export {Operation, AuthRequiredFlag, AuthRevocableFlag, AuthImmutableFlag} from "./operation";
-export {Memo} from "./memo";
+export * from "./memo";
 export {Account} from "./account";
 export {Network, Networks} from "./network";
 export {StrKey} from "./strkey";

--- a/src/memo.js
+++ b/src/memo.js
@@ -2,120 +2,231 @@ import {default as xdr} from "./generated/stellar-xdr_generated";
 import isUndefined from "lodash/isUndefined";
 import isNull from "lodash/isNull";
 import isString from "lodash/isString";
+import clone from "lodash/clone";
 import {UnsignedHyper} from "js-xdr";
 import BigNumber from 'bignumber.js';
 
 /**
- * `Memo` represents memos attached to transactions. Use static methods to create memos.
+ * Type of {@link Memo}.
+ */
+export const MemoNone = "none";
+/**
+ * Type of {@link Memo}.
+ */
+export const MemoID = "id";
+/**
+ * Type of {@link Memo}.
+ */
+export const MemoText = "text";
+/**
+ * Type of {@link Memo}.
+ */
+export const MemoHash = "hash";
+/**
+ * Type of {@link Memo}.
+ */
+export const MemoReturn = "return";
+
+/**
+ * `Memo` represents memos attached to transactions.
  *
+ * @param {string} type - `MemoNone`, `MemoID`, `MemoText`, `MemoHash` or `MemoReturn`
+ * @param {*} value - `string` for `MemoID`, `MemoText`, buffer of hex string for `MemoHash` or `MemoReturn`
  * @see [Transactions concept](https://www.stellar.org/developers/learn/concepts/transactions.html)
  * @class Memo
  */
- export class Memo {
-  /**
-   * Returns an empty memo (`MEMO_NONE`).
-   * @returns {xdr.Memo}
-   */
-  static none() {
-    return xdr.Memo.memoNone();
+export class Memo {
+  constructor(type, value = null) {
+    this._type = type;
+    this._value = value;
+
+    switch (this._type) {
+      case MemoNone:
+        break;
+      case MemoID:
+        Memo._validateIdValue(value);
+        break;
+      case MemoText:
+        Memo._validateTextValue(value);
+        break;
+      case MemoHash:
+      case MemoReturn:
+        Memo._validateHashValue(value);
+        // We want MemoHash and MemoReturn to have Buffer as a value
+        if (isString(value)) {
+          this._value = new Buffer(value, 'hex');
+        }
+        break;
+      default:
+        throw new Error("Invalid memo type");
+    }
   }
 
   /**
-   * Creates and returns a `MEMO_TEXT` memo.
-   * @param {string} text - memo text
-   * @returns {xdr.Memo}
+   * Contains memo type: `MemoNone`, `MemoID`, `MemoText`, `MemoHash` or `MemoReturn`
    */
-  static text(text) {
-    if (!isString(text)) {
-      throw new Error("Expects string type got a " + typeof(text));
-    }
-    if (Buffer.byteLength(text, "utf8") > 28) {
-      throw new Error("Text should be <= 28 bytes. Got " + Buffer.byteLength(text, "utf8"));
-    }
-    return xdr.Memo.memoText(text);
+  get type() {
+    return clone(this._type);
+  }
+
+  set type(type) {
+    throw new Error("Memo is immutable");
   }
 
   /**
-   * Creates and returns a `MEMO_ID` memo.
-   * @param {string} id - 64-bit number represented as a string
-   * @returns {xdr.Memo}
+   * Contains memo value:
+   * * `null` for `MemoNone`,
+   * * `string` for `MemoID`, `MemoText`,
+   * * `Buffer` for `MemoHash`, `MemoReturn`
    */
-  static id(id) {
-    let error = new Error("Expects a int64 as a string. Got " + id);
+  get value() {
+    return clone(this._value);
+  }
 
-    if (!isString(id)) {
+  set value(value) {
+    throw new Error("Memo is immutable");
+  }
+
+  static _validateIdValue(value) {
+    let error = new Error("Expects a int64 as a string. Got " + value);
+
+    if (!isString(value)) {
       throw error;
     }
 
     let number;
     try {
-      number = new BigNumber(id);
+      number = new BigNumber(value);
     } catch (e) {
       throw error;
     }
 
-      // Infinity
-      if (!number.isFinite()) {
-        throw error;
-      }
-
-      // NaN
-      if (number.isNaN()) {
-        throw error;
-      }
-
-      return xdr.Memo.memoId(UnsignedHyper.fromString(id));
-    }
-
-  /**
-   * Creates and returns a `MEMO_HASH` memo.
-   * @param {array|string} hash - 32 byte hash or hex encoded string
-   * @returns {xdr.Memo}
-   */
-  static hash(hash) {
-    let error = new Error("Expects a 32 byte hash value or hex encoded string. Got " + hash);
-
-    if (isUndefined(hash)) {
+    // Infinity
+    if (!number.isFinite()) {
       throw error;
     }
 
-    if (isString(hash)) {
-      if (!/^[0-9A-Fa-f]{64}$/g.test(hash)) {
-        throw error;
-      }
-      hash = new Buffer(hash, 'hex');
+    // NaN
+    if (number.isNaN()) {
+      throw error;
     }
+  }
 
-    if (!hash.length || hash.length != 32) {
+  static _validateTextValue(value) {
+    if (!isString(value)) {
+      throw new Error("Expects string type got " + typeof(value));
+    }
+    if (Buffer.byteLength(value, "utf8") > 28) {
+      throw new Error("Text should be <= 28 bytes. Got " + Buffer.byteLength(value, "utf8"));
+    }
+  }
+
+  static _validateHashValue(value) {
+    // We don't want side effects in this function
+    value = clone(value);
+
+    let error = new Error("Expects a 32 byte hash value or hex encoded string. Got " + value);
+
+    if (value === null || isUndefined(value)) {
       throw error;
     }
 
-    return xdr.Memo.memoHash(hash);
+    if (isString(value)) {
+      if (!/^[0-9A-Fa-f]{64}$/g.test(value)) {
+        throw error;
+      }
+      value = new Buffer(value, 'hex');
+    }
+
+    if (!value.length || value.length != 32) {
+      throw error;
+    }
   }
 
   /**
-   * Creates and returns a `MEMO_RETURN` memo.
+   * Returns an empty memo (`MemoNone`).
+   * @returns {Memo}
+   */
+  static none() {
+    return new Memo(MemoNone);
+  }
+
+  /**
+   * Creates and returns a `MemoText` memo.
+   * @param {string} text - memo text
+   * @returns {Memo}
+   */
+  static text(text) {
+    return new Memo(MemoText, text);
+  }
+
+  /**
+   * Creates and returns a `MemoID` memo.
+   * @param {string} id - 64-bit number represented as a string
+   * @returns {Memo}
+   */
+  static id(id) {
+    return new Memo(MemoID, id);
+  }
+
+  /**
+   * Creates and returns a `MemoHash` memo.
    * @param {array|string} hash - 32 byte hash or hex encoded string
+   * @returns {Memo}
+   */
+  static hash(hash) {
+    return new Memo(MemoHash, hash);
+  }
+
+  /**
+   * Creates and returns a `MemoReturn` memo.
+   * @param {array|string} hash - 32 byte hash or hex encoded string
+   * @returns {Memo}
+   */
+  static return(hash) {
+    return new Memo(MemoReturn, hash);
+  }
+
+  /**
+   * Returns XDR memo object.
    * @returns {xdr.Memo}
    */
-  static returnHash(hash) {
-    let error = new Error("Expects a 32 byte hash value or hex encoded string. Got " + hash);
+  toXDRObject() {
+    switch (this._type) {
+      case MemoNone:
+        return xdr.Memo.memoNone();
+      case MemoID:
+        return xdr.Memo.memoId(UnsignedHyper.fromString(this._value));
+      case MemoText:
+        return xdr.Memo.memoText(this._value);
+      case MemoHash:
+        return xdr.Memo.memoHash(this._value);
+      case MemoReturn:
+        return xdr.Memo.memoReturn(this._value);
+    }
+  }
 
-    if (isUndefined(hash)) {
-      throw error;
+  /**
+   * Returns {@link Memo} from XDR memo object.
+   * @param {xdr.Memo}
+   * @returns {Memo}
+   */
+  static fromXDRObject(object) {
+    switch (object.arm()) {
+      case "id":
+        return Memo.id(object.value().toString());
+      case "text":
+        return Memo.text(object.value());
+      case "hash":
+        return Memo.hash(object.value());
+      case "retHash":
+        return Memo.return(object.value());
     }
 
-    if (isString(hash)) {
-      if (!/^[0-9A-Fa-f]{64}$/g.test(hash)) {
-        throw error;
-      }
-      hash = new Buffer(hash, 'hex');
+    if (typeof object.value() === "undefined") {
+      return Memo.none();
     }
 
-    if (!hash.length || hash.length != 32) {
-      throw error;
-    }
-
-    return xdr.Memo.memoReturn(hash);
+    throw new Error("Unknown type");
   }
 }

--- a/src/operation.js
+++ b/src/operation.js
@@ -107,8 +107,8 @@ export class Operation {
 
     let attributes = {};
     attributes.destination  = Keypair.fromPublicKey(opts.destination).xdrAccountId();
-    attributes.asset        = opts.asset.toXdrObject();
-    attributes.amount        = this._toXDRAmount(opts.amount);
+    attributes.asset        = opts.asset.toXDRObject();
+    attributes.amount       = this._toXDRAmount(opts.amount);
     let payment             = new xdr.PaymentOp(attributes);
 
     let opAttributes = {};
@@ -150,16 +150,16 @@ export class Operation {
     }
 
     let attributes = {};
-    attributes.sendAsset    = opts.sendAsset.toXdrObject();
+    attributes.sendAsset    = opts.sendAsset.toXDRObject();
     attributes.sendMax      = this._toXDRAmount(opts.sendMax);
     attributes.destination  = Keypair.fromPublicKey(opts.destination).xdrAccountId();
-    attributes.destAsset    = opts.destAsset.toXdrObject();
+    attributes.destAsset    = opts.destAsset.toXDRObject();
     attributes.destAmount   = this._toXDRAmount(opts.destAmount);
 
     let path        = opts.path ? opts.path : [];
     attributes.path = [];
     for (let i in path) {
-      attributes.path.push(path[i].toXdrObject());
+      attributes.path.push(path[i].toXDRObject());
     }
 
     let payment = new xdr.PathPaymentOp(attributes);
@@ -184,7 +184,7 @@ export class Operation {
    */
   static changeTrust(opts) {
     let attributes      = {};
-    attributes.line     = opts.asset.toXdrObject();
+    attributes.line     = opts.asset.toXDRObject();
     if (!isUndefined(opts.limit) && !this.isValidAmount(opts.limit, true)) {
       throw new TypeError(Operation.constructAmountRequirementsError('limit'));
     }
@@ -372,8 +372,8 @@ export class Operation {
    */
   static manageOffer(opts) {
     let attributes = {};
-    attributes.selling = opts.selling.toXdrObject();
-    attributes.buying = opts.buying.toXdrObject();
+    attributes.selling = opts.selling.toXDRObject();
+    attributes.buying = opts.buying.toXDRObject();
     if (!this.isValidAmount(opts.amount, true)) {
       throw new TypeError(Operation.constructAmountRequirementsError('amount'));
     }
@@ -416,8 +416,8 @@ export class Operation {
    */
   static createPassiveOffer(opts) {
     let attributes = {};
-    attributes.selling = opts.selling.toXdrObject();
-    attributes.buying = opts.buying.toXdrObject();
+    attributes.selling = opts.selling.toXDRObject();
+    attributes.buying = opts.buying.toXDRObject();
     if (!this.isValidAmount(opts.amount)) {
       throw new TypeError(Operation.constructAmountRequirementsError('amount'));
     }
@@ -522,7 +522,7 @@ export class Operation {
    * @param {xdr.Operation} operation - An XDR Operation.
    * @return {Operation}
    */
-  static operationToObject(operation) {
+  static fromXDRObject(operation) {
     function accountIdtoAddress(accountId) {
       return StrKey.encodeEd25519PublicKey(accountId.ed25519());
     }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -3,6 +3,7 @@ import {xdr, hash} from "./index";
 import {StrKey} from "./strkey";
 import {Operation} from "./operation";
 import {Network} from "./network";
+import {Memo} from "./memo";
 import map from "lodash/map";
 import each from "lodash/each";
 import isString from 'lodash/isString';
@@ -29,7 +30,7 @@ export class Transaction {
     this.tx       = envelope.tx();
     this.source   = StrKey.encodeEd25519PublicKey(envelope.tx().sourceAccount().ed25519());
     this.fee      = this.tx.fee();
-    this.memo     = this.tx.memo();
+    this._memo    = this.tx.memo();
     this.sequence = this.tx.seqNum().toString();
 
     let timeBounds = this.tx.timeBounds();
@@ -42,11 +43,19 @@ export class Transaction {
 
     let operations  = this.tx.operations() || [];
     this.operations = map(operations, op => {
-      return Operation.operationToObject(op);
+      return Operation.fromXDRObject(op);
     });
 
     let signatures = envelope.signatures() || [];
     this.signatures = map(signatures, s => s);
+  }
+
+  get memo() {
+    return Memo.fromXDRObject(this._memo);
+  }
+
+  set memo(value) {
+    throw new Error("Transaction is immutable");
   }
 
   /**

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -84,7 +84,7 @@ export class TransactionBuilder {
 
   /**
    * Adds a memo to the transaction.
-   * @param {xdr.Memo} memo The xdr memo object, use {@link Memo} static methods.
+   * @param {Memo} memo {@link Memo} object
    * @returns {TransactionBuilder}
    */
   addMemo(memo) {
@@ -104,7 +104,7 @@ export class TransactionBuilder {
       sourceAccount: Keypair.fromPublicKey(this.source.accountId()).xdrAccountId(),
       fee:           this.baseFee * this.operations.length,
       seqNum:        xdr.SequenceNumber.fromString(sequenceNumber.toString()),
-      memo:          this.memo,
+      memo:          this.memo ? this.memo.toXDRObject() : null,
       ext:           new xdr.TransactionExt(0)
     };
 

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -58,16 +58,16 @@ describe('Asset', function() {
         });
     });
 
-    describe("toXdrObject()", function () {
+    describe("toXDRObject()", function () {
         it("parses a native asset object", function () {
             var asset = new StellarBase.Asset.native();
-            var xdr = asset.toXdrObject();
+            var xdr = asset.toXDRObject();
             expect(xdr.toXDR().toString()).to.be.equal(new Buffer([0,0,0,0]).toString());
         });
 
         it("parses a 3-alphanum asset object", function () {
             var asset = new StellarBase.Asset("USD", "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ");
-            var xdr = asset.toXdrObject();
+            var xdr = asset.toXDRObject();
 
             expect(xdr).to.be.instanceof(StellarBase.xdr.Asset);
             expect(() => xdr.toXDR('hex')).to.not.throw();
@@ -78,7 +78,7 @@ describe('Asset', function() {
 
         it("parses a 4-alphanum asset object", function () {
             var asset = new StellarBase.Asset("BART", "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ");
-            var xdr = asset.toXdrObject();
+            var xdr = asset.toXDRObject();
 
             expect(xdr).to.be.instanceof(StellarBase.xdr.Asset);
             expect(() => xdr.toXDR('hex')).to.not.throw();
@@ -89,7 +89,7 @@ describe('Asset', function() {
 
         it("parses a 5-alphanum asset object", function () {
             var asset = new StellarBase.Asset("12345", "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ");
-            var xdr = asset.toXdrObject();
+            var xdr = asset.toXDRObject();
 
             expect(xdr).to.be.instanceof(StellarBase.xdr.Asset);
             expect(() => xdr.toXDR('hex')).to.not.throw();
@@ -100,7 +100,7 @@ describe('Asset', function() {
 
         it("parses a 12-alphanum asset object", function () {
             var asset = new StellarBase.Asset("123456789012", "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ");
-            var xdr = asset.toXdrObject();
+            var xdr = asset.toXDRObject();
 
             expect(xdr).to.be.instanceof(StellarBase.xdr.Asset);
             expect(() => xdr.toXDR('hex')).to.not.throw();

--- a/test/unit/memo_test.js
+++ b/test/unit/memo_test.js
@@ -1,4 +1,20 @@
 
+describe("Memo.constructor()", function() {
+  it("throws error when type is invalid", function() {
+    expect(() => new StellarBase.Memo("test")).to.throw(/Invalid memo type/);
+  });
+});
+
+describe("Memo.none()", function() {
+  it("converts to/from xdr object", function() {
+    let memo = StellarBase.Memo.none().toXDRObject();
+    expect(memo.value()).to.be.undefined;
+
+    let baseMemo = StellarBase.Memo.fromXDRObject(memo);
+    expect(baseMemo.type).to.be.equal(StellarBase.MemoNone);
+    expect(baseMemo.value).to.be.null;
+  });
+});
 
 describe("Memo.text()", function() {
 
@@ -6,22 +22,20 @@ describe("Memo.text()", function() {
     expect(() => StellarBase.Memo.text("test")).to.not.throw();
     let memoUtf8 = StellarBase.Memo.text("三代之時")
 
-    // Node 0.10, sigh...
-    let equal = true;
-    let a = new Buffer(memoUtf8._value, "utf8");
+    let a = new Buffer(memoUtf8.toXDRObject().value(), "utf8");
     let b = new Buffer("三代之時", "utf8");
-    if (a.length !== b.length) {
-        equal = false;
-    } else {
-        for (var i = 0; i < a.length; i++) {
-            if (a[i] !== b[i]) {
-                equal = false;
-                break;
-            }
-        }
-    }
+    expect(a).to.be.deep.equal(b);
+  });
 
-    expect(equal).to.be.true
+  it("converts to/from xdr object", function() {
+    let memo = StellarBase.Memo.text("test").toXDRObject();
+    expect(memo.arm()).to.equal('text');
+    expect(memo.text()).to.equal('test');
+    expect(memo.value()).to.equal('test');
+
+    let baseMemo = StellarBase.Memo.fromXDRObject(memo);
+    expect(baseMemo.type).to.be.equal(StellarBase.MemoText);
+    expect(baseMemo.value).to.be.equal('test');
   });
 
   it("throws an error when invalid argument was passed", function() {
@@ -45,6 +59,16 @@ describe("Memo.id()", function() {
     expect(() => StellarBase.Memo.id("0")).to.not.throw();
   });
 
+  it("converts to/from xdr object", function() {
+    let memo = StellarBase.Memo.id("1000").toXDRObject();
+    expect(memo.arm()).to.equal('id');
+    expect(memo.id().toString()).to.equal('1000');
+
+    let baseMemo = StellarBase.Memo.fromXDRObject(memo);
+    expect(baseMemo.type).to.be.equal(StellarBase.MemoID);
+    expect(baseMemo.value).to.be.equal('1000');
+  });
+
   it("throws an error when invalid argument was passed", function() {
     expect(() => StellarBase.Memo.id()).to.throw(/Expects a int64/);
     expect(() => StellarBase.Memo.id({})).to.throw(/Expects a int64/);
@@ -54,8 +78,34 @@ describe("Memo.id()", function() {
   });
 });
 
-describe("Memo.hash() & Memo.returnHash()", function() {
-  var methods = [StellarBase.Memo.hash, StellarBase.Memo.returnHash];
+describe("Memo.hash() & Memo.return()", function() {
+  it("hash converts to/from xdr object", function() {
+    let buffer = new Buffer(32).fill(10);
+
+    let memo = StellarBase.Memo.hash(buffer).toXDRObject();
+    expect(memo.arm()).to.equal('hash');
+    expect(memo.hash()).to.deep.equal(buffer);
+
+    let baseMemo = StellarBase.Memo.fromXDRObject(memo);
+    expect(baseMemo.type).to.be.equal(StellarBase.MemoHash);
+    expect(baseMemo.value).to.be.deep.equal(buffer);
+  });
+
+  it("return converts to/from xdr object", function() {
+    let buffer = new Buffer(32).fill(10);
+
+    // Testing string hash
+    let memo = StellarBase.Memo.return(buffer.toString("hex")).toXDRObject();
+    expect(memo.arm()).to.equal('retHash');
+    expect(memo.retHash().toString('hex')).to.equal(buffer.toString('hex'));
+
+    let baseMemo = StellarBase.Memo.fromXDRObject(memo);
+    expect(baseMemo.type).to.be.equal(StellarBase.MemoReturn);
+    expect(Buffer.isBuffer(baseMemo.value)).to.be.true;
+    expect(baseMemo.value.toString('hex')).to.be.equal(buffer.toString('hex'));
+  });
+
+  var methods = [StellarBase.Memo.hash, StellarBase.Memo.return];
 
   it("returns a value for a correct argument", function() {
     for (let i in methods) {

--- a/test/unit/memo_test.js
+++ b/test/unit/memo_test.js
@@ -84,11 +84,13 @@ describe("Memo.hash() & Memo.return()", function() {
 
     let memo = StellarBase.Memo.hash(buffer).toXDRObject();
     expect(memo.arm()).to.equal('hash');
+    expect(memo.hash().length).to.equal(32);
     expect(memo.hash()).to.deep.equal(buffer);
 
     let baseMemo = StellarBase.Memo.fromXDRObject(memo);
     expect(baseMemo.type).to.be.equal(StellarBase.MemoHash);
-    expect(baseMemo.value).to.be.deep.equal(buffer);
+    expect(baseMemo.value.length).to.equal(32);
+    expect(baseMemo.value.toString('hex')).to.be.equal(buffer.toString('hex'));
   });
 
   it("return converts to/from xdr object", function() {
@@ -97,11 +99,13 @@ describe("Memo.hash() & Memo.return()", function() {
     // Testing string hash
     let memo = StellarBase.Memo.return(buffer.toString("hex")).toXDRObject();
     expect(memo.arm()).to.equal('retHash');
+    expect(memo.retHash().length).to.equal(32);
     expect(memo.retHash().toString('hex')).to.equal(buffer.toString('hex'));
 
     let baseMemo = StellarBase.Memo.fromXDRObject(memo);
     expect(baseMemo.type).to.be.equal(StellarBase.MemoReturn);
     expect(Buffer.isBuffer(baseMemo.value)).to.be.true;
+    expect(baseMemo.value.length).to.equal(32);
     expect(baseMemo.value.toString('hex')).to.be.equal(buffer.toString('hex'));
   });
 

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -11,7 +11,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.createAccount({destination, startingBalance});
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("createAccount");
             expect(obj.destination).to.be.equal(destination);
             expect(operation.body().value().startingBalance().toString()).to.be.equal('10000000000');
@@ -54,7 +54,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.payment({destination, asset, amount});
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("payment");
             expect(obj.destination).to.be.equal(destination);
             expect(operation.body().value().amount().toString()).to.be.equal('10000000000');
@@ -95,7 +95,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.pathPayment({sendAsset, sendMax, destination, destAsset, destAmount, path});
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("pathPayment");
             expect(obj.sendAsset.equals(sendAsset)).to.be.true;
             expect(operation.body().value().sendMax().toString()).to.be.equal('30070000');
@@ -150,7 +150,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.changeTrust({asset: asset});
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("changeTrust");
             expect(obj.line).to.be.deep.equal(asset);
             expect(operation.body().value().limit().toString()).to.be.equal('9223372036854775807'); // MAX_INT64
@@ -162,7 +162,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.changeTrust({asset: asset, limit: "50"});
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("changeTrust");
             expect(obj.line).to.be.deep.equal(asset);
             expect(operation.body().value().limit().toString()).to.be.equal('500000000');
@@ -174,7 +174,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.changeTrust({asset: asset, limit: "0"});
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("changeTrust");
             expect(obj.line).to.be.deep.equal(asset);
             expect(obj.limit).to.be.equal("0");
@@ -199,7 +199,7 @@ describe('Operation', function() {
             });
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("allowTrust");
             expect(obj.trustor).to.be.equal(trustor);
             expect(obj.assetCode).to.be.equal(assetCode);
@@ -239,7 +239,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expect(obj.type).to.be.equal("setOptions");
             expect(obj.inflationDest).to.be.equal(opts.inflationDest);
@@ -268,7 +268,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expectBuffersToBeEqual(obj.signer.preAuthTx, hash);
             expect(obj.signer.weight).to.be.equal(opts.signer.weight);
@@ -288,7 +288,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expectBuffersToBeEqual(obj.signer.preAuthTx, hash);
             expect(obj.signer.weight).to.be.equal(opts.signer.weight);
@@ -307,7 +307,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expectBuffersToBeEqual(obj.signer.sha256Hash, hash);
             expect(obj.signer.weight).to.be.equal(opts.signer.weight);
@@ -327,7 +327,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expectBuffersToBeEqual(obj.signer.sha256Hash, hash);
             expect(obj.signer.weight).to.be.equal(opts.signer.weight);
@@ -340,7 +340,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expect(obj.type).to.be.equal("setOptions");
             expect(obj.setFlags).to.be.equal(4);
@@ -360,7 +360,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expect(obj.type).to.be.equal("setOptions");
             expect(obj.clearFlags).to.be.equal(4);
@@ -448,7 +448,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
             expect(obj.buying.equals(opts.buying)).to.be.true;
@@ -470,7 +470,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.price).to.be.equal(new BigNumber(opts.price.n).div(opts.price.d).toString());
         });
 
@@ -496,7 +496,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageOffer");
             expect(obj.price).to.be.equal(opts.price.toString());
         });
@@ -511,7 +511,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageOffer");
             expect(obj.price).to.be.equal("1.25");
         });
@@ -525,7 +525,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
             expect(obj.buying.equals(opts.buying)).to.be.true;
@@ -545,7 +545,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
             expect(obj.buying.equals(opts.buying)).to.be.true;
@@ -605,7 +605,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.createPassiveOffer(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("createPassiveOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
             expect(obj.buying.equals(opts.buying)).to.be.true;
@@ -623,7 +623,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.createPassiveOffer(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("createPassiveOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
             expect(obj.buying.equals(opts.buying)).to.be.true;
@@ -641,7 +641,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.createPassiveOffer(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("createPassiveOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
             expect(obj.buying.equals(opts.buying)).to.be.true;
@@ -687,7 +687,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.accountMerge(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("accountMerge");
             expect(obj.destination).to.be.equal(opts.destination);
         });
@@ -705,7 +705,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.inflation();
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("inflation");
         });
     });
@@ -719,7 +719,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.manageData(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageData");
             expect(obj.name).to.be.equal(opts.name);
             expect(obj.value.toString('hex')).to.be.equal(new Buffer(opts.value).toString('hex'));
@@ -733,7 +733,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.manageData(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageData");
             expect(obj.name).to.be.equal(opts.name);
             expect(obj.value.toString('hex')).to.be.equal(opts.value.toString('hex'));
@@ -747,7 +747,7 @@ describe('Operation', function() {
             let op = StellarBase.Operation.manageData(opts);
             var xdr = op.toXDR("hex");
             var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
-            var obj = StellarBase.Operation.operationToObject(operation);
+            var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageData");
             expect(obj.name).to.be.equal(opts.name);
             expect(obj.value).to.be.undefined;

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -21,7 +21,8 @@ describe('Transaction', function() {
 
     expect(transaction.source).to.be.equal(source.accountId());
     expect(transaction.fee).to.be.equal(100);
-    expect(transaction.memo.text()).to.be.equal('Happy birthday!');
+    expect(transaction.memo.type).to.be.equal(StellarBase.MemoText);
+    expect(transaction.memo.value).to.be.equal('Happy birthday!');
     expect(operation.type).to.be.equal('payment');
     expect(operation.destination).to.be.equal(destination);
     expect(operation.amount).to.be.equal(amount);


### PR DESCRIPTION
This PR makes it possible to instantiate `Memo` class so it's easier to check it's type and value (without dealing with low level `xdr.Memo` objects).

Also changed `Asset.toXdrObject` to `Asset.toXDRObject` and `Operation.operationToObject` to `Operation.toXDRObject` for consistency.

Close https://github.com/stellar/js-stellar-base/issues/100