### PR TITLE
Fix package.json `browser` build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "browser": {
-    "ed25519": false
+    "sodium-native": false
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The latest version broke our React storybook build with `Module not found: Error: Can't resolve 'fs'`. This is the fix. Was probably just forgotten when `ed25519` was replaced by `sodium-native`.