### PR TITLE
Support stellar-core protocol 12 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ This release adds support for [stellar-core protocol 12 release](https://github.
 
 ### Add ➕
 
- - `Operation.pathPaymentStrictSend`: Sends a path payments, debiting from the source account exactly an specified amount of one asset, crediting at least a given amount of another asset. ([#274](https://github.com/stellar/js-stellar-base/pull/274)).
+ - `Operation.pathPaymentStrictSend`: Sends a path payments, debiting from the source account exactly a specified amount of one asset, crediting at least a given amount of another asset. ([#274](https://github.com/stellar/js-stellar-base/pull/274)).
 
-    The following operation will debit exactly $10 USD from the source acount, crediting at least $9.2 EUR in the destination account 💸:
+    The following operation will debit exactly 10 USD from the source account, crediting at least 9.2 EUR in the destination account 💸:
     ```js
     var sendAsset = new StellarBase.Asset(
       'USD',
@@ -46,7 +46,7 @@ This release adds support for [stellar-core protocol 12 release](https://github.
     ```
  - `Operation.pathPaymentStrictReceive`: This behaves the same as the former `pathPayments` operation. ([#274](https://github.com/stellar/js-stellar-base/pull/274)).
 
-   The following operation will debit maximum $10 USD from the source acount, crediting exactly $9.2 EUR in the destination account  💸:
+   The following operation will debit maximum 10 USD from the source account, crediting exactly 9.2 EUR in the destination account  💸:
    ```js
    var sendAsset = new StellarBase.Asset(
      'USD',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ A breaking change will get clearly notified in this log.
 
 ## Unreleased
 
+This release adds support for [stellar-core protocol 12 release](https://github.com/stellar/stellar-core/projects/11) and [CAP 24](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0024.md) ("Make PathPayment Symmetrical").
+
+### Add
+
+ - `Operation.pathPaymentStrictSend`: Sends a path payments, debiting from the source account exactly an specified amount of one asset, crediting at least a given amount of another asset. ([#274](https://github.com/stellar/js-stellar-base/pull/274)).
+ - `Operation.pathPaymentStrictReceive`: This behaves the same as the former `pathPayments` operation. ([#274](https://github.com/stellar/js-stellar-base/pull/274)).
+
+## Deprecated
+
+- `Operation.pathPayment` is being deprecated in favor of `Operation.pathPaymentStrictReceive`. Both functions take the same arguments and behave the same. ([#274](https://github.com/stellar/js-stellar-base/pull/274)).
+
 ## [v2.0.2](https://github.com/stellar/js-stellar-base/compare/v2.0.1...v2.0.2)
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,80 @@ A breaking change will get clearly notified in this log.
 
 This release adds support for [stellar-core protocol 12 release](https://github.com/stellar/stellar-core/projects/11) and [CAP 24](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0024.md) ("Make PathPayment Symmetrical").
 
-### Add
+### Add ➕
 
  - `Operation.pathPaymentStrictSend`: Sends a path payments, debiting from the source account exactly an specified amount of one asset, crediting at least a given amount of another asset. ([#274](https://github.com/stellar/js-stellar-base/pull/274)).
+
+    The following operation will debit exactly $10 USD from the source acount, crediting at least $9.2 EUR in the destination account 💸:
+    ```js
+    var sendAsset = new StellarBase.Asset(
+      'USD',
+      'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+    );
+    var sendAmount = '10';
+    var destination =
+      'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+    var destAsset = new StellarBase.Asset(
+      'USD',
+      'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+    );
+    var destMin = '9.2';
+    var path = [
+      new StellarBase.Asset(
+        'USD',
+        'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
+      ),
+      new StellarBase.Asset(
+        'EUR',
+        'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
+      )
+    ];
+    let op = StellarBase.Operation.pathPaymentStrictSend({
+      sendAsset,
+      sendAmount,
+      destination,
+      destAsset,
+      destMin,
+      path
+    });
+    ```
  - `Operation.pathPaymentStrictReceive`: This behaves the same as the former `pathPayments` operation. ([#274](https://github.com/stellar/js-stellar-base/pull/274)).
 
-## Deprecated
+   The following operation will debit maximum $10 USD from the source acount, crediting exactly $9.2 EUR in the destination account  💸:
+   ```js
+   var sendAsset = new StellarBase.Asset(
+     'USD',
+     'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+   );
+   var sendMax = '10';
+   var destination =
+     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+   var destAsset = new StellarBase.Asset(
+     'USD',
+     'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+   );
+   var destAmount = '9.2';
+   var path = [
+     new StellarBase.Asset(
+       'USD',
+       'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
+     ),
+     new StellarBase.Asset(
+       'EUR',
+       'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
+     )
+   ];
+   let op = StellarBase.Operation.pathPaymentStrictReceive({
+     sendAsset,
+     sendMax,
+     destination,
+     destAsset,
+     destAmount,
+     path
+   });
+   ```
+
+## Deprecated ❗️
 
 - `Operation.pathPayment` is being deprecated in favor of `Operation.pathPaymentStrictReceive`. Both functions take the same arguments and behave the same. ([#274](https://github.com/stellar/js-stellar-base/pull/274)).
 

--- a/src/generated/stellar-xdr_generated.js
+++ b/src/generated/stellar-xdr_generated.js
@@ -1,4 +1,4 @@
-// Automatically generated on 2019-04-30T12:43:38-07:00
+// Automatically generated on 2019-10-02T15:45:16-07:00
 // DO NOT EDIT or your changes may be overwritten
 
 /* jshint maxstatements:2147483647  */
@@ -2072,7 +2072,7 @@ xdr.struct("DecoratedSignature", [
 //   {
 //       CREATE_ACCOUNT = 0,
 //       PAYMENT = 1,
-//       PATH_PAYMENT = 2,
+//       PATH_PAYMENT_STRICT_RECEIVE = 2,
 //       MANAGE_SELL_OFFER = 3,
 //       CREATE_PASSIVE_SELL_OFFER = 4,
 //       SET_OPTIONS = 5,
@@ -2082,14 +2082,15 @@ xdr.struct("DecoratedSignature", [
 //       INFLATION = 9,
 //       MANAGE_DATA = 10,
 //       BUMP_SEQUENCE = 11,
-//       MANAGE_BUY_OFFER = 12
+//       MANAGE_BUY_OFFER = 12,
+//       PATH_PAYMENT_STRICT_SEND = 13
 //   };
 //
 // ===========================================================================
 xdr.enum("OperationType", {
   createAccount: 0,
   payment: 1,
-  pathPayment: 2,
+  pathPaymentStrictReceive: 2,
   manageSellOffer: 3,
   createPassiveSellOffer: 4,
   setOption: 5,
@@ -2100,6 +2101,7 @@ xdr.enum("OperationType", {
   manageDatum: 10,
   bumpSequence: 11,
   manageBuyOffer: 12,
+  pathPaymentStrictSend: 13,
 });
 
 // === xdr source ============================================================
@@ -2134,7 +2136,7 @@ xdr.struct("PaymentOp", [
 
 // === xdr source ============================================================
 //
-//   struct PathPaymentOp
+//   struct PathPaymentStrictReceiveOp
 //   {
 //       Asset sendAsset; // asset we pay with
 //       int64 sendMax;   // the maximum amount of sendAsset to
@@ -2149,12 +2151,38 @@ xdr.struct("PaymentOp", [
 //   };
 //
 // ===========================================================================
-xdr.struct("PathPaymentOp", [
+xdr.struct("PathPaymentStrictReceiveOp", [
   ["sendAsset", xdr.lookup("Asset")],
   ["sendMax", xdr.lookup("Int64")],
   ["destination", xdr.lookup("AccountId")],
   ["destAsset", xdr.lookup("Asset")],
   ["destAmount", xdr.lookup("Int64")],
+  ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
+]);
+
+// === xdr source ============================================================
+//
+//   struct PathPaymentStrictSendOp
+//   {
+//       Asset sendAsset;  // asset we pay with
+//       int64 sendAmount; // amount of sendAsset to send (excluding fees)
+//   
+//       AccountID destination; // recipient of the payment
+//       Asset destAsset;       // what they end up with
+//       int64 destMin;         // the minimum amount of dest asset to
+//                              // be received
+//                              // The operation will fail if it can't be met
+//   
+//       Asset path<5>; // additional hops it must go through to get there
+//   };
+//
+// ===========================================================================
+xdr.struct("PathPaymentStrictSendOp", [
+  ["sendAsset", xdr.lookup("Asset")],
+  ["sendAmount", xdr.lookup("Int64")],
+  ["destination", xdr.lookup("AccountId")],
+  ["destAsset", xdr.lookup("Asset")],
+  ["destMin", xdr.lookup("Int64")],
   ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
 ]);
 
@@ -2362,8 +2390,8 @@ xdr.struct("BumpSequenceOp", [
 //           CreateAccountOp createAccountOp;
 //       case PAYMENT:
 //           PaymentOp paymentOp;
-//       case PATH_PAYMENT:
-//           PathPaymentOp pathPaymentOp;
+//       case PATH_PAYMENT_STRICT_RECEIVE:
+//           PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
 //       case MANAGE_SELL_OFFER:
 //           ManageSellOfferOp manageSellOfferOp;
 //       case CREATE_PASSIVE_SELL_OFFER:
@@ -2384,6 +2412,8 @@ xdr.struct("BumpSequenceOp", [
 //           BumpSequenceOp bumpSequenceOp;
 //       case MANAGE_BUY_OFFER:
 //           ManageBuyOfferOp manageBuyOfferOp;
+//       case PATH_PAYMENT_STRICT_SEND:
+//           PathPaymentStrictSendOp pathPaymentStrictSendOp;
 //       }
 //
 // ===========================================================================
@@ -2393,7 +2423,7 @@ xdr.union("OperationBody", {
   switches: [
     ["createAccount", "createAccountOp"],
     ["payment", "paymentOp"],
-    ["pathPayment", "pathPaymentOp"],
+    ["pathPaymentStrictReceive", "pathPaymentStrictReceiveOp"],
     ["manageSellOffer", "manageSellOfferOp"],
     ["createPassiveSellOffer", "createPassiveSellOfferOp"],
     ["setOption", "setOptionsOp"],
@@ -2404,11 +2434,12 @@ xdr.union("OperationBody", {
     ["manageDatum", "manageDataOp"],
     ["bumpSequence", "bumpSequenceOp"],
     ["manageBuyOffer", "manageBuyOfferOp"],
+    ["pathPaymentStrictSend", "pathPaymentStrictSendOp"],
   ],
   arms: {
     createAccountOp: xdr.lookup("CreateAccountOp"),
     paymentOp: xdr.lookup("PaymentOp"),
-    pathPaymentOp: xdr.lookup("PathPaymentOp"),
+    pathPaymentStrictReceiveOp: xdr.lookup("PathPaymentStrictReceiveOp"),
     manageSellOfferOp: xdr.lookup("ManageSellOfferOp"),
     createPassiveSellOfferOp: xdr.lookup("CreatePassiveSellOfferOp"),
     setOptionsOp: xdr.lookup("SetOptionsOp"),
@@ -2418,6 +2449,7 @@ xdr.union("OperationBody", {
     manageDataOp: xdr.lookup("ManageDataOp"),
     bumpSequenceOp: xdr.lookup("BumpSequenceOp"),
     manageBuyOfferOp: xdr.lookup("ManageBuyOfferOp"),
+    pathPaymentStrictSendOp: xdr.lookup("PathPaymentStrictSendOp"),
   },
 });
 
@@ -2436,8 +2468,8 @@ xdr.union("OperationBody", {
 //           CreateAccountOp createAccountOp;
 //       case PAYMENT:
 //           PaymentOp paymentOp;
-//       case PATH_PAYMENT:
-//           PathPaymentOp pathPaymentOp;
+//       case PATH_PAYMENT_STRICT_RECEIVE:
+//           PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
 //       case MANAGE_SELL_OFFER:
 //           ManageSellOfferOp manageSellOfferOp;
 //       case CREATE_PASSIVE_SELL_OFFER:
@@ -2458,6 +2490,8 @@ xdr.union("OperationBody", {
 //           BumpSequenceOp bumpSequenceOp;
 //       case MANAGE_BUY_OFFER:
 //           ManageBuyOfferOp manageBuyOfferOp;
+//       case PATH_PAYMENT_STRICT_SEND:
+//           PathPaymentStrictSendOp pathPaymentStrictSendOp;
 //       }
 //       body;
 //   };
@@ -2790,41 +2824,41 @@ xdr.union("PaymentResult", {
 
 // === xdr source ============================================================
 //
-//   enum PathPaymentResultCode
+//   enum PathPaymentStrictReceiveResultCode
 //   {
 //       // codes considered as "success" for the operation
-//       PATH_PAYMENT_SUCCESS = 0, // success
+//       PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
 //   
 //       // codes considered as "failure" for the operation
-//       PATH_PAYMENT_MALFORMED = -1,          // bad input
-//       PATH_PAYMENT_UNDERFUNDED = -2,        // not enough funds in source account
-//       PATH_PAYMENT_SRC_NO_TRUST = -3,       // no trust line on source account
-//       PATH_PAYMENT_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-//       PATH_PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
-//       PATH_PAYMENT_NO_TRUST = -6,           // dest missing a trust line for asset
-//       PATH_PAYMENT_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
-//       PATH_PAYMENT_LINE_FULL = -8,          // dest would go above their limit
-//       PATH_PAYMENT_NO_ISSUER = -9,          // missing issuer on one asset
-//       PATH_PAYMENT_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
-//       PATH_PAYMENT_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
-//       PATH_PAYMENT_OVER_SENDMAX = -12       // could not satisfy sendmax
+//       PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1,          // bad input
+//       PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED = -2,        // not enough funds in source account
+//       PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST = -3,       // no trust line on source account
+//       PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+//       PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION = -5,     // destination account does not exist
+//       PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST = -6,           // dest missing a trust line for asset
+//       PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
+//       PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL = -8,          // dest would go above their limit
+//       PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9,          // missing issuer on one asset
+//       PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
+//       PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
+//       PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12       // could not satisfy sendmax
 //   };
 //
 // ===========================================================================
-xdr.enum("PathPaymentResultCode", {
-  pathPaymentSuccess: 0,
-  pathPaymentMalformed: -1,
-  pathPaymentUnderfunded: -2,
-  pathPaymentSrcNoTrust: -3,
-  pathPaymentSrcNotAuthorized: -4,
-  pathPaymentNoDestination: -5,
-  pathPaymentNoTrust: -6,
-  pathPaymentNotAuthorized: -7,
-  pathPaymentLineFull: -8,
-  pathPaymentNoIssuer: -9,
-  pathPaymentTooFewOffer: -10,
-  pathPaymentOfferCrossSelf: -11,
-  pathPaymentOverSendmax: -12,
+xdr.enum("PathPaymentStrictReceiveResultCode", {
+  pathPaymentStrictReceiveSuccess: 0,
+  pathPaymentStrictReceiveMalformed: -1,
+  pathPaymentStrictReceiveUnderfunded: -2,
+  pathPaymentStrictReceiveSrcNoTrust: -3,
+  pathPaymentStrictReceiveSrcNotAuthorized: -4,
+  pathPaymentStrictReceiveNoDestination: -5,
+  pathPaymentStrictReceiveNoTrust: -6,
+  pathPaymentStrictReceiveNotAuthorized: -7,
+  pathPaymentStrictReceiveLineFull: -8,
+  pathPaymentStrictReceiveNoIssuer: -9,
+  pathPaymentStrictReceiveTooFewOffer: -10,
+  pathPaymentStrictReceiveOfferCrossSelf: -11,
+  pathPaymentStrictReceiveOverSendmax: -12,
 });
 
 // === xdr source ============================================================
@@ -2852,37 +2886,121 @@ xdr.struct("SimplePaymentResult", [
 //       }
 //
 // ===========================================================================
-xdr.struct("PathPaymentResultSuccess", [
+xdr.struct("PathPaymentStrictReceiveResultSuccess", [
   ["offers", xdr.varArray(xdr.lookup("ClaimOfferAtom"), 2147483647)],
   ["last", xdr.lookup("SimplePaymentResult")],
 ]);
 
 // === xdr source ============================================================
 //
-//   union PathPaymentResult switch (PathPaymentResultCode code)
+//   union PathPaymentStrictReceiveResult switch (PathPaymentStrictReceiveResultCode code)
 //   {
-//   case PATH_PAYMENT_SUCCESS:
+//   case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
 //       struct
 //       {
 //           ClaimOfferAtom offers<>;
 //           SimplePaymentResult last;
 //       } success;
-//   case PATH_PAYMENT_NO_ISSUER:
+//   case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
 //       Asset noIssuer; // the asset that caused the error
 //   default:
 //       void;
 //   };
 //
 // ===========================================================================
-xdr.union("PathPaymentResult", {
-  switchOn: xdr.lookup("PathPaymentResultCode"),
+xdr.union("PathPaymentStrictReceiveResult", {
+  switchOn: xdr.lookup("PathPaymentStrictReceiveResultCode"),
   switchName: "code",
   switches: [
-    ["pathPaymentSuccess", "success"],
-    ["pathPaymentNoIssuer", "noIssuer"],
+    ["pathPaymentStrictReceiveSuccess", "success"],
+    ["pathPaymentStrictReceiveNoIssuer", "noIssuer"],
   ],
   arms: {
-    success: xdr.lookup("PathPaymentResultSuccess"),
+    success: xdr.lookup("PathPaymentStrictReceiveResultSuccess"),
+    noIssuer: xdr.lookup("Asset"),
+  },
+  defaultArm: xdr.void(),
+});
+
+// === xdr source ============================================================
+//
+//   enum PathPaymentStrictSendResultCode
+//   {
+//       // codes considered as "success" for the operation
+//       PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
+//   
+//       // codes considered as "failure" for the operation
+//       PATH_PAYMENT_STRICT_SEND_MALFORMED = -1,          // bad input
+//       PATH_PAYMENT_STRICT_SEND_UNDERFUNDED = -2,        // not enough funds in source account
+//       PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST = -3,       // no trust line on source account
+//       PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+//       PATH_PAYMENT_STRICT_SEND_NO_DESTINATION = -5,     // destination account does not exist
+//       PATH_PAYMENT_STRICT_SEND_NO_TRUST = -6,           // dest missing a trust line for asset
+//       PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
+//       PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8,          // dest would go above their limit
+//       PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9,          // missing issuer on one asset
+//       PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
+//       PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
+//       PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12      // could not satisfy destMin
+//   };
+//
+// ===========================================================================
+xdr.enum("PathPaymentStrictSendResultCode", {
+  pathPaymentStrictSendSuccess: 0,
+  pathPaymentStrictSendMalformed: -1,
+  pathPaymentStrictSendUnderfunded: -2,
+  pathPaymentStrictSendSrcNoTrust: -3,
+  pathPaymentStrictSendSrcNotAuthorized: -4,
+  pathPaymentStrictSendNoDestination: -5,
+  pathPaymentStrictSendNoTrust: -6,
+  pathPaymentStrictSendNotAuthorized: -7,
+  pathPaymentStrictSendLineFull: -8,
+  pathPaymentStrictSendNoIssuer: -9,
+  pathPaymentStrictSendTooFewOffer: -10,
+  pathPaymentStrictSendOfferCrossSelf: -11,
+  pathPaymentStrictSendUnderDestmin: -12,
+});
+
+// === xdr source ============================================================
+//
+//   struct
+//       {
+//           ClaimOfferAtom offers<>;
+//           SimplePaymentResult last;
+//       }
+//
+// ===========================================================================
+xdr.struct("PathPaymentStrictSendResultSuccess", [
+  ["offers", xdr.varArray(xdr.lookup("ClaimOfferAtom"), 2147483647)],
+  ["last", xdr.lookup("SimplePaymentResult")],
+]);
+
+// === xdr source ============================================================
+//
+//   union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
+//   {
+//   case PATH_PAYMENT_STRICT_SEND_SUCCESS:
+//       struct
+//       {
+//           ClaimOfferAtom offers<>;
+//           SimplePaymentResult last;
+//       } success;
+//   case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
+//       Asset noIssuer; // the asset that caused the error
+//   default:
+//       void;
+//   };
+//
+// ===========================================================================
+xdr.union("PathPaymentStrictSendResult", {
+  switchOn: xdr.lookup("PathPaymentStrictSendResultCode"),
+  switchName: "code",
+  switches: [
+    ["pathPaymentStrictSendSuccess", "success"],
+    ["pathPaymentStrictSendNoIssuer", "noIssuer"],
+  ],
+  arms: {
+    success: xdr.lookup("PathPaymentStrictSendResultSuccess"),
     noIssuer: xdr.lookup("Asset"),
   },
   defaultArm: xdr.void(),
@@ -3450,8 +3568,8 @@ xdr.enum("OperationResultCode", {
 //           CreateAccountResult createAccountResult;
 //       case PAYMENT:
 //           PaymentResult paymentResult;
-//       case PATH_PAYMENT:
-//           PathPaymentResult pathPaymentResult;
+//       case PATH_PAYMENT_STRICT_RECEIVE:
+//           PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
 //       case MANAGE_SELL_OFFER:
 //           ManageSellOfferResult manageSellOfferResult;
 //       case CREATE_PASSIVE_SELL_OFFER:
@@ -3472,6 +3590,8 @@ xdr.enum("OperationResultCode", {
 //           BumpSequenceResult bumpSeqResult;
 //       case MANAGE_BUY_OFFER:
 //   	ManageBuyOfferResult manageBuyOfferResult;
+//       case PATH_PAYMENT_STRICT_SEND:
+//           PathPaymentStrictSendResult pathPaymentStrictSendResult;
 //       }
 //
 // ===========================================================================
@@ -3481,7 +3601,7 @@ xdr.union("OperationResultTr", {
   switches: [
     ["createAccount", "createAccountResult"],
     ["payment", "paymentResult"],
-    ["pathPayment", "pathPaymentResult"],
+    ["pathPaymentStrictReceive", "pathPaymentStrictReceiveResult"],
     ["manageSellOffer", "manageSellOfferResult"],
     ["createPassiveSellOffer", "createPassiveSellOfferResult"],
     ["setOption", "setOptionsResult"],
@@ -3492,11 +3612,12 @@ xdr.union("OperationResultTr", {
     ["manageDatum", "manageDataResult"],
     ["bumpSequence", "bumpSeqResult"],
     ["manageBuyOffer", "manageBuyOfferResult"],
+    ["pathPaymentStrictSend", "pathPaymentStrictSendResult"],
   ],
   arms: {
     createAccountResult: xdr.lookup("CreateAccountResult"),
     paymentResult: xdr.lookup("PaymentResult"),
-    pathPaymentResult: xdr.lookup("PathPaymentResult"),
+    pathPaymentStrictReceiveResult: xdr.lookup("PathPaymentStrictReceiveResult"),
     manageSellOfferResult: xdr.lookup("ManageSellOfferResult"),
     createPassiveSellOfferResult: xdr.lookup("ManageSellOfferResult"),
     setOptionsResult: xdr.lookup("SetOptionsResult"),
@@ -3507,6 +3628,7 @@ xdr.union("OperationResultTr", {
     manageDataResult: xdr.lookup("ManageDataResult"),
     bumpSeqResult: xdr.lookup("BumpSequenceResult"),
     manageBuyOfferResult: xdr.lookup("ManageBuyOfferResult"),
+    pathPaymentStrictSendResult: xdr.lookup("PathPaymentStrictSendResult"),
   },
 });
 
@@ -3521,8 +3643,8 @@ xdr.union("OperationResultTr", {
 //           CreateAccountResult createAccountResult;
 //       case PAYMENT:
 //           PaymentResult paymentResult;
-//       case PATH_PAYMENT:
-//           PathPaymentResult pathPaymentResult;
+//       case PATH_PAYMENT_STRICT_RECEIVE:
+//           PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
 //       case MANAGE_SELL_OFFER:
 //           ManageSellOfferResult manageSellOfferResult;
 //       case CREATE_PASSIVE_SELL_OFFER:
@@ -3543,6 +3665,8 @@ xdr.union("OperationResultTr", {
 //           BumpSequenceResult bumpSeqResult;
 //       case MANAGE_BUY_OFFER:
 //   	ManageBuyOfferResult manageBuyOfferResult;
+//       case PATH_PAYMENT_STRICT_SEND:
+//           PathPaymentStrictSendResult pathPaymentStrictSendResult;
 //       }
 //       tr;
 //   default:

--- a/src/operation.js
+++ b/src/operation.js
@@ -380,6 +380,7 @@ Operation.manageData = ops.manageData;
 Operation.manageSellOffer = ops.manageSellOffer;
 Operation.manageBuyOffer = ops.manageBuyOffer;
 Operation.pathPayment = ops.pathPayment;
+Operation.pathPaymentStrictReceive = ops.pathPaymentStrictReceive;
 Operation.payment = ops.payment;
 Operation.setOptions = ops.setOptions;
 

--- a/src/operation.js
+++ b/src/operation.js
@@ -92,8 +92,9 @@ export class Operation {
     }
 
     const attrs = operation.body().value();
+    const operationName = operation.body().switch().name;
 
-    switch (operation.body().switch().name) {
+    switch (operationName) {
       case 'createAccount': {
         result.type = 'createAccount';
         result.destination = accountIdtoAddress(attrs.destination());
@@ -107,8 +108,8 @@ export class Operation {
         result.amount = this._fromXDRAmount(attrs.amount());
         break;
       }
-      case 'pathPayment': {
-        result.type = 'pathPayment';
+      case 'pathPaymentStrictReceive': {
+        result.type = 'pathPaymentStrictReceive';
         result.sendAsset = Asset.fromOperation(attrs.sendAsset());
         result.sendMax = this._fromXDRAmount(attrs.sendMax());
         result.destination = accountIdtoAddress(attrs.destination());
@@ -236,7 +237,7 @@ export class Operation {
         break;
       }
       default: {
-        throw new Error('Unknown operation');
+        throw new Error(`Unknown operation: ${operationName}`);
       }
     }
     return result;

--- a/src/operation.js
+++ b/src/operation.js
@@ -125,6 +125,23 @@ export class Operation {
         });
         break;
       }
+      case 'pathPaymentStrictSend': {
+        result.type = 'pathPaymentStrictSend';
+        result.sendAsset = Asset.fromOperation(attrs.sendAsset());
+        result.sendAmount = this._fromXDRAmount(attrs.sendAmount());
+        result.destination = accountIdtoAddress(attrs.destination());
+        result.destAsset = Asset.fromOperation(attrs.destAsset());
+        result.destMin = this._fromXDRAmount(attrs.destMin());
+        result.path = [];
+
+        const path = attrs.path();
+
+        // note that Object.values isn't supported by node 6!
+        Object.keys(path).forEach((pathKey) => {
+          result.path.push(Asset.fromOperation(path[pathKey]));
+        });
+        break;
+      }
       case 'changeTrust': {
         result.type = 'changeTrust';
         result.line = Asset.fromOperation(attrs.line());
@@ -381,6 +398,7 @@ Operation.manageSellOffer = ops.manageSellOffer;
 Operation.manageBuyOffer = ops.manageBuyOffer;
 Operation.pathPayment = ops.pathPayment;
 Operation.pathPaymentStrictReceive = ops.pathPaymentStrictReceive;
+Operation.pathPaymentStrictSend = ops.pathPaymentStrictSend;
 Operation.payment = ops.payment;
 Operation.setOptions = ops.setOptions;
 

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -11,6 +11,7 @@ export { manageData } from './manage_data';
 export { manageBuyOffer } from './manage_buy_offer';
 export { pathPayment } from './path_payment';
 export { pathPaymentStrictReceive } from './path_payment_strict_receive';
+export { pathPaymentStrictSend } from './path_payment_strict_send';
 export { payment } from './payment';
 export { setOptions } from './set_options';
 

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -10,6 +10,7 @@ export { inflation } from './inflation';
 export { manageData } from './manage_data';
 export { manageBuyOffer } from './manage_buy_offer';
 export { pathPayment } from './path_payment';
+export { pathPaymentStrictReceive } from './path_payment_strict_receive';
 export { payment } from './payment';
 export { setOptions } from './set_options';
 

--- a/src/operations/path_payment.js
+++ b/src/operations/path_payment.js
@@ -46,10 +46,10 @@ export function pathPayment(opts) {
   const path = opts.path ? opts.path : [];
   attributes.path = path.map((x) => x.toXDRObject());
 
-  const payment = new xdr.PathPaymentOp(attributes);
+  const payment = new xdr.PathPaymentStrictReceiveOp(attributes);
 
   const opAttributes = {};
-  opAttributes.body = xdr.OperationBody.pathPayment(payment);
+  opAttributes.body = xdr.OperationBody.pathPaymentStrictReceive(payment);
   this.setSourceAccount(opAttributes, opts);
 
   return new xdr.Operation(opAttributes);

--- a/src/operations/path_payment.js
+++ b/src/operations/path_payment.js
@@ -5,7 +5,7 @@ import { pathPaymentStrictReceive } from './path_payment_strict_receive';
  * destination account, optionally through a path. XLM payments create the destination
  * account if it does not exist.
  * @function
- * @deprecated since version 2.0.3, use pathPaymentStrictReceive.
+ * @deprecated Use {@link Operation.pathPaymentStrictReceive}
  * @alias Operation.pathPayment
  * @param {object} opts Options object
  * @param {Asset} opts.sendAsset - The asset to pay with.

--- a/src/operations/path_payment.js
+++ b/src/operations/path_payment.js
@@ -1,12 +1,11 @@
-import xdr from '../generated/stellar-xdr_generated';
-import { Keypair } from '../keypair';
-import { StrKey } from '../strkey';
+import { pathPaymentStrictReceive } from './path_payment_strict_receive';
 
 /**
- * Returns a XDR PaymentOp. A "payment" operation send the specified amount to the
+ * Returns a XDR PathPaymentOp. A "payment" operation send the specified amount to the
  * destination account, optionally through a path. XLM payments create the destination
  * account if it does not exist.
  * @function
+ * @deprecated since version 2.0.3, use pathPaymentStrictReceive.
  * @alias Operation.pathPayment
  * @param {object} opts Options object
  * @param {Asset} opts.sendAsset - The asset to pay with.
@@ -19,38 +18,10 @@ import { StrKey } from '../strkey';
  * @returns {xdr.PathPaymentOp} Path Payment operation
  */
 export function pathPayment(opts) {
-  switch (true) {
-    case !opts.sendAsset:
-      throw new Error('Must specify a send asset');
-    case !this.isValidAmount(opts.sendMax):
-      throw new TypeError(this.constructAmountRequirementsError('sendMax'));
-    case !StrKey.isValidEd25519PublicKey(opts.destination):
-      throw new Error('destination is invalid');
-    case !opts.destAsset:
-      throw new Error('Must provide a destAsset for a payment operation');
-    case !this.isValidAmount(opts.destAmount):
-      throw new TypeError(this.constructAmountRequirementsError('destAmount'));
-    default:
-      break;
-  }
+  // eslint-disable-next-line no-console
+  console.log(
+    '[Operation] Operation.pathPayment has been renamed to Operation.pathPaymentStrictReceive - The old name is deprecated and will be removed in a later version!'
+  );
 
-  const attributes = {};
-  attributes.sendAsset = opts.sendAsset.toXDRObject();
-  attributes.sendMax = this._toXDRAmount(opts.sendMax);
-  attributes.destination = Keypair.fromPublicKey(
-    opts.destination
-  ).xdrAccountId();
-  attributes.destAsset = opts.destAsset.toXDRObject();
-  attributes.destAmount = this._toXDRAmount(opts.destAmount);
-
-  const path = opts.path ? opts.path : [];
-  attributes.path = path.map((x) => x.toXDRObject());
-
-  const payment = new xdr.PathPaymentStrictReceiveOp(attributes);
-
-  const opAttributes = {};
-  opAttributes.body = xdr.OperationBody.pathPaymentStrictReceive(payment);
-  this.setSourceAccount(opAttributes, opts);
-
-  return new xdr.Operation(opAttributes);
+  return pathPaymentStrictReceive.call(this, opts);
 }

--- a/src/operations/path_payment_strict_receive.js
+++ b/src/operations/path_payment_strict_receive.js
@@ -3,7 +3,7 @@ import { Keypair } from '../keypair';
 import { StrKey } from '../strkey';
 
 /**
- * Returns a XDR PathPaymentStrictReceiveOp. A "payment" operation send the specified amount to the
+ * Returns a XDR PathPaymentStrictReceiveOp. A "PathPaymentStrictReceive" operation send the specified amount to the
  * destination account, optionally through a path. XLM payments create the destination
  * account if it does not exist.
  * @function

--- a/src/operations/path_payment_strict_receive.js
+++ b/src/operations/path_payment_strict_receive.js
@@ -1,0 +1,56 @@
+import xdr from '../generated/stellar-xdr_generated';
+import { Keypair } from '../keypair';
+import { StrKey } from '../strkey';
+
+/**
+ * Returns a XDR PathPaymentStrictReceiveOp. A "payment" operation send the specified amount to the
+ * destination account, optionally through a path. XLM payments create the destination
+ * account if it does not exist.
+ * @function
+ * @alias Operation.pathPayment
+ * @param {object} opts Options object
+ * @param {Asset} opts.sendAsset - The asset to pay with.
+ * @param {string} opts.sendMax - The maximum amount of sendAsset to send.
+ * @param {string} opts.destination - The destination account to send to.
+ * @param {Asset} opts.destAsset - The asset the destination will receive.
+ * @param {string} opts.destAmount - The amount the destination receives.
+ * @param {Asset[]} opts.path - An array of Asset objects to use as the path.
+ * @param {string} [opts.source] - The source account for the payment. Defaults to the transaction's source account.
+ * @returns {xdr.PathPaymentStrictReceiveOp} Path Payment Strict Receive operation
+ */
+export function pathPaymentStrictReceive(opts) {
+  switch (true) {
+    case !opts.sendAsset:
+      throw new Error('Must specify a send asset');
+    case !this.isValidAmount(opts.sendMax):
+      throw new TypeError(this.constructAmountRequirementsError('sendMax'));
+    case !StrKey.isValidEd25519PublicKey(opts.destination):
+      throw new Error('destination is invalid');
+    case !opts.destAsset:
+      throw new Error('Must provide a destAsset for a payment operation');
+    case !this.isValidAmount(opts.destAmount):
+      throw new TypeError(this.constructAmountRequirementsError('destAmount'));
+    default:
+      break;
+  }
+
+  const attributes = {};
+  attributes.sendAsset = opts.sendAsset.toXDRObject();
+  attributes.sendMax = this._toXDRAmount(opts.sendMax);
+  attributes.destination = Keypair.fromPublicKey(
+    opts.destination
+  ).xdrAccountId();
+  attributes.destAsset = opts.destAsset.toXDRObject();
+  attributes.destAmount = this._toXDRAmount(opts.destAmount);
+
+  const path = opts.path ? opts.path : [];
+  attributes.path = path.map((x) => x.toXDRObject());
+
+  const payment = new xdr.PathPaymentStrictReceiveOp(attributes);
+
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.pathPaymentStrictReceive(payment);
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/path_payment_strict_receive.js
+++ b/src/operations/path_payment_strict_receive.js
@@ -3,11 +3,11 @@ import { Keypair } from '../keypair';
 import { StrKey } from '../strkey';
 
 /**
- * Returns a XDR PathPaymentStrictReceiveOp. A "PathPaymentStrictReceive" operation send the specified amount to the
+ * Returns a XDR PathPaymentStrictReceiveOp. A `PathPaymentStrictReceive` operation send the specified amount to the
  * destination account, optionally through a path. XLM payments create the destination
  * account if it does not exist.
  * @function
- * @alias Operation.pathPayment
+ * @alias Operation.pathPaymentStrictReceive
  * @param {object} opts Options object
  * @param {Asset} opts.sendAsset - The asset to pay with.
  * @param {string} opts.sendMax - The maximum amount of sendAsset to send.

--- a/src/operations/path_payment_strict_send.js
+++ b/src/operations/path_payment_strict_send.js
@@ -3,11 +3,11 @@ import { Keypair } from '../keypair';
 import { StrKey } from '../strkey';
 
 /**
- * Returns a XDR PathPaymentStrictSendOp. A "PathPaymentStrictSend" operation send the specified amount to the
+ * Returns a XDR PathPaymentStrictSendOp. A `PathPaymentStrictSend` operation send the specified amount to the
  * destination account crediting at least `destMin` of `destAsset`, optionally through a path. XLM payments create the destination
  * account if it does not exist.
  * @function
- * @alias Operation.pathPayment
+ * @alias Operation.pathPaymentStrictSend
  * @param {object} opts Options object
  * @param {Asset} opts.sendAsset - The asset to pay with.
  * @param {string} opts.sendAmount - Amount of sendAsset to send (excluding fees).
@@ -16,7 +16,7 @@ import { StrKey } from '../strkey';
  * @param {string} opts.destMin - The minimum amount of destAsset to be received
  * @param {Asset[]} opts.path - An array of Asset objects to use as the path.
  * @param {string} [opts.source] - The source account for the payment. Defaults to the transaction's source account.
- * @returns {xdr.PathPaymentStrictReceiveOp} Path Payment Strict Receive operation
+ * @returns {xdr.PathPaymentStrictSendOp} Path Payment Strict Receive operation
  */
 export function pathPaymentStrictSend(opts) {
   switch (true) {

--- a/src/operations/path_payment_strict_send.js
+++ b/src/operations/path_payment_strict_send.js
@@ -1,0 +1,56 @@
+import xdr from '../generated/stellar-xdr_generated';
+import { Keypair } from '../keypair';
+import { StrKey } from '../strkey';
+
+/**
+ * Returns a XDR PathPaymentStrictSendOp. A "payment" operation send the specified amount to the
+ * destination account, optionally through a path. XLM payments create the destination
+ * account if it does not exist.
+ * @function
+ * @alias Operation.pathPayment
+ * @param {object} opts Options object
+ * @param {Asset} opts.sendAsset - The asset to pay with.
+ * @param {string} opts.sendAmount - Amount of sendAsset to send (excluding fees).
+ * @param {string} opts.destination - The destination account to send to.
+ * @param {Asset} opts.destAsset - The asset the destination will receive.
+ * @param {string} opts.destMin - The minimum amount of destAsset to be received
+ * @param {Asset[]} opts.path - An array of Asset objects to use as the path.
+ * @param {string} [opts.source] - The source account for the payment. Defaults to the transaction's source account.
+ * @returns {xdr.PathPaymentStrictReceiveOp} Path Payment Strict Receive operation
+ */
+export function pathPaymentStrictSend(opts) {
+  switch (true) {
+    case !opts.sendAsset:
+      throw new Error('Must specify a send asset');
+    case !this.isValidAmount(opts.sendAmount):
+      throw new TypeError(this.constructAmountRequirementsError('sendAmount'));
+    case !StrKey.isValidEd25519PublicKey(opts.destination):
+      throw new Error('destination is invalid');
+    case !opts.destAsset:
+      throw new Error('Must provide a destAsset for a payment operation');
+    case !this.isValidAmount(opts.destMin):
+      throw new TypeError(this.constructAmountRequirementsError('destMin'));
+    default:
+      break;
+  }
+
+  const attributes = {};
+  attributes.sendAsset = opts.sendAsset.toXDRObject();
+  attributes.sendAmount = this._toXDRAmount(opts.sendAmount);
+  attributes.destination = Keypair.fromPublicKey(
+    opts.destination
+  ).xdrAccountId();
+  attributes.destAsset = opts.destAsset.toXDRObject();
+  attributes.destMin = this._toXDRAmount(opts.destMin);
+
+  const path = opts.path ? opts.path : [];
+  attributes.path = path.map((x) => x.toXDRObject());
+
+  const payment = new xdr.PathPaymentStrictSendOp(attributes);
+
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.pathPaymentStrictSend(payment);
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/path_payment_strict_send.js
+++ b/src/operations/path_payment_strict_send.js
@@ -3,8 +3,8 @@ import { Keypair } from '../keypair';
 import { StrKey } from '../strkey';
 
 /**
- * Returns a XDR PathPaymentStrictSendOp. A "payment" operation send the specified amount to the
- * destination account, optionally through a path. XLM payments create the destination
+ * Returns a XDR PathPaymentStrictSendOp. A "PathPaymentStrictSend" operation send the specified amount to the
+ * destination account crediting at least `destMin` of `destAsset`, optionally through a path. XLM payments create the destination
  * account if it does not exist.
  * @function
  * @alias Operation.pathPayment

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -346,6 +346,122 @@ describe('Operation', function() {
     });
   });
 
+  describe('.pathPaymentStrictSend()', function() {
+    it('creates a pathPaymentStrictSendOp', function() {
+      var sendAsset = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      var sendAmount = '3.0070000';
+      var destination =
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      var destAsset = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      var destMin = '3.1415000';
+      var path = [
+        new StellarBase.Asset(
+          'USD',
+          'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
+        ),
+        new StellarBase.Asset(
+          'EUR',
+          'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
+        )
+      ];
+      let op = StellarBase.Operation.pathPaymentStrictSend({
+        sendAsset,
+        sendAmount,
+        destination,
+        destAsset,
+        destMin,
+        path
+      });
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('pathPaymentStrictSend');
+      expect(obj.sendAsset.equals(sendAsset)).to.be.true;
+      expect(
+        operation
+          .body()
+          .value()
+          .sendAmount()
+          .toString()
+      ).to.be.equal('30070000');
+      expect(obj.sendAmount).to.be.equal(sendAmount);
+      expect(obj.destination).to.be.equal(destination);
+      expect(obj.destAsset.equals(destAsset)).to.be.true;
+      expect(
+        operation
+          .body()
+          .value()
+          .destMin()
+          .toString()
+      ).to.be.equal('31415000');
+      expect(obj.destMin).to.be.equal(destMin);
+      expect(obj.path[0].getCode()).to.be.equal('USD');
+      expect(obj.path[0].getIssuer()).to.be.equal(
+        'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
+      );
+      expect(obj.path[1].getCode()).to.be.equal('EUR');
+      expect(obj.path[1].getIssuer()).to.be.equal(
+        'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
+      );
+    });
+
+    it('fails to create path payment operation with an invalid destination address', function() {
+      let opts = {
+        destination: 'GCEZW',
+        sendAmount: '20',
+        destMin: '50',
+        sendAsset: StellarBase.Asset.native(),
+        destAsset: new StellarBase.Asset(
+          'USD',
+          'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        )
+      };
+      expect(() => StellarBase.Operation.pathPaymentStrictSend(opts)).to.throw(
+        /destination is invalid/
+      );
+    });
+
+    it('fails to create path payment operation with an invalid sendAmount', function() {
+      let opts = {
+        destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        sendAmount: 20,
+        destMin: '50',
+        sendAsset: StellarBase.Asset.native(),
+        destAsset: new StellarBase.Asset(
+          'USD',
+          'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        )
+      };
+      expect(() => StellarBase.Operation.pathPaymentStrictSend(opts)).to.throw(
+        /sendAmount argument must be of type String/
+      );
+    });
+
+    it('fails to create path payment operation with an invalid destMin', function() {
+      let opts = {
+        destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        sendAmount: '20',
+        destMin: 50,
+        sendAsset: StellarBase.Asset.native(),
+        destAsset: new StellarBase.Asset(
+          'USD',
+          'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        )
+      };
+      expect(() => StellarBase.Operation.pathPaymentStrictSend(opts)).to.throw(
+        /destMin argument must be of type String/
+      );
+    });
+  });
+
   describe('.changeTrust()', function() {
     it('creates a changeTrustOp', function() {
       let asset = new StellarBase.Asset(

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -115,7 +115,7 @@ describe('Operation', function() {
   });
 
   describe('.pathPayment()', function() {
-    it('creates a pathPaymentOp', function() {
+    it('creates a pathPaymentStrictReceiveOp', function() {
       var sendAsset = new StellarBase.Asset(
         'USD',
         'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
@@ -151,7 +151,7 @@ describe('Operation', function() {
         Buffer.from(xdr, 'hex')
       );
       var obj = StellarBase.Operation.fromXDRObject(operation);
-      expect(obj.type).to.be.equal('pathPayment');
+      expect(obj.type).to.be.equal('pathPaymentStrictReceive');
       expect(obj.sendAsset.equals(sendAsset)).to.be.true;
       expect(
         operation

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -230,6 +230,122 @@ describe('Operation', function() {
     });
   });
 
+  describe('.pathPaymentStrictReceive()', function() {
+    it('creates a pathPaymentStrictReceiveOp', function() {
+      var sendAsset = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      var sendMax = '3.0070000';
+      var destination =
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      var destAsset = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      var destAmount = '3.1415000';
+      var path = [
+        new StellarBase.Asset(
+          'USD',
+          'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
+        ),
+        new StellarBase.Asset(
+          'EUR',
+          'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
+        )
+      ];
+      let op = StellarBase.Operation.pathPaymentStrictReceive({
+        sendAsset,
+        sendMax,
+        destination,
+        destAsset,
+        destAmount,
+        path
+      });
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('pathPaymentStrictReceive');
+      expect(obj.sendAsset.equals(sendAsset)).to.be.true;
+      expect(
+        operation
+          .body()
+          .value()
+          .sendMax()
+          .toString()
+      ).to.be.equal('30070000');
+      expect(obj.sendMax).to.be.equal(sendMax);
+      expect(obj.destination).to.be.equal(destination);
+      expect(obj.destAsset.equals(destAsset)).to.be.true;
+      expect(
+        operation
+          .body()
+          .value()
+          .destAmount()
+          .toString()
+      ).to.be.equal('31415000');
+      expect(obj.destAmount).to.be.equal(destAmount);
+      expect(obj.path[0].getCode()).to.be.equal('USD');
+      expect(obj.path[0].getIssuer()).to.be.equal(
+        'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
+      );
+      expect(obj.path[1].getCode()).to.be.equal('EUR');
+      expect(obj.path[1].getIssuer()).to.be.equal(
+        'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
+      );
+    });
+
+    it('fails to create path payment operation with an invalid destination address', function() {
+      let opts = {
+        destination: 'GCEZW',
+        sendMax: '20',
+        destAmount: '50',
+        sendAsset: StellarBase.Asset.native(),
+        destAsset: new StellarBase.Asset(
+          'USD',
+          'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        )
+      };
+      expect(() =>
+        StellarBase.Operation.pathPaymentStrictReceive(opts)
+      ).to.throw(/destination is invalid/);
+    });
+
+    it('fails to create path payment operation with an invalid sendMax', function() {
+      let opts = {
+        destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        sendMax: 20,
+        destAmount: '50',
+        sendAsset: StellarBase.Asset.native(),
+        destAsset: new StellarBase.Asset(
+          'USD',
+          'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        )
+      };
+      expect(() =>
+        StellarBase.Operation.pathPaymentStrictReceive(opts)
+      ).to.throw(/sendMax argument must be of type String/);
+    });
+
+    it('fails to create path payment operation with an invalid destAmount', function() {
+      let opts = {
+        destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        sendMax: '20',
+        destAmount: 50,
+        sendAsset: StellarBase.Asset.native(),
+        destAsset: new StellarBase.Asset(
+          'USD',
+          'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        )
+      };
+      expect(() =>
+        StellarBase.Operation.pathPaymentStrictReceive(opts)
+      ).to.throw(/destAmount argument must be of type String/);
+    });
+  });
+
   describe('.changeTrust()', function() {
     it('creates a changeTrustOp', function() {
       let asset = new StellarBase.Asset(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -193,6 +193,7 @@ export namespace OperationType {
   type CreateAccount = 'createAccount';
   type Payment = 'payment';
   type PathPaymentStrictReceive = 'pathPaymentStrictReceive';
+  type PathPaymentStrictSend = 'pathPaymentStrictSend';
   type CreatePassiveSellOffer = 'createPassiveSellOffer';
   type ManageSellOffer = 'manageSellOffer';
   type ManageBuyOffer = 'manageBuyOffer';
@@ -208,6 +209,7 @@ export type OperationType =
   | OperationType.CreateAccount
   | OperationType.Payment
   | OperationType.PathPaymentStrictReceive
+  | OperationType.PathPaymentStrictSend
   | OperationType.CreatePassiveSellOffer
   | OperationType.ManageSellOffer
   | OperationType.ManageBuyOffer
@@ -271,6 +273,14 @@ export namespace OperationOptions {
     destAmount: string;
     path?: Asset[];
   }
+  interface PathPaymentStrictSend extends BaseOptions {
+    sendAsset: Asset;
+    sendAmount: string;
+    destination: string;
+    destAsset: Asset;
+    destMin: string;
+    path?: Asset[];
+  }
   interface Payment extends BaseOptions {
     amount: string;
     asset: Asset;
@@ -295,6 +305,7 @@ export type OperationOptions =
   | OperationOptions.CreateAccount
   | OperationOptions.Payment
   | OperationOptions.PathPaymentStrictReceive
+  | OperationOptions.PathPaymentStrictSend
   | OperationOptions.CreatePassiveSellOffer
   | OperationOptions.ManageSellOffer
   | OperationOptions.ManageBuyOffer
@@ -402,9 +413,22 @@ export namespace Operation {
   function pathPaymentStrictReceive(
     options: OperationOptions.PathPaymentStrictReceive
   ): xdr.Operation<PathPaymentStrictReceive>;
+
   function pathPayment(
     options: OperationOptions.PathPaymentStrictReceive
   ): xdr.Operation<PathPaymentStrictReceive>;
+
+  interface PathPaymentStrictSend extends BaseOperation<OperationType.PathPaymentStrictSend> {
+    sendAsset: Asset;
+    sendAmount: string;
+    destination: string;
+    destAsset: Asset;
+    destMin: string;
+    path: Asset[];
+  }
+  function pathPaymentStrictSend(
+    options: OperationOptions.PathPaymentStrictSend
+  ): xdr.Operation<PathPaymentStrictSend>;
 
   interface Payment extends BaseOperation<OperationType.Payment> {
     amount: string;
@@ -450,6 +474,7 @@ export type Operation =
   | Operation.CreateAccount
   | Operation.Payment
   | Operation.PathPaymentStrictReceive
+  | Operation.PathPaymentStrictSend
   | Operation.CreatePassiveSellOffer
   | Operation.ManageSellOffer
   | Operation.ManageBuyOffer

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -192,7 +192,7 @@ export type SignerOptions =
 export namespace OperationType {
   type CreateAccount = 'createAccount';
   type Payment = 'payment';
-  type PathPayment = 'pathPayment';
+  type PathPaymentStrictReceive = 'pathPaymentStrictReceive';
   type CreatePassiveSellOffer = 'createPassiveSellOffer';
   type ManageSellOffer = 'manageSellOffer';
   type ManageBuyOffer = 'manageBuyOffer';
@@ -207,7 +207,7 @@ export namespace OperationType {
 export type OperationType =
   | OperationType.CreateAccount
   | OperationType.Payment
-  | OperationType.PathPayment
+  | OperationType.PathPaymentStrictReceive
   | OperationType.CreatePassiveSellOffer
   | OperationType.ManageSellOffer
   | OperationType.ManageBuyOffer
@@ -263,7 +263,7 @@ export namespace OperationOptions {
     name: string;
     value: string | Buffer;
   }
-  interface PathPayment extends BaseOptions {
+  interface PathPaymentStrictReceive extends BaseOptions {
     sendAsset: Asset;
     sendMax: string;
     destination: string;
@@ -294,7 +294,7 @@ export namespace OperationOptions {
 export type OperationOptions =
   | OperationOptions.CreateAccount
   | OperationOptions.Payment
-  | OperationOptions.PathPayment
+  | OperationOptions.PathPaymentStrictReceive
   | OperationOptions.CreatePassiveSellOffer
   | OperationOptions.ManageSellOffer
   | OperationOptions.ManageBuyOffer
@@ -391,7 +391,7 @@ export namespace Operation {
     options: OperationOptions.ManageBuyOffer
   ): xdr.Operation<ManageBuyOffer>;
 
-  interface PathPayment extends BaseOperation<OperationType.PathPayment> {
+  interface PathPaymentStrictReceive extends BaseOperation<OperationType.PathPaymentStrictReceive> {
     sendAsset: Asset;
     sendMax: string;
     destination: string;
@@ -399,9 +399,12 @@ export namespace Operation {
     destAmount: string;
     path: Asset[];
   }
+  function pathPaymentStrictReceive(
+    options: OperationOptions.PathPaymentStrictReceive
+  ): xdr.Operation<PathPaymentStrictReceive>;
   function pathPayment(
-    options: OperationOptions.PathPayment
-  ): xdr.Operation<PathPayment>;
+    options: OperationOptions.PathPaymentStrictReceive
+  ): xdr.Operation<PathPaymentStrictReceive>;
 
   interface Payment extends BaseOperation<OperationType.Payment> {
     amount: string;
@@ -446,7 +449,7 @@ export namespace Operation {
 export type Operation =
   | Operation.CreateAccount
   | Operation.Payment
-  | Operation.PathPayment
+  | Operation.PathPaymentStrictReceive
   | Operation.CreatePassiveSellOffer
   | Operation.ManageSellOffer
   | Operation.ManageBuyOffer

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -17,7 +17,7 @@ enum OperationType
 {
     CREATE_ACCOUNT = 0,
     PAYMENT = 1,
-    PATH_PAYMENT = 2,
+    PATH_PAYMENT_STRICT_RECEIVE = 2,
     MANAGE_SELL_OFFER = 3,
     CREATE_PASSIVE_SELL_OFFER = 4,
     SET_OPTIONS = 5,
@@ -27,7 +27,8 @@ enum OperationType
     INFLATION = 9,
     MANAGE_DATA = 10,
     BUMP_SEQUENCE = 11,
-    MANAGE_BUY_OFFER = 12
+    MANAGE_BUY_OFFER = 12,
+    PATH_PAYMENT_STRICT_SEND = 13
 };
 
 /* CreateAccount
@@ -59,7 +60,7 @@ struct PaymentOp
     int64 amount;          // amount they end up with
 };
 
-/* PathPayment
+/* PathPaymentStrictReceive
 
 send an amount to a destination account through a path.
 (up to sendMax, sendAsset)
@@ -68,9 +69,9 @@ send an amount to a destination account through a path.
 
 Threshold: med
 
-Result: PathPaymentResult
+Result: PathPaymentStrictReceiveResult
 */
-struct PathPaymentOp
+struct PathPaymentStrictReceiveOp
 {
     Asset sendAsset; // asset we pay with
     int64 sendMax;   // the maximum amount of sendAsset to
@@ -83,6 +84,32 @@ struct PathPaymentOp
 
     Asset path<5>; // additional hops it must go through to get there
 };
+
+/* PathPaymentStrictSend
+
+send an amount to a destination account through a path.
+(sendMax, sendAsset)
+(X0, Path[0]) .. (Xn, Path[n])
+(at least destAmount, destAsset)
+
+Threshold: med
+
+Result: PathPaymentStrictSendResult
+*/
+struct PathPaymentStrictSendOp
+{
+    Asset sendAsset;  // asset we pay with
+    int64 sendAmount; // amount of sendAsset to send (excluding fees)
+
+    AccountID destination; // recipient of the payment
+    Asset destAsset;       // what they end up with
+    int64 destMin;         // the minimum amount of dest asset to
+                           // be received
+                           // The operation will fail if it can't be met
+
+    Asset path<5>; // additional hops it must go through to get there
+};
+
 
 /* Creates, updates or deletes an offer
 
@@ -266,8 +293,8 @@ struct Operation
         CreateAccountOp createAccountOp;
     case PAYMENT:
         PaymentOp paymentOp;
-    case PATH_PAYMENT:
-        PathPaymentOp pathPaymentOp;
+    case PATH_PAYMENT_STRICT_RECEIVE:
+        PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
     case MANAGE_SELL_OFFER:
         ManageSellOfferOp manageSellOfferOp;
     case CREATE_PASSIVE_SELL_OFFER:
@@ -288,6 +315,8 @@ struct Operation
         BumpSequenceOp bumpSequenceOp;
     case MANAGE_BUY_OFFER:
         ManageBuyOfferOp manageBuyOfferOp;
+    case PATH_PAYMENT_STRICT_SEND:
+        PathPaymentStrictSendOp pathPaymentStrictSendOp;
     }
     body;
 };
@@ -447,26 +476,26 @@ default:
     void;
 };
 
-/******* Payment Result ********/
+/******* PathPaymentStrictReceive Result ********/
 
-enum PathPaymentResultCode
+enum PathPaymentStrictReceiveResultCode
 {
     // codes considered as "success" for the operation
-    PATH_PAYMENT_SUCCESS = 0, // success
+    PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
 
     // codes considered as "failure" for the operation
-    PATH_PAYMENT_MALFORMED = -1,          // bad input
-    PATH_PAYMENT_UNDERFUNDED = -2,        // not enough funds in source account
-    PATH_PAYMENT_SRC_NO_TRUST = -3,       // no trust line on source account
-    PATH_PAYMENT_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-    PATH_PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
-    PATH_PAYMENT_NO_TRUST = -6,           // dest missing a trust line for asset
-    PATH_PAYMENT_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
-    PATH_PAYMENT_LINE_FULL = -8,          // dest would go above their limit
-    PATH_PAYMENT_NO_ISSUER = -9,          // missing issuer on one asset
-    PATH_PAYMENT_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
-    PATH_PAYMENT_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
-    PATH_PAYMENT_OVER_SENDMAX = -12       // could not satisfy sendmax
+    PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1,          // bad input
+    PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED = -2,        // not enough funds in source account
+    PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST = -3,       // no trust line on source account
+    PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+    PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION = -5,     // destination account does not exist
+    PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST = -6,           // dest missing a trust line for asset
+    PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
+    PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL = -8,          // dest would go above their limit
+    PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9,          // missing issuer on one asset
+    PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
+    PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
+    PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12       // could not satisfy sendmax
 };
 
 struct SimplePaymentResult
@@ -476,15 +505,51 @@ struct SimplePaymentResult
     int64 amount;
 };
 
-union PathPaymentResult switch (PathPaymentResultCode code)
+union PathPaymentStrictReceiveResult switch (PathPaymentStrictReceiveResultCode code)
 {
-case PATH_PAYMENT_SUCCESS:
+case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
     struct
     {
         ClaimOfferAtom offers<>;
         SimplePaymentResult last;
     } success;
-case PATH_PAYMENT_NO_ISSUER:
+case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
+    Asset noIssuer; // the asset that caused the error
+default:
+    void;
+};
+
+/******* PathPaymentStrictSend Result ********/
+
+enum PathPaymentStrictSendResultCode
+{
+    // codes considered as "success" for the operation
+    PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
+
+    // codes considered as "failure" for the operation
+    PATH_PAYMENT_STRICT_SEND_MALFORMED = -1,          // bad input
+    PATH_PAYMENT_STRICT_SEND_UNDERFUNDED = -2,        // not enough funds in source account
+    PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST = -3,       // no trust line on source account
+    PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+    PATH_PAYMENT_STRICT_SEND_NO_DESTINATION = -5,     // destination account does not exist
+    PATH_PAYMENT_STRICT_SEND_NO_TRUST = -6,           // dest missing a trust line for asset
+    PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
+    PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8,          // dest would go above their limit
+    PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9,          // missing issuer on one asset
+    PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
+    PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
+    PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12      // could not satisfy destMin
+};
+
+union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
+{
+case PATH_PAYMENT_STRICT_SEND_SUCCESS:
+    struct
+    {
+        ClaimOfferAtom offers<>;
+        SimplePaymentResult last;
+    } success;
+case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
     Asset noIssuer; // the asset that caused the error
 default:
     void;
@@ -762,8 +827,8 @@ case opINNER:
         CreateAccountResult createAccountResult;
     case PAYMENT:
         PaymentResult paymentResult;
-    case PATH_PAYMENT:
-        PathPaymentResult pathPaymentResult;
+    case PATH_PAYMENT_STRICT_RECEIVE:
+        PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
     case MANAGE_SELL_OFFER:
         ManageSellOfferResult manageSellOfferResult;
     case CREATE_PASSIVE_SELL_OFFER:
@@ -784,6 +849,8 @@ case opINNER:
         BumpSequenceResult bumpSeqResult;
     case MANAGE_BUY_OFFER:
 	ManageBuyOfferResult manageBuyOfferResult;
+    case PATH_PAYMENT_STRICT_SEND:
+        PathPaymentStrictSendResult pathPaymentStrictSendResult;
     }
     tr;
 default:


### PR DESCRIPTION
Add support for [stellar-core protocol 12 release](https://github.com/stellar/stellar-core/projects/11) and [CAP 24](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0024.md) ("Make PathPayment Symmetrical").

### Add ➕ 

 - `Operation.pathPaymentStrictSend`: Sends a path payment, debiting from the source account exactly a specified amount of one asset, crediting at least a given amount of another asset. 
    
   The following operation will debit exactly 10 USD from the source account, crediting at least 9.2 EUR in the destination account 💸:
    ```js
    var sendAsset = new StellarBase.Asset(
      'USD',
      'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
    );
    var sendAmount = '10';
    var destination =
      'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
    var destAsset = new StellarBase.Asset(
      'USD',
      'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
    );
    var destMin = '9.2';
    var path = [
      new StellarBase.Asset(
        'USD',
        'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
      ),
      new StellarBase.Asset(
        'EUR',
        'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
      )
    ];
    let op = StellarBase.Operation.pathPaymentStrictSend({
      sendAsset,
      sendAmount,
      destination,
      destAsset,
      destMin,
      path
    });
    ```
 - `Operation.pathPaymentStrictReceive`: This behaves the same as the former `pathPayments` operation.

   The following operation will debit maximum 10 USD from the source account, crediting exactly 9.2 EUR in the destination account 💸:
   ```js
   var sendAsset = new StellarBase.Asset(
     'USD',
     'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
   );
   var sendMax = '10';
   var destination =
     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
   var destAsset = new StellarBase.Asset(
     'USD',
     'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
   );
   var destAmount = '9.2';
   var path = [
     new StellarBase.Asset(
       'USD',
       'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
     ),
     new StellarBase.Asset(
       'EUR',
       'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
     )
   ];
   let op = StellarBase.Operation.pathPaymentStrictReceive({
     sendAsset,
     sendMax,
     destination,
     destAsset,
     destAmount,
     path
   });
   ```	

## Deprecated ❗️ 

- `Operation.pathPayment` is being deprecated in favor of `Operation.pathPaymentStrictReceive`. Both functions take the same arguments and behave the same. 
