### PR TITLE
Add optional format to TransactionBuilder xdr constructor

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -579,7 +579,7 @@ export namespace xdr {
     static fromXDR(xdr: Buffer): Memo;
   }
   class TransactionEnvelope extends XDRStruct {
-    static fromXDR(xdr: Buffer): TransactionEnvelope;
+    static fromXDR(xdr: Buffer, format?: string): TransactionEnvelope;
   }
   class DecoratedSignature extends XDRStruct {
     static fromXDR(xdr: Buffer): DecoratedSignature;


### PR DESCRIPTION
Fixes #306 

TransactionBuilder.fromXDR type definition was missing an optional string argument to specify the format of the xdr, as seen here: https://github.com/stellar/js-xdr/blob/master/src/io-mixin.js#L18

I am unclear if all the other classes fromXDR should also have this argument, anyone know?