### PR TITLE
Add `toString()` to Asset

### DIFF
--- a/src/asset.js
+++ b/src/asset.js
@@ -149,4 +149,12 @@ export class Asset {
   equals(asset) {
     return this.code === asset.getCode() && this.issuer === asset.getIssuer();
   }
+
+  toString() {
+    if (this.isNative()) {
+      return 'native';
+    }
+
+    return `${this.getCode()}-${this.getIssuer()}`;
+  }
 }

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -151,4 +151,21 @@ describe('Asset', function() {
         expect(asset.getIssuer()).to.equal(issuer);
       });
     });
+
+    describe('toString()', function() {
+      it("returns 'native' for native asset", function() {
+        var asset = StellarBase.Asset.native();
+        expect(asset.toString()).to.be.equal('native');
+      });
+
+      it("returns 'code-issuer' for non-native asset", function() {
+        var asset = new StellarBase.Asset(
+          'USD',
+          'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+        );
+        expect(asset.toString()).to.be.equal(
+          'USD-GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+        );
+      });
+    });
 });


### PR DESCRIPTION
Hi there! 👋 

What about overriding `Asset.toString()` method? I believe it would be useful to return something more meaningful from that. I ended up with `code-issuer` format and just `native` for lumens.

What do you think?

P.S. Sorry for the formating mess in a diff, it's prettier in the pre-commit hook 😕 