### PR TITLE
Replace ed25519 with libsodium/sodium-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ implementation in JavaScript that can be used on either Node.js or web browsers.
 - **[API Reference](https://stellar.github.io/js-stellar-base/)**
 
 > **Warning!** Node version of this package is using
-> [`ed25519`](https://www.npmjs.com/package/ed25519) package, a native
+> [`sodium-native`](https://www.npmjs.com/package/sodium-native) package, a native
 > implementation of [Ed25519](https://ed25519.cr.yp.to/) in Node.js, as an
 > [optional dependency](https://docs.npmjs.com/files/package.json#optionaldependencies).
 > This means that if for any reason installation of this package fails,
@@ -21,8 +21,8 @@ implementation in JavaScript that can be used on either Node.js or web browsers.
 > [`tweetnacl`](https://www.npmjs.com/package/tweetnacl).
 >
 > If you are using `stellar-base` in a browser you can ignore this. However, for
-> production backend deployments you should definitely be using `ed25519`. If
-> `ed25519` is successfully installed and working `StellarBase.FastSigning`
+> production backend deployments you should definitely be using `sodium-native`. If
+> `sodium-native` is successfully installed and working `StellarBase.FastSigning`
 > variable will be equal `true`. Otherwise it will be `false`.
 
 ## Quick start

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,8 +47,8 @@ gulp.task(
             ]
           },
           plugins: [
-            // Ignore native modules (ed25519)
-            new webpack.IgnorePlugin(/ed25519/)
+            // Ignore native modules (sodium-native)
+            new webpack.IgnorePlugin(/sodium-native/)
           ]
         })
       )

--- a/package.json
+++ b/package.json
@@ -106,6 +106,6 @@
     "tweetnacl": "^1.0.0"
   },
   "optionalDependencies": {
-    "ed25519": "0.0.4"
+    "sodium-native": "^2.3.0"
   }
 }

--- a/src/keypair.js
+++ b/src/keypair.js
@@ -1,6 +1,6 @@
 import nacl from 'tweetnacl';
 import { Network } from './network';
-import { sign, verify } from './signing';
+import { sign, verify, generate } from './signing';
 import * as base58 from './base58';
 import { StrKey } from './strkey';
 import xdr from './generated/stellar-xdr_generated';
@@ -37,12 +37,9 @@ export class Keypair {
         throw new Error('secretKey length is invalid');
       }
 
-      const secretKeyUint8 = new Uint8Array(keys.secretKey);
-      const naclKeys = nacl.sign.keyPair.fromSeed(secretKeyUint8);
-
       this._secretSeed = keys.secretKey;
-      this._secretKey = Buffer.from(naclKeys.secretKey);
-      this._publicKey = Buffer.from(naclKeys.publicKey);
+      this._publicKey = generate(keys.secretKey);
+      this._secretKey = Buffer.concat([keys.secretKey, this._publicKey]);
 
       if (
         keys.publicKey &&

--- a/src/signing.js
+++ b/src/signing.js
@@ -1,15 +1,15 @@
 //  This module provides the signing functionality used by the stellar network
 //  The code below may look a little strange... this is because we try to provide
 //  the most efficient signing method possible.  First, we try to load the
-//  native ed25519 package for node.js environments, and if that fails we
-//  fallback to tweetnacl.js
+//  native `sodium-native` package for node.js environments, and if that fails we
+//  fallback to `tweetnacl`
 
 const actualMethods = {};
 
 /**
- * Use this flag to check if fast signing (provided by `ed25519` package) is available.
+ * Use this flag to check if fast signing (provided by `sodium-native` package) is available.
  * If your app is signing a large number of transaction or verifying a large number
- * of signatures make sure `ed25519` package is installed.
+ * of signatures make sure `sodium-native` package is installed.
  */
 export const FastSigning = checkFastSigning();
 
@@ -34,26 +34,32 @@ function checkFastSigning() {
 function checkFastSigningNode() {
   // NOTE: we use commonjs style require here because es6 imports
   // can only occur at the top level.  thanks, obama.
-  let ed25519;
+  let sodium;
   try {
     // eslint-disable-next-line
-    ed25519 = require('ed25519');
+    sodium = require('sodium-native');
   } catch (err) {
     return checkFastSigningBrowser();
   }
 
   actualMethods.generate = (secretKey) => {
-    const keypair = ed25519.MakeKeypair(secretKey);
-    return keypair.publicKey;
+    const pk = Buffer.alloc(sodium.crypto_sign_PUBLICKEYBYTES);
+    const sk = Buffer.alloc(sodium.crypto_sign_SECRETKEYBYTES);
+    sodium.crypto_sign_seed_keypair(pk, sk, secretKey);
+    return pk;
   };
 
-  actualMethods.sign = (data, secretKey) =>
-    ed25519.Sign(Buffer.from(data), secretKey);
+  actualMethods.sign = (data, secretKey) => {
+    data = Buffer.from(data);
+    const signature = Buffer.alloc(sodium.crypto_sign_BYTES);
+    sodium.crypto_sign_detached(signature, data, secretKey);
+    return signature;
+  };
 
   actualMethods.verify = (data, signature, publicKey) => {
     data = Buffer.from(data);
     try {
-      return ed25519.Verify(data, signature, publicKey);
+      return sodium.crypto_sign_verify_detached(signature, data, publicKey);
     } catch (e) {
       return false;
     }
@@ -63,8 +69,8 @@ function checkFastSigningNode() {
 }
 
 function checkFastSigningBrowser() {
-  // fallback to tweetnacl.js if we're in the browser or
-  // if there was a failure installing ed25519
+  // fallback to `tweetnacl` if we're in the browser or
+  // if there was a failure installing `sodium-native`
   // eslint-disable-next-line
   const nacl = require('tweetnacl');
 


### PR DESCRIPTION
I just now realized I opened up the issue in the wrong repo,
https://github.com/stellar/js-stellar-sdk/issues/242

This PR replaces the `ed25519` package with `sodium-native` when running node, making transaction signing almost twice as fast. It also makes the necessary changes so that key generation is done natively, if possible, for a similar speedup.