### PR TITLE
Run sauce on node12 to avoid double call to deploy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - node_js: 11
     - node_js: 12
       env: TYPE_TEST=true
-    - node_js: 10.16.3
+    - node_js: 12
       env: SAUCE=true
 cache:
   directories:


### PR DESCRIPTION
The current version will call deploy twice since it will do it based on the node version. This will  avoid the double call and make the deploy happen on the min required version.

```
deploy:
  - provider: npm
    email: npm@stellar.org
    api_key: $NPM_TOKEN
    skip_cleanup: true
    on:
      tags: true
      repo: stellar/js-stellar-base
      node: 10.16.3
  - provider: script
    script: './bower_publish.sh'
    skip_cleanup: true
    on:
      tags: true
      repo: stellar/js-stellar-base
      node: 10.16.3
```