### PR TITLE
Restore deprecated functions

### DIFF
--- a/src/operation.js
+++ b/src/operation.js
@@ -56,6 +56,11 @@ export const AuthImmutableFlag = 1 << 2;
  * * `{@link Operation.manageData}`
  * * `{@link Operation.bumpSequence}`
  *
+ * These operations are deprecated and will be removed in a later version:
+ * * `{@link Operation.manageOffer}`
+ * * `{@link Operation.createPassiveOffer}`
+ *
+ *
  * @class Operation
  */
 export class Operation {
@@ -179,6 +184,8 @@ export class Operation {
         }
         break;
       }
+      // the next case intentionally falls through!
+      case 'manageOffer':
       case 'manageSellOffer': {
         result.type = 'manageSellOffer';
         result.selling = Asset.fromOperation(attrs.selling());
@@ -197,6 +204,8 @@ export class Operation {
         result.offerId = attrs.offerId().toString();
         break;
       }
+      // the next case intentionally falls through!
+      case 'createPassiveOffer':
       case 'createPassiveSellOffer': {
         result.type = 'createPassiveSellOffer';
         result.selling = Asset.fromOperation(attrs.selling());
@@ -372,3 +381,7 @@ Operation.manageBuyOffer = ops.manageBuyOffer;
 Operation.pathPayment = ops.pathPayment;
 Operation.payment = ops.payment;
 Operation.setOptions = ops.setOptions;
+
+// deprecated, to be removed after 1.0.1
+Operation.manageOffer = ops.manageOffer;
+Operation.createPassiveOffer = ops.createPassiveOffer;

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -1,13 +1,35 @@
+import { manageSellOffer } from './manage_sell_offer';
+import { createPassiveSellOffer } from './create_passive_sell_offer';
+
 export { accountMerge } from './account_merge';
 export { allowTrust } from './allow_trust';
 export { bumpSequence } from './bump_sequence';
 export { changeTrust } from './change_trust';
 export { createAccount } from './create_account';
-export { createPassiveSellOffer } from './create_passive_sell_offer';
 export { inflation } from './inflation';
 export { manageData } from './manage_data';
-export { manageSellOffer } from './manage_sell_offer';
 export { manageBuyOffer } from './manage_buy_offer';
 export { pathPayment } from './path_payment';
 export { payment } from './payment';
 export { setOptions } from './set_options';
+
+export { manageSellOffer };
+export { createPassiveSellOffer };
+
+export function manageOffer(opts) {
+  // eslint-disable-next-line no-console
+  console.log(
+    '[Operation] Operation.manageOffer has been renamed to Operation.manageSellOffer! The old name is deprecated and will be removed in a later version!'
+  );
+
+  return manageSellOffer.call(this, opts);
+}
+
+export function createPassiveOffer(opts) {
+  // eslint-disable-next-line no-console
+  console.log(
+    '[Operation] Operation.createPassiveOffer has been renamed to Operation.createPassiveSellOffer! The old name is deprecated and will be removed in a later version!'
+  );
+
+  return createPassiveSellOffer.call(this, opts);
+}

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -620,6 +620,52 @@ describe('Operation', function() {
     });
   });
 
+  describe('.manageOffer', function() {
+    beforeEach(function() {
+      sinon.spy(console, 'log');
+    });
+
+    afterEach(function() {
+      console.log.restore();
+    });
+
+    it('creates a manageSellOfferOp (string price) (and warns)', function() {
+      var opts = {};
+      opts.selling = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      opts.buying = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      opts.amount = '3.1234560';
+      opts.price = '8.141592';
+      opts.offerId = '1';
+      let op = StellarBase.Operation.manageOffer(opts);
+
+      expect(console.log).to.be.called;
+
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('manageSellOffer');
+      expect(obj.selling.equals(opts.selling)).to.be.true;
+      expect(obj.buying.equals(opts.buying)).to.be.true;
+      expect(
+        operation
+          .body()
+          .value()
+          .amount()
+          .toString()
+      ).to.be.equal('31234560');
+      expect(obj.amount).to.be.equal(opts.amount);
+      expect(obj.price).to.be.equal(opts.price);
+      expect(obj.offerId).to.be.equal(opts.offerId);
+    });
+  });
   describe('.manageSellOffer', function() {
     it('creates a manageSellOfferOp (string price)', function() {
       var opts = {};
@@ -1153,6 +1199,51 @@ describe('Operation', function() {
       expect(() => StellarBase.Operation.manageBuyOffer(opts)).to.throw(
         /not a number/
       );
+    });
+  });
+
+  describe('.createPassiveOffer', function() {
+    beforeEach(function() {
+      sinon.spy(console, 'log');
+    });
+
+    afterEach(function() {
+      console.log.restore();
+    });
+
+    it('creates a createPassiveSellOfferOp (string price) (and warns)', function() {
+      var opts = {};
+      opts.selling = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      opts.buying = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      opts.amount = '11.2782700';
+      opts.price = '3.07';
+      let op = StellarBase.Operation.createPassiveOffer(opts);
+
+      expect(console.log).to.be.called;
+
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('createPassiveSellOffer');
+      expect(obj.selling.equals(opts.selling)).to.be.true;
+      expect(obj.buying.equals(opts.buying)).to.be.true;
+      expect(
+        operation
+          .body()
+          .value()
+          .amount()
+          .toString()
+      ).to.be.equal('112782700');
+      expect(obj.amount).to.be.equal(opts.amount);
+      expect(obj.price).to.be.equal(opts.price);
     });
   });
 


### PR DESCRIPTION
Restore deprecated operations Operation.createPassiveOffer and Operation.manageOffer. When called, make them console.log an error, and return the correct new offer name. Fixes #190.