### PR TITLE
Convert text memo value to String from Buffer

### DIFF
--- a/src/memo.js
+++ b/src/memo.js
@@ -1,4 +1,6 @@
 import {default as xdr} from "./generated/stellar-xdr_generated";
+import isArray from "lodash/isArray";
+import isBuffer from "lodash/isBuffer";
 import isUndefined from "lodash/isUndefined";
 import isNull from "lodash/isNull";
 import isString from "lodash/isString";
@@ -85,7 +87,15 @@ export class Memo {
       case MemoNone:
         return null;
       case MemoID:
+        return clone(this._value);
       case MemoText:
+        if (isArray(this._value)) {
+          return (new Buffer(this._value)).toString("utf8");
+        }
+
+        if (isBuffer(this._value)) {
+          return this._value.toString("utf8");
+        }
         return clone(this._value);
       case MemoHash:
       case MemoReturn:

--- a/test/unit/memo_test.js
+++ b/test/unit/memo_test.js
@@ -55,19 +55,20 @@ describe("Memo.text()", function() {
   });
 
   it("converts to/from xdr object (array)", function() {
-    let memo = StellarBase.Memo.text([0xd1]).toXDRObject();
+    let array = [84, 101, 120, 116, 77, 101, 109, 111]
+    let memo = StellarBase.Memo.text(array).toXDRObject();
     expect(memo.arm()).to.equal('text');
 
-    expect(memo.text()).to.be.deep.equal([0xd1]);
-    expect(memo.value()).to.be.deep.equal([0xd1]);
+    expect(memo.text()).to.be.deep.equal(array);
+    expect(memo.value()).to.be.deep.equal(array);
 
     let baseMemo = StellarBase.Memo.fromXDRObject(memo);
     expect(baseMemo.type).to.be.equal(StellarBase.MemoText);
-    expect(baseMemo.value).to.be.deep.equal([0xd1]);
+    expect(baseMemo.value).to.be.equal("TextMemo");
   });
 
   it("converts to/from xdr object (buffer)", function() {
-    let buf = Buffer.from([0xd1]);
+    let buf = Buffer.from([84, 101, 120, 116, 77, 101, 109, 111]);
     let memo = StellarBase.Memo.text(buf).toXDRObject();
     expect(memo.arm()).to.equal('text');
 
@@ -76,7 +77,7 @@ describe("Memo.text()", function() {
 
     let baseMemo = StellarBase.Memo.fromXDRObject(memo);
     expect(baseMemo.type).to.be.equal(StellarBase.MemoText);
-    expect(baseMemo.value.equals(buf)).to.be.true;
+    expect(baseMemo.value).to.equal("TextMemo");
   });
 
   it("throws an error when invalid argument was passed", function() {


### PR DESCRIPTION
Wouldn't it be better to always return a string value for text memos, no matter, is it buffer or array underneath?

I realise that it breaks backward compatibility. However, maybe there is a way to handle that?