### PR TITLE
Docs: Account: typo (minor)

### DIFF
--- a/src/account.js
+++ b/src/account.js
@@ -8,7 +8,7 @@ export class Account {
    * Create a new Account object.
    *
    * `Account` represents a single account in Stellar network and it's sequence number.
-   * Account tracts the sequence number as it is used by {@link TransactionBuilder}.
+   * Account tracks the sequence number as it is used by {@link TransactionBuilder}.
    * See [Accounts](https://stellar.org/developers/learn/concepts/accounts.html) for more information about how
    * accounts work in Stellar.
    * @constructor


### PR DESCRIPTION
Was confused by the docs where “Account tracts the sequential number”. I suspect it should be “tracks”.