### PR TITLE
Add `browser` prop to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "version": "gulp build",
     "postversion": "git push && git push --tags"
   },
+  "browser": {
+    "ed25519": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/stellar/js-stellar-base.git"


### PR DESCRIPTION
Make webpack & friends ignore the `ed25519` package, so you don't need the `IgnorePlugin` in the application's webpack config. The `stellar-base` package knows best what dependencies it has and how they work, so it should do the ignoring 😉