### PR TITLE
Add support for CAP 0027 (MuxedAccounts)

### DIFF
--- a/src/keypair.js
+++ b/src/keypair.js
@@ -140,6 +140,10 @@ export class Keypair {
     return new xdr.PublicKey.publicKeyTypeEd25519(this._publicKey);
   }
 
+  xdrMuxedAccount() {
+    return new xdr.MuxedAccount.keyTypeEd25519(this._publicKey);
+  }
+
   /**
    * Returns raw public key
    * @returns {Buffer}

--- a/src/operation.js
+++ b/src/operation.js
@@ -73,7 +73,7 @@ export class Operation {
       }
       opAttributes.sourceAccount = Keypair.fromPublicKey(
         opts.source
-      ).xdrAccountId();
+      ).xdrMuxedAccount();
     }
   }
 

--- a/src/operations/account_merge.js
+++ b/src/operations/account_merge.js
@@ -17,7 +17,7 @@ export function accountMerge(opts) {
     throw new Error('destination is invalid');
   }
   opAttributes.body = xdr.OperationBody.accountMerge(
-    Keypair.fromPublicKey(opts.destination).xdrAccountId()
+    Keypair.fromPublicKey(opts.destination).xdrMuxedAccount()
   );
   this.setSourceAccount(opAttributes, opts);
 

--- a/src/operations/path_payment_strict_receive.js
+++ b/src/operations/path_payment_strict_receive.js
@@ -39,7 +39,7 @@ export function pathPaymentStrictReceive(opts) {
   attributes.sendMax = this._toXDRAmount(opts.sendMax);
   attributes.destination = Keypair.fromPublicKey(
     opts.destination
-  ).xdrAccountId();
+  ).xdrMuxedAccount();
   attributes.destAsset = opts.destAsset.toXDRObject();
   attributes.destAmount = this._toXDRAmount(opts.destAmount);
 

--- a/src/operations/path_payment_strict_send.js
+++ b/src/operations/path_payment_strict_send.js
@@ -39,7 +39,7 @@ export function pathPaymentStrictSend(opts) {
   attributes.sendAmount = this._toXDRAmount(opts.sendAmount);
   attributes.destination = Keypair.fromPublicKey(
     opts.destination
-  ).xdrAccountId();
+  ).xdrMuxedAccount();
   attributes.destAsset = opts.destAsset.toXDRObject();
   attributes.destMin = this._toXDRAmount(opts.destMin);
 

--- a/src/operations/payment.js
+++ b/src/operations/payment.js
@@ -27,7 +27,7 @@ export function payment(opts) {
   const attributes = {};
   attributes.destination = Keypair.fromPublicKey(
     opts.destination
-  ).xdrAccountId();
+  ).xdrMuxedAccount();
   attributes.asset = opts.asset.toXDRObject();
   attributes.amount = this._toXDRAmount(opts.amount);
   const paymentOp = new xdr.PaymentOp(attributes);

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -228,7 +228,7 @@ export class TransactionBuilder {
     if (this.v1) {
       attrs.sourceAccount = Keypair.fromPublicKey(
         this.source.accountId()
-      ).xdrAccountId();
+      ).xdrMuxedAccount();
       attrs.ext = new xdr.TransactionExt(0);
 
       const xtx = new xdr.Transaction(attrs);

--- a/test/unit/keypair_test.js
+++ b/test/unit/keypair_test.js
@@ -1,52 +1,64 @@
-
 describe('Keypair.contructor', function() {
-  it("fails when passes secret key does not match public key", function() {
-    let secret = "SD7X7LEHBNMUIKQGKPARG5TDJNBHKC346OUARHGZL5ITC6IJPXHILY36";
+  it('fails when passes secret key does not match public key', function() {
+    let secret = 'SD7X7LEHBNMUIKQGKPARG5TDJNBHKC346OUARHGZL5ITC6IJPXHILY36';
     let kp = StellarBase.Keypair.fromSecret(secret);
 
     let secretKey = kp.rawSecretKey();
     let publicKey = StellarBase.StrKey.decodeEd25519PublicKey(kp.publicKey());
     publicKey[0] = 0; // Make public key invalid
 
-    expect(() => new StellarBase.Keypair({type: 'ed25519', secretKey, publicKey})).to.throw(/secretKey does not match publicKey/)
+    expect(
+      () => new StellarBase.Keypair({ type: 'ed25519', secretKey, publicKey })
+    ).to.throw(/secretKey does not match publicKey/);
   });
 
-  it("fails when secretKey length is invalid", function() {
+  it('fails when secretKey length is invalid', function() {
     let secretKey = Buffer.alloc(33);
-    expect(() => new StellarBase.Keypair({type: 'ed25519', secretKey})).to.throw(/secretKey length is invalid/)
+    expect(
+      () => new StellarBase.Keypair({ type: 'ed25519', secretKey })
+    ).to.throw(/secretKey length is invalid/);
   });
 
-  it("fails when publicKey length is invalid", function() {
+  it('fails when publicKey length is invalid', function() {
     let publicKey = Buffer.alloc(33);
-    expect(() => new StellarBase.Keypair({type: 'ed25519', publicKey})).to.throw(/publicKey length is invalid/)
+    expect(
+      () => new StellarBase.Keypair({ type: 'ed25519', publicKey })
+    ).to.throw(/publicKey length is invalid/);
   });
 });
 
 describe('Keypair.fromSecret', function() {
-
-  it("creates a keypair correctly", function() {
-    let secret = "SD7X7LEHBNMUIKQGKPARG5TDJNBHKC346OUARHGZL5ITC6IJPXHILY36";
+  it('creates a keypair correctly', function() {
+    let secret = 'SD7X7LEHBNMUIKQGKPARG5TDJNBHKC346OUARHGZL5ITC6IJPXHILY36';
     let kp = StellarBase.Keypair.fromSecret(secret);
 
     expect(kp).to.be.instanceof(StellarBase.Keypair);
-    expect(kp.publicKey()).to.eql("GDFQVQCYYB7GKCGSCUSIQYXTPLV5YJ3XWDMWGQMDNM4EAXAL7LITIBQ7");
+    expect(kp.publicKey()).to.eql(
+      'GDFQVQCYYB7GKCGSCUSIQYXTPLV5YJ3XWDMWGQMDNM4EAXAL7LITIBQ7'
+    );
     expect(kp.secret()).to.eql(secret);
   });
 
   it("throw an error if the arg isn't strkey encoded as a seed", function() {
-
-    expect(() => StellarBase.Keypair.fromSecret("hel0")).to.throw()
-    expect(() => StellarBase.Keypair.fromSecret("SBWUBZ3SIPLLF5CCXLWUB2Z6UBTYAW34KVXOLRQ5HDAZG4ZY7MHNBWJ1")).to.throw()
-    expect(() => StellarBase.Keypair.fromSecret("masterpassphrasemasterpassphrase")).to.throw()
-    expect(() => StellarBase.Keypair.fromSecret("gsYRSEQhTffqA9opPepAENCr2WG6z5iBHHubxxbRzWaHf8FBWcu")).to.throw()
-
+    expect(() => StellarBase.Keypair.fromSecret('hel0')).to.throw();
+    expect(() =>
+      StellarBase.Keypair.fromSecret(
+        'SBWUBZ3SIPLLF5CCXLWUB2Z6UBTYAW34KVXOLRQ5HDAZG4ZY7MHNBWJ1'
+      )
+    ).to.throw();
+    expect(() =>
+      StellarBase.Keypair.fromSecret('masterpassphrasemasterpassphrase')
+    ).to.throw();
+    expect(() =>
+      StellarBase.Keypair.fromSecret(
+        'gsYRSEQhTffqA9opPepAENCr2WG6z5iBHHubxxbRzWaHf8FBWcu'
+      )
+    ).to.throw();
   });
-
 });
 
 describe('Keypair.fromBase58Seed', function() {
-
-  it("creates a keypair correctly", function() {
+  it('creates a keypair correctly', function() {
     let keys = [
       {
         oldSeed: 's3wpFU2RY8EyYRDKxhWNj3wJFBd4qHLKnaccXw9uGyYwrWVLDkB',
@@ -75,7 +87,6 @@ describe('Keypair.fromBase58Seed', function() {
       }
     ];
 
-
     for (let i in keys) {
       let key = keys[i];
       let keyPair = StellarBase.Keypair.fromBase58Seed(key.oldSeed);
@@ -85,67 +96,103 @@ describe('Keypair.fromBase58Seed', function() {
   });
 
   it("throw an error if the arg isn't base58 encoded as a seed", function() {
-
-    expect(() => StellarBase.Keypair.fromBase58Seed("hel0")).to.throw()
-    expect(() => StellarBase.Keypair.fromBase58Seed("masterpassphrasemasterpassphrase")).to.throw()
-    expect(() => StellarBase.Keypair.fromBase58Seed("gsYRSEQhTffqA9opPepAENCr2WG6z5iBHHubxxbRzWaHf8FBWcu")).to.throw()
-
+    expect(() => StellarBase.Keypair.fromBase58Seed('hel0')).to.throw();
+    expect(() =>
+      StellarBase.Keypair.fromBase58Seed('masterpassphrasemasterpassphrase')
+    ).to.throw();
+    expect(() =>
+      StellarBase.Keypair.fromBase58Seed(
+        'gsYRSEQhTffqA9opPepAENCr2WG6z5iBHHubxxbRzWaHf8FBWcu'
+      )
+    ).to.throw();
   });
-
 });
 
 describe('Keypair.fromRawEd25519Seed', function() {
-
-  it("creates a keypair correctly", function() {
-    let seed = "masterpassphrasemasterpassphrase";
+  it('creates a keypair correctly', function() {
+    let seed = 'masterpassphrasemasterpassphrase';
     let kp = StellarBase.Keypair.fromRawEd25519Seed(seed);
 
     expect(kp).to.be.instanceof(StellarBase.Keypair);
-    expect(kp.publicKey()).to.eql("GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH");
-    expect(kp.secret()).to.eql("SBWWC43UMVZHAYLTONYGQ4TBONSW2YLTORSXE4DBONZXA2DSMFZWLP2R");
-    expect(kp.rawPublicKey().toString("hex")).to.eql("2e3c35010749c1de3d9a5bdd6a31c12458768da5ce87cca6aad63ebbaaef7432");
+    expect(kp.publicKey()).to.eql(
+      'GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH'
+    );
+    expect(kp.secret()).to.eql(
+      'SBWWC43UMVZHAYLTONYGQ4TBONSW2YLTORSXE4DBONZXA2DSMFZWLP2R'
+    );
+    expect(kp.rawPublicKey().toString('hex')).to.eql(
+      '2e3c35010749c1de3d9a5bdd6a31c12458768da5ce87cca6aad63ebbaaef7432'
+    );
   });
 
   it("throws an error if the arg isn't 32 bytes", function() {
-    expect(() => StellarBase.Keypair.fromRawEd25519Seed("masterpassphrasemasterpassphras")).to.throw()
-    expect(() => StellarBase.Keypair.fromRawEd25519Seed("masterpassphrasemasterpassphrase1")).to.throw()
-    expect(() => StellarBase.Keypair.fromRawEd25519Seed(null)).to.throw()
-    expect(() => StellarBase.Keypair.fromRawEd25519Seed()).to.throw()
+    expect(() =>
+      StellarBase.Keypair.fromRawEd25519Seed('masterpassphrasemasterpassphras')
+    ).to.throw();
+    expect(() =>
+      StellarBase.Keypair.fromRawEd25519Seed(
+        'masterpassphrasemasterpassphrase1'
+      )
+    ).to.throw();
+    expect(() => StellarBase.Keypair.fromRawEd25519Seed(null)).to.throw();
+    expect(() => StellarBase.Keypair.fromRawEd25519Seed()).to.throw();
   });
-
 });
 
-
 describe('Keypair.fromPublicKey', function() {
-
-  it("creates a keypair correctly", function() {
-    let kp = StellarBase.Keypair.fromPublicKey("GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH");
+  it('creates a keypair correctly', function() {
+    let kp = StellarBase.Keypair.fromPublicKey(
+      'GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH'
+    );
     expect(kp).to.be.instanceof(StellarBase.Keypair);
-    expect(kp.publicKey()).to.eql("GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH");
-    expect(kp.rawPublicKey().toString("hex")).to.eql("2e3c35010749c1de3d9a5bdd6a31c12458768da5ce87cca6aad63ebbaaef7432");
+    expect(kp.publicKey()).to.eql(
+      'GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH'
+    );
+    expect(kp.rawPublicKey().toString('hex')).to.eql(
+      '2e3c35010749c1de3d9a5bdd6a31c12458768da5ce87cca6aad63ebbaaef7432'
+    );
   });
 
   it("throw an error if the arg isn't strkey encoded as a accountid", function() {
-    expect(() => StellarBase.Keypair.fromPublicKey("hel0")).to.throw()
-    expect(() => StellarBase.Keypair.fromPublicKey("masterpassphrasemasterpassphrase")).to.throw()
-    expect(() => StellarBase.Keypair.fromPublicKey("sfyjodTxbwLtRToZvi6yQ1KnpZriwTJ7n6nrASFR6goRviCU3Ff")).to.throw()
+    expect(() => StellarBase.Keypair.fromPublicKey('hel0')).to.throw();
+    expect(() =>
+      StellarBase.Keypair.fromPublicKey('masterpassphrasemasterpassphrase')
+    ).to.throw();
+    expect(() =>
+      StellarBase.Keypair.fromPublicKey(
+        'sfyjodTxbwLtRToZvi6yQ1KnpZriwTJ7n6nrASFR6goRviCU3Ff'
+      )
+    ).to.throw();
   });
 
   it("throws an error if the address isn't 32 bytes", function() {
-    expect(() => StellarBase.Keypair.fromPublicKey("masterpassphrasemasterpassphrase")).to.throw()
-    expect(() => StellarBase.Keypair.fromPublicKey("masterpassphrasemasterpassphrase")).to.throw()
-    expect(() => StellarBase.Keypair.fromPublicKey(null)).to.throw()
-    expect(() => StellarBase.Keypair.fromPublicKey()).to.throw()
+    expect(() =>
+      StellarBase.Keypair.fromPublicKey('masterpassphrasemasterpassphrase')
+    ).to.throw();
+    expect(() =>
+      StellarBase.Keypair.fromPublicKey('masterpassphrasemasterpassphrase')
+    ).to.throw();
+    expect(() => StellarBase.Keypair.fromPublicKey(null)).to.throw();
+    expect(() => StellarBase.Keypair.fromPublicKey()).to.throw();
   });
-
 });
 
-
 describe('Keypair.random', function() {
-
-  it("creates a keypair correctly", function() {
+  it('creates a keypair correctly', function() {
     let kp = StellarBase.Keypair.random();
     expect(kp).to.be.instanceof(StellarBase.Keypair);
   });
+});
 
+describe('Keypair.xdrMuxedAccount', function() {
+  it('returns a valid MuxedAccount with a Ed25519 key type', function() {
+    const kp = StellarBase.Keypair.fromPublicKey(
+      'GAXDYNIBA5E4DXR5TJN522RRYESFQ5UNUXHIPTFGVLLD5O5K552DF5ZH'
+    );
+    const muxed = kp.xdrMuxedAccount();
+    expect(muxed).to.be.instanceof(StellarBase.xdr.MuxedAccount);
+    expect(muxed.switch()).to.be.equal(
+      StellarBase.xdr.CryptoKeyType.keyTypeEd25519()
+    );
+  });
 });

--- a/xdr/Stellar-ledger.x
+++ b/xdr/Stellar-ledger.x
@@ -366,7 +366,6 @@ struct LedgerCloseMetaV0
 union LedgerCloseMeta switch (int v)
 {
 case 0:
-     LedgerCloseMetaV0 v0;
+    LedgerCloseMetaV0 v0;
 };
-
 }

--- a/xdr/Stellar-overlay.x
+++ b/xdr/Stellar-overlay.x
@@ -172,8 +172,8 @@ struct TopologyResponseBody
 
 union SurveyResponseBody switch (SurveyMessageCommandType type)
 {
-    case SURVEY_TOPOLOGY:
-        TopologyResponseBody topologyResponseBody;
+case SURVEY_TOPOLOGY:
+    TopologyResponseBody topologyResponseBody;
 };
 
 union StellarMessage switch (MessageType type)
@@ -220,10 +220,10 @@ union AuthenticatedMessage switch (uint32 v)
 {
 case 0:
     struct
-{
-   uint64 sequence;
-   StellarMessage message;
-   HmacSha256Mac mac;
+    {
+        uint64 sequence;
+        StellarMessage message;
+        HmacSha256Mac mac;
     } v0;
 };
 }

--- a/xdr/Stellar-types.x
+++ b/xdr/Stellar-types.x
@@ -18,7 +18,10 @@ enum CryptoKeyType
 {
     KEY_TYPE_ED25519 = 0,
     KEY_TYPE_PRE_AUTH_TX = 1,
-    KEY_TYPE_HASH_X = 2
+    KEY_TYPE_HASH_X = 2,
+    // MUXED enum values for supported type are derived from the enum values
+    // above by ORing them with 0x100
+    KEY_TYPE_MUXED_ED25519 = 0x100
 };
 
 enum PublicKeyType
@@ -60,22 +63,21 @@ typedef PublicKey NodeID;
 
 struct Curve25519Secret
 {
-        opaque key[32];
+    opaque key[32];
 };
 
 struct Curve25519Public
 {
-        opaque key[32];
+    opaque key[32];
 };
 
 struct HmacSha256Key
 {
-        opaque key[32];
+    opaque key[32];
 };
 
 struct HmacSha256Mac
 {
-        opaque mac[32];
+    opaque mac[32];
 };
-
 }


### PR DESCRIPTION
## What

Add support for CAP0027.

## Why

Protocol 13 introduces multiplexed accounts, replacing some fields with the union `xdr.MuxedAccount` where `xdr.PublicKey` was previously used.

This pull requests:

- Extends `Keypair` with a new method `.xdrMuxedAccount` which creates a new `MuxedAccount` using the `ed25519` discriminant.
- Updates all the operations which changed their attribute from `PublicKey` to `MuxedAccount`.

Fixes #324 

## Breaking changes

This update doesn't include breaking changes for users of this library. However, if you are relying on XDRs, you'll get now a `MuxedAccount` where a `PublicKey` was returned. 

As long as you are not checking for the instance type, your code should continue to work since both `MuxedAccount` and `PublicKey` have the discriminant `ed25519` which returns the same data type. 

## What is not implemented in this pull request
- SEP0023 support - I'll handle that in a different PR.
- Passing an envelope to `new Transaction(envelope)` which contains `MuxedAccount`s with the `med25519` discriminant, won't work. For now, we expect an envelope to contain muxed accounts with the `ed25519` discriminant.  I'll update this code to be able to read the `med25519` discriminant in the same PR where I'll add SEP0023 support.
