### PR TITLE
Fix crash on partially defined time bounds

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -211,12 +211,15 @@ export class TransactionBuilder {
         this.timebounds.maxTime = this.timebounds.maxTime.getTime() / 1000;
       }
 
-      this.timebounds.minTime = UnsignedHyper.fromString(
-        this.timebounds.minTime.toString()
-      );
-      this.timebounds.maxTime = UnsignedHyper.fromString(
-        this.timebounds.maxTime.toString()
-      );
+      this.timebounds.minTime =
+        typeof this.timebounds.minTime !== 'undefined'
+          ? UnsignedHyper.fromString(this.timebounds.minTime.toString())
+          : undefined;
+
+      this.timebounds.maxTime =
+        typeof this.timebounds.maxTime !== 'undefined'
+          ? UnsignedHyper.fromString(this.timebounds.maxTime.toString())
+          : undefined;
 
       attrs.timeBounds = new xdr.TimeBounds(this.timebounds);
     }

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -384,5 +384,26 @@ describe('TransactionBuilder', function() {
         timeoutTimestamp.toString()
       );
     });
+
+    it('does not crash when timebounds are only partially set', function() {
+      let source = new StellarBase.Account(
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        '0'
+      );
+      expect(() => {
+        new StellarBase.TransactionBuilder(source, {
+          timebounds: {
+            minTime: '1455287522'
+          },
+          fee: 100
+        });
+        new StellarBase.TransactionBuilder(source, {
+          timebounds: {
+            maxTime: '1455287522'
+          },
+          fee: 100
+        });
+      }).to.not.throw();
+    });
   });
 });


### PR DESCRIPTION
Fix `Cannot read property 'toString' of undefined` error. Did occur when either `timebounds.minTime` or `timebounds.maxTime` were set, but not both.

PS: Need to test this fix some more.