### PR TITLE
fix(typescript): xdr - add plenty of types

### DIFF
--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -6,184 +6,185 @@
 
 declare module "js-xdr" {  // `IOMixin`.
 
-    export class IOMixin {
-        static toXDR(val: Buffer): Buffer
-        /**
-         * **REMEMBER TO REPLACE** static method `fromXDR` to return the appropriate class.
-         */
-        static fromXDR(input: Buffer, format?: 'raw'): IOMixin
-        static fromXDR(input: string, format: 'hex' | 'base64'): IOMixin
-        toXDR(format?: 'raw'): Buffer
-        toXDR(format: 'hex' | 'base64'): string
-    }
+export class IOMixin {
+  static toXDR(val: Buffer): Buffer
+  /**
+  * **REMEMBER TO REPLACE** static method `fromXDR` to return the appropriate class.
+  */
+  static fromXDR(input: Buffer, format?: 'raw'): IOMixin
+  static fromXDR(input: string, format: 'hex' | 'base64'): IOMixin
+  toXDR(format?: 'raw'): Buffer
+  toXDR(format: 'hex' | 'base64'): string
+}
 }
 
 declare module "js-xdr" {  // Primitives Void, Hyper, Int, Float, Double, Quadruple, Bool, String, Opaque, VarOpaque.
-    import Long from "long";
-    import { IOMixin } from "js-xdr";
-
-    export class Void {
-        static fromXDR(input: Buffer, format?: 'raw'): Void
-        static fromXDR(input: string, format: 'hex' | 'base64'): Void
-    }
-
-    export class Hyper extends Long implements IOMixin {
-        static MAX_VALUE: Hyper
-        static MIN_VALUE: Hyper
-        static toXDR(val: Buffer): Buffer
-        static fromXDR(input: Buffer, format?: 'raw'): Hyper
-        static fromXDR(input: string, format: 'hex' | 'base64'): Hyper
-        toXDR(format?: 'raw'): Buffer
-        toXDR(format: 'hex' | 'base64'): string
-        isValid(value: Buffer): boolean
-    }
-    export class UnsignedHyper extends Long implements IOMixin {
-        static MAX_VALUE: Hyper
-        static MIN_VALUE: Hyper
-        static toXDR(val: Buffer): Buffer
-        static fromXDR(input: Buffer, format?: 'raw'): UnsignedHyper
-        static fromXDR(input: string, format: 'hex' | 'base64'): UnsignedHyper
-        toXDR(format?: 'raw'): Buffer
-        toXDR(format: 'hex' | 'base64'): string
-    }
-    export class Int extends IOMixin {
-        static MAX_VALUE: number
-        static MIN_VALUE: number
-        static fromXDR(input: Buffer, format?: 'raw'): Int
-        static fromXDR(input: string, format: 'hex' | 'base64'): Int
-    }
-    export class UnsignedInt extends IOMixin {
-        static MAX_VALUE: number
-        static MIN_VALUE: number
-        static fromXDR(input: Buffer, format?: 'raw'): Int
-        static fromXDR(input: string, format: 'hex' | 'base64'): Int
-    }
-    export class Float extends IOMixin {
-    }
-    export class Double extends IOMixin {
-    }
-    export class Quadruple extends IOMixin {
-    }
-
-    export class Bool extends IOMixin {
-    }
-
-    export class String extends IOMixin {
-        constructor(maxLength?: number);
-    }
-
-    export class Opaque extends IOMixin {
-        constructor(length: number);
-    }
-    export class VarOpaque {
-        constructor(length?: number);
-    }
-
+  import Long from "long";
+  import { IOMixin } from "js-xdr";
+  
+  export class Void {
+    static fromXDR(input: Buffer, format?: 'raw'): Void
+    static fromXDR(input: string, format: 'hex' | 'base64'): Void
+  }
+  
+  export class Hyper extends Long implements IOMixin {
+    static MAX_VALUE: Hyper
+    static MIN_VALUE: Hyper
+    static toXDR(val: Buffer): Buffer
+    static fromXDR(input: Buffer, format?: 'raw'): Hyper
+    static fromXDR(input: string, format: 'hex' | 'base64'): Hyper
+    toXDR(format?: 'raw'): Buffer
+    toXDR(format: 'hex' | 'base64'): string
+    isValid(value: Buffer): boolean
+    static fromString( str: string, unsigned?: boolean | number, radix?: number ): Hyper;
+  }
+  export class UnsignedHyper extends Long implements IOMixin {
+    static MAX_VALUE: Hyper
+    static MIN_VALUE: Hyper
+    static toXDR(val: Buffer): Buffer
+    static fromXDR(input: Buffer, format?: 'raw'): UnsignedHyper
+    static fromXDR(input: string, format: 'hex' | 'base64'): UnsignedHyper
+    toXDR(format?: 'raw'): Buffer
+    toXDR(format: 'hex' | 'base64'): string
+  }
+  export class Int extends IOMixin {
+    static MAX_VALUE: number
+    static MIN_VALUE: number
+    static fromXDR(input: Buffer, format?: 'raw'): Int
+    static fromXDR(input: string, format: 'hex' | 'base64'): Int
+  }
+  export class UnsignedInt extends IOMixin {
+    static MAX_VALUE: number
+    static MIN_VALUE: number
+    static fromXDR(input: Buffer, format?: 'raw'): Int
+    static fromXDR(input: string, format: 'hex' | 'base64'): Int
+  }
+  export class Float extends IOMixin {
+  }
+  export class Double extends IOMixin {
+  }
+  export class Quadruple extends IOMixin {
+  }
+  
+  export class Bool extends IOMixin {
+  }
+  
+  export class String extends IOMixin {
+    constructor(maxLength?: number);
+  }
+  
+  export class Opaque extends IOMixin {
+    constructor(length: number);
+  }
+  export class VarOpaque {
+    constructor(length?: number);
+  }
+  
 }
 
 declare module "js-xdr" {  // Array and VarArray.
-
-    // export * from './array';
-    // export * from './var-array';
-
-    // export * from './option';
-
-    // export * from './enum';
-    // export * from './struct';
-    // export * from './union';
-
-
-    export class Array<T extends IOMixin> {
-        constructor(childType: T, length: number);
-        public _childType: T;
-        public _length: number;
-    }
-    export class VarArray {
-        public _childType: any;
-        public _length: number;
-    }
-
-    export class ChildStruct extends Struct {
-    }
-
-    export class Enum {
-        public name: string;
-        public value: number;
-        public fromName(string: string): Enum;
-    }
-
-
-    export class Struct {
-        public _attributes: object;
-    }
-
-
-    export class Union {
-        public switch(): any;
-        public armType(): any;
-        public value(): any;
-        public arm(): any;
-    }
-
-
-
-    export class Option {
-        public _childType: any;
-    }
-
-
+  
+  // export * from './array';
+  // export * from './var-array';
+  
+  // export * from './option';
+  
+  // export * from './enum';
+  // export * from './struct';
+  // export * from './union';
+  
+  
+  export class Array<T extends IOMixin> {
+    constructor(childType: T, length: number);
+    public _childType: T;
+    public _length: number;
+  }
+  export class VarArray {
+    public _childType: any;
+    public _length: number;
+  }
+  
+  export class ChildStruct extends Struct {
+  }
+  
+  export class Enum {
+    public name: string;
+    public value: number;
+    public fromName(string: string): Enum;
+  }
+  
+  
+  export class Struct {
+    public _attributes: object;
+  }
+  
+  
+  export class Union {
+    public switch(): any;
+    public armType(): any;
+    public value(): any;
+    public arm(): any;
+  }
+  
+  
+  
+  export class Option {
+    public _childType: any;
+  }
+  
+  
 }
 
 declare module "js-xdr" {  // `XDR.config`.
 
-    interface UnionConfigurationInt {
-        switchOn: Int,
-        switchName: string,
-        switches: [number, string | Void][],
-        arms: Record<string, Reference>
-    }
-    interface UnionConfigurationEnum {
-        switchOn: Reference,
-        switchName: string,
-        switches: [string, string | Void][],
-        arms: Record<string, Reference>
-        defaultArm?: IOMixin
-    }
+interface UnionConfigurationInt {
+  switchOn: Int,
+  switchName: string,
+  switches: [number, string | Void][],
+  arms: Record<string, Reference>
+}
+interface UnionConfigurationEnum {
+  switchOn: Reference,
+  switchName: string,
+  switches: [string, string | Void][],
+  arms: Record<string, Reference>
+  defaultArm?: IOMixin
+}
 
-    class Reference {
-        resolve(context: unknown): void
-    }
-    class TypeBuilder {
-        constructor(destination: {})
+class Reference {
+  resolve(context: unknown): void
+}
+class TypeBuilder {
+  constructor(destination: {})
+  
+  enum(name: string, members: Record<string, number>): void
+  struct(name: string, members: [string, Reference | IOMixin][]): void
+  union(name: string, cfg: UnionConfigurationInt | UnionConfigurationEnum): void
+  typedef(name: string, cfg: Reference | IOMixin): void
+  const(name: string, cfg: number): void
+  
+  void(): Void;
+  bool(): Bool;
+  int(): Int;
+  hyper(): Hyper;
+  uint(): UnsignedInt;
+  uhyper(): UnsignedHyper;
+  float(): Float;
+  double(): Double;
+  quadruple(): Quadruple;
+  
+  string(length: number): Reference
+  opaque(length: number): Reference
+  varOpaque(length?: number): Reference
+  
+  array(childType: IOMixin, length: number): Reference
+  varArray(childType: IOMixin, maxLength: Reference | number): Reference
+  
+  option(childType: IOMixin): Reference
+  
+  lookup(name: string): Reference
+}
 
-        enum(name: string, members: Record<string, number>): void
-        struct(name: string, members: [string, Reference | IOMixin][]): void
-        union(name: string, cfg: UnionConfigurationInt | UnionConfigurationEnum): void
-        typedef(name: string, cfg: Reference | IOMixin): void
-        const(name: string, cfg: number): void
-
-        void(): Void;
-        bool(): Bool;
-        int(): Int;
-        hyper(): Hyper;
-        uint(): UnsignedInt;
-        uhyper(): UnsignedHyper;
-        float(): Float;
-        double(): Double;
-        quadruple(): Quadruple;
-
-        string(length: number): Reference
-        opaque(length: number): Reference
-        varOpaque(length?: number): Reference
-
-        array(childType: IOMixin, length: number): Reference
-        varArray(childType: IOMixin, maxLength: Reference | number): Reference
-
-        option(childType: IOMixin): Reference
-
-        lookup(name: string): Reference
-    }
-
-    export function config(fn: (builder: TypeBuilder) => void, types?: any): any;
+export function config(fn: (builder: TypeBuilder) => void, types?: any): any;
 
 }

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -103,6 +103,38 @@ declare module "js-xdr" {  // Array and VarArray.
   export class ChildStruct extends Struct {
   }
 
+  /**
+   * Example definition:
+   * ```ts
+   * xdr.enum("AssetType", {
+   *   assetTypeNative: 0,
+   *   assetTypeCreditAlphanum4: 1,
+   *   assetTypeCreditAlphanum12: 2,
+   * });
+   *
+   * // becomes...
+   * export type AssetType =
+   *   | AssetType.assetTypeNative
+   *   | AssetType.assetTypeCreditAlphanum4
+   *   | AssetType.assetTypeCreditAlphanum12
+   * export namespace AssetType {
+   *   export type assetTypeNative = Enum<'assetTypeNative', 0>
+   *   export type assetTypeCreditAlphanum4 = Enum<'assetTypeCreditAlphanum4', 1>
+   *   export type assetTypeCreditAlphanum12 = Enum<'assetTypeCreditAlphanum12', 2>
+   *   export const assetTypeNative: () => Enum<'assetTypeNative', 0>
+   *   export const assetTypeCreditAlphanum4: () => Enum<'assetTypeCreditAlphanum4', 1>
+   *   export const assetTypeCreditAlphanum12: () => Enum<'assetTypeCreditAlphanum12', 2>
+   * }
+   *
+   * // But shortcut works fine if Enum is not used directly (excluding AssetType):
+   * export enum AssetType {
+   *   assetTypeNative = 0,
+   *   assetTypeCreditAlphanum4 = 1,
+   *   assetTypeCreditAlphanum12 = 2,
+   * }
+   * ```
+   *
+   */
   export class Enum<TName extends string, TValue extends number> extends IOMixin {
     public name: TName;
     public value: TValue;

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -6,6 +6,41 @@
 declare module "js-xdr" {
     import Long from "long";
 
+    // interface IOMixin {
+    //     toXDR(format?: 'raw'): Buffer
+    //     toXDR(format: 'hex' | 'base64'): string
+    // }
+    // interface IOMixinBuilder<TInstance extends IOMixin> {
+    //     new (): TInstance;
+    //     toXDR(val: Buffer): Buffer
+    //     fromXDR(input: Buffer, format: 'raw'): TInstance
+    //     fromXDR(input: string, format?: 'hex' | 'base64'): TInstance
+    // }
+    export class IOMixin {
+        /**
+         * **REMEMBER TO REPLACE** static method `toXDR` to return the appropriate class.
+         */
+        static toXDR(val: Buffer): IOMixin
+        /**
+         * **REMEMBER TO REPLACE** static method `fromXDR` to return the appropriate class.
+         */
+        static fromXDR(input: Buffer, format: 'raw'): IOMixin
+        static fromXDR(input: string, format?: 'hex' | 'base64'): IOMixin
+    }
+
+    export class Bool extends IOMixin {
+    }
+    export class UnsignedInt extends IOMixin {
+    }
+    export class Float extends IOMixin {
+    }
+    export class Double extends IOMixin {
+    }
+    export class Quadruple extends IOMixin {
+    }
+    export class Int extends IOMixin {
+    }
+
     export class Array {
         public _childType: any;
         public _length: number;
@@ -13,8 +48,6 @@ declare module "js-xdr" {
 
     export class ChildStruct extends Struct {
     }
-
-    export function config(fn: any, types?: any): any;
 
     export class Enum {
         public name: string;
@@ -25,12 +58,12 @@ declare module "js-xdr" {
     export class Hyper extends Long {
     }
 
-    export class Opaque {
+    export class Opaque extends IOMixin {
+        new (length: number): Opaque;
     }
 
     export class Struct {
         public _attributes: object;
-        public toXDR(): Buffer;
     }
 
     export class String {
@@ -52,9 +85,68 @@ declare module "js-xdr" {
     }
 
     export class VarOpaque {
+        constructor(length?: number);
     }
 
     export class Option {
         public _childType: any;
     }
+
+    export class Void {
+    }
+
+}
+
+declare module "js-xdr" {  // `XDR.config`.
+
+    interface UnionConfigurationInt {
+        switchOn: Int,
+        switchName: string,
+        switches: [number, string | Void][],
+        arms: Record<string, Reference>
+    }
+    interface UnionConfigurationEnum {
+        switchOn: Reference,
+        switchName: string,
+        switches: [string, string | Void][],
+        arms: Record<string, Reference>
+        defaultArm?: IOMixin
+    }
+
+    class Reference {
+        resolve(context: unknown): void
+    }
+    class TypeBuilder {
+        constructor(destination: {})
+
+        enum(name: string, members: Record<string, number>): void
+        struct(name: string, members: [string, Reference | IOMixin][]): void
+        union(name: string, cfg: UnionConfigurationInt | UnionConfigurationEnum): void
+        typedef(name: string, cfg: Reference | IOMixin): void
+        const(name: string, cfg: number): void
+
+        void(): Void;
+        bool(): Bool;
+        int(): Int;
+        hyper(): Hyper;
+        uint(): UnsignedInt;
+        uhyper(): UnsignedHyper;
+        float(): Float;
+        double(): Double;
+        quadruple(): Quadruple;
+
+        string(length: number): Reference
+        opaque(length: number): Reference
+        varOpaque(length?: number): Reference
+
+        array(childType: IOMixin, length: number): Reference
+        varArray(childType: IOMixin, maxLength: Reference | number): Reference
+
+        option(childType: IOMixin): Reference
+
+        lookup(name: string): Reference
+    }
+
+    export function config(fn: (builder: TypeBuilder) => void, types?: any): any;
+
 }

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Adolfo Builes <https://github.com/abuiles>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.4.1
-/// <reference types="utility-types" />
+
 
 declare module "js-xdr" {  // `IOMixin`.
 

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -187,6 +187,13 @@ declare module "js-xdr" {  // Array and VarArray.
    */
   export type Union = never
 
+  class UnionHidden<T> extends IOMixin {
+    public switch(): T;
+    public armType(): unknown;
+    public value(): unknown;  // TODO: type as return value between instance methods that's conditional on T
+    public arm(): unknown;  // TODO: type as literal name of T
+  }
+
   /**
    * #### Example definition for direct call:
    * ```ts
@@ -222,16 +229,12 @@ declare module "js-xdr" {  // Array and VarArray.
    * ```
    *
    */
-  export class UnionWithFunctions<T extends new (...args: any) => any> extends IOMixin {
+  export class UnionWithFunctions<T extends new (...args: any) => any, U> extends UnionHidden<U> {
     /**
      * @param {magic} switches Instance of a class on T static property.
      * @memberof Union
      */
     constructor(switches: InstanceType<Extract<T[keyof Omit<T, 'fromXDR' | 'toXDR'>], new (...args: any) => any>>)
-    public switch(): any;
-    public armType(): any;
-    public value(): any;
-    public arm(): any;
   }
 
   /**
@@ -260,16 +263,12 @@ declare module "js-xdr" {  // Array and VarArray.
    * }
    * ```
    */
-  export class UnionWithConstructors<T extends new (...args: any) => any> extends IOMixin {
+  export class UnionWithConstructors<T extends new (...args: any) => any, U> extends UnionHidden<U> {
     /**
      * @param {magic} switches Instance of a class on T static property.
      * @memberof Union
      */
     constructor(switches: InstanceType<Extract<T[keyof Omit<T, 'fromXDR' | 'toXDR'>], new (...args: any) => any>>)
-    public switch(): any;
-    public armType(): any;
-    public value(): any;
-    public arm(): any;
   }
 
 

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -121,12 +121,12 @@ declare module "js-xdr" {  // Array and VarArray.
    *   export type assetTypeNative = Enum<'assetTypeNative', 0>
    *   export type assetTypeCreditAlphanum4 = Enum<'assetTypeCreditAlphanum4', 1>
    *   export type assetTypeCreditAlphanum12 = Enum<'assetTypeCreditAlphanum12', 2>
-   *   export const assetTypeNative: () => Enum<'assetTypeNative', 0>
-   *   export const assetTypeCreditAlphanum4: () => Enum<'assetTypeCreditAlphanum4', 1>
-   *   export const assetTypeCreditAlphanum12: () => Enum<'assetTypeCreditAlphanum12', 2>
+   *   export const assetTypeNative: () => assetTypeNative
+   *   export const assetTypeCreditAlphanum4: () => assetTypeCreditAlphanum4
+   *   export const assetTypeCreditAlphanum12: () => assetTypeCreditAlphanum12
    * }
    *
-   * // But shortcut works fine if Enum is not used directly (excluding AssetType):
+   * // But shortcut works fine if Enum is not used directly (excluding AssetType, OperationType):
    * export enum AssetType {
    *   assetTypeNative = 0,
    *   assetTypeCreditAlphanum4 = 1,
@@ -188,10 +188,10 @@ declare module "js-xdr" {  // Array and VarArray.
   export type Union = never
 
   class UnionHidden<T> extends IOMixin {
-    public switch(): T;
-    public armType(): unknown;
-    public value(): unknown;  // TODO: type as return value between instance methods that's conditional on T
     public arm(): unknown;  // TODO: type as literal name of T
+    public armType(): unknown;
+    public switch(): T;
+    public value(): ReturnType<Extract<this[keyof Omit<this, keyof UnionHidden<unknown>>], () => any>>;
   }
 
   /**

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -135,7 +135,39 @@ declare module "js-xdr" {  // Array and VarArray.
     }
   }
 
-  export class Union extends IOMixin {
+
+  /**
+   * Example definition:
+   * ```ts
+   * xdr.union("AllowTrustOpAsset", {
+   *   switchOn: xdr.lookup("AssetType"),
+   *   switchName: "type",
+   *   switches: [
+   *     ["assetTypeCreditAlphanum4", "assetCode4"],
+   *     ["assetTypeCreditAlphanum12", "assetCode12"],
+   *   ],
+   *   arms: {
+   *     assetCode4: xdr.lookup("AssetCode4"),
+   *     assetCode12: xdr.lookup("AssetCode12"),
+   *   },
+   * });
+   * ```
+   * Example matching types:
+   * ```ts
+   * export class AllowTrustOpAsset extends Union<typeof AllowTrustOpAsset> {
+   *   static assetTypeCreditAlphanum4(...args: ConstructorParameters<typeof AssetCode4>): AssetCode4
+   *   static assetTypeCreditAlphanum12(...args: ConstructorParameters<typeof AssetCode12>): AssetCode12
+   *   assetCode4(): AssetCode4
+   *   assetCode12(): AssetCode12
+   * }
+   * ```
+   */
+  export class Union<T extends new (...args: any) => any> extends IOMixin {
+    /**
+     * @param {magic} switches Instance of a class on T static property.
+     * @memberof Union
+     */
+    constructor(switches: InstanceType<Extract<T[keyof Omit<T, 'fromXDR' | 'toXDR'>], new (...args: any) => any>>)
     public switch(): any;
     public armType(): any;
     public value(): any;

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -3,34 +3,60 @@
 // Definitions by: Adolfo Builes <https://github.com/abuiles>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.4.1
-declare module "js-xdr" {
-    import Long from "long";
 
-    // interface IOMixin {
-    //     toXDR(format?: 'raw'): Buffer
-    //     toXDR(format: 'hex' | 'base64'): string
-    // }
-    // interface IOMixinBuilder<TInstance extends IOMixin> {
-    //     new (): TInstance;
-    //     toXDR(val: Buffer): Buffer
-    //     fromXDR(input: Buffer, format: 'raw'): TInstance
-    //     fromXDR(input: string, format?: 'hex' | 'base64'): TInstance
-    // }
+declare module "js-xdr" {  // `IOMixin`.
+
     export class IOMixin {
-        /**
-         * **REMEMBER TO REPLACE** static method `toXDR` to return the appropriate class.
-         */
-        static toXDR(val: Buffer): IOMixin
+        static toXDR(val: Buffer): Buffer
         /**
          * **REMEMBER TO REPLACE** static method `fromXDR` to return the appropriate class.
          */
-        static fromXDR(input: Buffer, format: 'raw'): IOMixin
-        static fromXDR(input: string, format?: 'hex' | 'base64'): IOMixin
+        static fromXDR(input: Buffer, format?: 'raw'): IOMixin
+        static fromXDR(input: string, format: 'hex' | 'base64'): IOMixin
+        toXDR(format?: 'raw'): Buffer
+        toXDR(format: 'hex' | 'base64'): string
+    }
+}
+
+declare module "js-xdr" {  // Primitives Void, Hyper, Int, Float, Double, Quadruple, Bool, String, Opaque, VarOpaque.
+    import Long from "long";
+    import { IOMixin } from "js-xdr";
+
+    export class Void {
+        static fromXDR(input: Buffer, format?: 'raw'): Void
+        static fromXDR(input: string, format: 'hex' | 'base64'): Void
     }
 
-    export class Bool extends IOMixin {
+    export class Hyper extends Long implements IOMixin {
+        static MAX_VALUE: Hyper
+        static MIN_VALUE: Hyper
+        static toXDR(val: Buffer): Buffer
+        static fromXDR(input: Buffer, format?: 'raw'): Hyper
+        static fromXDR(input: string, format: 'hex' | 'base64'): Hyper
+        toXDR(format?: 'raw'): Buffer
+        toXDR(format: 'hex' | 'base64'): string
+        isValid(value: Buffer): boolean
+    }
+    export class UnsignedHyper extends Long implements IOMixin {
+        static MAX_VALUE: Hyper
+        static MIN_VALUE: Hyper
+        static toXDR(val: Buffer): Buffer
+        static fromXDR(input: Buffer, format?: 'raw'): UnsignedHyper
+        static fromXDR(input: string, format: 'hex' | 'base64'): UnsignedHyper
+        toXDR(format?: 'raw'): Buffer
+        toXDR(format: 'hex' | 'base64'): string
+    }
+    export class Int extends IOMixin {
+        static MAX_VALUE: number
+        static MIN_VALUE: number
+        static fromXDR(input: Buffer, format?: 'raw'): Int
+        static fromXDR(input: string, format: 'hex' | 'base64'): Int
     }
     export class UnsignedInt extends IOMixin {
+        static MAX_VALUE: number
+        static MIN_VALUE: number
+        static fromXDR(input: Buffer, format?: 'raw'): Int
+        static fromXDR(input: string, format: 'hex' | 'base64'): Int
     }
     export class Float extends IOMixin {
     }
@@ -38,10 +64,41 @@ declare module "js-xdr" {
     }
     export class Quadruple extends IOMixin {
     }
-    export class Int extends IOMixin {
+
+    export class Bool extends IOMixin {
     }
 
-    export class Array {
+    export class String extends IOMixin {
+        constructor(maxLength?: number);
+    }
+
+    export class Opaque extends IOMixin {
+        constructor(length: number);
+    }
+    export class VarOpaque {
+        constructor(length?: number);
+    }
+
+}
+
+declare module "js-xdr" {  // Array and VarArray.
+
+    // export * from './array';
+    // export * from './var-array';
+
+    // export * from './option';
+
+    // export * from './enum';
+    // export * from './struct';
+    // export * from './union';
+
+
+    export class Array<T extends IOMixin> {
+        constructor(childType: T, length: number);
+        public _childType: T;
+        public _length: number;
+    }
+    export class VarArray {
         public _childType: any;
         public _length: number;
     }
@@ -55,19 +112,11 @@ declare module "js-xdr" {
         public fromName(string: string): Enum;
     }
 
-    export class Hyper extends Long {
-    }
-
-    export class Opaque extends IOMixin {
-        new (length: number): Opaque;
-    }
 
     export class Struct {
         public _attributes: object;
     }
 
-    export class String {
-    }
 
     export class Union {
         public switch(): any;
@@ -76,24 +125,12 @@ declare module "js-xdr" {
         public arm(): any;
     }
 
-    export class UnsignedHyper extends Long {
-    }
 
-    export class VarArray {
-        public _childType: any;
-        public _length: number;
-    }
-
-    export class VarOpaque {
-        constructor(length?: number);
-    }
 
     export class Option {
         public _childType: any;
     }
 
-    export class Void {
-    }
 
 }
 

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -34,10 +34,10 @@ declare module "js-xdr" {  // Primitives Void, Hyper, Int, Float, Double, Quadru
     static toXDR(val: Buffer): Buffer
     static fromXDR(input: Buffer, format?: 'raw'): Hyper
     static fromXDR(input: string, format: 'hex' | 'base64'): Hyper
+    static fromString( str: string, unsigned?: boolean | number, radix?: number ): Hyper;
     toXDR(format?: 'raw'): Buffer
     toXDR(format: 'hex' | 'base64'): string
     isValid(value: Buffer): boolean
-    static fromString( str: string, unsigned?: boolean | number, radix?: number ): Hyper;
   }
   export class UnsignedHyper extends Long implements IOMixin {
     static MAX_VALUE: Hyper
@@ -45,6 +45,7 @@ declare module "js-xdr" {  // Primitives Void, Hyper, Int, Float, Double, Quadru
     static toXDR(val: Buffer): Buffer
     static fromXDR(input: Buffer, format?: 'raw'): UnsignedHyper
     static fromXDR(input: string, format: 'hex' | 'base64'): UnsignedHyper
+    static fromString(str: string, unsigned?: boolean | number, radix?: number ): UnsignedHyper;
     toXDR(format?: 'raw'): Buffer
     toXDR(format: 'hex' | 'base64'): string
   }
@@ -98,10 +99,9 @@ declare module "js-xdr" {  // Array and VarArray.
   export class ChildStruct extends Struct {
   }
 
-  export class Enum extends IOMixin {
-    public name: string;
-    public value: number;
-    public fromName(string: string): Enum;
+  export class Enum<TName extends string, TValue extends number> extends IOMixin {
+    public name: TName;
+    public value: TValue;
   }
 
   /**

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -76,7 +76,7 @@ declare module "js-xdr" {  // Primitives Void, Hyper, Int, Float, Double, Quadru
   export class Opaque extends IOMixin {
     constructor(length: number);
   }
-  export class VarOpaque {
+  export class VarOpaque extends IOMixin {
     constructor(length?: number);
   }
   
@@ -107,19 +107,19 @@ declare module "js-xdr" {  // Array and VarArray.
   export class ChildStruct extends Struct {
   }
   
-  export class Enum {
+  export class Enum extends IOMixin {
     public name: string;
     public value: number;
     public fromName(string: string): Enum;
   }
   
   
-  export class Struct {
+  export class Struct extends IOMixin {
     public _attributes: object;
   }
   
   
-  export class Union {
+  export class Union extends IOMixin {
     public switch(): any;
     public armType(): any;
     public value(): any;
@@ -128,7 +128,7 @@ declare module "js-xdr" {  // Array and VarArray.
   
   
   
-  export class Option {
+  export class Option<T> extends IOMixin {
     public _childType: any;
   }
   
@@ -137,54 +137,54 @@ declare module "js-xdr" {  // Array and VarArray.
 
 declare module "js-xdr" {  // `XDR.config`.
 
-interface UnionConfigurationInt {
-  switchOn: Int,
-  switchName: string,
-  switches: [number, string | Void][],
-  arms: Record<string, Reference>
-}
-interface UnionConfigurationEnum {
-  switchOn: Reference,
-  switchName: string,
-  switches: [string, string | Void][],
-  arms: Record<string, Reference>
-  defaultArm?: IOMixin
-}
+  interface UnionConfigurationInt {
+    switchOn: Int,
+    switchName: string,
+    switches: [number, string | Void][],
+    arms: Record<string, Reference>
+  }
+  interface UnionConfigurationEnum {
+    switchOn: Reference,
+    switchName: string,
+    switches: [string, string | Void][],
+    arms: Record<string, Reference>
+    defaultArm?: IOMixin
+  }
 
-class Reference {
-  resolve(context: unknown): void
-}
-class TypeBuilder {
-  constructor(destination: {})
-  
-  enum(name: string, members: Record<string, number>): void
-  struct(name: string, members: [string, Reference | IOMixin][]): void
-  union(name: string, cfg: UnionConfigurationInt | UnionConfigurationEnum): void
-  typedef(name: string, cfg: Reference | IOMixin): void
-  const(name: string, cfg: number): void
-  
-  void(): Void;
-  bool(): Bool;
-  int(): Int;
-  hyper(): Hyper;
-  uint(): UnsignedInt;
-  uhyper(): UnsignedHyper;
-  float(): Float;
-  double(): Double;
-  quadruple(): Quadruple;
-  
-  string(length: number): Reference
-  opaque(length: number): Reference
-  varOpaque(length?: number): Reference
-  
-  array(childType: IOMixin, length: number): Reference
-  varArray(childType: IOMixin, maxLength: Reference | number): Reference
-  
-  option(childType: IOMixin): Reference
-  
-  lookup(name: string): Reference
-}
+  class Reference {
+    resolve(context: unknown): void
+  }
+  class TypeBuilder {
+    constructor(destination: {})
+    
+    enum(name: string, members: Record<string, number>): void
+    struct(name: string, members: [string, Reference | IOMixin][]): void
+    union(name: string, cfg: UnionConfigurationInt | UnionConfigurationEnum): void
+    typedef(name: string, cfg: Reference | IOMixin): void
+    const(name: string, cfg: number): void
+    
+    void(): Void;
+    bool(): Bool;
+    int(): Int;
+    hyper(): Hyper;
+    uint(): UnsignedInt;
+    uhyper(): UnsignedHyper;
+    float(): Float;
+    double(): Double;
+    quadruple(): Quadruple;
+    
+    string(length: number): Reference
+    opaque(length: number): Reference
+    varOpaque(length?: number): Reference
+    
+    array(childType: IOMixin, length: number): Reference
+    varArray(childType: IOMixin, maxLength: Reference | number): Reference
+    
+    option(childType: IOMixin): Reference
+    
+    lookup(name: string): Reference
+  }
 
-export function config(fn: (builder: TypeBuilder) => void, types?: any): any;
+  export function config(fn: (builder: TypeBuilder) => void, types?: any): any;
 
 }

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -75,8 +75,12 @@ declare module "js-xdr" {  // Primitives Void, Hyper, Int, Float, Double, Quadru
     constructor(maxLength?: number);
   }
 
-  export class Opaque extends IOMixin {
+  export class Opaque extends Buffer implements IOMixin {
     constructor(length: number);
+    static fromXDR(input: Buffer, format?: 'raw'): Opaque
+    static fromXDR(input: string, format: 'hex' | 'base64'): Opaque
+    toXDR(format?: 'raw'): Buffer
+    toXDR(format: 'hex' | 'base64'): string
   }
   export class VarOpaque extends IOMixin {
     constructor(length?: number);
@@ -91,9 +95,9 @@ declare module "js-xdr" {  // Array and VarArray.
     public _childType: T;
     public _length: number;
   }
-  export class VarArray {
-    public _childType: any;
-    public _length: number;
+  export class VarArray<T extends IOMixin> {
+    static _childType: any;
+    static _length: number;
   }
 
   export class ChildStruct extends Struct {
@@ -140,11 +144,7 @@ declare module "js-xdr" {  // Array and VarArray.
 
 
 
-  export class Option<T> extends IOMixin {
-    public _childType: any;
-  }
-
-
+  export type Option<T extends IOMixin> = T | undefined
 }
 
 declare module "js-xdr" {  // `XDR.config`.

--- a/src/@types/xdr.d.ts
+++ b/src/@types/xdr.d.ts
@@ -114,8 +114,9 @@ declare module "js-xdr" {  // Array and VarArray.
   }
   
   
-  export class Struct extends IOMixin {
-    public _attributes: object;
+  export class Struct<TAttributes extends object = object> extends IOMixin {
+    constructor(attributes: TAttributes)
+    public _attributes: TAttributes;
   }
   
   

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -76,7 +76,7 @@ export class Asset {
       case xdr.AssetType.assetTypeCreditAlphanum12():
         anum = anum || assetXdr.alphaNum12();
         issuer = StrKey.encodeEd25519PublicKey(anum.issuer().ed25519());
-        code = trimEnd(anum.assetCode(), '\0');
+        code = trimEnd(String(anum.assetCode()), '\0');
         return new this(code, issuer);
       default:
         throw new Error(`Invalid asset type: ${assetXdr.switch().name}`);

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -88,14 +88,18 @@ declare namespace xdr {  // Array and VarArray.
     static fromXDR(input: string, format: 'hex' | 'base64'): TransactionEnvelope
   }
 
-  export class DecoratedSignature extends Struct {
+  export class DecoratedSignature extends Struct<DecoratedSignature.IAttributes> {
     static fromXDR(input: Buffer, format?: 'raw'): DecoratedSignature
     static fromXDR(input: string, format: 'hex' | 'base64'): DecoratedSignature
 
-    constructor(keys: { hint: SignatureHint; signature: Signature });
-
     hint(): SignatureHint;
-    signature(): Buffer;
+    signature(): Signature;
+  }
+  export namespace DecoratedSignature {
+    export interface IAttributes {
+      hint: SignatureHint
+      signature: Signature
+    }
   }
 
   export class PublicKeyTypeEd25519 extends Struct {

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -198,84 +198,84 @@ declare namespace xdr {  // Array and VarArray.
 
 declare namespace xdr {  // Operations
   export class CreateAccountOp extends Struct<CreateAccountOp> {
-    destination: AccountId
-    startingBalance: Int64
+    destination(): AccountId
+    startingBalance(): Int64
   }
 
 
   export class PaymentOp extends Struct<PaymentOp> {
-    destination: AccountId
-    asset: Asset
-    amount: Int64
+    destination(): AccountId
+    asset(): Asset
+    amount(): Int64
   }
 
 
   export class PathPaymentOp extends Struct<PathPaymentOp> {
-    sendAsset: Asset
-    sendMax: Int64
-    destination: AccountId
-    destAsset: Asset
-    destAmount: Int64
+    sendAsset(): Asset
+    sendMax(): Int64
+    destination(): AccountId
+    destAsset(): Asset
+    destAmount(): Int64
     // ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
   }
 
   export class ManageSellOfferOp extends Struct<ManageSellOfferOp> {
-    selling: Asset
-    buying: Asset
-    amount: Int64
-    price: Price
-    offerId: Int64
+    selling(): Asset
+    buying(): Asset
+    amount(): Int64
+    price(): Price
+    offerId(): Int64
   }
 
 
   export class ManageBuyOfferOp extends Struct<ManageBuyOfferOp> {
-    selling: Asset
-    buying: Asset
-    buyAmount: Int64
-    price: Price
-    offerId: Int64
+    selling(): Asset
+    buying(): Asset
+    buyAmount(): Int64
+    price(): Price
+    offerId(): Int64
   }
 
 
   export class CreatePassiveSellOfferOp extends Struct<CreatePassiveSellOfferOp> {
-    selling: Asset
-    buying: Asset
-    amount: Int64
-    price: Price
+    selling(): Asset
+    buying(): Asset
+    amount(): Int64
+    price(): Price
   }
 
 
   export class SetOptionsOp extends Struct<SetOptionsOp> {
-    inflationDest: AccountId
-    clearFlags: Uint32
-    setFlags: Uint32
-    masterWeight: Uint32
-    lowThreshold: Uint32
-    medThreshold: Uint32
-    highThreshold: Uint32
+    inflationDest(): AccountId
+    clearFlags(): Uint32
+    setFlags(): Uint32
+    masterWeight(): Uint32
+    lowThreshold(): Uint32
+    medThreshold(): Uint32
+    highThreshold(): Uint32
   }
 
   export class ChangeTrustOp extends Struct<ChangeTrustOp> {
-    line: Asset
-    limit: Int64
+    line(): Asset
+    limit(): Int64
   }
 
 
   export class AllowTrustOp extends Struct<AllowTrustOp> {
-    trustor: AccountId
-    asset: AllowTrustOpAsset
-    authorize: Bool
+    trustor(): AccountId
+    asset(): AllowTrustOpAsset
+    authorize(): Bool
   }
 
 
   export class ManageDataOp extends Struct<ManageDataOp> {
-    dataName: String64
-    dataValue: DataValue
+    dataName(): String64
+    dataValue(): DataValue
   }
 
 
   export class BumpSequenceOp extends Struct<BumpSequenceOp> {
-    bumpTo: SequenceNumber
+    bumpTo(): SequenceNumber
   }
 
 

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -39,14 +39,14 @@ declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadrupl
 declare namespace xdr {  // Array and VarArray.
 
   // TS-TODO: Can someone double check this achieve the same as https://github.com/stellar/js-stellar-base/blob/typescript/types/index.d.ts#L530 ?
-  export class Operation<T extends BaseOperation = BaseOperation> extends Struct {
+  export class Operation<T extends BaseOperation = BaseOperation> extends Struct<AbstractAssetAlphaNum> {
     static fromXDR(input: Buffer, format?: 'raw'): Operation
     static fromXDR(input: string, format: 'hex' | 'base64'): Operation
     sourceAccount: Option<AccountId>
     body: OperationBody
   }
 
-  export class AssetType extends Struct {
+  export class AssetType extends Struct<AssetType> {
     static fromXDR(input: Buffer, format?: 'raw'): AssetType
     static fromXDR(input: string, format: 'hex' | 'base64'): AssetType
     static assetTypeNative(): AssetType;
@@ -54,7 +54,7 @@ declare namespace xdr {  // Array and VarArray.
     static assetTypeCreditAlphanum12(): AssetType;
     name: string;
   }
-  export abstract class AbstractAssetAlphaNum<TAssetCode extends Void | AssetCode4 | AssetCode12 = Void | AssetCode4 | AssetCode12> extends Struct {
+  export abstract class AbstractAssetAlphaNum<TAssetCode extends Void | AssetCode4 | AssetCode12 = Void | AssetCode4 | AssetCode12> extends Struct<AbstractAssetAlphaNum> {
     constructor(attributes: {
       assetCode: string,
       issuer: any,
@@ -83,18 +83,19 @@ declare namespace xdr {  // Array and VarArray.
     // },
   }
 
-  export class TransactionEnvelope extends Struct {
+  export class TransactionEnvelope extends Struct<TransactionEnvelope> {
     static fromXDR(input: Buffer, format?: 'raw'): TransactionEnvelope
     static fromXDR(input: string, format: 'hex' | 'base64'): TransactionEnvelope
   }
+  type asdf<TAttributes extends object> = {[key in keyof TAttributes]: () => TAttributes[key]}
 
-  export class DecoratedSignature extends Struct<DecoratedSignature.IAttributes> {
+  export class DecoratedSignature extends Struct<DecoratedSignature> {
     static fromXDR(input: Buffer, format?: 'raw'): DecoratedSignature
     static fromXDR(input: string, format: 'hex' | 'base64'): DecoratedSignature
-
-    hint(): SignatureHint;
-    signature(): Signature;
+    hint(): SignatureHint
+    signature(): Signature
   }
+
   export namespace DecoratedSignature {
     export interface IAttributes {
       hint: SignatureHint
@@ -102,13 +103,13 @@ declare namespace xdr {  // Array and VarArray.
     }
   }
 
-  export class PublicKeyTypeEd25519 extends Struct {
+  export class PublicKeyTypeEd25519 extends Struct<PublicKeyTypeEd25519> {
     static fromXDR(input: Buffer, format?: 'raw'): PublicKeyTypeEd25519
     static fromXDR(input: string, format: 'hex' | 'base64'): PublicKeyTypeEd25519
     constructor(somekindBuffer: Buffer);
   }
 
-  export class Price extends Struct {}
+  export class Price extends Struct<Price> {}
 
   export class OperationBody extends Union {
 
@@ -143,32 +144,32 @@ declare namespace xdr {  // Array and VarArray.
   }
 
 
-  export class TransactionResult extends Struct {
+  export class TransactionResult extends Struct<TransactionResult> {
     static fromXDR(input: Buffer, format?: 'raw'): TransactionResult
     static fromXDR(input: string, format: 'hex' | 'base64'): TransactionResult
   }
 
   export class AllowTrustOpAsset extends Union {}
 
-  export class AllowTrust extends Struct {}
+  export class AllowTrust extends Struct<AllowTrust> {}
 
 }
 
 declare namespace xdr {  // Operations
-  export class CreateAccountOp extends Struct {
+  export class CreateAccountOp extends Struct<CreateAccountOp> {
     destination: AccountId
     startingBalance: Int64
   }
 
 
-  export class PaymentOp extends Struct {
+  export class PaymentOp extends Struct<PaymentOp> {
     destination: AccountId
     asset: Asset
     amount: Int64
   }
 
 
-  export class PathPaymentOp extends Struct {
+  export class PathPaymentOp extends Struct<PathPaymentOp> {
     sendAsset: Asset
     sendMax: Int64
     destination: AccountId
@@ -177,7 +178,7 @@ declare namespace xdr {  // Operations
     // ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
   }
 
-  export class ManageSellOfferOp extends Struct {
+  export class ManageSellOfferOp extends Struct<ManageSellOfferOp> {
     selling: Asset
     buying: Asset
     amount: Int64
@@ -186,7 +187,7 @@ declare namespace xdr {  // Operations
   }
 
 
-  export class ManageBuyOfferOp extends Struct {
+  export class ManageBuyOfferOp extends Struct<ManageBuyOfferOp> {
     selling: Asset
     buying: Asset
     buyAmount: Int64
@@ -195,7 +196,7 @@ declare namespace xdr {  // Operations
   }
 
 
-  export class CreatePassiveSellOfferOp extends Struct {
+  export class CreatePassiveSellOfferOp extends Struct<CreatePassiveSellOfferOp> {
     selling: Asset
     buying: Asset
     amount: Int64
@@ -203,7 +204,7 @@ declare namespace xdr {  // Operations
   }
 
 
-  export class SetOptionsOp extends Struct {
+  export class SetOptionsOp extends Struct<SetOptionsOp> {
     inflationDest: AccountId
     clearFlags: Uint32
     setFlags: Uint32
@@ -213,26 +214,26 @@ declare namespace xdr {  // Operations
     highThreshold: Uint32
   }
 
-  export class ChangeTrustOp extends Struct {
+  export class ChangeTrustOp extends Struct<ChangeTrustOp> {
     line: Asset
     limit: Int64
   }
 
 
-  export class AllowTrustOp extends Struct {
+  export class AllowTrustOp extends Struct<AllowTrustOp> {
     trustor: AccountId
     asset: AllowTrustOpAsset
     authorize: Bool
   }
 
 
-  export class ManageDataOp extends Struct {
+  export class ManageDataOp extends Struct<ManageDataOp> {
     dataName: String64
     dataValue: DataValue
   }
 
 
-  export class BumpSequenceOp extends Struct {
+  export class BumpSequenceOp extends Struct<BumpSequenceOp> {
     bumpTo: SequenceNumber
   }
 

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -36,7 +36,7 @@ declare namespace xdr {  // Array and VarArray.
     static assetTypeCreditAlphanum12(value: AssetAlphaNum4): Asset<AssetType.assetTypeCreditAlphanum12>
     alphaNum12(): T extends AssetType.assetTypeCreditAlphanum12 ? AssetAlphaNum12 : never;
     alphaNum4(): T extends AssetType.assetTypeCreditAlphanum4 ? AssetAlphaNum4 : never;
-    switch(): AssetType;
+    switch(): T;
   }
 
   // TS-TODO: Can someone double check this achieve the same as https://github.com/stellar/js-stellar-base/blob/typescript/types/index.d.ts#L530 ?
@@ -173,10 +173,17 @@ declare namespace xdr {  // Array and VarArray.
     static fromXDR(input: string, format: 'hex' | 'base64'): TransactionResult
   }
 
-  export enum AssetType {
-    assetTypeNative = 0,
-    assetTypeCreditAlphanum4 = 1,
-    assetTypeCreditAlphanum12 = 2,
+  export type AssetType =
+    | AssetType.assetTypeNative
+    | AssetType.assetTypeCreditAlphanum4
+    | AssetType.assetTypeCreditAlphanum12
+  export namespace AssetType {
+    export type assetTypeNative = Enum<'assetTypeNative', 0>
+    export type assetTypeCreditAlphanum4 = Enum<'assetTypeCreditAlphanum4', 1>
+    export type assetTypeCreditAlphanum12 = Enum<'assetTypeCreditAlphanum12', 2>
+    export const assetTypeNative: () => Enum<'assetTypeNative', 0>
+    export const assetTypeCreditAlphanum4: () => Enum<'assetTypeCreditAlphanum4', 1>
+    export const assetTypeCreditAlphanum12: () => Enum<'assetTypeCreditAlphanum12', 2>
   }
   export class AllowTrustOpAsset<T extends AssetType = AssetType> extends UnionWithFunctions<typeof AllowTrustOpAsset> {
     static assetTypeCreditAlphanum4(assetCode: AssetCode4): AllowTrustOpAsset

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -27,7 +27,7 @@ declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadrupl
 
 declare namespace xdr {  // Array and VarArray.
 
-  export class Asset<T extends AssetType = AssetType> extends UnionWithFunctions<typeof Asset> {
+  export class Asset<T extends AssetType = AssetType> extends UnionWithFunctions<typeof Asset, AssetType> {
     static fromXDR(input: Buffer, format?: 'raw'): Asset
     static fromXDR(input: string, format: 'hex' | 'base64'): Asset
     constructor(xdrTypeString: 'assetTypeCreditAlphanum4' | 'assetTypeCreditAlphanum12', xdrType: AssetAlphaNum4 | AssetAlphaNum12)
@@ -36,7 +36,6 @@ declare namespace xdr {  // Array and VarArray.
     static assetTypeCreditAlphanum12(value: AssetAlphaNum4): Asset<AssetType.assetTypeCreditAlphanum12>
     alphaNum12(): T extends AssetType.assetTypeCreditAlphanum12 ? AssetAlphaNum12 : never;
     alphaNum4(): T extends AssetType.assetTypeCreditAlphanum4 ? AssetAlphaNum4 : never;
-    switch(): T;
   }
 
   // TS-TODO: Can someone double check this achieve the same as https://github.com/stellar/js-stellar-base/blob/typescript/types/index.d.ts#L530 ?
@@ -70,7 +69,7 @@ declare namespace xdr {  // Array and VarArray.
     Hash = 3,
     Return = 4,
   }
-  export class Memo<T extends MemoType = MemoType> extends UnionWithFunctions<typeof Memo> {
+  export class Memo<T extends MemoType = MemoType> extends UnionWithFunctions<typeof Memo, MemoType> {
     static fromXDR(input: Buffer, format?: 'raw'): Memo
     static fromXDR(input: string, format: 'hex' | 'base64'): Memo
     static memoNone(): Memo<MemoType.None>
@@ -139,7 +138,7 @@ declare namespace xdr {  // Array and VarArray.
   export enum PublicKeyType {
     publicKeyTypeEd25519 = 0,
   }
-  export class PublicKey<T extends PublicKeyType = PublicKeyType> extends UnionWithConstructors<typeof PublicKey> {
+  export class PublicKey<T extends PublicKeyType = PublicKeyType> extends UnionWithConstructors<typeof PublicKey, PublicKeyType> {
     static publicKeyTypeEd25519: new (...args: ConstructorParameters<typeof PublicKeyTypeEd25519>) => PublicKey<PublicKeyType.publicKeyTypeEd25519>
     ed25519(): T extends PublicKeyType.publicKeyTypeEd25519 ? Uint256 : never
   }
@@ -152,7 +151,7 @@ declare namespace xdr {  // Array and VarArray.
     signerKeyTypePreAuthTx = 1,
     signerKeyTypeHashX = 2,
   }
-  export class SignerKey<T extends SignerKeyType = SignerKeyType> extends UnionWithConstructors<typeof SignerKey> {
+  export class SignerKey<T extends SignerKeyType = SignerKeyType> extends UnionWithConstructors<typeof SignerKey, SignerKeyType> {
     static signerKeyTypeEd25519: new (...args: ConstructorParameters<typeof Uint256>) => SignerKey<SignerKeyType.signerKeyTypeEd25519>
     static signerKeyTypePreAuthTx: new (...args: ConstructorParameters<typeof Uint256>) => SignerKey<SignerKeyType.signerKeyTypePreAuthTx>
     static signerKeyTypeHashX: new (...args: ConstructorParameters<typeof Uint256>) => SignerKey<SignerKeyType.signerKeyTypeHashX>
@@ -185,7 +184,7 @@ declare namespace xdr {  // Array and VarArray.
     export const assetTypeCreditAlphanum4: () => Enum<'assetTypeCreditAlphanum4', 1>
     export const assetTypeCreditAlphanum12: () => Enum<'assetTypeCreditAlphanum12', 2>
   }
-  export class AllowTrustOpAsset<T extends AssetType = AssetType> extends UnionWithFunctions<typeof AllowTrustOpAsset> {
+  export class AllowTrustOpAsset<T extends AssetType = AssetType> extends UnionWithFunctions<typeof AllowTrustOpAsset, AssetType> {
     static assetTypeCreditAlphanum4(assetCode: AssetCode4): AllowTrustOpAsset
     static assetTypeCreditAlphanum12(assetCode: AssetCode12): AllowTrustOpAsset
     assetCode4(): T extends AssetType.assetTypeCreditAlphanum4 ? AssetCode4 : never
@@ -293,7 +292,7 @@ declare namespace xdr {  // Operations
     bumpSequence = 11,
     manageBuyOffer = 12,
   }
-  export class OperationBody<T extends OperationType = OperationType> extends UnionWithFunctions<typeof OperationBody> {
+  export class OperationBody<T extends OperationType = OperationType> extends UnionWithFunctions<typeof OperationBody, OperationType> {
     static createAccount(op: CreateAccountOp): OperationBody<OperationType.createAccount>
     static payment(op: PaymentOp): OperationBody<OperationType.payment>
     static pathPayment(op: PathPaymentOp): OperationBody<OperationType.pathPayment>

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -18,7 +18,7 @@ declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadrupl
   export class AssetCode4 extends Opaque {}
   export class AssetCode12 extends Opaque {}
 
-  export class Asset extends Union {
+  export class Asset extends Union<typeof Asset> {
     static fromXDR(input: Buffer, format?: 'raw'): Asset
     static fromXDR(input: string, format: 'hex' | 'base64'): Asset
     constructor(xdrTypeString: 'assetTypeCreditAlphanum4' | 'assetTypeCreditAlphanum12', xdrType: AssetAlphaNum4 | AssetAlphaNum12)
@@ -77,7 +77,7 @@ declare namespace xdr {  // Array and VarArray.
     static Return(): Enum<'Return', 4>
   }
 
-  export class Memo extends Union {
+  export class Memo extends Union<typeof Memo> {
     static fromXDR(input: Buffer, format?: 'raw'): Memo
     static fromXDR(input: string, format: 'hex' | 'base64'): Memo
     static memoNone(): Memo
@@ -109,7 +109,7 @@ declare namespace xdr {  // Array and VarArray.
     maxTime(): TimePoint
   }
 
-  export class TransactionExt extends Union {}
+  export class TransactionExt extends Union<typeof TransactionExt> {}
 
   export class Transaction extends Struct<Transaction> {
     static fromXDR(input: Buffer, format?: 'raw'): Transaction
@@ -151,38 +151,46 @@ declare namespace xdr {  // Array and VarArray.
     constructor(somekindBuffer: Buffer);
   }
 
-  export class Price extends Struct<Price> {}
+  export class Price extends Struct<Price> {
+    n(): Int32
+    d(): Int32
+  }
 
-  export class OperationBody extends Union {}
-
-  export class PublicKey extends Union {
+  export class PublicKey extends Union<typeof PublicKey> {
     static publicKeyTypeEd25519: typeof PublicKeyTypeEd25519
     ed25519(): Uint256
   }
   export class AccountId extends PublicKey {}
 
-  export class SignerKey extends Union {
-    // switchOn: xdr.lookup("SignerKeyType"),
-    // switchName: "type",
-    // switches: [
-    //   ["signerKeyTypeEd25519", "ed25519"],
-    //   ["signerKeyTypePreAuthTx", "preAuthTx"],
-    //   ["signerKeyTypeHashX", "hashX"],
-    // ],
-    // arms: {
-    //   ed25519: xdr.lookup("Uint256"),
-    //   preAuthTx: xdr.lookup("Uint256"),
-    //   hashX: xdr.lookup("Uint256"),
-    // },
+
+
+  export class SignerKey extends Union<typeof SignerKey> {
+    static signerKeyTypeEd25519(...args: ConstructorParameters<typeof Uint256>): Uint256
+    static signerKeyTypePreAuthTx(...args: ConstructorParameters<typeof Uint256>): Uint256
+    static signerKeyTypeHashX(...args: ConstructorParameters<typeof Uint256>): Uint256
+    ed25519(): Uint256
+    preAuthTx(): Uint256
+    hashX(): Uint256
   }
 
+  export class Signer extends Struct<Signer> {
+    static fromXDR(input: Buffer, format?: 'raw'): Signer
+    static fromXDR(input: string, format: 'hex' | 'base64'): Signer
+    key(): SignerKey
+    weight(): Uint32
+  }
 
   export class TransactionResult extends Struct<TransactionResult> {
     static fromXDR(input: Buffer, format?: 'raw'): TransactionResult
     static fromXDR(input: string, format: 'hex' | 'base64'): TransactionResult
   }
 
-  export class AllowTrustOpAsset extends Union {}
+  export class AllowTrustOpAsset extends Union<typeof AllowTrustOpAsset> {
+    static assetTypeCreditAlphanum4(...args: ConstructorParameters<typeof AssetCode4>): AssetCode4
+    static assetTypeCreditAlphanum12(...args: ConstructorParameters<typeof AssetCode12>): AssetCode12
+    assetCode4(): AssetCode4
+    assetCode12(): AssetCode12
+  }
 
   export class AllowTrust extends Struct<AllowTrust> {}
 
@@ -271,6 +279,35 @@ declare namespace xdr {  // Operations
   }
 
 
+  export class OperationBody extends Union<typeof OperationBody> {
+    // switchOn: xdr.lookup("OperationType"),
+    // switchName: "type",
+    static createAccount(...args: ConstructorParameters<typeof CreateAccountOp>): CreateAccountOp
+    static payment(...args: ConstructorParameters<typeof PaymentOp>): PaymentOp
+    static pathPayment(...args: ConstructorParameters<typeof PathPaymentOp>): PathPaymentOp
+    static manageSellOffer(...args: ConstructorParameters<typeof ManageSellOfferOp>): ManageSellOfferOp
+    static createPassiveSellOffer(...args: ConstructorParameters<typeof CreatePassiveSellOfferOp>): CreatePassiveSellOfferOp
+    static setOption(...args: ConstructorParameters<typeof SetOptionsOp>): SetOptionsOp
+    static changeTrust(...args: ConstructorParameters<typeof ChangeTrustOp>): ChangeTrustOp
+    static allowTrust(...args: ConstructorParameters<typeof AllowTrustOp>): AllowTrustOp
+    static accountMerge(...args: ConstructorParameters<typeof AccountId>): AccountId
+    static inflation(...args: ConstructorParameters<typeof Void>): Void
+    static manageDatum(...args: ConstructorParameters<typeof ManageDataOp>): ManageDataOp
+    static bumpSequence(...args: ConstructorParameters<typeof BumpSequenceOp>): BumpSequenceOp
+    static manageBuyOffer(...args: ConstructorParameters<typeof ManageBuyOfferOp>): ManageBuyOfferOp
+    createAccountOp(): CreateAccountOp
+    paymentOp(): PaymentOp
+    pathPaymentOp(): PathPaymentOp
+    manageSellOfferOp(): ManageSellOfferOp
+    createPassiveSellOfferOp(): CreatePassiveSellOfferOp
+    setOptionsOp(): SetOptionsOp
+    changeTrustOp(): ChangeTrustOp
+    allowTrustOp(): AllowTrustOp
+    destination(): AccountId
+    manageDataOp(): ManageDataOp
+    bumpSequenceOp(): BumpSequenceOp
+    manageBuyOfferOp(): ManageBuyOfferOp
+  }
 
 }
 

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -1,5 +1,5 @@
 import { Operation as BaseOperation } from '../operation';
-import { Struct, Opaque, Void, Union, Hyper, UnsignedHyper, UnsignedInt, Int, VarOpaque, String as StringXDR, Bool, Option } from 'js-xdr';
+import { Struct, Opaque, Void, Union, Hyper, UnsignedHyper, UnsignedInt, Int, VarOpaque, String as StringXDR, Bool, Option, Enum } from 'js-xdr';
 
 declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadruple, Bool, String, Opaque, VarOpaque.
 
@@ -39,7 +39,7 @@ declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadrupl
 declare namespace xdr {  // Array and VarArray.
 
   // TS-TODO: Can someone double check this achieve the same as https://github.com/stellar/js-stellar-base/blob/typescript/types/index.d.ts#L530 ?
-  export class Operation<T extends BaseOperation = BaseOperation> extends Struct<AbstractAssetAlphaNum> {
+  export class Operation<T extends BaseOperation = BaseOperation> extends Struct {
     static fromXDR(input: Buffer, format?: 'raw'): Operation
     static fromXDR(input: string, format: 'hex' | 'base64'): Operation
     sourceAccount: Option<AccountId>
@@ -63,9 +63,22 @@ declare namespace xdr {  // Array and VarArray.
     issuer(): any;
   }
 
+  export class MemoType extends Enum<never, never> {
+    static None: Enum<'None', 0>
+    static Text: Enum<'Text', 1>
+    static Id: Enum<'Id', 2>
+    static Hash: Enum<'Hash', 3>
+    static Return: Enum<'Return', 4>
+  }
+
   export class Memo extends Union {
     static fromXDR(input: Buffer, format?: 'raw'): Memo
     static fromXDR(input: string, format: 'hex' | 'base64'): Memo
+    static memoNone(): Memo
+    static memoText(value: StringXDR): Memo
+    static memoId(value: Uint64): Memo
+    static memoHash(value: Hash): Memo
+    static memoReturn(value: Hash): Memo
     // switchOn: xdr.lookup("MemoType"),
     // switchName: "type",
     // switches: [

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -1,19 +1,14 @@
 import { Operation as BaseOperation } from '../operation';
+import { Struct, Opaque, Void } from 'js-xdr';
 
 declare namespace xdr {
-  export class XDRStruct {
-    static fromXDR(xdr: Buffer): XDRStruct;
-
-    toXDR(base?: string): Buffer;
-    toXDR(encoding: string): string;
-  }
 
   // TS-TODO: Can someone double check this achieve the same as https://github.com/stellar/js-stellar-base/blob/typescript/types/index.d.ts#L530 ?
-  export class Operation<T extends BaseOperation = BaseOperation> extends XDRStruct {
+  export class Operation<T extends BaseOperation = BaseOperation> extends Struct {
     static fromXDR(xdr: Buffer): Operation;
   }
 
-  export class AssetType extends XDRStruct {
+  export class AssetType extends Struct {
     static fromXDR(xdr: Buffer): AssetType;
     static assetTypeNative(): AssetType;
     static assetTypeCreditAlphanum4(): AssetType;
@@ -21,7 +16,10 @@ declare namespace xdr {
     name: string;
   }
 
-  export class Asset extends XDRStruct {
+  export class AssetCode4 extends Opaque {}
+  export class AssetCode12 extends Opaque {}
+
+  export class Asset extends Struct {
     constructor(xdrTypeString: 'assetTypeCreditAlphanum4' | 'assetTypeCreditAlphanum12', xdrType: AssetAlphaNum4 | AssetAlphaNum12)
     static fromXDR(xdr: Buffer): Asset;
     static assetTypeNative(): Asset;
@@ -30,28 +28,28 @@ declare namespace xdr {
     switch(): AssetType;
   }
 
-  export abstract class AbstractAssetAlphaNum extends XDRStruct {
+  export abstract class AbstractAssetAlphaNum<TAssetCode extends Void | AssetCode4 | AssetCode12 = Void | AssetCode4 | AssetCode12> extends Struct {
     constructor(attributes: {
       assetCode: string,
       issuer: any,
     })
-    assetCode(): any;
+    assetCode(): TAssetCode;
     issuer(): any;
   }
-  export class AssetAlphaNum4 extends AbstractAssetAlphaNum {
+  export class AssetAlphaNum4 extends AbstractAssetAlphaNum<AssetCode4> {
   }
-  export class AssetAlphaNum12 extends AbstractAssetAlphaNum {
+  export class AssetAlphaNum12 extends AbstractAssetAlphaNum<AssetCode12> {
   }
 
-  export class Memo extends XDRStruct {
+  export class Memo extends Struct {
     static fromXDR(xdr: Buffer): Memo;
   }
 
-  export class TransactionEnvelope extends XDRStruct {
+  export class TransactionEnvelope extends Struct {
     static fromXDR(xdr: Buffer): TransactionEnvelope;
   }
 
-  export class DecoratedSignature extends XDRStruct {
+  export class DecoratedSignature extends Struct {
     static fromXDR(xdr: Buffer): DecoratedSignature;
 
     constructor(keys: { hint: SignatureHint; signature: Signature });
@@ -60,20 +58,20 @@ declare namespace xdr {
     signature(): Buffer;
   }
 
-  export class PublicKeyTypeEd25519 extends XDRStruct {
+  export class PublicKeyTypeEd25519 extends Struct {
       constructor(somekindBuffer: Buffer);
   }
-  export class AccountId extends XDRStruct {
+  export class AccountId extends Struct {
     static publicKeyTypeEd25519: typeof PublicKeyTypeEd25519
   }
-  export class PublicKey extends XDRStruct {
+  export class PublicKey extends Struct {
     static publicKeyTypeEd25519: typeof PublicKeyTypeEd25519
   }
 
   export type SignatureHint = Buffer;
   export type Signature = Buffer;
 
-  export class TransactionResult extends XDRStruct {
+  export class TransactionResult extends Struct {
     static fromXDR(xdr: Buffer): TransactionResult;
   }
 }

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -1,5 +1,5 @@
 import { Operation as BaseOperation } from '../operation';
-import { Struct, Opaque, Void, Union, Hyper, UnsignedHyper, UnsignedInt, Int, VarOpaque, String as StringXDR, Bool, Option, Enum } from 'js-xdr';
+import { Struct, Opaque, Void, Union, Hyper, UnsignedHyper, UnsignedInt, Int, VarOpaque, String as StringXDR, Bool, Option, Enum, VarArray } from 'js-xdr';
 
 declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadruple, Bool, String, Opaque, VarOpaque.
 
@@ -63,12 +63,18 @@ declare namespace xdr {  // Array and VarArray.
     issuer(): any;
   }
 
+  export class EnvelopeType extends Enum<never, never> {
+    static envelopeTypeScp(): Enum<'envelopeTypeScp', 1>
+    static envelopeTypeTx(): Enum<'envelopeTypeTx', 2>
+    static envelopeTypeAuth(): Enum<'envelopeTypeAuth', 3>
+    static envelopeTypeScpvalue(): Enum<'envelopeTypeScpvalue', 4>
+  }
   export class MemoType extends Enum<never, never> {
-    static None: Enum<'None', 0>
-    static Text: Enum<'Text', 1>
-    static Id: Enum<'Id', 2>
-    static Hash: Enum<'Hash', 3>
-    static Return: Enum<'Return', 4>
+    static None(): Enum<'None', 0>
+    static Text(): Enum<'Text', 1>
+    static Id(): Enum<'Id', 2>
+    static Hash(): Enum<'Hash', 3>
+    static Return(): Enum<'Return', 4>
   }
 
   export class Memo extends Union {
@@ -96,9 +102,32 @@ declare namespace xdr {  // Array and VarArray.
     // },
   }
 
+  export class TimeBounds extends Struct<TimeBounds> {
+    static fromXDR(input: Buffer, format?: 'raw'): TimeBounds
+    static fromXDR(input: string, format: 'hex' | 'base64'): TimeBounds
+    minTime(): TimePoint
+    maxTime(): TimePoint
+  }
+
+  export class TransactionExt extends Union {}
+
+  export class Transaction extends Struct<Transaction> {
+    static fromXDR(input: Buffer, format?: 'raw'): Transaction
+    static fromXDR(input: string, format: 'hex' | 'base64'): Transaction
+    sourceAccount(): AccountId
+    fee(): Uint32
+    seqNum(): SequenceNumber
+    timeBounds(): Option<TimeBounds>
+    memo(): Memo
+    operations(): VarArray<Operation>
+    ext(): TransactionExt
+  }
+
   export class TransactionEnvelope extends Struct<TransactionEnvelope> {
     static fromXDR(input: Buffer, format?: 'raw'): TransactionEnvelope
     static fromXDR(input: string, format: 'hex' | 'base64'): TransactionEnvelope
+    tx(): Transaction
+    signatures(): VarArray<DecoratedSignature>
   }
   type asdf<TAttributes extends object> = {[key in keyof TAttributes]: () => TAttributes[key]}
 
@@ -124,20 +153,11 @@ declare namespace xdr {  // Array and VarArray.
 
   export class Price extends Struct<Price> {}
 
-  export class OperationBody extends Union {
-
-  }
+  export class OperationBody extends Union {}
 
   export class PublicKey extends Union {
     static publicKeyTypeEd25519: typeof PublicKeyTypeEd25519
-    // switchOn: xdr.lookup("PublicKeyType"),
-    // switchName: "type",
-    // switches: [
-    //   ["publicKeyTypeEd25519", "ed25519"],
-    // ],
-    // arms: {
-    //   ed25519: xdr.lookup("Uint256"),
-    // },
+    ed25519(): Uint256
   }
   export class AccountId extends PublicKey {}
 

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -1,20 +1,8 @@
 import { Operation as BaseOperation } from '../operation';
-import { Struct, Opaque, Void } from 'js-xdr';
+import { Struct, Opaque, Void, Union } from 'js-xdr';
 
-declare namespace xdr {
+declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadruple, Bool, String, Opaque, VarOpaque.
 
-  // TS-TODO: Can someone double check this achieve the same as https://github.com/stellar/js-stellar-base/blob/typescript/types/index.d.ts#L530 ?
-  export class Operation<T extends BaseOperation = BaseOperation> extends Struct {
-    static fromXDR(xdr: Buffer): Operation;
-  }
-
-  export class AssetType extends Struct {
-    static fromXDR(xdr: Buffer): AssetType;
-    static assetTypeNative(): AssetType;
-    static assetTypeCreditAlphanum4(): AssetType;
-    static assetTypeCreditAlphanum12(): AssetType;
-    name: string;
-  }
 
   export class AssetCode4 extends Opaque {}
   export class AssetCode12 extends Opaque {}
@@ -28,6 +16,30 @@ declare namespace xdr {
     switch(): AssetType;
   }
 
+  export class AssetAlphaNum4 extends AbstractAssetAlphaNum<AssetCode4> {
+  }
+  export class AssetAlphaNum12 extends AbstractAssetAlphaNum<AssetCode12> {
+  }
+
+  export type SignatureHint = Buffer;
+  export type Signature = Buffer;
+
+}
+
+declare namespace xdr {  // Array and VarArray.
+
+  // TS-TODO: Can someone double check this achieve the same as https://github.com/stellar/js-stellar-base/blob/typescript/types/index.d.ts#L530 ?
+  export class Operation<T extends BaseOperation = BaseOperation> extends Struct {
+    static fromXDR(xdr: Buffer): Operation;
+  }
+
+  export class AssetType extends Struct {
+    static fromXDR(xdr: Buffer): AssetType;
+    static assetTypeNative(): AssetType;
+    static assetTypeCreditAlphanum4(): AssetType;
+    static assetTypeCreditAlphanum12(): AssetType;
+    name: string;
+  }
   export abstract class AbstractAssetAlphaNum<TAssetCode extends Void | AssetCode4 | AssetCode12 = Void | AssetCode4 | AssetCode12> extends Struct {
     constructor(attributes: {
       assetCode: string,
@@ -35,10 +47,6 @@ declare namespace xdr {
     })
     assetCode(): TAssetCode;
     issuer(): any;
-  }
-  export class AssetAlphaNum4 extends AbstractAssetAlphaNum<AssetCode4> {
-  }
-  export class AssetAlphaNum12 extends AbstractAssetAlphaNum<AssetCode12> {
   }
 
   export class Memo extends Struct {
@@ -61,6 +69,14 @@ declare namespace xdr {
   export class PublicKeyTypeEd25519 extends Struct {
       constructor(somekindBuffer: Buffer);
   }
+
+  export class Price extends Struct {
+  }
+
+  export class OperationBody extends Union {
+
+  }
+
   export class AccountId extends Struct {
     static publicKeyTypeEd25519: typeof PublicKeyTypeEd25519
   }
@@ -68,13 +84,11 @@ declare namespace xdr {
     static publicKeyTypeEd25519: typeof PublicKeyTypeEd25519
   }
 
-  export type SignatureHint = Buffer;
-  export type Signature = Buffer;
-
   export class TransactionResult extends Struct {
     static fromXDR(xdr: Buffer): TransactionResult;
   }
 }
+
 
 export default xdr
 // export as namespace xdr

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -60,6 +60,16 @@ declare namespace xdr {
     signature(): Buffer;
   }
 
+  export class PublicKeyTypeEd25519 extends XDRStruct {
+      constructor(somekindBuffer: Buffer);
+  }
+  export class AccountId extends XDRStruct {
+    static publicKeyTypeEd25519: typeof PublicKeyTypeEd25519
+  }
+  export class PublicKey extends XDRStruct {
+    static publicKeyTypeEd25519: typeof PublicKeyTypeEd25519
+  }
+
   export type SignatureHint = Buffer;
   export type Signature = Buffer;
 

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -1,5 +1,5 @@
 import { Operation as BaseOperation } from '../operation';
-import { Struct, Opaque, Void, Union, Hyper, UnsignedHyper, UnsignedInt, Int, VarOpaque, String as StringXDR, Bool } from 'js-xdr';
+import { Struct, Opaque, Void, Union, Hyper, UnsignedHyper, UnsignedInt, Int, VarOpaque, String as StringXDR, Bool, Option } from 'js-xdr';
 
 declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadruple, Bool, String, Opaque, VarOpaque.
 
@@ -18,9 +18,10 @@ declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadrupl
   export class AssetCode4 extends Opaque {}
   export class AssetCode12 extends Opaque {}
 
-  export class Asset extends Struct {
+  export class Asset extends Union {
+    static fromXDR(input: Buffer, format?: 'raw'): Asset
+    static fromXDR(input: string, format: 'hex' | 'base64'): Asset
     constructor(xdrTypeString: 'assetTypeCreditAlphanum4' | 'assetTypeCreditAlphanum12', xdrType: AssetAlphaNum4 | AssetAlphaNum12)
-    static fromXDR(xdr: Buffer): Asset;
     static assetTypeNative(): Asset;
     alphaNum12(): AssetAlphaNum12;
     alphaNum4(): AssetAlphaNum4;
@@ -39,11 +40,15 @@ declare namespace xdr {  // Array and VarArray.
 
   // TS-TODO: Can someone double check this achieve the same as https://github.com/stellar/js-stellar-base/blob/typescript/types/index.d.ts#L530 ?
   export class Operation<T extends BaseOperation = BaseOperation> extends Struct {
-    static fromXDR(xdr: Buffer): Operation;
+    static fromXDR(input: Buffer, format?: 'raw'): Operation
+    static fromXDR(input: string, format: 'hex' | 'base64'): Operation
+    sourceAccount: Option<AccountId>
+    body: OperationBody
   }
 
   export class AssetType extends Struct {
-    static fromXDR(xdr: Buffer): AssetType;
+    static fromXDR(input: Buffer, format?: 'raw'): AssetType
+    static fromXDR(input: string, format: 'hex' | 'base64'): AssetType
     static assetTypeNative(): AssetType;
     static assetTypeCreditAlphanum4(): AssetType;
     static assetTypeCreditAlphanum12(): AssetType;
@@ -58,16 +63,34 @@ declare namespace xdr {  // Array and VarArray.
     issuer(): any;
   }
 
-  export class Memo extends Struct {
-    static fromXDR(xdr: Buffer): Memo;
+  export class Memo extends Union {
+    static fromXDR(input: Buffer, format?: 'raw'): Memo
+    static fromXDR(input: string, format: 'hex' | 'base64'): Memo
+    // switchOn: xdr.lookup("MemoType"),
+    // switchName: "type",
+    // switches: [
+    //   ["memoNone", xdr.void()],
+    //   ["memoText", "text"],
+    //   ["memoId", "id"],
+    //   ["memoHash", "hash"],
+    //   ["memoReturn", "retHash"],
+    // ],
+    // arms: {
+    //   text: xdr.string(28),
+    //   id: xdr.lookup("Uint64"),
+    //   hash: xdr.lookup("Hash"),
+    //   retHash: xdr.lookup("Hash"),
+    // },
   }
 
   export class TransactionEnvelope extends Struct {
-    static fromXDR(xdr: Buffer): TransactionEnvelope;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionEnvelope
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionEnvelope
   }
 
   export class DecoratedSignature extends Struct {
-    static fromXDR(xdr: Buffer): DecoratedSignature;
+    static fromXDR(input: Buffer, format?: 'raw'): DecoratedSignature
+    static fromXDR(input: string, format: 'hex' | 'base64'): DecoratedSignature
 
     constructor(keys: { hint: SignatureHint; signature: Signature });
 
@@ -76,8 +99,8 @@ declare namespace xdr {  // Array and VarArray.
   }
 
   export class PublicKeyTypeEd25519 extends Struct {
-    static fromXDR(xdr: Buffer): PublicKeyTypeEd25519;
-    toXDR(): Buffer;
+    static fromXDR(input: Buffer, format?: 'raw'): PublicKeyTypeEd25519
+    static fromXDR(input: string, format: 'hex' | 'base64'): PublicKeyTypeEd25519
     constructor(somekindBuffer: Buffer);
   }
 
@@ -117,7 +140,8 @@ declare namespace xdr {  // Array and VarArray.
 
 
   export class TransactionResult extends Struct {
-    static fromXDR(xdr: Buffer): TransactionResult;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResult
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionResult
   }
 
   export class AllowTrustOpAsset extends Union {}

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -277,20 +277,47 @@ declare namespace xdr {  // Operations
     bumpTo(): SequenceNumber
   }
 
-  export enum OperationType {
-    createAccount = 0,
-    payment = 1,
-    pathPayment = 2,
-    manageSellOffer = 3,
-    createPassiveSellOffer = 4,
-    setOption = 5,
-    changeTrust = 6,
-    allowTrust = 7,
-    accountMerge = 8,
-    inflation = 9,
-    manageDatum = 10,
-    bumpSequence = 11,
-    manageBuyOffer = 12,
+  export type OperationType =
+    | OperationType.createAccount
+    | OperationType.payment
+    | OperationType.pathPayment
+    | OperationType.manageSellOffer
+    | OperationType.createPassiveSellOffer
+    | OperationType.setOption
+    | OperationType.changeTrust
+    | OperationType.allowTrust
+    | OperationType.accountMerge
+    | OperationType.inflation
+    | OperationType.manageDatum
+    | OperationType.bumpSequence
+    | OperationType.manageBuyOffer
+  export namespace OperationType {
+    export type createAccount = Enum<'createAccount', 0>
+    export type payment = Enum<'payment', 1>
+    export type pathPayment = Enum<'pathPayment', 2>
+    export type manageSellOffer = Enum<'manageSellOffer', 3>
+    export type createPassiveSellOffer = Enum<'createPassiveSellOffer', 4>
+    export type setOption = Enum<'setOption', 5>
+    export type changeTrust = Enum<'changeTrust', 6>
+    export type allowTrust = Enum<'allowTrust', 7>
+    export type accountMerge = Enum<'accountMerge', 8>
+    export type inflation = Enum<'inflation', 9>
+    export type manageDatum = Enum<'manageDatum', 10>
+    export type bumpSequence = Enum<'bumpSequence', 11>
+    export type manageBuyOffer = Enum<'manageBuyOffer', 12>
+    export const createAccount: () => createAccount
+    export const payment: () => payment
+    export const pathPayment: () => pathPayment
+    export const manageSellOffer: () => manageSellOffer
+    export const createPassiveSellOffer: () => createPassiveSellOffer
+    export const setOption: () => setOption
+    export const changeTrust: () => changeTrust
+    export const allowTrust: () => allowTrust
+    export const accountMerge: () => accountMerge
+    export const inflation: () => inflation
+    export const manageDatum: () => manageDatum
+    export const bumpSequence: () => bumpSequence
+    export const manageBuyOffer: () => manageBuyOffer
   }
   export class OperationBody<T extends OperationType = OperationType> extends UnionWithFunctions<typeof OperationBody, OperationType> {
     static createAccount(op: CreateAccountOp): OperationBody<OperationType.createAccount>

--- a/src/generated/stellar-xdr_generated.d.ts
+++ b/src/generated/stellar-xdr_generated.d.ts
@@ -1,9 +1,20 @@
 import { Operation as BaseOperation } from '../operation';
-import { Struct, Opaque, Void, Union } from 'js-xdr';
+import { Struct, Opaque, Void, Union, Hyper, UnsignedHyper, UnsignedInt, Int, VarOpaque, String as StringXDR, Bool } from 'js-xdr';
 
 declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadruple, Bool, String, Opaque, VarOpaque.
 
-
+  export class Hash extends Opaque {}
+  export class Uint256 extends Opaque {}
+  export class Uint32 extends UnsignedInt {}
+  export class Int32 extends Int {}
+  export class Uint64 extends UnsignedHyper {}
+  export class Int64 extends Hyper {}
+  export class Thresholds extends Opaque {}
+  export class String32 extends StringXDR {}
+  export class String64 extends StringXDR {}
+  export class SequenceNumber extends Int64 {}
+  export class TimePoint extends Uint64 {}
+  export class DataValue extends VarOpaque {}
   export class AssetCode4 extends Opaque {}
   export class AssetCode12 extends Opaque {}
 
@@ -16,10 +27,8 @@ declare namespace xdr {  // Primitives Void, Hyper, Int, Float, Double, Quadrupl
     switch(): AssetType;
   }
 
-  export class AssetAlphaNum4 extends AbstractAssetAlphaNum<AssetCode4> {
-  }
-  export class AssetAlphaNum12 extends AbstractAssetAlphaNum<AssetCode12> {
-  }
+  export class AssetAlphaNum4 extends AbstractAssetAlphaNum<AssetCode4> {}
+  export class AssetAlphaNum12 extends AbstractAssetAlphaNum<AssetCode12> {}
 
   export type SignatureHint = Buffer;
   export type Signature = Buffer;
@@ -67,27 +76,143 @@ declare namespace xdr {  // Array and VarArray.
   }
 
   export class PublicKeyTypeEd25519 extends Struct {
-      constructor(somekindBuffer: Buffer);
+    static fromXDR(xdr: Buffer): PublicKeyTypeEd25519;
+    toXDR(): Buffer;
+    constructor(somekindBuffer: Buffer);
   }
 
-  export class Price extends Struct {
-  }
+  export class Price extends Struct {}
 
   export class OperationBody extends Union {
 
   }
 
-  export class AccountId extends Struct {
+  export class PublicKey extends Union {
     static publicKeyTypeEd25519: typeof PublicKeyTypeEd25519
+    // switchOn: xdr.lookup("PublicKeyType"),
+    // switchName: "type",
+    // switches: [
+    //   ["publicKeyTypeEd25519", "ed25519"],
+    // ],
+    // arms: {
+    //   ed25519: xdr.lookup("Uint256"),
+    // },
   }
-  export class PublicKey extends Struct {
-    static publicKeyTypeEd25519: typeof PublicKeyTypeEd25519
+  export class AccountId extends PublicKey {}
+
+  export class SignerKey extends Union {
+    // switchOn: xdr.lookup("SignerKeyType"),
+    // switchName: "type",
+    // switches: [
+    //   ["signerKeyTypeEd25519", "ed25519"],
+    //   ["signerKeyTypePreAuthTx", "preAuthTx"],
+    //   ["signerKeyTypeHashX", "hashX"],
+    // ],
+    // arms: {
+    //   ed25519: xdr.lookup("Uint256"),
+    //   preAuthTx: xdr.lookup("Uint256"),
+    //   hashX: xdr.lookup("Uint256"),
+    // },
   }
+
 
   export class TransactionResult extends Struct {
     static fromXDR(xdr: Buffer): TransactionResult;
   }
+
+  export class AllowTrustOpAsset extends Union {}
+
+  export class AllowTrust extends Struct {}
+
 }
+
+declare namespace xdr {  // Operations
+  export class CreateAccountOp extends Struct {
+    destination: AccountId
+    startingBalance: Int64
+  }
+
+
+  export class PaymentOp extends Struct {
+    destination: AccountId
+    asset: Asset
+    amount: Int64
+  }
+
+
+  export class PathPaymentOp extends Struct {
+    sendAsset: Asset
+    sendMax: Int64
+    destination: AccountId
+    destAsset: Asset
+    destAmount: Int64
+    // ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
+  }
+
+  export class ManageSellOfferOp extends Struct {
+    selling: Asset
+    buying: Asset
+    amount: Int64
+    price: Price
+    offerId: Int64
+  }
+
+
+  export class ManageBuyOfferOp extends Struct {
+    selling: Asset
+    buying: Asset
+    buyAmount: Int64
+    price: Price
+    offerId: Int64
+  }
+
+
+  export class CreatePassiveSellOfferOp extends Struct {
+    selling: Asset
+    buying: Asset
+    amount: Int64
+    price: Price
+  }
+
+
+  export class SetOptionsOp extends Struct {
+    inflationDest: AccountId
+    clearFlags: Uint32
+    setFlags: Uint32
+    masterWeight: Uint32
+    lowThreshold: Uint32
+    medThreshold: Uint32
+    highThreshold: Uint32
+  }
+
+  export class ChangeTrustOp extends Struct {
+    line: Asset
+    limit: Int64
+  }
+
+
+  export class AllowTrustOp extends Struct {
+    trustor: AccountId
+    asset: AllowTrustOpAsset
+    authorize: Bool
+  }
+
+
+  export class ManageDataOp extends Struct {
+    dataName: String64
+    dataValue: DataValue
+  }
+
+
+  export class BumpSequenceOp extends Struct {
+    bumpTo: SequenceNumber
+  }
+
+
+
+}
+
+
 
 
 export default xdr

--- a/src/keypair.ts
+++ b/src/keypair.ts
@@ -150,7 +150,7 @@ export class Keypair {
     return this._publicKey;
   }
 
-  public signatureHint() {
+  public signatureHint(): Buffer {
     const a = this.xdrAccountId().toXDR();
 
     return a.slice(a.length - 4);
@@ -221,7 +221,7 @@ export class Keypair {
     return verify(data, signature, this._publicKey);
   }
 
-  public signDecorated(data: Buffer) {
+  public signDecorated(data: Buffer): xdr.DecoratedSignature {
     const signature = this.sign(data);
     const hint = this.signatureHint();
 

--- a/src/memo.ts
+++ b/src/memo.ts
@@ -148,13 +148,13 @@ export class Memo<T extends MemoType = MemoType> {
     }
   }
 
-  static _validateTextValue(value: MemoValue<MemoType.Text>) {
+  static _validateTextValue(value: MemoValue<MemoType.Text>): void {
     if (!xdr.Memo.armTypeForArm('text').isValid(value)) {
       throw new Error('Expects string, array or buffer, max 28 bytes');
     }
   }
 
-  static _validateHashValue(value: MemoValue<MemoType.Hash>) {
+  static _validateHashValue(value: MemoValue<MemoType.Hash>): void {
     const error = new Error(
       `Expects a 32 byte hash value or hex encoded string. Got ${value}`
     );

--- a/src/memo.ts
+++ b/src/memo.ts
@@ -5,45 +5,44 @@ import { UnsignedHyper } from 'js-xdr';
 import BigNumber from 'bignumber.js';
 import xdr from './generated/stellar-xdr_generated';
 
-/**
- * Type of {@link Memo}.
- */
-export const MemoNone = 'none';
-/**
- * Type of {@link Memo}.
- */
-export const MemoID = 'id';
-/**
- * Type of {@link Memo}.
- */
-export const MemoText = 'text';
-/**
- * Type of {@link Memo}.
- */
-export const MemoHash = 'hash';
-/**
- * Type of {@link Memo}.
- */
-export const MemoReturn = 'return';
-
-export namespace MemoType {
-  export type None = typeof MemoNone;
-  export type ID = typeof MemoID;
-  export type Text = typeof MemoText;
-  export type Hash = typeof MemoHash;
-  export type Return = typeof MemoReturn;
+export enum MemoType {
+  None = 'none',
+  Text = 'text',
+  Id = 'id',
+  Hash = 'hash',
+  Return = 'return',
 }
 
-export type MemoType =
-  | MemoType.None
-  | MemoType.ID
-  | MemoType.Text
-  | MemoType.Hash
-  | MemoType.Return;
+/**
+ * Type of {@link Memo}.
+ * @deprecated use `(MemoType.None)` instead.
+ */
+export const MemoNone = (MemoType.None);
+/**
+ * Type of {@link Memo}.
+ * @deprecated use `MemoType.Id` instead.
+ */
+export const MemoID = MemoType.Id;
+/**
+ * Type of {@link Memo}.
+ * @deprecated use `MemoType.Text` instead.
+ */
+export const MemoText = MemoType.Text;
+/**
+ * Type of {@link Memo}.
+ * @deprecated use `MemoType.Hash` instead.
+ */
+export const MemoHash = MemoType.Hash;
+/**
+ * Type of {@link Memo}.
+ * @deprecated use `MemoType.Return` instead.
+ */
+export const MemoReturn = MemoType.Return;
+
 
 export type MemoValue<T> =
   T extends MemoType.None ? null :
-  T extends MemoType.ID ? string :
+  T extends MemoType.Id ? string :
   T extends MemoType.Text ? string | Buffer : // github.com/stellar/js-stellar-base/issues/152
   T extends MemoType.Hash ? string | Buffer :
   T extends MemoType.Return ? string | Buffer
@@ -52,8 +51,8 @@ export type MemoValue<T> =
 /**
  * `Memo` represents memos attached to transactions.
  *
- * @param {string} memoType - `MemoNone`, `MemoID`, `MemoText`, `MemoHash` or `MemoReturn`
- * @param {*} value - `string` for `MemoID`, `MemoText`, buffer of hex string for `MemoHash` or `MemoReturn`
+ * @param {string} memoType - `(MemoType.None)`, `MemoType.Id`, `MemoType.Text`, `MemoType.Hash` or `MemoType.Return`
+ * @param {*} value - `string` for `MemoType.Id`, `MemoType.Text`, buffer of hex string for `MemoType.Hash` or `MemoType.Return`
  * @see [Transactions concept](https://www.stellar.org/developers/learn/concepts/transactions.html)
  * @class Memo
  */
@@ -66,16 +65,16 @@ export class Memo<T extends MemoType = MemoType> {
     this._value = value as MemoValue<T>;
 
     switch (this._type) {
-      case MemoNone:
+      case (MemoType.None):
         break;
-      case MemoID:
-        Memo._validateIdValue(value as MemoValue<MemoType.ID>);
+      case MemoType.Id:
+        Memo._validateIdValue(value as MemoValue<MemoType.Id>);
         break;
-      case MemoText:
+      case MemoType.Text:
         Memo._validateTextValue(value as MemoValue<MemoType.Text>);
         break;
-      case MemoHash:
-      case MemoReturn:
+      case MemoType.Hash:
+      case MemoType.Return:
         Memo._validateHashValue(value as MemoValue<MemoType.Hash>);
         // We want MemoHash and MemoReturn to have Buffer as a value
         if (isString(value)) {
@@ -88,7 +87,7 @@ export class Memo<T extends MemoType = MemoType> {
   }
 
   /**
-   * Contains memo type: `MemoNone`, `MemoID`, `MemoText`, `MemoHash` or `MemoReturn`
+   * Contains memo type: `(MemoType.None)`, `MemoType.Id`, `MemoType.Text`, `MemoType.Hash` or `MemoType.Return`.
    */
   get type(): T {
     return clone(this._type);
@@ -100,20 +99,20 @@ export class Memo<T extends MemoType = MemoType> {
 
   /**
    * Contains memo value:
-   * * `null` for `MemoNone`,
-   * * `string` for `MemoID`,
-   * * `Buffer` for `MemoText` after decoding using `fromXDRObject`, original value otherwise,
-   * * `Buffer` for `MemoHash`, `MemoReturn`.
+   * * `null` for `(MemoType.None)`,
+   * * `string` for `MemoType.Id`,
+   * * `Buffer` for `MemoType.Text` after decoding using `fromXDRObject`, original value otherwise,
+   * * `Buffer` for `MemoType.Hash`, `MemoType.Return`.
    */
   get value(): MemoValue<T> {
     switch (this._type) {
-      case MemoNone:
+      case (MemoType.None):
         return null as MemoValue<T>;
-      case MemoID:
+      case MemoType.Id:
       case MemoText:
         return clone(this._value);
-      case MemoHash:
-      case MemoReturn:
+      case MemoType.Hash:
+      case MemoType.Return:
         return Buffer.from(this._value as string) as MemoValue<T>;
       default:
         throw new Error('Invalid memo type');
@@ -124,7 +123,7 @@ export class Memo<T extends MemoType = MemoType> {
     throw new Error('Memo is immutable');
   }
 
-  static _validateIdValue(value: MemoValue<MemoType.ID>) {
+  static _validateIdValue(value: MemoValue<MemoType.Id>) {
     const error = new Error(`Expects a int64 as a string. Got ${value}`);
 
     if (!isString(value)) {
@@ -182,47 +181,47 @@ export class Memo<T extends MemoType = MemoType> {
   }
 
   /**
-   * Returns an empty memo (`MemoNone`).
+   * Returns an empty memo (`(MemoType.None)`).
    * @returns {Memo}
    */
   static none(): Memo {
-    return new Memo(MemoNone);
+    return new Memo((MemoType.None));
   }
 
   /**
-   * Creates and returns a `MemoText` memo.
+   * Creates and returns a `MemoType.Text` memo.
    * @param {string} text - memo text
    * @returns {Memo}
    */
   static text(text: MemoValue<MemoType.Text>): Memo {
-    return new Memo(MemoText, text);
+    return new Memo(MemoType.Text, text);
   }
 
   /**
-   * Creates and returns a `MemoID` memo.
+   * Creates and returns a `MemoType.Id` memo.
    * @param {string} id - 64-bit number represented as a string
    * @returns {Memo}
    */
-  static id(id: MemoValue<MemoType.ID>): Memo {
-    return new Memo(MemoID, id);
+  static id(id: MemoValue<MemoType.Id>): Memo {
+    return new Memo(MemoType.Id, id);
   }
 
   /**
-   * Creates and returns a `MemoHash` memo.
+   * Creates and returns a `MemoType.Hash` memo.
    * @param {array|string} hash - 32 byte hash or hex encoded string
    * @returns {Memo}
    */
   static hash(hash: MemoValue<MemoType.Hash>): Memo {
-    return new Memo(MemoHash, hash);
+    return new Memo(MemoType.Hash, hash);
   }
 
   /**
-   * Creates and returns a `MemoReturn` memo.
+   * Creates and returns a `MemoType.Return` memo.
    * @param {array|string} hash - 32 byte hash or hex encoded string
    * @returns {Memo}
    */
   static return(hash: MemoValue<MemoType.Return>): Memo {
-    return new Memo(MemoReturn, hash);
+    return new Memo(MemoType.Return, hash);
   }
 
   /**
@@ -230,17 +229,18 @@ export class Memo<T extends MemoType = MemoType> {
    * @returns {xdr.Memo}
    */
   toXDRObject(): xdr.Memo | null {
-    switch (this._type) {
-      case MemoNone:
+    const type: MemoType = this._type
+    switch (type) {
+      case (MemoType.None):
         return xdr.Memo.memoNone();
-      case MemoID:
-        return xdr.Memo.memoId(UnsignedHyper.fromString(this._value));
-      case MemoText:
-        return xdr.Memo.memoText(this._value);
-      case MemoHash:
-        return xdr.Memo.memoHash(this._value);
-      case MemoReturn:
-        return xdr.Memo.memoReturn(this._value);
+      case MemoType.Id:
+        return xdr.Memo.memoId(UnsignedHyper.fromString(this._value as MemoValue<typeof type>));
+      case MemoType.Text:
+        return xdr.Memo.memoText(this._value as MemoValue<typeof type>);
+      case MemoType.Hash:
+        return xdr.Memo.memoHash(this._value as MemoValue<typeof type>);
+      case MemoType.Return:
+        return xdr.Memo.memoReturn(this._value as MemoValue<typeof type>);
       default:
         return null;
     }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -6,6 +6,7 @@ import { Asset } from './asset';
 import { StrKey } from './strkey';
 import { BaseOperation } from './operations';
 import { Operation as OperationNS } from './@types/operation';
+import xdr from './generated/stellar-xdr_generated';
 
 const ONE = 10000000;
 const MAX_INT64 = '9223372036854775807';
@@ -63,7 +64,7 @@ export class Operation extends BaseOperation {
    * @param {xdr.Operation} operation - An XDR Operation.
    * @return {Operation}
    */
-  static fromXDRObject(operation): OperationNS {
+  static fromXDRObject(operation: xdr.Operation): OperationNS {
     function accountIdtoAddress(accountId) {
       return StrKey.encodeEd25519PublicKey(accountId.ed25519());
     }
@@ -229,7 +230,7 @@ export class Operation extends BaseOperation {
    * @param {string|BigNumber} value XDR amount
    * @returns {BigNumber} Number
    */
-  static _fromXDRAmount(value) {
+  static _fromXDRAmount(value: xdr.Int64) {
     return new BigNumber(value).div(ONE).toFixed(7);
   }
 
@@ -240,7 +241,7 @@ export class Operation extends BaseOperation {
    * @param {function} price.d denominator function that returns a value
    * @returns {BigNumber} Big string
    */
-  static _fromXDRPrice(price) {
+  static _fromXDRPrice(price: xdr.Price) {
     const n = new BigNumber(price.n());
     return n.div(new BigNumber(price.d())).toString();
   }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -4,7 +4,8 @@ import BigNumber from 'bignumber.js';
 import trimEnd from 'lodash/trimEnd';
 import { Asset } from './asset';
 import { StrKey } from './strkey';
-import { BaseOperation } from './operations/index';
+import { BaseOperation } from './operations';
+import { Operation as OperationNS } from './@types/operation';
 
 const ONE = 10000000;
 const MAX_INT64 = '9223372036854775807';
@@ -62,7 +63,7 @@ export class Operation extends BaseOperation {
    * @param {xdr.Operation} operation - An XDR Operation.
    * @return {Operation}
    */
-  static fromXDRObject(operation) {
+  static fromXDRObject(operation): OperationNS {
     function accountIdtoAddress(accountId) {
       return StrKey.encodeEd25519PublicKey(accountId.ed25519());
     }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -265,7 +265,7 @@ export class Operation extends BaseOperation {
    * @param {string|BigNumber} value XDR amount
    * @returns {BigNumber} Number
    */
-  static _fromXDRAmount(value: xdr.Int64) {
+  static _fromXDRAmount(value: xdr.Int64): BigNumber {
     return new BigNumber(value).div(ONE).toFixed(7);
   }
 
@@ -276,7 +276,7 @@ export class Operation extends BaseOperation {
    * @param {function} price.d denominator function that returns a value
    * @returns {BigNumber} Big string
    */
-  static _fromXDRPrice(price: xdr.Price) {
+  static _fromXDRPrice(price: xdr.Price): BigNumber {
     const n = new BigNumber(price.n());
     return n.div(new BigNumber(price.d())).toString();
   }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -65,39 +65,47 @@ export class Operation extends BaseOperation {
    * @return {Operation}
    */
   static fromXDRObject(operation: xdr.Operation): OperationNS {
-    function accountIdtoAddress(accountId) {
+    function accountIdtoAddress(accountId: xdr.AccountId) {
       return StrKey.encodeEd25519PublicKey(accountId.ed25519());
     }
 
-    const result = {};
-    if (operation.sourceAccount()) {
-      result.source = accountIdtoAddress(operation.sourceAccount());
-    }
-
-    const attrs = operation.body().value();
+    const sourceAccount = operation.sourceAccount()
+    const withSource: {source?: string} = sourceAccount
+      ? {source: accountIdtoAddress(sourceAccount)}
+      : {}
 
     switch (operation.body().switch().name) {
       case 'createAccount': {
-        result.type = 'createAccount';
-        result.destination = accountIdtoAddress(attrs.destination());
-        result.startingBalance = this._fromXDRAmount(attrs.startingBalance());
-        break;
+        const attrs = operation.body().value() as xdr.CreateAccountOp;
+        return {
+          ...withSource,
+          type: 'createAccount',
+          destination: accountIdtoAddress(attrs.destination()),
+          startingBalance: this._fromXDRAmount(attrs.startingBalance()),
+        }
       }
       case 'payment': {
-        result.type = 'payment';
-        result.destination = accountIdtoAddress(attrs.destination());
-        result.asset = Asset.fromOperation(attrs.asset());
-        result.amount = this._fromXDRAmount(attrs.amount());
-        break;
+        const attrs = operation.body().value() as xdr.PaymentOp;
+        return {
+          ...withSource,
+          type: 'payment',
+          destination: accountIdtoAddress(attrs.destination()),
+          asset: Asset.fromOperation(attrs.asset()),
+          amount: this._fromXDRAmount(attrs.amount()),
+        }
       }
       case 'pathPayment': {
-        result.type = 'pathPayment';
-        result.sendAsset = Asset.fromOperation(attrs.sendAsset());
-        result.sendMax = this._fromXDRAmount(attrs.sendMax());
-        result.destination = accountIdtoAddress(attrs.destination());
-        result.destAsset = Asset.fromOperation(attrs.destAsset());
-        result.destAmount = this._fromXDRAmount(attrs.destAmount());
-        result.path = [];
+        const attrs = operation.body().value() as xdr.PathPaymentOp;
+        const result = {
+          ...withSource,
+          type: 'pathPayment',
+          sendAsset: Asset.fromOperation(attrs.sendAsset()),
+          sendMax: this._fromXDRAmount(attrs.sendMax()),
+          destination: accountIdtoAddress(attrs.destination()),
+          destAsset: Asset.fromOperation(attrs.destAsset()),
+          destAmount: this._fromXDRAmount(attrs.destAmount()),
+          path: [],
+        }
 
         const path = attrs.path();
 
@@ -108,24 +116,34 @@ export class Operation extends BaseOperation {
         break;
       }
       case 'changeTrust': {
-        result.type = 'changeTrust';
-        result.line = Asset.fromOperation(attrs.line());
-        result.limit = this._fromXDRAmount(attrs.limit());
-        break;
+        const attrs = operation.body().value() as xdr.ChangeTrustOp;
+        return {
+          ...withSource,
+          type: 'changeTrust',
+          line: Asset.fromOperation(attrs.line()),
+          limit: this._fromXDRAmount(attrs.limit()),
+        }
       }
       case 'allowTrust': {
-        result.type = 'allowTrust';
-        result.trustor = accountIdtoAddress(attrs.trustor());
-        result.assetCode = attrs
-          .asset()
-          .value()
-          .toString();
-        result.assetCode = trimEnd(result.assetCode, '\0');
-        result.authorize = attrs.authorize();
-        break;
+        const attrs = operation.body().value() as xdr.AllowTrustOp;
+        const assetCode = attrs
+            .asset()
+            .value()
+            .toString()
+        return {
+          ...withSource,
+          type: 'allowTrust',
+          trustor: accountIdtoAddress(attrs.trustor()),
+          assetCode: trimEnd(assetCode, '\0'),
+          authorize: attrs.authorize(),
+        }
       }
       case 'setOption': {
-        result.type = 'setOptions';
+        const attrs = operation.body().value() as xdr.SetOptionsOp;
+        const result = {
+          ...withSource,
+          type: 'setOptions',
+        }
         if (attrs.inflationDest()) {
           result.inflationDest = accountIdtoAddress(attrs.inflationDest());
         }
@@ -170,59 +188,76 @@ export class Operation extends BaseOperation {
       // the next case intentionally falls through!
       case 'manageOffer':
       case 'manageSellOffer': {
-        result.type = 'manageSellOffer';
-        result.selling = Asset.fromOperation(attrs.selling());
-        result.buying = Asset.fromOperation(attrs.buying());
-        result.amount = this._fromXDRAmount(attrs.amount());
-        result.price = this._fromXDRPrice(attrs.price());
-        result.offerId = attrs.offerId().toString();
-        break;
+        const attrs = operation.body().value() as xdr.ManageSellOfferOp;
+        return {
+          ...withSource,
+          type: 'manageSellOffer',
+          selling: Asset.fromOperation(attrs.selling()),
+          buying: Asset.fromOperation(attrs.buying()),
+          amount: this._fromXDRAmount(attrs.amount()),
+          price: this._fromXDRPrice(attrs.price()),
+          offerId: attrs.offerId().toString(),
+        }
       }
       case 'manageBuyOffer': {
-        result.type = 'manageBuyOffer';
-        result.selling = Asset.fromOperation(attrs.selling());
-        result.buying = Asset.fromOperation(attrs.buying());
-        result.buyAmount = this._fromXDRAmount(attrs.buyAmount());
-        result.price = this._fromXDRPrice(attrs.price());
-        result.offerId = attrs.offerId().toString();
-        break;
+        const attrs = operation.body().value() as xdr.ManageBuyOfferOp;
+        return {
+          ...withSource,
+          type: 'manageBuyOffer',
+          selling: Asset.fromOperation(attrs.selling()),
+          buying: Asset.fromOperation(attrs.buying()),
+          buyAmount: this._fromXDRAmount(attrs.buyAmount()),
+          price: this._fromXDRPrice(attrs.price()),
+          offerId: attrs.offerId().toString(),
+        }
       }
       // the next case intentionally falls through!
       case 'createPassiveOffer':
       case 'createPassiveSellOffer': {
-        result.type = 'createPassiveSellOffer';
-        result.selling = Asset.fromOperation(attrs.selling());
-        result.buying = Asset.fromOperation(attrs.buying());
-        result.amount = this._fromXDRAmount(attrs.amount());
-        result.price = this._fromXDRPrice(attrs.price());
-        break;
+        const attrs = operation.body().value() as xdr.CreatePassiveSellOfferOp;
+        return {
+          ...withSource,
+          type: 'createPassiveSellOffer',
+          selling: Asset.fromOperation(attrs.selling()),
+          buying: Asset.fromOperation(attrs.buying()),
+          amount: this._fromXDRAmount(attrs.amount()),
+          price: this._fromXDRPrice(attrs.price()),
+        }
       }
       case 'accountMerge': {
-        result.type = 'accountMerge';
-        result.destination = accountIdtoAddress(attrs);
-        break;
+        const attrs = operation.body().value() as xdr.AccountId;
+        return {
+          ...withSource,
+          type: 'accountMerge',
+          destination: accountIdtoAddress(attrs),
+        }
       }
       case 'manageDatum': {
-        result.type = 'manageData';
-        // manage_data.name is checked by iscntrl in stellar-core
-        result.name = attrs.dataName().toString('ascii');
-        result.value = attrs.dataValue();
-        break;
+        const attrs = operation.body().value() as xdr.ManageDataOp;
+        return {
+          ...withSource,
+          type: 'manageData',
+          // manage_data.name is checked by iscntrl in stellar-core
+          name: attrs.dataName().toString('ascii'),
+          value: attrs.dataValue(),
+        }
       }
       case 'inflation': {
-        result.type = 'inflation';
-        break;
+        return {
+          ...withSource,
+          type: 'inflation',
+        }
       }
       case 'bumpSequence': {
-        result.type = 'bumpSequence';
-        result.bumpTo = attrs.bumpTo().toString();
-        break;
-      }
-      default: {
-        throw new Error('Unknown operation');
+        const attrs = operation.body().value() as xdr.BumpSequenceOp;
+        return {
+          ...withSource,
+          type: 'bumpSequence',
+          bumpTo: attrs.bumpTo().toString(),
+        }
       }
     }
-    return result;
+    throw new Error('Unknown operation');
   }
 
   /**

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -125,7 +125,7 @@ export abstract class BaseOperation {
    * @returns {object} XDR price object
    */
   public static _toXDRPrice(price: any) {
-    let xdrObject;
+    let xdrObject: xdr.Price;
     if (price.n && price.d) {
       xdrObject = new xdr.Price(price);
     } else {
@@ -645,7 +645,7 @@ export abstract class BaseOperation {
         signer.weight,
         weightCheckFunction
       );
-      let key;
+      let key: xdr.Uint256;
 
       let setValues = 0;
 

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -178,7 +178,7 @@ export abstract class BaseOperation {
       throw new Error('trustor is invalid');
     }
 
-    let asset: any
+    let asset: xdr.AllowTrustOpAsset
     if (opts.assetCode.length <= 4) {
       const code = padEnd(opts.assetCode, 4, '\0');
       asset = xdr.AllowTrustOpAsset.assetTypeCreditAlphanum4(code);
@@ -645,7 +645,7 @@ export abstract class BaseOperation {
         signer.weight,
         weightCheckFunction
       );
-      let key: xdr.Uint256;
+      let key: xdr.SignerKey;
 
       let setValues = 0;
 

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,4 +1,4 @@
-import {xdr, IXdr} from '../xdr_definitions';
+import xdr from '../generated/stellar-xdr_generated';
 import { Keypair } from '../keypair';
 import { StrKey } from '../strkey';
 import { Operation, OperationOptions } from '../@types/operation';
@@ -153,7 +153,7 @@ export abstract class BaseOperation {
    * @param {string} [opts.source] - The source account (defaults to transaction source).
    * @returns {xdr.AccountMergeOp} Account Merge operation
    */
-  public static accountMerge(opts: OperationOptions.AccountMerge): IXdr.Operation<Operation.AccountMerge> {
+  public static accountMerge(opts: OperationOptions.AccountMerge): xdr.Operation<Operation.AccountMerge> {
     if (!StrKey.isValidEd25519PublicKey(opts.destination)) {
       throw new Error('destination is invalid');
     }
@@ -173,7 +173,7 @@ export abstract class BaseOperation {
    * @param {string} [opts.source] - The source account (defaults to transaction source).
    * @returns {xdr.AllowTrustOp} Allow Trust operation
    */
-  public static allowTrust(opts: OperationOptions.AllowTrust): IXdr.Operation<Operation.AllowTrust> {
+  public static allowTrust(opts: OperationOptions.AllowTrust): xdr.Operation<Operation.AllowTrust> {
     if (!StrKey.isValidEd25519PublicKey(opts.trustor)) {
       throw new Error('trustor is invalid');
     }
@@ -207,7 +207,7 @@ export abstract class BaseOperation {
    * @param {string} [opts.source] - The optional source account.
    * @returns {xdr.BumpSequenceOp} Operation
    */
-  public static bumpSequence(opts: OperationOptions.BumpSequence): IXdr.Operation<Operation.BumpSequence> {
+  public static bumpSequence(opts: OperationOptions.BumpSequence): xdr.Operation<Operation.BumpSequence> {
     if (!isString(opts.bumpTo)) {
       throw new Error('bumpTo must be a string');
     }
@@ -239,7 +239,7 @@ export abstract class BaseOperation {
    * @param {string} [opts.source] - The source account (defaults to transaction source).
    * @returns {xdr.ChangeTrustOp} Change Trust operation
    */
-  public static changeTrust(opts: OperationOptions.ChangeTrust): IXdr.Operation<Operation.ChangeTrust> {
+  public static changeTrust(opts: OperationOptions.ChangeTrust): xdr.Operation<Operation.ChangeTrust> {
     if (!isUndefined(opts.limit) && !this.isValidAmount(opts.limit, true)) {
       throw new TypeError(this.constructAmountRequirementsError('limit'));
     }
@@ -270,7 +270,7 @@ export abstract class BaseOperation {
    * @param {string} [opts.source] - The source account for the payment. Defaults to the transaction's source account.
    * @returns {xdr.CreateAccountOp} Create account operation
    */
-  public static createAccount(opts: OperationOptions.CreateAccount): IXdr.Operation<Operation.CreateAccount> {
+  public static createAccount(opts: OperationOptions.CreateAccount): xdr.Operation<Operation.CreateAccount> {
     if (!StrKey.isValidEd25519PublicKey(opts.destination)) {
       throw new Error('destination is invalid');
     }
@@ -306,7 +306,7 @@ export abstract class BaseOperation {
    * @throws {Error} Throws `Error` when the best rational approximation of `price` cannot be found.
    * @returns {xdr.CreatePassiveSellOfferOp} Create Passive Sell Offer operation
    */
-  public static createPassiveSellOffer(opts: OperationOptions.CreatePassiveSellOffer): IXdr.Operation<Operation.CreatePassiveSellOffer> {
+  public static createPassiveSellOffer(opts: OperationOptions.CreatePassiveSellOffer): xdr.Operation<Operation.CreatePassiveSellOffer> {
     if (!this.isValidAmount(opts.amount)) {
       throw new TypeError(this.constructAmountRequirementsError('amount'));
     }
@@ -325,7 +325,7 @@ export abstract class BaseOperation {
   }
 
   // deprecated, to be removed after 1.0.1
-  public static createPassiveOffer(opts: OperationOptions.CreatePassiveSellOffer): IXdr.Operation<Operation.CreatePassiveSellOffer> {
+  public static createPassiveOffer(opts: OperationOptions.CreatePassiveSellOffer): xdr.Operation<Operation.CreatePassiveSellOffer> {
     // eslint-disable-next-line no-console
     console.log(
       '[Operation] Operation.createPassiveOffer has been renamed to Operation.createPassiveSellOffer! The old name is deprecated and will be removed in a later version!'
@@ -342,7 +342,7 @@ export abstract class BaseOperation {
    * @param {string} [opts.source] - The optional source account.
    * @returns {xdr.InflationOp} Inflation operation
    */
-  public static inflation(opts: OperationOptions.Inflation = {}): IXdr.Operation<Operation.Inflation> {
+  public static inflation(opts: OperationOptions.Inflation = {}): xdr.Operation<Operation.Inflation> {
     return this.toXdrOperation(xdr.OperationBody.inflation(), opts)
   }
 
@@ -363,7 +363,7 @@ export abstract class BaseOperation {
    * @throws {Error} Throws `Error` when the best rational approximation of `price` cannot be found.
    * @returns {xdr.ManageBuyOfferOp} Manage Buy Offer operation
    */
-  public static manageBuyOffer(opts: OperationOptions.ManageBuyOffer): IXdr.Operation<Operation.ManageBuyOffer> {
+  public static manageBuyOffer(opts: OperationOptions.ManageBuyOffer): xdr.Operation<Operation.ManageBuyOffer> {
     if (!this.isValidAmount(opts.buyAmount, true)) {
       throw new TypeError(this.constructAmountRequirementsError('buyAmount'));
     }
@@ -397,7 +397,7 @@ export abstract class BaseOperation {
    * @param {string} [opts.source] - The optional source account.
    * @returns {xdr.ManageDataOp} Manage Data operation
    */
-  public static manageData(opts: OperationOptions.ManageData): IXdr.Operation<Operation.ManageData> {
+  public static manageData(opts: OperationOptions.ManageData): xdr.Operation<Operation.ManageData> {
     if (!(isString(opts.name) && opts.name.length <= 64)) {
       throw new Error('name must be a string, up to 64 characters');
     }
@@ -446,7 +446,7 @@ export abstract class BaseOperation {
    * @throws {Error} Throws `Error` when the best rational approximation of `price` cannot be found.
    * @returns {xdr.ManageSellOfferOp} Manage Sell Offer operation
    */
-  public static manageSellOffer(opts: OperationOptions.ManageSellOffer): IXdr.Operation<Operation.ManageSellOffer> {
+  public static manageSellOffer(opts: OperationOptions.ManageSellOffer): xdr.Operation<Operation.ManageSellOffer> {
     if (!this.isValidAmount(opts.amount, true)) {
       throw new TypeError(this.constructAmountRequirementsError('amount'));
     }
@@ -472,7 +472,7 @@ export abstract class BaseOperation {
   }
 
   // deprecated, to be removed after 1.0.1
-  public static manageOffer(opts: OperationOptions.ManageSellOffer): IXdr.Operation<Operation.ManageSellOffer> {
+  public static manageOffer(opts: OperationOptions.ManageSellOffer): xdr.Operation<Operation.ManageSellOffer> {
     // eslint-disable-next-line no-console
     console.log(
       '[Operation] Operation.manageOffer has been renamed to Operation.manageSellOffer! The old name is deprecated and will be removed in a later version!'
@@ -497,7 +497,7 @@ export abstract class BaseOperation {
    * @param {string} [opts.source] - The source account for the payment. Defaults to the transaction's source account.
    * @returns {xdr.PathPaymentOp} Path Payment operation
    */
-  public static pathPayment(opts: OperationOptions.PathPayment): IXdr.Operation<Operation.PathPayment> {
+  public static pathPayment(opts: OperationOptions.PathPayment): xdr.Operation<Operation.PathPayment> {
     if(!opts.sendAsset) {
         throw new Error('Must specify a send asset');
     }
@@ -539,7 +539,7 @@ export abstract class BaseOperation {
    * @param {string} [opts.source] - The source account for the payment. Defaults to the transaction's source account.
    * @returns {xdr.PaymentOp} Payment operation
    */
-  public static payment(opts: OperationOptions.Payment): IXdr.Operation<Operation.Payment> {
+  public static payment(opts: OperationOptions.Payment): xdr.Operation<Operation.Payment> {
     if (!StrKey.isValidEd25519PublicKey(opts.destination)) {
       throw new Error('destination is invalid');
     }
@@ -589,7 +589,7 @@ export abstract class BaseOperation {
    * @returns {xdr.SetOptionsOp}  XDR operation
    * @see [Account flags](https://www.stellar.org/developers/guides/concepts/accounts.html#flags)
    */
-  public static setOptions<T extends SignerOptions = never>(opts: OperationOptions.SetOptions<T>): IXdr.Operation<Operation.SetOptions<T>> {
+  public static setOptions<T extends SignerOptions = never>(opts: OperationOptions.SetOptions<T>): xdr.Operation<Operation.SetOptions<T>> {
     // TS-TODO: `Partial<SetOptionsOp.IAttributes>`
     const attributes: Record<string, unknown> = {};
 

--- a/src/strkey.ts
+++ b/src/strkey.ts
@@ -109,7 +109,7 @@ export class StrKey {
   }
 }
 
-function isValid(versionByteName: string, encoded: string) {
+function isValid(versionByteName: string, encoded: string): boolean {
   if (encoded && encoded.length !== 56) {
     return false;
   }
@@ -125,7 +125,7 @@ function isValid(versionByteName: string, encoded: string) {
   return true;
 }
 
-export function decodeCheck(versionByteName: string, encoded: string) {
+export function decodeCheck(versionByteName: string, encoded: string): Buffer {
   if (!isString(encoded)) {
     throw new TypeError('encoded argument must be of type String');
   }
@@ -163,7 +163,7 @@ export function decodeCheck(versionByteName: string, encoded: string) {
   return Buffer.from(data);
 }
 
-export function encodeCheck(versionByteName: string, data: Buffer) {
+export function encodeCheck(versionByteName: string, data: Buffer): string {
   if (isNull(data) || isUndefined(data)) {
     throw new Error('cannot encode null data');
   }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -65,11 +65,11 @@ export class Transaction {
     this.signatures = map(signatures, (s) => s);
   }
 
-  public get memo() {
+  public get memo(): Memo {
     return Memo.fromXDRObject(this._memo);
   }
 
-  public set memo(value: unknown) {
+  public set memo(value: Memo) {
     throw new Error('Transaction is immutable');
   }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -30,7 +30,7 @@ export class Transaction {
     maxTime: string,
   }
   public readonly operations: any[]
-  public readonly signatures: any[]
+  public readonly signatures: xdr.DecoratedSignature[]
 
   public constructor(envelope: any) {
     if (typeof envelope === 'string') {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -9,6 +9,7 @@ import { Network } from './network';
 import { Memo } from './memo';
 import { Keypair } from './keypair';
 import { hash } from './hashing';
+import { Operation as OperationNS } from './@types/operation';
 
 /**
  * Use {@link TransactionBuilder} to build a transaction object, unless you have
@@ -20,19 +21,19 @@ import { hash } from './hashing';
  * @param {string|xdr.TransactionEnvelope} envelope - The transaction envelope object or base64 encoded string.
  */
 export class Transaction {
-  public readonly tx: any
+  public readonly tx: xdr.Transaction
   public readonly source: string
-  public readonly fee: any
-  protected readonly _memo: any
+  public readonly fee: xdr.Uint32
+  protected readonly _memo: xdr.Memo
   public readonly sequence: string
   public readonly timeBounds?: {
     minTime: string,
     maxTime: string,
   }
-  public readonly operations: any[]
+  public readonly operations: OperationNS[]
   public readonly signatures: xdr.DecoratedSignature[]
 
-  public constructor(envelope: any) {
+  public constructor(envelope: string | xdr.TransactionEnvelope) {
     if (typeof envelope === 'string') {
       const buffer = Buffer.from(envelope, 'base64');
       envelope = xdr.TransactionEnvelope.fromXDR(buffer);
@@ -223,7 +224,7 @@ export class Transaction {
    * To envelope returns a xdr.TransactionEnvelope which can be submitted to the network.
    * @returns {xdr.TransactionEnvelope}
    */
-  public toEnvelope(): any {
+  public toEnvelope(): xdr.TransactionEnvelope {
     const tx = this.tx;
     const signatures = this.signatures;
     const envelope = new xdr.TransactionEnvelope({ tx, signatures });

--- a/src/transaction_builder.ts
+++ b/src/transaction_builder.ts
@@ -100,7 +100,7 @@ export class TransactionBuilder {
    * @param {xdr.Operation} operation The xdr operation object, use {@link Operation} static methods.
    * @returns {TransactionBuilder}
    */
-  addOperation(operation) {
+  addOperation(operation): this {
     this.operations.push(operation);
     return this;
   }
@@ -110,7 +110,7 @@ export class TransactionBuilder {
    * @param {Memo} memo {@link Memo} object
    * @returns {TransactionBuilder}
    */
-  addMemo(memo) {
+  addMemo(memo): this {
     this.memo = memo;
     return this;
   }
@@ -133,7 +133,7 @@ export class TransactionBuilder {
    * @return {TransactionBuilder}
    * @see TimeoutInfinite
    */
-  setTimeout(timeout) {
+  setTimeout(timeout): this {
     if (this.timebounds != null && this.timebounds.maxTime > 0) {
       throw new Error(
         'TimeBounds.max_time has been already set - setting timeout would overwrite it.'
@@ -165,7 +165,7 @@ export class TransactionBuilder {
    * It will also increment the source account's sequence number by 1.
    * @returns {Transaction} This method will return the built {@link Transaction}.
    */
-  build() {
+  build(): Transaction {
     // Ensure setTimeout called or maxTime is set
     if (
       (this.timebounds === null ||
@@ -224,8 +224,8 @@ export class TransactionBuilder {
  * @argument {Date} d date object
  * @returns {boolean}
  */
-export function isValidDate(d) {
+export function isValidDate(d: Date): boolean {
   // isnan is okay here because it correctly checks for invalid date objects
   // eslint-disable-next-line no-restricted-globals
-  return d instanceof Date && !isNaN(d);
+  return d instanceof Date && !isNaN(d as any);
 }


### PR DESCRIPTION
Ref #188

Summary:
- I'm struggling to type xdr definitions without experience with them
- "accidentally" typed a lot of `js-xdr` library along the way
- overall far from done, but LGTM to merge - it's better than before

RFC:
- the only place where code, not types, were touched is at 117cd16 . That should not change behavior, but I may have missed something.

TODO:
- more types
- Can someone who understands what's going on at xdr help to type them?
- Perhaps `js-xdr` types should be moved upstream?
- At many places there's type mismatch, plain `number` where Int32 is expected, or `string` for Opaque, etc. Is that expected? Should we leave it like that?