### PR TITLE
Warn about non-explicit transaction fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ A breaking change will get clearly notified in this log.
 
 ## In `master`
 
+- _Warning_ Calling TransactionBuilder without a `fee` param is now deprecated
+  and will issue a warning. In a later release, it throw an error.
 - Add a `toXDR` function for transactions that lets you get the transaction as a
   base64-encoded string (so you may enter it into the Stellar Laboratory XDR
   viewer, for one)
 - Fix TransactionBuilder example syntax errors
 - Use more thorough "create account" documentation
 - Add `Date` support for `TransactionBuilder` `timebounds`
-- _Warning_ Calling TransactionBuilder without a `fee` param is now deprecated
-  and will issue a warning. In a later release, it will instead throw an error.
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ A breaking change will get clearly notified in this log.
 - Fix TransactionBuilder example syntax errors
 - Use more thorough "create account" documentation
 - Add `Date` support for `TransactionBuilder` `timebounds`
+- _Warning_ Calling TransactionBuilder without a `fee` param is now deprecated
+  and will issue a warning. In a later release, it will instead throw an error.
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ A breaking change will get clearly notified in this log.
 ## In `master`
 
 - _Warning_ Calling TransactionBuilder without a `fee` param is now deprecated
-  and will issue a warning. In a later release, it throw an error.
+  and will issue a warning. In a later release, it will throw an error.
 - Add a `toXDR` function for transactions that lets you get the transaction as a
   base64-encoded string (so you may enter it into the Stellar Laboratory XDR
   viewer, for one)

