### PR TITLE
Fix Buffer for node v10 deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
   include:
   - node_js: 6
   - node_js: 8
+  - node_js: 10
   - node_js: 6
     env: SAUCE=true
 before_install:

--- a/src/base58.js
+++ b/src/base58.js
@@ -36,7 +36,7 @@ export function decodeBase58Check(versionByteName, encoded) {
     throw new Error(`Decoded address length is invalid. Expected 37, got ${decoded.length}`);
   }
 
-  return new Buffer(data);
+  return Buffer.from(data);
 }
 
 function calculateChecksum(payload) {

--- a/src/keypair.js
+++ b/src/keypair.js
@@ -31,7 +31,7 @@ export class Keypair {
     this.type = keys.type;
 
     if (keys.secretKey) {
-      keys.secretKey = new Buffer(keys.secretKey);
+      keys.secretKey = Buffer.from(keys.secretKey);
 
       if (keys.secretKey.length != 32) {
         throw new Error("secretKey length is invalid");
@@ -41,14 +41,14 @@ export class Keypair {
       let naclKeys = nacl.sign.keyPair.fromSeed(secretKeyUint8);
 
       this._secretSeed = keys.secretKey;
-      this._secretKey = new Buffer(naclKeys.secretKey);
-      this._publicKey = new Buffer(naclKeys.publicKey);
+      this._secretKey = Buffer.from(naclKeys.secretKey);
+      this._publicKey = Buffer.from(naclKeys.publicKey);
 
-      if (keys.publicKey && !this._publicKey.equals(new Buffer(keys.publicKey))) {
+      if (keys.publicKey && !this._publicKey.equals(Buffer.from(keys.publicKey))) {
         throw new Error("secretKey does not match publicKey");
       }
     } else {
-      this._publicKey = new Buffer(keys.publicKey);
+      this._publicKey = Buffer.from(keys.publicKey);
 
       if (this._publicKey.length != 32) {
         throw new Error("publicKey length is invalid");

--- a/src/memo.js
+++ b/src/memo.js
@@ -54,7 +54,7 @@ export class Memo {
         Memo._validateHashValue(value);
         // We want MemoHash and MemoReturn to have Buffer as a value
         if (isString(value)) {
-          this._value = new Buffer(value, 'hex');
+          this._value = Buffer.from(value, 'hex');
         }
         break;
       default:
@@ -88,7 +88,7 @@ export class Memo {
         return clone(this._value);
       case MemoHash:
       case MemoReturn:
-        return new Buffer(this._value);
+        return Buffer.from(this._value);
       default:
         throw new Error("Invalid memo type");
     }
@@ -144,9 +144,9 @@ export class Memo {
       if (!/^[0-9A-Fa-f]{64}$/g.test(value)) {
         throw error;
       }
-      valueBuffer = new Buffer(value, 'hex');
+      valueBuffer = Buffer.from(value, 'hex');
     } else if (Buffer.isBuffer(value)) {
-      valueBuffer = new Buffer(value);
+      valueBuffer = Buffer.from(value);
     } else {
       throw error;
     }

--- a/src/operation.js
+++ b/src/operation.js
@@ -483,7 +483,7 @@ export class Operation {
     }
 
     if (isString(opts.value)) {
-      attributes.dataValue = new Buffer(opts.value);
+      attributes.dataValue = Buffer.from(opts.value);
     } else {
       attributes.dataValue = opts.value;
     }

--- a/src/signing.js
+++ b/src/signing.js
@@ -56,17 +56,17 @@ function checkFastSigningBrowser() {
     let nacl = require("tweetnacl");
 
     actualMethods.sign = function(data, secretKey) {
-      data      = new Buffer(data);
+      data      = Buffer.from(data);
       data      = new Uint8Array(data.toJSON().data);
       secretKey = new Uint8Array(secretKey.toJSON().data);
 
       let signature = nacl.sign.detached(data, secretKey);
 
-      return new Buffer(signature);
+      return Buffer.from(signature);
     };
 
     actualMethods.verify = function(data, signature, publicKey) {
-      data      = new Buffer(data);
+      data      = Buffer.from(data);
       data      = new Uint8Array(data.toJSON().data);
       signature = new Uint8Array(signature.toJSON().data);
       publicKey = new Uint8Array(publicKey.toJSON().data);

--- a/src/strkey.js
+++ b/src/strkey.js
@@ -154,7 +154,7 @@ export function decodeCheck(versionByteName, encoded) {
     throw new Error(`invalid checksum`);
   }
 
-  return new Buffer(data);
+  return Buffer.from(data);
 }
 
 export function encodeCheck(versionByteName, data) {
@@ -168,8 +168,8 @@ export function encodeCheck(versionByteName, data) {
     throw new Error(`${versionByteName} is not a valid version byte name.  expected one of "ed25519PublicKey", "ed25519SecretSeed", "preAuthTx", "sha256Hash"`);
   }
 
-  data              = new Buffer(data);
-  let versionBuffer = new Buffer([versionByte]);
+  data              = Buffer.from(data);
+  let versionBuffer = Buffer.from([versionByte]);
   let payload       = Buffer.concat([versionBuffer, data]);
   let checksum      = calculateChecksum(payload);
   let unencoded     = Buffer.concat([payload, checksum]);
@@ -180,7 +180,7 @@ export function encodeCheck(versionByteName, data) {
 function calculateChecksum(payload) {
   // This code calculates CRC16-XModem checksum of payload
   // and returns it as Buffer in little-endian order.
-  let checksum = new Buffer(2);
+  let checksum = Buffer.alloc(2);
   checksum.writeUInt16LE(crc.crc16xmodem(payload), 0);
   return checksum;
 }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -23,7 +23,7 @@ let MAX_LEDGER   = 0xFFFFFFFF; // max uint32
 export class Transaction {
   constructor(envelope) {
     if (typeof envelope === "string") {
-      let buffer = new Buffer(envelope, "base64");
+      let buffer = Buffer.from(envelope, "base64");
       envelope = xdr.TransactionEnvelope.fromXDR(buffer);
     }
     // since this transaction is immutable, save the tx

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -62,7 +62,7 @@ describe('Asset', function() {
         it("parses a native asset object", function () {
             var asset = new StellarBase.Asset.native();
             var xdr = asset.toXDRObject();
-            expect(xdr.toXDR().toString()).to.be.equal(new Buffer([0,0,0,0]).toString());
+            expect(xdr.toXDR().toString()).to.be.equal(Buffer.from([0,0,0,0]).toString());
         });
 
         it("parses a 3-alphanum asset object", function () {

--- a/test/unit/hashing_test.js
+++ b/test/unit/hashing_test.js
@@ -11,7 +11,7 @@ describe('StellarBase#hash', function() {
 
 
   it("hashes a buffer properly, using SHA256", function() {
-    let msg         = new Buffer("hello world", 'utf8');
+    let msg         = Buffer.from("hello world", 'utf8');
     let expectedHex = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
     let actualHex   = StellarBase.hash(msg).toString('hex');
 

--- a/test/unit/keypair_test.js
+++ b/test/unit/keypair_test.js
@@ -12,12 +12,12 @@ describe('Keypair.contructor', function() {
   });
 
   it("fails when secretKey length is invalid", function() {
-    let secretKey = new Buffer(33);
+    let secretKey = Buffer.alloc(33);
     expect(() => new StellarBase.Keypair({type: 'ed25519', secretKey})).to.throw(/secretKey length is invalid/)
   });
 
   it("fails when publicKey length is invalid", function() {
-    let publicKey = new Buffer(33);
+    let publicKey = Buffer.alloc(33);
     expect(() => new StellarBase.Keypair({type: 'ed25519', publicKey})).to.throw(/publicKey length is invalid/)
   });
 });

--- a/test/unit/memo_test.js
+++ b/test/unit/memo_test.js
@@ -22,8 +22,8 @@ describe("Memo.text()", function() {
     expect(() => StellarBase.Memo.text("test")).to.not.throw();
     let memoUtf8 = StellarBase.Memo.text("三代之時")
 
-    let a = new Buffer(memoUtf8.toXDRObject().value(), "utf8");
-    let b = new Buffer("三代之時", "utf8");
+    let a = Buffer.from(memoUtf8.toXDRObject().value(), "utf8");
+    let b = Buffer.from("三代之時", "utf8");
     expect(a).to.be.deep.equal(b);
   });
 
@@ -80,7 +80,7 @@ describe("Memo.id()", function() {
 
 describe("Memo.hash() & Memo.return()", function() {
   it("hash converts to/from xdr object", function() {
-    let buffer = new Buffer(32).fill(10);
+    let buffer = Buffer.alloc(32, 10);
 
     let memo = StellarBase.Memo.hash(buffer).toXDRObject();
     expect(memo.arm()).to.equal('hash');
@@ -94,7 +94,7 @@ describe("Memo.hash() & Memo.return()", function() {
   });
 
   it("return converts to/from xdr object", function() {
-    let buffer = new Buffer(32).fill(10);
+    let buffer = Buffer.alloc(32, 10);
 
     // Testing string hash
     let memo = StellarBase.Memo.return(buffer.toString("hex")).toXDRObject();
@@ -114,7 +114,7 @@ describe("Memo.hash() & Memo.return()", function() {
   it("returns a value for a correct argument", function() {
     for (let i in methods) {
       let method = methods[i];
-      expect(() => method(new Buffer(32))).to.not.throw();
+      expect(() => method(Buffer.alloc(32))).to.not.throw();
       expect(() => method('0000000000000000000000000000000000000000000000000000000000000000')).to.not.throw();
     }
   });
@@ -128,7 +128,7 @@ describe("Memo.hash() & Memo.return()", function() {
       expect(() => method(NaN)).to.throw(/Expects a 32 byte hash value/);
       expect(() => method("test")).to.throw(/Expects a 32 byte hash value/);
       expect(() => method([0, 10, 20])).to.throw(/Expects a 32 byte hash value/);
-      expect(() => method(new Buffer(33))).to.throw(/Expects a 32 byte hash value/);
+      expect(() => method(Buffer.alloc(33))).to.throw(/Expects a 32 byte hash value/);
       expect(() => method('00000000000000000000000000000000000000000000000000000000000000')).to.throw(/Expects a 32 byte hash value/);
       expect(() => method('000000000000000000000000000000000000000000000000000000000000000000')).to.throw(/Expects a 32 byte hash value/);
     }

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -10,7 +10,7 @@ describe('Operation', function() {
             var startingBalance = '1000';
             let op = StellarBase.Operation.createAccount({destination, startingBalance});
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("createAccount");
             expect(obj.destination).to.be.equal(destination);
@@ -53,7 +53,7 @@ describe('Operation', function() {
             var asset = new StellarBase.Asset("USDUSD", "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7");
             let op = StellarBase.Operation.payment({destination, asset, amount});
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("payment");
             expect(obj.destination).to.be.equal(destination);
@@ -94,7 +94,7 @@ describe('Operation', function() {
             ];
             let op = StellarBase.Operation.pathPayment({sendAsset, sendMax, destination, destAsset, destAmount, path});
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("pathPayment");
             expect(obj.sendAsset.equals(sendAsset)).to.be.true;
@@ -149,7 +149,7 @@ describe('Operation', function() {
             let asset = new StellarBase.Asset("USD", "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7");
             let op = StellarBase.Operation.changeTrust({asset: asset});
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("changeTrust");
             expect(obj.line).to.be.deep.equal(asset);
@@ -161,7 +161,7 @@ describe('Operation', function() {
             let asset = new StellarBase.Asset("USD", "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7");
             let op = StellarBase.Operation.changeTrust({asset: asset, limit: "50"});
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("changeTrust");
             expect(obj.line).to.be.deep.equal(asset);
@@ -173,7 +173,7 @@ describe('Operation', function() {
             let asset = new StellarBase.Asset("USD", "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7");
             let op = StellarBase.Operation.changeTrust({asset: asset, limit: "0"});
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("changeTrust");
             expect(obj.line).to.be.deep.equal(asset);
@@ -198,7 +198,7 @@ describe('Operation', function() {
                 authorize: authorize
             });
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("allowTrust");
             expect(obj.trustor).to.be.equal(trustor);
@@ -238,7 +238,7 @@ describe('Operation', function() {
             opts.homeDomain = "www.example.com";
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expect(obj.type).to.be.equal("setOptions");
@@ -267,7 +267,7 @@ describe('Operation', function() {
             
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expectBuffersToBeEqual(obj.signer.preAuthTx, hash);
@@ -287,7 +287,7 @@ describe('Operation', function() {
 
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expectBuffersToBeEqual(obj.signer.preAuthTx, hash);
@@ -306,7 +306,7 @@ describe('Operation', function() {
             
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expectBuffersToBeEqual(obj.signer.sha256Hash, hash);
@@ -326,7 +326,7 @@ describe('Operation', function() {
 
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expectBuffersToBeEqual(obj.signer.sha256Hash, hash);
@@ -339,7 +339,7 @@ describe('Operation', function() {
             };
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expect(obj.type).to.be.equal("setOptions");
@@ -359,7 +359,7 @@ describe('Operation', function() {
             };
             let op = StellarBase.Operation.setOptions(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
 
             expect(obj.type).to.be.equal("setOptions");
@@ -394,7 +394,7 @@ describe('Operation', function() {
             let opts = {
                 signer: {
                     ed25519PublicKey: "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7",
-                    sha256Hash: new Buffer(32),
+                    sha256Hash: Buffer.alloc(32),
                     weight: 1
                 }
             };
@@ -447,7 +447,7 @@ describe('Operation', function() {
             opts.offerId = '1';
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
@@ -469,7 +469,7 @@ describe('Operation', function() {
             opts.offerId = '1';
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.price).to.be.equal(new BigNumber(opts.price.n).div(opts.price.d).toString());
         });
@@ -495,7 +495,7 @@ describe('Operation', function() {
             opts.offerId = 1;
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageOffer");
             expect(obj.price).to.be.equal(opts.price.toString());
@@ -510,7 +510,7 @@ describe('Operation', function() {
             opts.offerId = '1';
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageOffer");
             expect(obj.price).to.be.equal("1.25");
@@ -524,7 +524,7 @@ describe('Operation', function() {
             opts.price = '3.141592';
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
@@ -544,7 +544,7 @@ describe('Operation', function() {
             opts.offerId = '1';
             let op = StellarBase.Operation.manageOffer(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
@@ -604,7 +604,7 @@ describe('Operation', function() {
             opts.price = '3.07';
             let op = StellarBase.Operation.createPassiveOffer(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("createPassiveOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
@@ -622,7 +622,7 @@ describe('Operation', function() {
             opts.price = 3.07;
             let op = StellarBase.Operation.createPassiveOffer(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("createPassiveOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
@@ -640,7 +640,7 @@ describe('Operation', function() {
             opts.price = new BigNumber(5).dividedBy(4);
             let op = StellarBase.Operation.createPassiveOffer(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("createPassiveOffer");
             expect(obj.selling.equals(opts.selling)).to.be.true;
@@ -686,7 +686,7 @@ describe('Operation', function() {
             opts.destination = "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7";
             let op = StellarBase.Operation.accountMerge(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("accountMerge");
             expect(obj.destination).to.be.equal(opts.destination);
@@ -704,7 +704,7 @@ describe('Operation', function() {
         it("creates a inflationOp", function () {
             let op = StellarBase.Operation.inflation();
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("inflation");
         });
@@ -718,21 +718,21 @@ describe('Operation', function() {
             };
             let op = StellarBase.Operation.manageData(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageData");
             expect(obj.name).to.be.equal(opts.name);
-            expect(obj.value.toString('hex')).to.be.equal(new Buffer(opts.value).toString('hex'));
+            expect(obj.value.toString('hex')).to.be.equal(Buffer.from(opts.value).toString('hex'));
         });
 
         it("creates a manageDataOp with Buffer value", function () {
             var opts = {
                 name: "name",
-                value: new Buffer("value")
+                value: Buffer.from("value")
             };
             let op = StellarBase.Operation.manageData(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageData");
             expect(obj.name).to.be.equal(opts.name);
@@ -746,7 +746,7 @@ describe('Operation', function() {
             };
             let op = StellarBase.Operation.manageData(opts);
             var xdr = op.toXDR("hex");
-            var operation = StellarBase.xdr.Operation.fromXDR(new Buffer(xdr, "hex"));
+            var operation = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, "hex"));
             var obj = StellarBase.Operation.fromXDRObject(operation);
             expect(obj.type).to.be.equal("manageData");
             expect(obj.name).to.be.equal(opts.name);
@@ -763,7 +763,7 @@ describe('Operation', function() {
             });
 
             it("value is too long", function () {
-                expect(() => StellarBase.Operation.manageData({name: "a", value: new Buffer(65)})).to.throw()
+                expect(() => StellarBase.Operation.manageData({name: "a", value: Buffer.alloc(65)})).to.throw()
             });
         });
     });

--- a/test/unit/signing_test.js
+++ b/test/unit/signing_test.js
@@ -1,8 +1,8 @@
 
 // NOTE: key and signature constants were generated using rbnacl
-let seed        = new Buffer("1123740522f11bfef6b3671f51e159ccf589ccf8965262dd5f97d1721d383dd4", 'hex');
-let publicKey   = new Buffer("ffbdd7ef9933fe7249dc5ca1e7120b6d7b7b99a7a367e1a2fc6cb062fe420437", 'hex');
-let secretKey   = new Buffer("1123740522f11bfef6b3671f51e159ccf589ccf8965262dd5f97d1721d383dd4ffbdd7ef9933fe7249dc5ca1e7120b6d7b7b99a7a367e1a2fc6cb062fe420437", 'hex');
+let seed        = Buffer.from("1123740522f11bfef6b3671f51e159ccf589ccf8965262dd5f97d1721d383dd4", 'hex');
+let publicKey   = Buffer.from("ffbdd7ef9933fe7249dc5ca1e7120b6d7b7b99a7a367e1a2fc6cb062fe420437", 'hex');
+let secretKey   = Buffer.from("1123740522f11bfef6b3671f51e159ccf589ccf8965262dd5f97d1721d383dd4ffbdd7ef9933fe7249dc5ca1e7120b6d7b7b99a7a367e1a2fc6cb062fe420437", 'hex');
  
 describe('StellarBase#sign', function() {
   let expectedSig = "587d4b472eeef7d07aafcd0b049640b0bb3f39784118c2e2b73a04fa2f64c9c538b4b2d0f5335e968a480021fdc23e98c0ddf424cb15d8131df8cb6c4bb58309";
@@ -14,7 +14,7 @@ describe('StellarBase#sign', function() {
   });
 
   it("can sign an buffer properly", function() {
-    let data        = new Buffer("hello world", 'utf8');
+    let data        = Buffer.from("hello world", 'utf8');
     let actualSig   = StellarBase.sign(data, secretKey).toString('hex');
     expect(actualSig).to.eql(expectedSig);
   });
@@ -27,8 +27,8 @@ describe('StellarBase#sign', function() {
 });
 
 describe('StellarBase#verify', function() {
-  let sig    = new Buffer("587d4b472eeef7d07aafcd0b049640b0bb3f39784118c2e2b73a04fa2f64c9c538b4b2d0f5335e968a480021fdc23e98c0ddf424cb15d8131df8cb6c4bb58309", 'hex');
-  let badSig = new Buffer("687d4b472eeef7d07aafcd0b049640b0bb3f39784118c2e2b73a04fa2f64c9c538b4b2d0f5335e968a480021fdc23e98c0ddf424cb15d8131df8cb6c4bb58309", 'hex');
+  let sig    = Buffer.from("587d4b472eeef7d07aafcd0b049640b0bb3f39784118c2e2b73a04fa2f64c9c538b4b2d0f5335e968a480021fdc23e98c0ddf424cb15d8131df8cb6c4bb58309", 'hex');
+  let badSig = Buffer.from("687d4b472eeef7d07aafcd0b049640b0bb3f39784118c2e2b73a04fa2f64c9c538b4b2d0f5335e968a480021fdc23e98c0ddf424cb15d8131df8cb6c4bb58309", 'hex');
 
   it("can verify an string properly", function() {
     let data = "hello world";
@@ -38,7 +38,7 @@ describe('StellarBase#verify', function() {
   });
 
   it("can verify an buffer properly", function() {
-    let data        = new Buffer("hello world", 'utf8');
+    let data        = Buffer.from("hello world", 'utf8');
     expect(StellarBase.verify(data, sig, publicKey)).to.be.truthy;
     expect(StellarBase.verify("corrupted", sig, publicKey)).to.be.falsey;
     expect(StellarBase.verify(data, badSig, publicKey)).to.be.falsey;


### PR DESCRIPTION
As of node v10, `new Buffer` is deprecated.

They recommend we replace it with one of the following:
* Buffer.from(str, encoding="utf8")
* Buffer.alloc(number, fill)
* Buffer.allocUnsafe()

Here is what node.js says:

> Drop support for Node.js ≤ 4.4.x and 5.0.0 — 5.9.x
> This is the recommended solution nowadays that would imply only minimal overhead.
> 
> The Node.js 5.x release line has been unsupported since July 2016, and the Node.js 4.x release line reaches its End of Life in April 2018 (→ Schedule). This means that these versions of Node.js will not receive any updates, even in case of security issues, so using these release lines should be avoided, if at all possible.
> 
> What you would do in this case is to convert all new Buffer() or Buffer() calls to use Buffer.alloc() or Buffer.from(), in the following way:
> 
> For new Buffer(number), replace it with Buffer.alloc(number).
> For new Buffer(string) (or new Buffer(string, encoding)), replace it with Buffer.from(string) (or Buffer.from(string, encoding)).
> For all other combinations of arguments (these are much rarer), also replace new Buffer(...arguments) with Buffer.from(...arguments).

References:
- https://nodesource.com/blog/understanding-the-buffer-deprecation-in-node-js-10/
- https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/
- https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe

