### PR TITLE
Release v2.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ A breaking change will get clearly notified in this log.
 
 ## Unreleased
 
+## [v2.0.0](https://github.com/stellar/js-stellar-base/compare/v1.1.2...v2.0.0)
+
+### BREAKING CHANGES
+
+- Drop Support for Node 6 since it has been end-of-lifed and no longer in LTS. We now require Node 10 which is the current LTS until April 1st, 2021. ([#255](https://github.com/stellar/js-stellar-base/pull/255))
+
 ## [v1.1.2](https://github.com/stellar/js-stellar-base/compare/v1.1.1...v1.1.2)
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Low level stellar support library",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
### BREAKING CHANGES

 - Drop Support for Node 6 since it has been end-of-lifed and no longer in LTS. We now require Node 10 which is the current LTS until April 1st, 2021. ([#255](https://github.com/stellar/js-stellar-base/pull/255))
