### PR TITLE
Deprecate base fee with error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ A breaking change will get clearly notified in this log.
 
 ## unreleased
 
-- Add Stellar Protocol 11 compatibility (breaking change)
-  - Rename `manage_offer` to `manage_sell_offer`.
-  - Rename `create_passive_offer` to `create_passive_sell_offer`.
-  - Add `manage_buy_offer`.
+- **Breaking change** Stellar Protocol 11 compatibility
+  - Rename `Operation.manageOffer` to `Operation.manageSellOffer`.
+  - Rename `Operation.createPassiveOffer` to `Operation.createPassiveSellOffer`.
+  - Add `Operation.manageBuyOffer`.
+- **Breaking change** The `fee` parameter to `TransactionBuilder` is now
+  required. Failing to provide a fee in stroops will throw an error.
 
 ## [v0.13.2](https://github.com/stellar/js-stellar-base/compare/v0.13.1...v0.13.2)
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -73,7 +73,7 @@ export class TransactionBuilder {
     }
 
     if (isUndefined(opts.fee)) {
-      throw new Error('must specify fee for the transaction');
+      throw new Error('must specify fee for the transaction (in stroops)');
     }
 
     this.source = sourceAccount;

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -71,15 +71,13 @@ export class TransactionBuilder {
     if (!sourceAccount) {
       throw new Error('must specify source account for the transaction');
     }
-    this.source = sourceAccount;
-    this.operations = [];
 
     if (isUndefined(opts.fee)) {
-      // eslint-disable-next-line no-console
-      console.log(
-        '[TransactionBuilder] The `fee` parameter of `TransactionBuilder` is required. Future versions of this library will error if not provided.'
-      );
+      throw new Error('must specify fee for the transaction');
     }
+
+    this.source = sourceAccount;
+    this.operations = [];
 
     this.baseFee = isUndefined(opts.fee) ? BASE_FEE : opts.fee;
     this.timebounds = clone(opts.timebounds) || null;

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -75,7 +75,6 @@ describe('Transaction', function() {
       'GDJJRRMBK4IWLEPJGIE6SXD2LP7REGZODU7WDC3I2D6MR37F4XSHBKX2';
     let asset = StellarBase.Asset.native();
     let amount = '2000';
-    let signer = StellarBase.Keypair.master();
 
     expect(() =>
       new StellarBase.TransactionBuilder(source)

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -66,6 +66,27 @@ describe('Transaction', function() {
     expect(() => tx.sign(signer)).to.throw(/No network selected/);
   });
 
+  it('throws when no fee is provided', function() {
+    let source = new StellarBase.Account(
+      'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
+      '0'
+    );
+    let destination =
+      'GDJJRRMBK4IWLEPJGIE6SXD2LP7REGZODU7WDC3I2D6MR37F4XSHBKX2';
+    let asset = StellarBase.Asset.native();
+    let amount = '2000';
+    let signer = StellarBase.Keypair.master();
+
+    expect(() =>
+      new StellarBase.TransactionBuilder(source)
+        .addOperation(
+          StellarBase.Operation.payment({ destination, asset, amount })
+        )
+        .setTimeout(StellarBase.TimeoutInfinite)
+        .build()
+    ).to.throw(/must specify fee/);
+  });
+
   it('signs correctly', function() {
     let source = new StellarBase.Account(
       'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',


### PR DESCRIPTION
If someone tries to build a transaction without providing the base fee, throw an error. Closes #166.