--- a/docs/reference/base-examples.md
+++ b/docs/reference/base-examples.md
@@ -26,7 +26,9 @@ server.accounts()
   .call()
   .then(({ sequence }) => {
     const account = new StellarSdk.Account(source.publicKey(), sequence)
-    const transaction = new StellarSdk.TransactionBuilder(account)
+    const transaction = new StellarSdk.TransactionBuilder(account, {
+      fee: StellarSdk.BASE_FEE
+    })
       .addOperation(StellarSdk.Operation.createAccount({
         destination: destination.publicKey(),
         startingBalance: '25'
@@ -80,7 +82,9 @@ StellarSdk.Network.useTestNetwork();
 var keypair = StellarSdk.Keypair.fromSecret(secretString);
 
 var source = new StellarSdk.Account(keypair.publicKey(), "46316927324160");
-var transaction = new StellarSdk.TransactionBuilder(source)
+var transaction = new StellarSdk.TransactionBuilder(source, {
+    fee: StellarSdk.BASE_FEE
+  })
   .addOperation(StellarSdk.Operation.pathPayment({
       sendAsset: StellarSdk.Asset.native(),
       sendMax: "1000",
@@ -127,7 +131,9 @@ var account = new StellarSdk.Account(rootkeypair.publicKey(), "46316927324160");
 
 var secondaryAddress = "GC6HHHS7SH7KNUAOBKVGT2QZIQLRB5UA7QAGLA3IROWPH4TN65UKNJPK";
 
-var transaction = new StellarSdk.TransactionBuilder(account)
+var transaction = new StellarSdk.TransactionBuilder(account, {
+    fee: StellarSdk.BASE_FEE
+  })
   .addOperation(StellarSdk.Operation.setOptions({
     signer: {
       ed25519PublicKey: secondaryAddress,
@@ -147,7 +153,9 @@ transaction.sign(rootKeypair); // only need to sign with the root signer as the 
 
 // now create a payment with the account that has two signers
 
-var transaction = new StellarSdk.TransactionBuilder(account)
+var transaction = new StellarSdk.TransactionBuilder(account, {
+      fee: StellarSdk.BASE_FEE
+    })
     .addOperation(StellarSdk.Operation.payment({
         destination: "GBTVUCDT5CNSXIHJTDHYSZG3YJFXBAJ6FM4CKS5GKSAWJOLZW6XX7NVC",
         asset: StellarSdk.Asset.native(),

--- a/docs/reference/building-transactions.md
+++ b/docs/reference/building-transactions.md
@@ -32,7 +32,9 @@ StellarSdk.Network.useTestNetwork();
 // Create an Account object from an address and sequence number.
 var account=new StellarBase.Account("GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD","2319149195853854");
 
-var transaction = new StellarBase.TransactionBuilder(account)
+var transaction = new StellarBase.TransactionBuilder(account, {
+      fee: StellarBase.BASE_FEE
+    })
         // add a payment operation to the transaction
         .addOperation(StellarBase.Operation.payment({
                 destination: "GASOCNHNNLYFNMDJYQ3XFMI7BYHIOCFW3GJEOWRPEGK2TDPGTG2E5EDW",
@@ -78,7 +80,10 @@ There are 5 types of memos:
 
 ```js
 var memo = Memo.text('Happy birthday!');
-var transaction = new StellarBase.TransactionBuilder(account, {memo:memo})
+var transaction = new StellarBase.TransactionBuilder(account, { 
+    memo: memo,
+    fee: StellarBase.BASE_FEE
+})
         .addOperation(StellarBase.Operation.payment({
                 destination: "GASOCNHNNLYFNMDJYQ3XFMI7BYHIOCFW3GJEOWRPEGK2TDPGTG2E5EDW",
                 asset: StellarBase.Asset.native(),
@@ -144,7 +149,9 @@ var key2 = Keypair.fromSecret('SAMZUAAPLRUH62HH3XE7NVD6ZSMTWPWGM6DS4X47HLVRHEBKP
 // Create an Account object from an address and sequence number.
 var account=new StellarBase.Account("GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD","2319149195853854");
 
-var transaction = new StellarBase.TransactionBuilder(account)
+var transaction = new StellarBase.TransactionBuilder(account, {
+    fee: StellarBase.BASE_FEE
+})
         .addOperation(StellarBase.Operation.payment({
                 destination: "GASOCNHNNLYFNMDJYQ3XFMI7BYHIOCFW3GJEOWRPEGK2TDPGTG2E5EDW",
                 asset: StellarBase.Asset.native(),

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,11 @@ export { sign, verify, FastSigning } from './signing';
 export { Keypair } from './keypair';
 export { UnsignedHyper, Hyper } from 'js-xdr';
 export { Transaction } from './transaction';
-export { TransactionBuilder, TimeoutInfinite } from './transaction_builder';
+export {
+  TransactionBuilder,
+  TimeoutInfinite,
+  BASE_FEE
+} from './transaction_builder';
 export { Asset } from './asset';
 export {
   Operation,

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -59,8 +59,8 @@ export const TimeoutInfinite = 0;
  * ```
  * @constructor
  * @param {Account} sourceAccount - The source account for this transaction.
- * @param {object} [opts] Options object
- * @param {number} [opts.fee] - The max fee willing to pay per operation in this transaction (**in stroops**).
+ * @param {object} opts Options object
+ * @param {number} opts.fee - The max fee willing to pay per operation in this transaction (**in stroops**). Required.
  * @param {object} [opts.timebounds] - The timebounds for the validity of this transaction.
  * @param {number|string|Date} [opts.timebounds.minTime] - 64 bit unix timestamp or Date object
  * @param {number|string|Date} [opts.timebounds.maxTime] - 64 bit unix timestamp or Date object
@@ -73,6 +73,13 @@ export class TransactionBuilder {
     }
     this.source = sourceAccount;
     this.operations = [];
+
+    if (isUndefined(opts.fee)) {
+      console.log(
+        '[TransactionBuilder] The `fee` parameter of `TransactionBuilder` is required. Future versions of this library will error if not provided.'
+      );
+    }
+
     this.baseFee = isUndefined(opts.fee) ? BASE_FEE : opts.fee;
     this.timebounds = clone(opts.timebounds) || null;
     this.memo = opts.memo || Memo.none();

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -7,7 +7,7 @@ import { Keypair } from './keypair';
 import { Transaction } from './transaction';
 import { Memo } from './memo';
 
-const BASE_FEE = 100; // Stroops
+export const BASE_FEE = 100; // Stroops
 
 /**
  * @constant

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -492,13 +492,13 @@ describe('Operation', function() {
       const account = new StellarBase.Account(keypair.publicKey(), '0');
 
       // First operation do nothing.
-      const tx1 = new StellarBase.TransactionBuilder(account)
+      const tx1 = new StellarBase.TransactionBuilder(account, { fee: 100 })
         .addOperation(StellarBase.Operation.setOptions({}))
         .setTimeout(StellarBase.TimeoutInfinite)
         .build();
 
       // Second operation unset homeDomain
-      const tx2 = new StellarBase.TransactionBuilder(account)
+      const tx2 = new StellarBase.TransactionBuilder(account, { fee: 100 })
         .addOperation(StellarBase.Operation.setOptions({ homeDomain: '' }))
         .setTimeout(StellarBase.TimeoutInfinite)
         .build();

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -18,7 +18,7 @@ describe('TransactionBuilder', function() {
       asset = StellarBase.Asset.native();
       memo = StellarBase.Memo.id('100');
 
-      transaction = new StellarBase.TransactionBuilder(source)
+      transaction = new StellarBase.TransactionBuilder(source, { fee: 100 })
         .addOperation(
           StellarBase.Operation.payment({
             destination: destination,
@@ -78,7 +78,7 @@ describe('TransactionBuilder', function() {
       destination2 = 'GC6ACGSA2NJGD6YWUNX2BYBL3VM4MZRSEU2RLIUZZL35NLV5IAHAX2E2';
       amount2 = '2000';
 
-      transaction = new StellarBase.TransactionBuilder(source)
+      transaction = new StellarBase.TransactionBuilder(source, { fee: 100 })
         .addOperation(
           StellarBase.Operation.payment({
             destination: destination1,
@@ -181,7 +181,8 @@ describe('TransactionBuilder', function() {
         maxTime: '1455297545'
       };
       let transaction = new StellarBase.TransactionBuilder(source, {
-        timebounds
+        timebounds,
+        fee: 100
       })
         .addOperation(
           StellarBase.Operation.payment({
@@ -234,7 +235,8 @@ describe('TransactionBuilder', function() {
       };
 
       let transaction = new StellarBase.TransactionBuilder(source, {
-        timebounds
+        timebounds,
+        fee: 100
       })
         .addOperation(
           StellarBase.Operation.payment({
@@ -265,9 +267,9 @@ describe('TransactionBuilder', function() {
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
         '0'
       );
-      let transactionBuilder = new StellarBase.TransactionBuilder(
-        source
-      ).addOperation(
+      let transactionBuilder = new StellarBase.TransactionBuilder(source, {
+        fee: 100
+      }).addOperation(
         StellarBase.Operation.payment({
           destination:
             'GDJJRRMBK4IWLEPJGIE6SXD2LP7REGZODU7WDC3I2D6MR37F4XSHBKX2',
@@ -287,9 +289,9 @@ describe('TransactionBuilder', function() {
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
         '0'
       );
-      let transactionBuilder = new StellarBase.TransactionBuilder(
-        source
-      ).addOperation(
+      let transactionBuilder = new StellarBase.TransactionBuilder(source, {
+        fee: 100
+      }).addOperation(
         StellarBase.Operation.payment({
           destination:
             'GDJJRRMBK4IWLEPJGIE6SXD2LP7REGZODU7WDC3I2D6MR37F4XSHBKX2',
@@ -309,7 +311,7 @@ describe('TransactionBuilder', function() {
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
         '0'
       );
-      let transaction = new StellarBase.TransactionBuilder(source)
+      let transaction = new StellarBase.TransactionBuilder(source, { fee: 100 })
         .addOperation(
           StellarBase.Operation.payment({
             destination:
@@ -337,7 +339,8 @@ describe('TransactionBuilder', function() {
         '0'
       );
       let transactionBuilder = new StellarBase.TransactionBuilder(source, {
-        timebounds
+        timebounds,
+        fee: 100
       }).addOperation(
         StellarBase.Operation.payment({
           destination:
@@ -362,7 +365,8 @@ describe('TransactionBuilder', function() {
         '0'
       );
       let transaction = new StellarBase.TransactionBuilder(source, {
-        timebounds
+        timebounds,
+        fee: 100
       })
         .addOperation(
           StellarBase.Operation.payment({

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -11,7 +11,7 @@ describe('Transaction', function() {
     let asset = StellarBase.Asset.native();
     let amount = '2000.0000000';
 
-    let input = new StellarBase.TransactionBuilder(source)
+    let input = new StellarBase.TransactionBuilder(source, { fee: 100 })
       .addOperation(
         StellarBase.Operation.payment({ destination, asset, amount })
       )
@@ -57,7 +57,7 @@ describe('Transaction', function() {
     let amount = '2000';
     let signer = StellarBase.Keypair.random();
 
-    let tx = new StellarBase.TransactionBuilder(source)
+    let tx = new StellarBase.TransactionBuilder(source, { fee: 100 })
       .addOperation(
         StellarBase.Operation.payment({ destination, asset, amount })
       )
@@ -77,7 +77,7 @@ describe('Transaction', function() {
     let amount = '2000';
     let signer = StellarBase.Keypair.master();
 
-    let tx = new StellarBase.TransactionBuilder(source)
+    let tx = new StellarBase.TransactionBuilder(source, { fee: 100 })
       .addOperation(
         StellarBase.Operation.payment({ destination, asset, amount })
       )
@@ -108,7 +108,7 @@ describe('Transaction', function() {
       .update(preimage)
       .digest();
 
-    let tx = new StellarBase.TransactionBuilder(source)
+    let tx = new StellarBase.TransactionBuilder(source, { fee: 100 })
       .addOperation(
         StellarBase.Operation.payment({ destination, asset, amount })
       )
@@ -140,7 +140,7 @@ describe('Transaction', function() {
       .update(preimage)
       .digest();
 
-    let tx = new StellarBase.TransactionBuilder(source)
+    let tx = new StellarBase.TransactionBuilder(source, { fee: 100 })
       .addOperation(
         StellarBase.Operation.payment({ destination, asset, amount })
       )
@@ -161,7 +161,6 @@ describe('Transaction', function() {
       'GDJJRRMBK4IWLEPJGIE6SXD2LP7REGZODU7WDC3I2D6MR37F4XSHBKX2';
     let asset = StellarBase.Asset.native();
     let amount = '2000';
-    let fee = 0;
 
     let input = new StellarBase.TransactionBuilder(source, { fee: 0 })
       .addOperation(


### PR DESCRIPTION
If a user calls `TransactionBuilder` without a fee, issue a console log. Also update code examples to provide a fee, and export BASE_FEE. Part of #166. 