### PR TITLE
Miss match source code logic and error message in validate length check(memo-hash)

### DIFF
--- a/src/memo.js
+++ b/src/memo.js
@@ -131,7 +131,7 @@ export class Memo {
   }
 
   static _validateHashValue(value) {
-    let error = new Error("Expects a 32 byte hash value or hex encoded string. Got " + value);
+    let error = new Error("Expects a 64 byte hash value or hex encoded string. Got " + value);
 
     if (value === null || isUndefined(value)) {
       throw error;


### PR DESCRIPTION
Hi core developer.

I Setted less than 64byte string  when I want to use hash-memo. 
` addMemo(StellarSdk.Memo.hash('xxxxxxxxxxxxxxxxxxxxx ')) `

Validation check 64byte in souce dode, but defined error message 'Expect a 32 byte hash..... '

* source code 
```js
 if (isString(value)) {
      if (!/^[0-9A-Fa-f]{64}$/g.test(value)) {
        throw error;
      }
    }
```

* error message
```js
new Error("Expects a 32 byte hash value or hex encoded string. Got " + value);
```