### PR TITLE
feat: deprecate Network, use explicit passphrase (1)

### DIFF
--- a/src/keypair.js
+++ b/src/keypair.js
@@ -90,15 +90,21 @@ export class Keypair {
 
   /**
    * Returns `Keypair` object representing network master key.
+   * @param {string} [networkPassphrase] passphrase of the target stellar network (e.g. "Public Global Stellar Network ; September 2015").
    * @returns {Keypair}
    */
-  static master() {
-    if (Network.current() === null) {
+  static master(networkPassphrase) {
+    // Deprecation warning. TODO: remove optionality with next major release.
+    if (!networkPassphrase) {
+      console.warn('Global `Network.current()` is deprecated. Please pass explicit argument instead, e.g. `Keypair.master(Networks.PUBLIC)`.')
+      networkPassphrase = Network.current()
+    }
+    if (networkPassphrase === null) {
       throw new Error(
         'No network selected. Use `Network.use`, `Network.usePublicNetwork` or `Network.useTestNetwork` helper methods to select network.'
       );
     }
-    return this.fromRawEd25519Seed(Network.current().networkId());
+    return this.fromRawEd25519Seed(networkPassphrase);
   }
 
   /**

--- a/src/network.js
+++ b/src/network.js
@@ -24,6 +24,7 @@ let current = null;
  * Creates a new `Network` object.
  * @constructor
  * @param {string} networkPassphrase Network passphrase
+ * @deprecated
  */
 export class Network {
   constructor(networkPassphrase) {


### PR DESCRIPTION
**See discussion at https://github.com/stellar/js-stellar-base/issues/112#issuecomment-512733154**

The following methods take optional network passphrase, and `console.warn` if it is not passed.
- static method `Keypair.master` 
- method `Transaction.addSignature`
- method `Transaction.getKeypairSignature`
- method `Transaction.hash`
- method `Transaction.sign`
- method `Transaction.signatureBase`

Also, tag whole class `Network` as deprecated.

Closes #112