### PR TITLE
Allow `undefined` issuer for `Asset` constructor.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,7 +24,7 @@ export class Asset {
   static native(): Asset;
   static fromOperation(xdr: xdr.Asset): Asset;
 
-  constructor(code: string, issuer: string);
+  constructor(code: string, issuer?: string);
 
   getCode(): string;
   getIssuer(): string;


### PR DESCRIPTION
This is required for deserializing the native asset, e.g., when parsing the value `JSON.stringify(Asset.native())` and handing the result to the `Asset` constructor.

The javascript is perfectly able to handle this case anyway.