### PR TITLE
Add FeeBumpTransaction class

### DIFF
--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -37,13 +37,6 @@ export class FeeBumpTransaction extends TransactionBase {
 
     super(tx, signatures, fee, networkPassphrase);
 
-    const feeSource = txEnvelope
-      .tx()
-      .feeSource()
-      .ed25519();
-
-    this._feeSource = StrKey.encodeEd25519PublicKey(feeSource);
-
     const innerTxEnvelope = xdr.TransactionEnvelope.envelopeTypeTx(
       tx.innerTx().v1()
     );
@@ -67,7 +60,7 @@ export class FeeBumpTransaction extends TransactionBase {
    * @readonly
    */
   get feeSource() {
-    return this._feeSource;
+    return this._muxedToString(this.tx.feeSource());
   }
 
   /**

--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -54,10 +54,18 @@ export class FeeBumpTransaction extends TransactionBase {
     );
   }
 
+  /**
+   * @type {Transaction}
+   * @readonly
+   */
   get innerTransaction() {
     return this._innerTransaction;
   }
 
+  /**
+   * @type {string}
+   * @readonly
+   */
   get feeSource() {
     return this._feeSource;
   }

--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -6,8 +6,10 @@ import { Transaction } from './transaction';
 import { TransactionBase } from './transaction_base';
 
 /**
- * Use {@link TransactionBuilder.buildFeeBumpTransaction} to build a FeeBumpTransaction object, unless you have
- * an object or base64-encoded string of the transaction envelope XDR.
+ * Use {@link TransactionBuilder.buildFeeBumpTransaction} to build a
+ * FeeBumpTransaction object. If you have an object or base64-encoded string of
+ * the transaction envelope XDR use {@link TransactionBuilder.fromXDR}.
+ *
  * Once a {@link FeeBumpTransaction} has been created, its attributes and operations
  * should not be changed. You should only add signatures (using {@link FeeBumpTransaction#sign}) before
  * submitting to the network or forwarding on to additional signers.

--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -33,7 +33,7 @@ export class FeeBumpTransaction extends TransactionBase {
     const tx = txEnvelope.tx();
     const fee = tx.fee().toString();
     // clone signatures
-    const signatures = txEnvelope.signatures().slice();
+    const signatures = (txEnvelope.signatures() || []).slice();
 
     super(tx, signatures, fee, networkPassphrase);
 

--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -11,12 +11,13 @@ import { Transaction } from './transaction';
 /**
  * Use {@link TransactionBuilder.buildFeeBumpTransaction} to build a FeeBumpTransaction object, unless you have
  * an object or base64-encoded string of the transaction envelope XDR.
- * Once a FeeBumpTransaction has been created, its attributes and operations
- * should not be changed. You should only add signatures (using {@link FeeBumpTransaction#sign}) to a Transaction object before
+ * Once a {@link FeeBumpTransaction} has been created, its attributes and operations
+ * should not be changed. You should only add signatures (using {@link FeeBumpTransaction#sign}) before
  * submitting to the network or forwarding on to additional signers.
  * @constructor
  * @param {string|xdr.TransactionEnvelope} envelope - The transaction envelope object or base64 encoded string.
  * @param {string} networkPassphrase passphrase of the target stellar network (e.g. "Public Global Stellar Network ; September 2015").
+ * @ignore tell jsdoc to now show this class
  */
 export class FeeBumpTransaction {
   constructor(envelope, networkPassphrase) {
@@ -146,7 +147,7 @@ export class FeeBumpTransaction {
    *
    * @param {string} publicKey The public key of the signer
    * @param {string} signature The base64 value of the signature XDR
-   * @returns {TransactionBuilder}
+   * @returns {void}
    */
   addSignature(publicKey = '', signature = '') {
     if (!signature || typeof signature !== 'string') {

--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -1,12 +1,9 @@
-import map from 'lodash/map';
-import each from 'lodash/each';
-import isString from 'lodash/isString';
 import xdr from './generated/stellar-xdr_generated';
 import { hash } from './hashing';
 
 import { StrKey } from './strkey';
-import { Keypair } from './keypair';
 import { Transaction } from './transaction';
+import TransactionBase from './transaction_base';
 
 /**
  * Use {@link TransactionBuilder.buildFeeBumpTransaction} to build a FeeBumpTransaction object, unless you have
@@ -19,19 +16,12 @@ import { Transaction } from './transaction';
  * @param {string} networkPassphrase passphrase of the target stellar network (e.g. "Public Global Stellar Network ; September 2015").
  * @ignore tell jsdoc to now show this class
  */
-export class FeeBumpTransaction {
+export class FeeBumpTransaction extends TransactionBase {
   constructor(envelope, networkPassphrase) {
     if (typeof envelope === 'string') {
       const buffer = Buffer.from(envelope, 'base64');
       envelope = xdr.TransactionEnvelope.fromXDR(buffer);
     }
-
-    if (typeof networkPassphrase !== 'string') {
-      throw new Error(
-        `Invalid passphrase provided to Transaction: expected a string but got a ${typeof networkPassphrase}`
-      );
-    }
-    this._networkPassphrase = networkPassphrase;
 
     const envelopeType = envelope.switch();
     if (envelopeType !== xdr.EnvelopeType.envelopeTypeTxFeeBump()) {
@@ -41,28 +31,28 @@ export class FeeBumpTransaction {
     }
 
     const txEnvelope = envelope.value();
-    const sourceAccount = txEnvelope
+    const tx = txEnvelope.tx();
+    const fee = tx.fee().toString();
+    // clone signatures
+    const signatures = txEnvelope.signatures().slice();
+
+    super(tx, signatures, fee, networkPassphrase);
+
+    const feeSource = txEnvelope
       .tx()
       .feeSource()
       .ed25519();
 
-    // since this transaction is immutable, save the tx
-    this._tx = txEnvelope.tx();
-    this._feeSource = StrKey.encodeEd25519PublicKey(sourceAccount);
-    this._fee = this._tx.fee().toString();
+    this._feeSource = StrKey.encodeEd25519PublicKey(feeSource);
 
     const innerTxEnvelope = xdr.TransactionEnvelope.envelopeTypeTx(
-      this.tx.innerTx().v1()
+      tx.innerTx().v1()
     );
+
     this._innerTransaction = new Transaction(
       innerTxEnvelope,
       networkPassphrase
     );
-    this.signatures = map(txEnvelope.signatures() || [], (s) => s);
-  }
-
-  get tx() {
-    return this._tx;
   }
 
   get innerTransaction() {
@@ -71,142 +61,6 @@ export class FeeBumpTransaction {
 
   get feeSource() {
     return this._feeSource;
-  }
-
-  get fee() {
-    return this._fee;
-  }
-
-  get networkPassphrase() {
-    return this._networkPassphrase;
-  }
-
-  set networkPassphrase(networkPassphrase) {
-    this.innerTransaction.networkPassphrase = networkPassphrase;
-    this._networkPassphrase = networkPassphrase;
-  }
-
-  /**
-   * Signs the transaction with the given {@link Keypair}.
-   * @param {...Keypair} keypairs Keypairs of signers
-   * @returns {void}
-   */
-  sign(...keypairs) {
-    const txHash = this.hash();
-    each(keypairs, (kp) => {
-      const sig = kp.signDecorated(txHash);
-      this.signatures.push(sig);
-    });
-  }
-
-  /**
-   * Signs a transaction with the given {@link Keypair}. Useful if someone sends
-   * you a transaction XDR for you to sign and return (see
-   * {@link FeeBumpTransaction#addSignature} for how that works).
-   *
-   * When you get a transaction XDR to sign....
-   * - Instantiate a `Transaction` object with the XDR
-   * - Use {@link Keypair} to generate a keypair object for your Stellar seed.
-   * - Run `getKeypairSignature` with that keypair
-   * - Send back the signature along with your publicKey (not your secret seed!)
-   *
-   * Example:
-   * ```javascript
-   * // `transactionXDR` is a string from the person generating the transaction
-   * const transaction = new FeeBumpTransaction(transactionXDR, networkPassphrase);
-   * const keypair = Keypair.fromSecret(myStellarSeed);
-   * return transaction.getKeypairSignature(keypair);
-   * ```
-   *
-   * @param {Keypair} keypair Keypair of signer
-   * @returns {string} Signature string
-   */
-  getKeypairSignature(keypair) {
-    return keypair.sign(this.hash()).toString('base64');
-  }
-
-  /**
-   * Add a signature to the transaction. Useful when a party wants to pre-sign
-   * a transaction but doesn't want to give access to their secret keys.
-   * This will also verify whether the signature is valid.
-   *
-   * Here's how you would use this feature to solicit multiple signatures.
-   * - Use `TransactionBuilder` to build a new transaction.
-   * - Make sure to set a long enough timeout on that transaction to give your
-   * signers enough time to sign!
-   * - Once you build the transaction, use `transaction.toXDR()` to get the
-   * base64-encoded XDR string.
-   * - _Warning!_ Once you've built this transaction, don't submit any other
-   * transactions onto your account! Doing so will invalidate this pre-compiled
-   * transaction!
-   * - Send this XDR string to your other parties. They can use the instructions
-   * for {@link FeeBumpTransaction#getKeypairSignature} to sign the transaction.
-   * - They should send you back their `publicKey` and the `signature` string
-   * from {@link FeeBumpTransaction#getKeypairSignature}, both of which you pass to
-   * this function.
-   *
-   * @param {string} publicKey The public key of the signer
-   * @param {string} signature The base64 value of the signature XDR
-   * @returns {void}
-   */
-  addSignature(publicKey = '', signature = '') {
-    if (!signature || typeof signature !== 'string') {
-      throw new Error('Invalid signature');
-    }
-
-    if (!publicKey || typeof publicKey !== 'string') {
-      throw new Error('Invalid publicKey');
-    }
-
-    let keypair;
-    let hint;
-    const signatureBuffer = Buffer.from(signature, 'base64');
-
-    try {
-      keypair = Keypair.fromPublicKey(publicKey);
-      hint = keypair.signatureHint();
-    } catch (e) {
-      throw new Error('Invalid publicKey');
-    }
-
-    if (!keypair.verify(this.hash(), signatureBuffer)) {
-      throw new Error('Invalid signature');
-    }
-
-    this.signatures.push(
-      new xdr.DecoratedSignature({
-        hint,
-        signature: signatureBuffer
-      })
-    );
-  }
-
-  /**
-   * Add `hashX` signer preimage as signature.
-   * @param {Buffer|String} preimage Preimage of hash used as signer
-   * @returns {void}
-   */
-  signHashX(preimage) {
-    if (isString(preimage)) {
-      preimage = Buffer.from(preimage, 'hex');
-    }
-
-    if (preimage.length > 64) {
-      throw new Error('preimage cannnot be longer than 64 bytes');
-    }
-
-    const signature = preimage;
-    const hashX = hash(preimage);
-    const hint = hashX.slice(hashX.length - 4);
-    this.signatures.push(new xdr.DecoratedSignature({ hint, signature }));
-  }
-
-  /**
-   * Returns a hash for this transaction, suitable for signing.
-   * @returns {Buffer}
-   */
-  hash() {
-    return hash(this.signatureBase());
   }
 
   /**
@@ -242,15 +96,5 @@ export class FeeBumpTransaction {
     });
 
     return new xdr.TransactionEnvelope.envelopeTypeTxFeeBump(envelope);
-  }
-
-  /**
-   * Get the transaction envelope as a base64-encoded string
-   * @returns {string} XDR string
-   */
-  toXDR() {
-    return this.toEnvelope()
-      .toXDR()
-      .toString('base64');
   }
 }

--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -98,8 +98,8 @@ export class FeeBumpTransaction extends TransactionBase {
    */
   toEnvelope() {
     const envelope = new xdr.FeeBumpTransactionEnvelope({
-      tx: this.tx,
-      signatures: this.signatures
+      tx: xdr.FeeBumpTransaction.fromXDR(this.tx.toXDR()), // make a copy of the tx
+      signatures: this.signatures.slice() // make a copy of the signatures
     });
 
     return new xdr.TransactionEnvelope.envelopeTypeTxFeeBump(envelope);

--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -3,7 +3,7 @@ import { hash } from './hashing';
 
 import { StrKey } from './strkey';
 import { Transaction } from './transaction';
-import TransactionBase from './transaction_base';
+import { TransactionBase } from './transaction_base';
 
 /**
  * Use {@link TransactionBuilder.buildFeeBumpTransaction} to build a FeeBumpTransaction object, unless you have
@@ -11,10 +11,9 @@ import TransactionBase from './transaction_base';
  * Once a {@link FeeBumpTransaction} has been created, its attributes and operations
  * should not be changed. You should only add signatures (using {@link FeeBumpTransaction#sign}) before
  * submitting to the network or forwarding on to additional signers.
- * @constructor
  * @param {string|xdr.TransactionEnvelope} envelope - The transaction envelope object or base64 encoded string.
  * @param {string} networkPassphrase passphrase of the target stellar network (e.g. "Public Global Stellar Network ; September 2015").
- * @ignore tell jsdoc to now show this class
+ * @extends TransactionBase
  */
 export class FeeBumpTransaction extends TransactionBase {
   constructor(envelope, networkPassphrase) {

--- a/src/generated/stellar-xdr_generated.js
+++ b/src/generated/stellar-xdr_generated.js
@@ -1,4 +1,4 @@
-// Automatically generated on 2020-04-14T16:01:24-05:00
+// Automatically generated on 2020-04-16T16:15:58-05:00
 // DO NOT EDIT or your changes may be overwritten
 
 /* jshint maxstatements:2147483647  */
@@ -1481,7 +1481,7 @@ xdr.union("FeeBumpTransactionExt", {
 //
 //   struct FeeBumpTransaction
 //   {
-//       AccountID feeSource;
+//       MuxedAccount feeSource;
 //       int64 fee;
 //       union switch (EnvelopeType type)
 //       {
@@ -1499,7 +1499,7 @@ xdr.union("FeeBumpTransactionExt", {
 //
 // ===========================================================================
 xdr.struct("FeeBumpTransaction", [
-  ["feeSource", xdr.lookup("AccountId")],
+  ["feeSource", xdr.lookup("MuxedAccount")],
   ["fee", xdr.lookup("Int64")],
   ["innerTx", xdr.lookup("FeeBumpTransactionInnerTx")],
   ["ext", xdr.lookup("FeeBumpTransactionExt")],

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export { hash } from './hashing';
 export { sign, verify, FastSigning } from './signing';
 export { Keypair } from './keypair';
 export { UnsignedHyper, Hyper } from 'js-xdr';
+export { TransactionBase } from './transaction_base';
 export { Transaction } from './transaction';
 export { FeeBumpTransaction } from './fee_bump_transaction';
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ export { sign, verify, FastSigning } from './signing';
 export { Keypair } from './keypair';
 export { UnsignedHyper, Hyper } from 'js-xdr';
 export { Transaction } from './transaction';
+export { FeeBumpTransaction } from './fee_bump_transaction';
 export {
   TransactionBuilder,
   TimeoutInfinite,

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -47,10 +47,7 @@ export class Transaction {
         sourceAccount = txEnvelope.tx().sourceAccountEd25519();
         break;
       case xdr.EnvelopeType.envelopeTypeTx():
-        sourceAccount = txEnvelope
-          .tx()
-          .sourceAccount()
-          .ed25519();
+        sourceAccount = this._getSourceAccount(txEnvelope.tx().sourceAccount());
         break;
       case xdr.EnvelopeType.envelopeTypeTxFeeBump():
         sourceAccount = txEnvelope
@@ -78,7 +75,9 @@ export class Transaction {
       // make inner transaction the source account and add field feeSource
       this.feeSource = StrKey.encodeEd25519PublicKey(sourceAccount);
 
-      this.source = StrKey.encodeEd25519PublicKey(tx.sourceAccount().ed25519());
+      this.source = StrKey.encodeEd25519PublicKey(
+        this._getSourceAccount(tx.sourceAccount())
+      );
       this.innerSignatures = map(innerTxEnvelope.signatures() || [], (s) => s);
       this.innerFee = tx.fee().toString();
     }
@@ -348,5 +347,13 @@ export class Transaction {
     return this.toEnvelope()
       .toXDR()
       .toString('base64');
+  }
+
+  _getSourceAccount(muxedAccount) {
+    if (muxedAccount.switch() === xdr.CryptoKeyType.keyTypeEd25519()) {
+      return muxedAccount.ed25519();
+    }
+
+    return muxedAccount.med25519().ed25519();
   }
 }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -168,7 +168,7 @@ export class Transaction {
    *
    * @param {string} publicKey The public key of the signer
    * @param {string} signature The base64 value of the signature XDR
-   * @returns {TransactionBuilder}
+   * @returns {void}
    */
   addSignature(publicKey = '', signature = '') {
     if (!signature || typeof signature !== 'string') {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -8,8 +8,9 @@ import { Memo } from './memo';
 import { TransactionBase } from './transaction_base';
 
 /**
- * Use {@link TransactionBuilder} to build a transaction object, unless you have
- * an object or base64-encoded string of the transaction envelope XDR.
+ * Use {@link TransactionBuilder} to build a transaction object. If you have
+ * an object or base64-encoded string of the transaction envelope XDR use {@link TransactionBuilder.fromXDR}.
+ *
  * Once a Transaction has been created, its attributes and operations
  * should not be changed. You should only add signatures (using {@link Transaction#sign}) to a Transaction object before
  * submitting to the network or forwarding on to additional signers.

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -190,8 +190,8 @@ export class Transaction extends TransactionBase {
    * @returns {xdr.TransactionEnvelope}
    */
   toEnvelope() {
-    const rawTx = Buffer.concat([this.tx.toXDR()]);
-    const signatures = this.signatures.slice(); // make a copy of signatures
+    const rawTx = this.tx.toXDR();
+    const signatures = this.signatures.slice(); // make a copy of the signatures
 
     let envelope;
     switch (this._envelopeType) {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -98,21 +98,7 @@ export class Transaction extends TransactionBase {
         source = StrKey.encodeEd25519PublicKey(this.tx.sourceAccountEd25519());
         break;
       default:
-        if (
-          this.tx.sourceAccount().switch() ===
-          xdr.CryptoKeyType.keyTypeEd25519()
-        ) {
-          source = StrKey.encodeEd25519PublicKey(
-            this.tx.sourceAccount().ed25519()
-          );
-        } else {
-          source = StrKey.encodeMuxedAccount(
-            this.tx
-              .sourceAccount()
-              .med25519()
-              .toXDR()
-          );
-        }
+        source = this._muxedToString(this.tx.sourceAccount());
         break;
     }
 

--- a/src/transaction_base.js
+++ b/src/transaction_base.js
@@ -19,6 +19,10 @@ export class TransactionBase {
     this._fee = fee;
   }
 
+  /**
+   * @type {Array.<xdr.DecoratedSignature>}
+   * @readonly
+   */
   get signatures() {
     return this._signatures;
   }
@@ -31,6 +35,10 @@ export class TransactionBase {
     throw new Error('Transaction is immutable');
   }
 
+  /**
+   * @type {string}
+   * @readonly
+   */
   get fee() {
     return this._fee;
   }
@@ -39,6 +47,10 @@ export class TransactionBase {
     throw new Error('Transaction is immutable');
   }
 
+  /**
+   * @type {string}
+   * @readonly
+   */
   get networkPassphrase() {
     return this._networkPassphrase;
   }
@@ -63,7 +75,7 @@ export class TransactionBase {
   /**
    * Signs a transaction with the given {@link Keypair}. Useful if someone sends
    * you a transaction XDR for you to sign and return (see
-   * {@link FeeBumpTransaction#addSignature} for how that works).
+   * {@link #addSignature} for how that works).
    *
    * When you get a transaction XDR to sign....
    * - Instantiate a `Transaction` object with the XDR
@@ -74,7 +86,7 @@ export class TransactionBase {
    * Example:
    * ```javascript
    * // `transactionXDR` is a string from the person generating the transaction
-   * const transaction = new FeeBumpTransaction(transactionXDR, networkPassphrase);
+   * const transaction = new Transaction(transactionXDR, networkPassphrase);
    * const keypair = Keypair.fromSecret(myStellarSeed);
    * return transaction.getKeypairSignature(keypair);
    * ```
@@ -101,9 +113,9 @@ export class TransactionBase {
    * transactions onto your account! Doing so will invalidate this pre-compiled
    * transaction!
    * - Send this XDR string to your other parties. They can use the instructions
-   * for {@link FeeBumpTransaction#getKeypairSignature} to sign the transaction.
+   * for {@link #getKeypairSignature} to sign the transaction.
    * - They should send you back their `publicKey` and the `signature` string
-   * from {@link FeeBumpTransaction#getKeypairSignature}, both of which you pass to
+   * from {@link #getKeypairSignature}, both of which you pass to
    * this function.
    *
    * @param {string} publicKey The public key of the signer

--- a/src/transaction_base.js
+++ b/src/transaction_base.js
@@ -2,7 +2,10 @@ import xdr from './generated/stellar-xdr_generated';
 import { hash } from './hashing';
 import { Keypair } from './keypair';
 
-export default class TransactionBase {
+/**
+ * @ignore
+ */
+export class TransactionBase {
   constructor(tx, signatures, fee, networkPassphrase) {
     if (typeof networkPassphrase !== 'string') {
       throw new Error(

--- a/src/transaction_base.js
+++ b/src/transaction_base.js
@@ -1,0 +1,187 @@
+import xdr from './generated/stellar-xdr_generated';
+import { hash } from './hashing';
+import { Keypair } from './keypair';
+
+export default class TransactionBase {
+  constructor(tx, signatures, fee, networkPassphrase) {
+    if (typeof networkPassphrase !== 'string') {
+      throw new Error(
+        `Invalid passphrase provided to Transaction: expected a string but got a ${typeof networkPassphrase}`
+      );
+    }
+
+    this._networkPassphrase = networkPassphrase;
+    this._tx = tx;
+    this._signatures = signatures;
+    this._fee = fee;
+  }
+
+  get signatures() {
+    return this._signatures;
+  }
+
+  get tx() {
+    return this._tx;
+  }
+
+  set tx(value) {
+    throw new Error('Transaction is immutable');
+  }
+
+  get fee() {
+    return this._fee;
+  }
+
+  set fee(value) {
+    throw new Error('Transaction is immutable');
+  }
+
+  get networkPassphrase() {
+    return this._networkPassphrase;
+  }
+
+  set networkPassphrase(networkPassphrase) {
+    this._networkPassphrase = networkPassphrase;
+  }
+
+  /**
+   * Signs the transaction with the given {@link Keypair}.
+   * @param {...Keypair} keypairs Keypairs of signers
+   * @returns {void}
+   */
+  sign(...keypairs) {
+    const txHash = this.hash();
+    keypairs.forEach((kp) => {
+      const sig = kp.signDecorated(txHash);
+      this.signatures.push(sig);
+    });
+  }
+
+  /**
+   * Signs a transaction with the given {@link Keypair}. Useful if someone sends
+   * you a transaction XDR for you to sign and return (see
+   * {@link FeeBumpTransaction#addSignature} for how that works).
+   *
+   * When you get a transaction XDR to sign....
+   * - Instantiate a `Transaction` object with the XDR
+   * - Use {@link Keypair} to generate a keypair object for your Stellar seed.
+   * - Run `getKeypairSignature` with that keypair
+   * - Send back the signature along with your publicKey (not your secret seed!)
+   *
+   * Example:
+   * ```javascript
+   * // `transactionXDR` is a string from the person generating the transaction
+   * const transaction = new FeeBumpTransaction(transactionXDR, networkPassphrase);
+   * const keypair = Keypair.fromSecret(myStellarSeed);
+   * return transaction.getKeypairSignature(keypair);
+   * ```
+   *
+   * @param {Keypair} keypair Keypair of signer
+   * @returns {string} Signature string
+   */
+  getKeypairSignature(keypair) {
+    return keypair.sign(this.hash()).toString('base64');
+  }
+
+  /**
+   * Add a signature to the transaction. Useful when a party wants to pre-sign
+   * a transaction but doesn't want to give access to their secret keys.
+   * This will also verify whether the signature is valid.
+   *
+   * Here's how you would use this feature to solicit multiple signatures.
+   * - Use `TransactionBuilder` to build a new transaction.
+   * - Make sure to set a long enough timeout on that transaction to give your
+   * signers enough time to sign!
+   * - Once you build the transaction, use `transaction.toXDR()` to get the
+   * base64-encoded XDR string.
+   * - _Warning!_ Once you've built this transaction, don't submit any other
+   * transactions onto your account! Doing so will invalidate this pre-compiled
+   * transaction!
+   * - Send this XDR string to your other parties. They can use the instructions
+   * for {@link FeeBumpTransaction#getKeypairSignature} to sign the transaction.
+   * - They should send you back their `publicKey` and the `signature` string
+   * from {@link FeeBumpTransaction#getKeypairSignature}, both of which you pass to
+   * this function.
+   *
+   * @param {string} publicKey The public key of the signer
+   * @param {string} signature The base64 value of the signature XDR
+   * @returns {void}
+   */
+  addSignature(publicKey = '', signature = '') {
+    if (!signature || typeof signature !== 'string') {
+      throw new Error('Invalid signature');
+    }
+
+    if (!publicKey || typeof publicKey !== 'string') {
+      throw new Error('Invalid publicKey');
+    }
+
+    let keypair;
+    let hint;
+    const signatureBuffer = Buffer.from(signature, 'base64');
+
+    try {
+      keypair = Keypair.fromPublicKey(publicKey);
+      hint = keypair.signatureHint();
+    } catch (e) {
+      throw new Error('Invalid publicKey');
+    }
+
+    if (!keypair.verify(this.hash(), signatureBuffer)) {
+      throw new Error('Invalid signature');
+    }
+
+    this.signatures.push(
+      new xdr.DecoratedSignature({
+        hint,
+        signature: signatureBuffer
+      })
+    );
+  }
+
+  /**
+   * Add `hashX` signer preimage as signature.
+   * @param {Buffer|String} preimage Preimage of hash used as signer
+   * @returns {void}
+   */
+  signHashX(preimage) {
+    if (typeof preimage === 'string') {
+      preimage = Buffer.from(preimage, 'hex');
+    }
+
+    if (preimage.length > 64) {
+      throw new Error('preimage cannnot be longer than 64 bytes');
+    }
+
+    const signature = preimage;
+    const hashX = hash(preimage);
+    const hint = hashX.slice(hashX.length - 4);
+    this.signatures.push(new xdr.DecoratedSignature({ hint, signature }));
+  }
+
+  /**
+   * Returns a hash for this transaction, suitable for signing.
+   * @returns {Buffer}
+   */
+  hash() {
+    return hash(this.signatureBase());
+  }
+
+  signatureBase() {
+    throw new Error('Implement in subclass');
+  }
+
+  toEnvelope() {
+    throw new Error('Implement in subclass');
+  }
+
+  /**
+   * Get the transaction envelope as a base64-encoded string
+   * @returns {string} XDR string
+   */
+  toXDR() {
+    return this.toEnvelope()
+      .toXDR()
+      .toString('base64');
+  }
+}

--- a/src/transaction_base.js
+++ b/src/transaction_base.js
@@ -1,6 +1,7 @@
 import xdr from './generated/stellar-xdr_generated';
 import { hash } from './hashing';
 import { Keypair } from './keypair';
+import { StrKey } from './strkey';
 
 /**
  * @ignore
@@ -198,5 +199,13 @@ export class TransactionBase {
     return this.toEnvelope()
       .toXDR()
       .toString('base64');
+  }
+
+  _muxedToString(muxedAccount) {
+    if (muxedAccount.switch() === xdr.CryptoKeyType.keyTypeEd25519()) {
+      return StrKey.encodeEd25519PublicKey(muxedAccount.ed25519());
+    }
+
+    return StrKey.encodeMuxedAccount(muxedAccount.med25519().toXDR());
   }
 }

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -322,19 +322,21 @@ export class TransactionBuilder {
   }
 
   /**
-   * Build a {@link Transaction} or {@link FeeBumpTransaction} from a TransactionEnvelope encoded in base64.
-   * @param {string} envelope - TransactionEnvelope encoded in base64.
+   * Build a {@link Transaction} or {@link FeeBumpTransaction} from an xdr.TransactionEnvelope.
+   * @param {string|xdr.TransactionEnvelope} envelope - The transaction envelope object or base64 encoded string.
    * @param {string} networkPassphrase - networkPassphrase of the target stellar network (e.g. "Public Global Stellar Network ; September 2015").
    * @returns {Transaction|FeeBumpTransaction}
    */
   static fromXDR(envelope, networkPassphrase) {
-    const txEnvelope = xdr.TransactionEnvelope.fromXDR(envelope, 'base64');
-
-    if (txEnvelope.switch() === xdr.EnvelopeType.envelopeTypeTxFeeBump()) {
-      return new FeeBumpTransaction(txEnvelope, networkPassphrase);
+    if (typeof envelope === 'string') {
+      envelope = xdr.TransactionEnvelope.fromXDR(envelope, 'base64');
     }
 
-    return new Transaction(txEnvelope, networkPassphrase);
+    if (envelope.switch() === xdr.EnvelopeType.envelopeTypeTxFeeBump()) {
+      return new FeeBumpTransaction(envelope, networkPassphrase);
+    }
+
+    return new Transaction(envelope, networkPassphrase);
   }
 }
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -265,7 +265,7 @@ export class TransactionBuilder {
    * @param {string} baseFee - The max fee willing to pay per operation in inner transaction (**in stroops**). Required.
    * @param {Transaction} innerTx - The Transaction to be bumped by the fee bump transaction.
    * @param {string} networkPassphrase - networkPassphrase of the target stellar network (e.g. "Public Global Stellar Network ; September 2015").
-   * @returns {Transaction}
+   * @returns {FeeBumpTransaction}
    * @ignore tell jsdoc to not show this method for now
    */
   static buildFeeBumpTransaction(

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -260,13 +260,12 @@ export class TransactionBuilder {
   }
 
   /**
-   * Builds a FeeBumpTransaction
+   * Builds a {@link FeeBumpTransaction}
    * @param {StrKey} feeSource - The account paying for the transaction.
    * @param {string} baseFee - The max fee willing to pay per operation in inner transaction (**in stroops**). Required.
    * @param {Transaction} innerTx - The Transaction to be bumped by the fee bump transaction.
    * @param {string} networkPassphrase - networkPassphrase of the target stellar network (e.g. "Public Global Stellar Network ; September 2015").
    * @returns {FeeBumpTransaction}
-   * @ignore tell jsdoc to not show this method for now
    */
   static buildFeeBumpTransaction(
     feeSource,
@@ -320,6 +319,22 @@ export class TransactionBuilder {
     );
 
     return new FeeBumpTransaction(envelope, networkPassphrase);
+  }
+
+  /**
+   * Build a {@link Transaction} or {@link FeeBumpTransaction} from a TransactionEnvelope encoded in base64.
+   * @param {string} envelope - TransactionEnvelope encoded in base64.
+   * @param {string} networkPassphrase - networkPassphrase of the target stellar network (e.g. "Public Global Stellar Network ; September 2015").
+   * @returns {Transaction|FeeBumpTransaction}
+   */
+  static fromXDR(envelope, networkPassphrase) {
+    const txEnvelope = xdr.TransactionEnvelope.fromXDR(envelope, 'base64');
+
+    if (txEnvelope.switch() === xdr.EnvelopeType.envelopeTypeTxFeeBump()) {
+      return new FeeBumpTransaction(txEnvelope, networkPassphrase);
+    }
+
+    return new Transaction(txEnvelope, networkPassphrase);
   }
 }
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -303,7 +303,7 @@ export class TransactionBuilder {
     }
 
     const tx = new xdr.FeeBumpTransaction({
-      feeSource: feeSource.xdrAccountId(),
+      feeSource: feeSource.xdrMuxedAccount(),
       fee: xdr.Int64.fromString(base.mul(innerOps + 1).toString()),
       innerTx: xdr.FeeBumpTransactionInnerTx.envelopeTypeTx(
         innerTxEnvelope.v1()

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -5,6 +5,7 @@ import isUndefined from 'lodash/isUndefined';
 import xdr from './generated/stellar-xdr_generated';
 import { Keypair } from './keypair';
 import { Transaction } from './transaction';
+import { FeeBumpTransaction } from './fee_bump_transaction';
 import { Memo } from './memo';
 
 /**
@@ -318,7 +319,7 @@ export class TransactionBuilder {
       feeBumpTxEnvelope
     );
 
-    return new Transaction(envelope, networkPassphrase);
+    return new FeeBumpTransaction(envelope, networkPassphrase);
   }
 }
 

--- a/test/unit/fee_bump_transation_test.js
+++ b/test/unit/fee_bump_transation_test.js
@@ -179,6 +179,23 @@ describe('FeeBumpTransaction', function() {
     );
   });
 
+  describe('toEnvelope', function() {
+    it('does not return a reference to source signatures', function() {
+      const transaction = this.transaction;
+      const envelope = transaction.toEnvelope().value();
+      envelope.signatures().push({});
+
+      expect(transaction.signatures.length).to.equal(0);
+    });
+    it('does not return a reference to the source transaction', function() {
+      const transaction = this.transaction;
+      const envelope = transaction.toEnvelope().value();
+      envelope.tx().fee(StellarBase.xdr.Int64.fromString('300'));
+
+      expect(transaction.tx.fee().toString()).to.equal('200');
+    });
+  });
+
   it('adds signature correctly', function() {
     const transaction = this.transaction;
     const signer = this.feeSource;

--- a/test/unit/fee_bump_transation_test.js
+++ b/test/unit/fee_bump_transation_test.js
@@ -1,0 +1,130 @@
+describe('FeeBumpTransaction', function() {
+  it('constructs a FeeBumTransaction object from a TransactionEnvelope', function() {
+    let baseFee = '100';
+    const networkPassphrase = 'Standalone Network ; February 2017';
+    const innerSource = StellarBase.Keypair.master(networkPassphrase);
+    const innerAccount = new StellarBase.Account(innerSource.publicKey(), '7');
+    const destination =
+      'GDQERENWDDSQZS7R7WKHZI3BSOYMV3FSWR7TFUYFTKQ447PIX6NREOJM';
+    const amount = '2000.0000000';
+    const asset = StellarBase.Asset.native();
+
+    let innerTx = new StellarBase.TransactionBuilder(innerAccount, {
+      fee: '100',
+      networkPassphrase: networkPassphrase,
+      timebounds: {
+        minTime: 0,
+        maxTime: 0
+      },
+      v1: true
+    })
+      .addOperation(
+        StellarBase.Operation.payment({
+          destination,
+          asset,
+          amount
+        })
+      )
+      .addMemo(StellarBase.Memo.text('Happy birthday!'))
+      .build();
+    innerTx.sign(innerSource);
+
+    let feeSource = StellarBase.Keypair.fromSecret(
+      'SB7ZMPZB3YMMK5CUWENXVLZWBK4KYX4YU5JBXQNZSK2DP2Q7V3LVTO5V'
+    );
+
+    let transaction = StellarBase.TransactionBuilder.buildFeeBumpTransaction(
+      feeSource,
+      '100',
+      innerTx,
+      networkPassphrase
+    );
+
+    transaction.sign(feeSource);
+    expect(transaction.feeSource).to.be.equal(feeSource.publicKey());
+    expect(transaction.fee).to.be.equal('200');
+
+    const innerTransaction = transaction.innerTransaction;
+
+    expect(innerTransaction.toXDR()).to.be.equal(innerTx.toXDR());
+    expect(innerTransaction.source).to.be.equal(innerSource.publicKey());
+    expect(innerTransaction.fee).to.be.equal('100');
+    expect(innerTransaction.memo.type).to.be.equal(StellarBase.MemoText);
+    expect(innerTransaction.memo.value.toString('ascii')).to.be.equal(
+      'Happy birthday!'
+    );
+    let operation = innerTransaction.operations[0];
+    expect(operation.type).to.be.equal('payment');
+    expect(operation.destination).to.be.equal(destination);
+    expect(operation.amount).to.be.equal(amount);
+
+    const expectedXDR =
+      'AAAABQAAAADgSJG2GOUMy/H9lHyjYZOwyuyytH8y0wWaoc596L+bEgAAAAAAAADIAAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAACAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAA9IYXBweSBiaXJ0aGRheSEAAAAAAQAAAAAAAAABAAAAAOBIkbYY5QzL8f2UfKNhk7DK7LK0fzLTBZqhzn3ov5sSAAAAAAAAAASoF8gAAAAAAAAAAAERuUbWAAAAQK933Dnt1pxXlsf1B5CYn81PLxeYsx+MiV9EGbMdUfEcdDWUySyIkdzJefjpR5ejdXVp/KXosGmNUQ+DrIBlzg0AAAAAAAAAAei/mxIAAABAijIIQpL6KlFefiL4FP8UWQktWEz4wFgGNSaXe7mZdVMuiREntehi1b7MRqZ1h+W+Y0y+Z2HtMunsilT2yS5mAA==';
+
+    expect(
+      transaction
+        .toEnvelope()
+        .toXDR()
+        .toString('base64')
+    ).to.be.equal(expectedXDR);
+    let expectedTxEnvelope = StellarBase.xdr.TransactionEnvelope.fromXDR(
+      expectedXDR,
+      'base64'
+    ).value();
+
+    expect(innerTransaction.source).to.equal(
+      StellarBase.StrKey.encodeEd25519PublicKey(
+        expectedTxEnvelope
+          .tx()
+          .innerTx()
+          .value()
+          .tx()
+          .sourceAccount()
+          .ed25519()
+      )
+    );
+    expect(transaction.feeSource).to.equal(
+      StellarBase.StrKey.encodeEd25519PublicKey(
+        expectedTxEnvelope
+          .tx()
+          .feeSource()
+          .ed25519()
+      )
+    );
+
+    expect(transaction.innerTransaction.fee).to.equal(
+      expectedTxEnvelope
+        .tx()
+        .innerTx()
+        .value()
+        .tx()
+        .fee()
+        .toString()
+    );
+    expect(transaction.fee).to.equal(
+      expectedTxEnvelope
+        .tx()
+        .fee()
+        .toString()
+    );
+
+    expect(innerTransaction.signatures.length).to.equal(1);
+    expect(innerTransaction.signatures[0].toXDR().toString('base64')).to.equal(
+      expectedTxEnvelope
+        .tx()
+        .innerTx()
+        .value()
+        .signatures()[0]
+        .toXDR()
+        .toString('base64')
+    );
+
+    expect(transaction.signatures.length).to.equal(1);
+    expect(transaction.signatures[0].toXDR().toString('base64')).to.equal(
+      expectedTxEnvelope
+        .signatures()[0]
+        .toXDR()
+        .toString('base64')
+    );
+  });
+});

--- a/test/unit/fee_bump_transation_test.js
+++ b/test/unit/fee_bump_transation_test.js
@@ -312,6 +312,30 @@ describe('FeeBumpTransaction', function() {
     expect(transaction).to.be.instanceof(StellarBase.FeeBumpTransaction);
     expect(transaction.toXDR()).to.be.equal(xdrString);
   });
+
+  it('handles muxed accounts', function() {
+    let med25519 = new StellarBase.xdr.MuxedAccountMed25519({
+      id: StellarBase.xdr.Uint64.fromString('0'),
+      ed25519: this.feeSource.rawPublicKey()
+    });
+
+    let muxedAccount = StellarBase.xdr.MuxedAccount.keyTypeMuxedEd25519(
+      med25519
+    );
+
+    const envelope = this.transaction.toEnvelope();
+    envelope
+      .feeBump()
+      .tx()
+      .feeSource(muxedAccount);
+    const txWithMuxedAccount = new StellarBase.FeeBumpTransaction(
+      envelope,
+      this.networkPassphrase
+    );
+    expect(txWithMuxedAccount.feeSource).to.equal(
+      StellarBase.StrKey.encodeMuxedAccount(med25519.toXDR())
+    );
+  });
 });
 
 function expectBuffersToBeEqual(left, right) {

--- a/test/unit/fee_bump_transation_test.js
+++ b/test/unit/fee_bump_transation_test.js
@@ -1,17 +1,22 @@
-describe('FeeBumpTransaction', function() {
-  it('constructs a FeeBumTransaction object from a TransactionEnvelope', function() {
-    let baseFee = '100';
-    const networkPassphrase = 'Standalone Network ; February 2017';
-    const innerSource = StellarBase.Keypair.master(networkPassphrase);
-    const innerAccount = new StellarBase.Account(innerSource.publicKey(), '7');
-    const destination =
-      'GDQERENWDDSQZS7R7WKHZI3BSOYMV3FSWR7TFUYFTKQ447PIX6NREOJM';
-    const amount = '2000.0000000';
-    const asset = StellarBase.Asset.native();
+import randomBytes from 'randombytes';
 
-    let innerTx = new StellarBase.TransactionBuilder(innerAccount, {
+describe('FeeBumpTransaction', function() {
+  beforeEach(function() {
+    this.baseFee = '100';
+    this.networkPassphrase = 'Standalone Network ; February 2017';
+    this.innerSource = StellarBase.Keypair.master(this.networkPassphrase);
+    this.innerAccount = new StellarBase.Account(
+      this.innerSource.publicKey(),
+      '7'
+    );
+    this.destination =
+      'GDQERENWDDSQZS7R7WKHZI3BSOYMV3FSWR7TFUYFTKQ447PIX6NREOJM';
+    this.amount = '2000.0000000';
+    this.asset = StellarBase.Asset.native();
+
+    this.innerTx = new StellarBase.TransactionBuilder(this.innerAccount, {
       fee: '100',
-      networkPassphrase: networkPassphrase,
+      networkPassphrase: this.networkPassphrase,
       timebounds: {
         minTime: 0,
         maxTime: 0
@@ -20,43 +25,45 @@ describe('FeeBumpTransaction', function() {
     })
       .addOperation(
         StellarBase.Operation.payment({
-          destination,
-          asset,
-          amount
+          destination: this.destination,
+          asset: this.asset,
+          amount: this.amount
         })
       )
       .addMemo(StellarBase.Memo.text('Happy birthday!'))
       .build();
-    innerTx.sign(innerSource);
-
-    let feeSource = StellarBase.Keypair.fromSecret(
+    this.innerTx.sign(this.innerSource);
+    this.feeSource = StellarBase.Keypair.fromSecret(
       'SB7ZMPZB3YMMK5CUWENXVLZWBK4KYX4YU5JBXQNZSK2DP2Q7V3LVTO5V'
     );
-
-    let transaction = StellarBase.TransactionBuilder.buildFeeBumpTransaction(
-      feeSource,
+    this.transaction = StellarBase.TransactionBuilder.buildFeeBumpTransaction(
+      this.feeSource,
       '100',
-      innerTx,
-      networkPassphrase
+      this.innerTx,
+      this.networkPassphrase
     );
+  });
 
-    transaction.sign(feeSource);
-    expect(transaction.feeSource).to.be.equal(feeSource.publicKey());
+  it('constructs a FeeBumTransaction object from a TransactionEnvelope', function() {
+    const transaction = this.transaction;
+    transaction.sign(this.feeSource);
+
+    expect(transaction.feeSource).to.be.equal(this.feeSource.publicKey());
     expect(transaction.fee).to.be.equal('200');
 
     const innerTransaction = transaction.innerTransaction;
 
-    expect(innerTransaction.toXDR()).to.be.equal(innerTx.toXDR());
-    expect(innerTransaction.source).to.be.equal(innerSource.publicKey());
+    expect(innerTransaction.toXDR()).to.be.equal(this.innerTx.toXDR());
+    expect(innerTransaction.source).to.be.equal(this.innerSource.publicKey());
     expect(innerTransaction.fee).to.be.equal('100');
     expect(innerTransaction.memo.type).to.be.equal(StellarBase.MemoText);
     expect(innerTransaction.memo.value.toString('ascii')).to.be.equal(
       'Happy birthday!'
     );
-    let operation = innerTransaction.operations[0];
+    const operation = innerTransaction.operations[0];
     expect(operation.type).to.be.equal('payment');
-    expect(operation.destination).to.be.equal(destination);
-    expect(operation.amount).to.be.equal(amount);
+    expect(operation.destination).to.be.equal(this.destination);
+    expect(operation.amount).to.be.equal(this.amount);
 
     const expectedXDR =
       'AAAABQAAAADgSJG2GOUMy/H9lHyjYZOwyuyytH8y0wWaoc596L+bEgAAAAAAAADIAAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAACAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAA9IYXBweSBiaXJ0aGRheSEAAAAAAQAAAAAAAAABAAAAAOBIkbYY5QzL8f2UfKNhk7DK7LK0fzLTBZqhzn3ov5sSAAAAAAAAAASoF8gAAAAAAAAAAAERuUbWAAAAQK933Dnt1pxXlsf1B5CYn81PLxeYsx+MiV9EGbMdUfEcdDWUySyIkdzJefjpR5ejdXVp/KXosGmNUQ+DrIBlzg0AAAAAAAAAAei/mxIAAABAijIIQpL6KlFefiL4FP8UWQktWEz4wFgGNSaXe7mZdVMuiREntehi1b7MRqZ1h+W+Y0y+Z2HtMunsilT2yS5mAA==';
@@ -67,7 +74,7 @@ describe('FeeBumpTransaction', function() {
         .toXDR()
         .toString('base64')
     ).to.be.equal(expectedXDR);
-    let expectedTxEnvelope = StellarBase.xdr.TransactionEnvelope.fromXDR(
+    const expectedTxEnvelope = StellarBase.xdr.TransactionEnvelope.fromXDR(
       expectedXDR,
       'base64'
     ).value();
@@ -127,4 +134,171 @@ describe('FeeBumpTransaction', function() {
         .toString('base64')
     );
   });
+
+  it('throws when a garbage Network is selected', function() {
+    const input = this.transaction.toEnvelope();
+
+    expect(() => {
+      new StellarBase.FeeBumpTransaction(input, { garbage: 'yes' });
+    }).to.throw(/expected a string/);
+
+    expect(() => {
+      new StellarBase.FeeBumpTransaction(input, 1234);
+    }).to.throw(/expected a string/);
+  });
+
+  it('signs correctly', function() {
+    const tx = this.transaction;
+    tx.sign(this.feeSource);
+    const rawSig = tx
+      .toEnvelope()
+      .feeBump()
+      .signatures()[0]
+      .signature();
+    expect(this.feeSource.verify(tx.hash(), rawSig)).to.equal(true);
+  });
+
+  it('signs using hash preimage', function() {
+    let preimage = randomBytes(64);
+    let hash = StellarBase.hash(preimage);
+    let tx = this.transaction;
+    tx.signHashX(preimage);
+    let env = tx.toEnvelope().feeBump();
+    expectBuffersToBeEqual(env.signatures()[0].signature(), preimage);
+    expectBuffersToBeEqual(
+      env.signatures()[0].hint(),
+      hash.slice(hash.length - 4)
+    );
+  });
+
+  it('returns error when signing using hash preimage that is too long', function() {
+    let preimage = randomBytes(2 * 64);
+    let tx = this.transaction;
+    expect(() => tx.signHashX(preimage)).to.throw(
+      /preimage cannnot be longer than 64 bytes/
+    );
+  });
+
+  it('adds signature correctly', function() {
+    const transaction = this.transaction;
+    const signer = this.feeSource;
+    const presignHash = transaction.hash();
+
+    const addedSignatureTx = new StellarBase.FeeBumpTransaction(
+      transaction.toEnvelope(),
+      this.networkPassphrase
+    );
+
+    const signature = signer.sign(presignHash).toString('base64');
+
+    addedSignatureTx.addSignature(signer.publicKey(), signature);
+
+    const envelopeAddedSignature = addedSignatureTx.toEnvelope().feeBump();
+
+    expect(
+      signer.verify(
+        addedSignatureTx.hash(),
+        envelopeAddedSignature.signatures()[0].signature()
+      )
+    ).to.equal(true);
+
+    transaction.sign(signer);
+    const envelopeSigned = transaction.toEnvelope().feeBump();
+
+    expectBuffersToBeEqual(
+      envelopeSigned.signatures()[0].signature(),
+      envelopeAddedSignature.signatures()[0].signature()
+    );
+
+    expectBuffersToBeEqual(
+      envelopeSigned.signatures()[0].hint(),
+      envelopeAddedSignature.signatures()[0].hint()
+    );
+
+    expectBuffersToBeEqual(addedSignatureTx.hash(), transaction.hash());
+  });
+
+  it('adds signature generated by getKeypairSignature', function() {
+    const transaction = this.transaction;
+    const presignHash = transaction.hash();
+    const signer = this.feeSource;
+
+    const signature = new StellarBase.FeeBumpTransaction(
+      transaction.toEnvelope(),
+      this.networkPassphrase
+    ).getKeypairSignature(signer);
+
+    expect(signer.sign(presignHash).toString('base64')).to.equal(signature);
+
+    const addedSignatureTx = new StellarBase.FeeBumpTransaction(
+      transaction.toEnvelope(),
+      this.networkPassphrase
+    );
+
+    expect(addedSignatureTx.signatures.length).to.equal(0);
+    addedSignatureTx.addSignature(signer.publicKey(), signature);
+
+    const envelopeAddedSignature = addedSignatureTx.toEnvelope().feeBump();
+
+    expect(
+      signer.verify(
+        transaction.hash(),
+        envelopeAddedSignature.signatures()[0].signature()
+      )
+    ).to.equal(true);
+
+    expect(transaction.signatures.length).to.equal(0);
+    transaction.sign(signer);
+    const envelopeSigned = transaction.toEnvelope().feeBump();
+
+    expectBuffersToBeEqual(
+      envelopeSigned.signatures()[0].signature(),
+      envelopeAddedSignature.signatures()[0].signature()
+    );
+
+    expectBuffersToBeEqual(
+      envelopeSigned.signatures()[0].hint(),
+      envelopeAddedSignature.signatures()[0].hint()
+    );
+
+    expectBuffersToBeEqual(addedSignatureTx.hash(), transaction.hash());
+  });
+
+  it('does not add invalid signature', function() {
+    const transaction = this.transaction;
+    const signer = this.feeSource;
+
+    const signature = new StellarBase.FeeBumpTransaction(
+      transaction.toEnvelope(),
+      this.networkPassphrase
+    ).getKeypairSignature(signer);
+
+    const alteredTx = StellarBase.TransactionBuilder.buildFeeBumpTransaction(
+      this.feeSource,
+      '200',
+      this.innerTx,
+      this.networkPassphrase
+    );
+
+    expect(() => {
+      alteredTx.addSignature(signer.publicKey(), signature);
+    }).to.throw('Invalid signature');
+  });
+
+  it('outputs xdr as a string', function() {
+    const xdrString =
+      'AAAABQAAAADgSJG2GOUMy/H9lHyjYZOwyuyytH8y0wWaoc596L+bEgAAAAAAAADIAAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAACAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAA9IYXBweSBiaXJ0aGRheSEAAAAAAQAAAAAAAAABAAAAAOBIkbYY5QzL8f2UfKNhk7DK7LK0fzLTBZqhzn3ov5sSAAAAAAAAAASoF8gAAAAAAAAAAAERuUbWAAAAQK933Dnt1pxXlsf1B5CYn81PLxeYsx+MiV9EGbMdUfEcdDWUySyIkdzJefjpR5ejdXVp/KXosGmNUQ+DrIBlzg0AAAAAAAAAAei/mxIAAABAijIIQpL6KlFefiL4FP8UWQktWEz4wFgGNSaXe7mZdVMuiREntehi1b7MRqZ1h+W+Y0y+Z2HtMunsilT2yS5mAA==';
+    const transaction = new StellarBase.FeeBumpTransaction(
+      xdrString,
+      this.networkPassphrase
+    );
+    expect(transaction).to.be.instanceof(StellarBase.FeeBumpTransaction);
+    expect(transaction.toXDR()).to.be.equal(xdrString);
+  });
 });
+
+function expectBuffersToBeEqual(left, right) {
+  let leftHex = left.toString('hex');
+  let rightHex = right.toString('hex');
+  expect(leftHex).to.eql(rightHex);
+}

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -712,13 +712,19 @@ describe('Operation', function() {
       const account = new StellarBase.Account(keypair.publicKey(), '0');
 
       // First operation do nothing.
-      const tx1 = new StellarBase.TransactionBuilder(account, { fee: 100 })
+      const tx1 = new StellarBase.TransactionBuilder(account, {
+        fee: 100,
+        networkPassphrase: 'Some Network'
+      })
         .addOperation(StellarBase.Operation.setOptions({}))
         .setTimeout(StellarBase.TimeoutInfinite)
         .build();
 
       // Second operation unset homeDomain
-      const tx2 = new StellarBase.TransactionBuilder(account, { fee: 100 })
+      const tx2 = new StellarBase.TransactionBuilder(account, {
+        fee: 100,
+        networkPassphrase: 'Some Network'
+      })
         .addOperation(StellarBase.Operation.setOptions({ homeDomain: '' }))
         .setTimeout(StellarBase.TimeoutInfinite)
         .build();

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -595,20 +595,36 @@ describe('TransactionBuilder', function() {
     it('builds a fee bump transaction', function() {
       const xdr =
         'AAAABQAAAADgSJG2GOUMy/H9lHyjYZOwyuyytH8y0wWaoc596L+bEgAAAAAAAADIAAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAACAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAA9IYXBweSBiaXJ0aGRheSEAAAAAAQAAAAAAAAABAAAAAOBIkbYY5QzL8f2UfKNhk7DK7LK0fzLTBZqhzn3ov5sSAAAAAAAAAASoF8gAAAAAAAAAAAERuUbWAAAAQK933Dnt1pxXlsf1B5CYn81PLxeYsx+MiV9EGbMdUfEcdDWUySyIkdzJefjpR5ejdXVp/KXosGmNUQ+DrIBlzg0AAAAAAAAAAei/mxIAAABAijIIQpL6KlFefiL4FP8UWQktWEz4wFgGNSaXe7mZdVMuiREntehi1b7MRqZ1h+W+Y0y+Z2HtMunsilT2yS5mAA==';
-      const tx = StellarBase.TransactionBuilder.fromXDR(
+      let tx = StellarBase.TransactionBuilder.fromXDR(
         xdr,
         StellarBase.Networks.TESTNET
       );
       expect(tx).to.be.an.instanceof(StellarBase.FeeBumpTransaction);
+      expect(tx.toXDR()).to.equal(xdr);
+
+      tx = StellarBase.TransactionBuilder.fromXDR(
+        tx.toEnvelope(), // xdr object
+        StellarBase.Networks.TESTNET
+      );
+      expect(tx).to.be.an.instanceof(StellarBase.FeeBumpTransaction);
+      expect(tx.toXDR()).to.equal(xdr);
     });
     it('builds a transaction', function() {
       const xdr =
         'AAAAAAW8Dk9idFR5Le+xi0/h/tU47bgC1YWjtPH1vIVO3BklAAAAZACoKlYAAAABAAAAAAAAAAEAAAALdmlhIGtleWJhc2UAAAAAAQAAAAAAAAAIAAAAAN7aGcXNPO36J1I8MR8S4QFhO79T5JGG2ZeS5Ka1m4mJAAAAAAAAAAFO3BklAAAAQP0ccCoeHdm3S7bOhMjXRMn3EbmETJ9glxpKUZjPSPIxpqZ7EkyTgl3FruieqpZd9LYOzdJrNik1GNBLhgTh/AU=';
-      const tx = StellarBase.TransactionBuilder.fromXDR(
+      let tx = StellarBase.TransactionBuilder.fromXDR(
         xdr,
         StellarBase.Networks.TESTNET
       );
       expect(tx).to.be.an.instanceof(StellarBase.Transaction);
+      expect(tx.toXDR()).to.equal(xdr);
+
+      tx = StellarBase.TransactionBuilder.fromXDR(
+        tx.toEnvelope(), // xdr object
+        StellarBase.Networks.TESTNET
+      );
+      expect(tx).to.be.an.instanceof(StellarBase.Transaction);
+      expect(tx.toXDR()).to.equal(xdr);
     });
   });
 });

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -595,7 +595,6 @@ describe('TransactionBuilder', function() {
     it('builds a fee bump transaction', function() {
       const xdr =
         'AAAABQAAAADgSJG2GOUMy/H9lHyjYZOwyuyytH8y0wWaoc596L+bEgAAAAAAAADIAAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAACAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAA9IYXBweSBiaXJ0aGRheSEAAAAAAQAAAAAAAAABAAAAAOBIkbYY5QzL8f2UfKNhk7DK7LK0fzLTBZqhzn3ov5sSAAAAAAAAAASoF8gAAAAAAAAAAAERuUbWAAAAQK933Dnt1pxXlsf1B5CYn81PLxeYsx+MiV9EGbMdUfEcdDWUySyIkdzJefjpR5ejdXVp/KXosGmNUQ+DrIBlzg0AAAAAAAAAAei/mxIAAABAijIIQpL6KlFefiL4FP8UWQktWEz4wFgGNSaXe7mZdVMuiREntehi1b7MRqZ1h+W+Y0y+Z2HtMunsilT2yS5mAA==';
-
       const tx = StellarBase.TransactionBuilder.fromXDR(
         xdr,
         StellarBase.Networks.TESTNET

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -489,7 +489,6 @@ describe('TransactionBuilder', function() {
             amount
           })
         )
-        .addMemo(StellarBase.Memo.text('Happy birthday!'))
         .build();
 
       let feeSource = StellarBase.Keypair.fromSecret(
@@ -502,7 +501,7 @@ describe('TransactionBuilder', function() {
         networkPassphrase
       );
 
-      expect(transaction.isFeeBump()).to.equal(true);
+      expect(transaction).to.be.an.instanceof(StellarBase.FeeBumpTransaction);
 
       // The fee rate for fee bump is at least the fee rate of the inner transaction
       expect(() => {

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -590,4 +590,26 @@ describe('TransactionBuilder', function() {
       done();
     });
   });
+
+  describe('.fromXDR', function() {
+    it('builds a fee bump transaction', function() {
+      const xdr =
+        'AAAABQAAAADgSJG2GOUMy/H9lHyjYZOwyuyytH8y0wWaoc596L+bEgAAAAAAAADIAAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAACAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAA9IYXBweSBiaXJ0aGRheSEAAAAAAQAAAAAAAAABAAAAAOBIkbYY5QzL8f2UfKNhk7DK7LK0fzLTBZqhzn3ov5sSAAAAAAAAAASoF8gAAAAAAAAAAAERuUbWAAAAQK933Dnt1pxXlsf1B5CYn81PLxeYsx+MiV9EGbMdUfEcdDWUySyIkdzJefjpR5ejdXVp/KXosGmNUQ+DrIBlzg0AAAAAAAAAAei/mxIAAABAijIIQpL6KlFefiL4FP8UWQktWEz4wFgGNSaXe7mZdVMuiREntehi1b7MRqZ1h+W+Y0y+Z2HtMunsilT2yS5mAA==';
+
+      const tx = StellarBase.TransactionBuilder.fromXDR(
+        xdr,
+        StellarBase.Networks.TESTNET
+      );
+      expect(tx).to.be.an.instanceof(StellarBase.FeeBumpTransaction);
+    });
+    it('builds a transaction', function() {
+      const xdr =
+        'AAAAAAW8Dk9idFR5Le+xi0/h/tU47bgC1YWjtPH1vIVO3BklAAAAZACoKlYAAAABAAAAAAAAAAEAAAALdmlhIGtleWJhc2UAAAAAAQAAAAAAAAAIAAAAAN7aGcXNPO36J1I8MR8S4QFhO79T5JGG2ZeS5Ka1m4mJAAAAAAAAAAFO3BklAAAAQP0ccCoeHdm3S7bOhMjXRMn3EbmETJ9glxpKUZjPSPIxpqZ7EkyTgl3FruieqpZd9LYOzdJrNik1GNBLhgTh/AU=';
+      const tx = StellarBase.TransactionBuilder.fromXDR(
+        xdr,
+        StellarBase.Networks.TESTNET
+      );
+      expect(tx).to.be.an.instanceof(StellarBase.Transaction);
+    });
+  });
 });

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -18,7 +18,10 @@ describe('TransactionBuilder', function() {
       asset = StellarBase.Asset.native();
       memo = StellarBase.Memo.id('100');
 
-      transaction = new StellarBase.TransactionBuilder(source, { fee: 100 })
+      transaction = new StellarBase.TransactionBuilder(source, {
+        fee: 100,
+        networkPassphrase: StellarBase.Networks.TESTNET
+      })
         .addOperation(
           StellarBase.Operation.payment({
             destination: destination,
@@ -78,7 +81,10 @@ describe('TransactionBuilder', function() {
       destination2 = 'GC6ACGSA2NJGD6YWUNX2BYBL3VM4MZRSEU2RLIUZZL35NLV5IAHAX2E2';
       amount2 = '2000';
 
-      transaction = new StellarBase.TransactionBuilder(source, { fee: 100 })
+      transaction = new StellarBase.TransactionBuilder(source, {
+        fee: 100,
+        networkPassphrase: StellarBase.Networks.TESTNET
+      })
         .addOperation(
           StellarBase.Operation.payment({
             destination: destination1,
@@ -145,7 +151,10 @@ describe('TransactionBuilder', function() {
       destination2 = 'GC6ACGSA2NJGD6YWUNX2BYBL3VM4MZRSEU2RLIUZZL35NLV5IAHAX2E2';
       amount2 = '2000';
 
-      transaction = new StellarBase.TransactionBuilder(source, { fee: 1000 })
+      transaction = new StellarBase.TransactionBuilder(source, {
+        fee: 1000,
+        networkPassphrase: StellarBase.Networks.TESTNET
+      })
         .addOperation(
           StellarBase.Operation.payment({
             destination: destination1,
@@ -182,7 +191,8 @@ describe('TransactionBuilder', function() {
       };
       let transaction = new StellarBase.TransactionBuilder(source, {
         timebounds,
-        fee: 100
+        fee: 100,
+        networkPassphrase: StellarBase.Networks.TESTNET
       })
         .addOperation(
           StellarBase.Operation.payment({
@@ -236,7 +246,8 @@ describe('TransactionBuilder', function() {
 
       let transaction = new StellarBase.TransactionBuilder(source, {
         timebounds,
-        fee: 100
+        fee: 100,
+        networkPassphrase: StellarBase.Networks.TESTNET
       })
         .addOperation(
           StellarBase.Operation.payment({
@@ -304,7 +315,8 @@ describe('TransactionBuilder', function() {
             minTime: '1',
             maxTime: '10'
           },
-          fee: 100
+          fee: 100,
+          networkPassphrase: StellarBase.Networks.TESTNET
         }).build();
       }).to.not.throw();
     });
@@ -373,7 +385,10 @@ describe('TransactionBuilder', function() {
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
         '0'
       );
-      let transaction = new StellarBase.TransactionBuilder(source, { fee: 100 })
+      let transaction = new StellarBase.TransactionBuilder(source, {
+        fee: 100,
+        networkPassphrase: StellarBase.Networks.TESTNET
+      })
         .addOperation(
           StellarBase.Operation.payment({
             destination:
@@ -428,7 +443,8 @@ describe('TransactionBuilder', function() {
       );
       let transaction = new StellarBase.TransactionBuilder(source, {
         timebounds,
-        fee: 100
+        fee: 100,
+        networkPassphrase: StellarBase.Networks.TESTNET
       })
         .addOperation(
           StellarBase.Operation.payment({
@@ -453,7 +469,8 @@ describe('TransactionBuilder', function() {
       );
       expect(() => {
         new StellarBase.TransactionBuilder(source, {
-          fee: 100
+          fee: 100,
+          networkPassphrase: StellarBase.Networks.TESTNET
         })
           .setTimeout(0)
           .build();

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -43,28 +43,6 @@ describe('Transaction', function() {
     done();
   });
 
-  it('does not sign when no Network selected', function() {
-    let source = new StellarBase.Account(
-      'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
-      '0'
-    );
-    let destination =
-      'GDJJRRMBK4IWLEPJGIE6SXD2LP7REGZODU7WDC3I2D6MR37F4XSHBKX2';
-    let asset = StellarBase.Asset.native();
-    let amount = '2000';
-    let signer = StellarBase.Keypair.random();
-
-    let tx = new StellarBase.TransactionBuilder(source, {
-      fee: 100
-    })
-      .addOperation(
-        StellarBase.Operation.payment({ destination, asset, amount })
-      )
-      .setTimeout(StellarBase.TimeoutInfinite)
-      .build();
-    expect(() => tx.sign(signer)).to.throw(/No network selected/);
-  });
-
   it('throws when a garbage Network is selected', () => {
     let source = new StellarBase.Account(
       'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
@@ -75,7 +53,10 @@ describe('Transaction', function() {
     let asset = StellarBase.Asset.native();
     let amount = '2000.0000000';
 
-    let input = new StellarBase.TransactionBuilder(source, { fee: 100 })
+    let input = new StellarBase.TransactionBuilder(source, {
+      fee: 100,
+      networkPassphrase: StellarBase.Networks.TESTNET
+    })
       .addOperation(
         StellarBase.Operation.payment({ destination, asset, amount })
       )
@@ -91,6 +72,34 @@ describe('Transaction', function() {
 
     expect(() => {
       new StellarBase.Transaction(input, 1234);
+    }).to.throw(/expected a string/);
+  });
+
+  it('throws when a Network is not passed', () => {
+    let source = new StellarBase.Account(
+      'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
+      '0'
+    );
+    let destination =
+      'GDJJRRMBK4IWLEPJGIE6SXD2LP7REGZODU7WDC3I2D6MR37F4XSHBKX2';
+    let asset = StellarBase.Asset.native();
+    let amount = '2000.0000000';
+
+    let input = new StellarBase.TransactionBuilder(source, {
+      fee: 100,
+      networkPassphrase: StellarBase.Networks.TESTNET
+    })
+      .addOperation(
+        StellarBase.Operation.payment({ destination, asset, amount })
+      )
+      .addMemo(StellarBase.Memo.text('Happy birthday!'))
+      .setTimeout(StellarBase.TimeoutInfinite)
+      .build()
+      .toEnvelope()
+      .toXDR('base64');
+
+    expect(() => {
+      new StellarBase.Transaction(input);
     }).to.throw(/expected a string/);
   });
 

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -457,21 +457,17 @@ describe('Transaction', function() {
     expect(transaction.toXDR()).to.be.equal(xdrString);
   });
 
-  describe('FeeBumpTransaction', function() {
-    it('handles fee bump transactions', function(done) {
+  describe('TransactionEnvelope with MuxedAccount', function() {
+    it('handles muxed accounts', function() {
       let baseFee = '100';
       const networkPassphrase = 'Standalone Network ; February 2017';
-      const innerSource = StellarBase.Keypair.master(networkPassphrase);
-      const innerAccount = new StellarBase.Account(
-        innerSource.publicKey(),
-        '7'
-      );
+      const source = StellarBase.Keypair.master(networkPassphrase);
+      const account = new StellarBase.Account(source.publicKey(), '7');
       const destination =
         'GDQERENWDDSQZS7R7WKHZI3BSOYMV3FSWR7TFUYFTKQ447PIX6NREOJM';
       const amount = '2000.0000000';
       const asset = StellarBase.Asset.native();
-
-      let innerTx = new StellarBase.TransactionBuilder(innerAccount, {
+      let tx = new StellarBase.TransactionBuilder(account, {
         fee: '100',
         networkPassphrase: networkPassphrase,
         timebounds: {
@@ -489,196 +485,23 @@ describe('Transaction', function() {
         )
         .addMemo(StellarBase.Memo.text('Happy birthday!'))
         .build();
-      innerTx.sign(innerSource);
-
-      let feeSource = StellarBase.Keypair.fromSecret(
-        'SB7ZMPZB3YMMK5CUWENXVLZWBK4KYX4YU5JBXQNZSK2DP2Q7V3LVTO5V'
+      let med25519 = new StellarBase.xdr.MuxedAccountMed25519({
+        id: StellarBase.xdr.Uint64.fromString('0'),
+        ed25519: source.rawPublicKey()
+      });
+      let muxedAccount = StellarBase.xdr.MuxedAccount.keyTypeMuxedEd25519(
+        med25519
       );
-      let transaction = StellarBase.TransactionBuilder.buildFeeBumpTransaction(
-        feeSource,
-        '100',
-        innerTx,
+      const envelope = tx.toEnvelope();
+      envelope
+        .v1()
+        .tx()
+        .sourceAccount(muxedAccount);
+      const txWithMuxedAccount = new StellarBase.Transaction(
+        envelope,
         networkPassphrase
       );
-      transaction.sign(feeSource);
-
-      expect(transaction.isFeeBump()).to.equal(true);
-
-      expect(transaction.source).to.be.equal(innerSource.publicKey());
-      expect(transaction.feeSource).to.be.equal(feeSource.publicKey());
-
-      // shows new fee
-      expect(transaction.fee).to.be.equal('200');
-
-      // can read inner fee
-      expect(transaction.innerFee).to.be.equal('100');
-
-      // show innerTx operations and memo
-      let operation = transaction.operations[0];
-      expect(transaction.memo.type).to.be.equal(StellarBase.MemoText);
-      expect(transaction.memo.value.toString('ascii')).to.be.equal(
-        'Happy birthday!'
-      );
-      expect(operation.type).to.be.equal('payment');
-      expect(operation.destination).to.be.equal(destination);
-      expect(operation.amount).to.be.equal(amount);
-
-      const expectedXDR =
-        'AAAABQAAAADgSJG2GOUMy/H9lHyjYZOwyuyytH8y0wWaoc596L+bEgAAAAAAAADIAAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAACAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAA9IYXBweSBiaXJ0aGRheSEAAAAAAQAAAAAAAAABAAAAAOBIkbYY5QzL8f2UfKNhk7DK7LK0fzLTBZqhzn3ov5sSAAAAAAAAAASoF8gAAAAAAAAAAAERuUbWAAAAQK933Dnt1pxXlsf1B5CYn81PLxeYsx+MiV9EGbMdUfEcdDWUySyIkdzJefjpR5ejdXVp/KXosGmNUQ+DrIBlzg0AAAAAAAAAAei/mxIAAABAijIIQpL6KlFefiL4FP8UWQktWEz4wFgGNSaXe7mZdVMuiREntehi1b7MRqZ1h+W+Y0y+Z2HtMunsilT2yS5mAA==';
-
-      expect(
-        transaction
-          .toEnvelope()
-          .toXDR()
-          .toString('base64')
-      ).to.be.equal(expectedXDR);
-      let expectedTxEnvelope = StellarBase.xdr.TransactionEnvelope.fromXDR(
-        expectedXDR,
-        'base64'
-      ).value();
-
-      expect(transaction.source).to.equal(
-        StellarBase.StrKey.encodeEd25519PublicKey(
-          expectedTxEnvelope
-            .tx()
-            .innerTx()
-            .value()
-            .tx()
-            .sourceAccount()
-            .ed25519()
-        )
-      );
-      expect(transaction.feeSource).to.equal(
-        StellarBase.StrKey.encodeEd25519PublicKey(
-          expectedTxEnvelope
-            .tx()
-            .feeSource()
-            .ed25519()
-        )
-      );
-
-      expect(transaction.innerFee).to.equal(
-        expectedTxEnvelope
-          .tx()
-          .innerTx()
-          .value()
-          .tx()
-          .fee()
-          .toString()
-      );
-      expect(transaction.fee).to.equal(
-        expectedTxEnvelope
-          .tx()
-          .fee()
-          .toString()
-      );
-
-      expect(transaction.innerSignatures.length).to.equal(1);
-      expect(
-        transaction.innerSignatures[0].toXDR().toString('base64')
-      ).to.equal(
-        expectedTxEnvelope
-          .tx()
-          .innerTx()
-          .value()
-          .signatures()[0]
-          .toXDR()
-          .toString('base64')
-      );
-
-      expect(transaction.signatures.length).to.equal(1);
-      expect(transaction.signatures[0].toXDR().toString('base64')).to.equal(
-        expectedTxEnvelope
-          .signatures()[0]
-          .toXDR()
-          .toString('base64')
-      );
-
-      let tampered = transaction.toEnvelope();
-      tampered._switch = {
-        name: 'envelopeTypeTxInvalid',
-        value: 99
-      };
-
-      expect(() => {
-        new StellarBase.Transaction(tampered, networkPassphrase);
-      }).to.throw(/Invalid EnvelopeType: envelopeTypeTxInvalid./);
-
-      transaction._envelopeType = {
-        name: 'envelopeTypeTxInvalid',
-        value: 99
-      };
-
-      expect(() => {
-        transaction.toEnvelope();
-      }).to.throw(/Invalid EnvelopeType: envelopeTypeTxInvalid./);
-
-      done();
-    });
-
-    describe('TransactionEnvelope with MuxedAccount', function() {
-      it('handles muxed accounts', function() {
-        let baseFee = '100';
-        const networkPassphrase = 'Standalone Network ; February 2017';
-        const source = StellarBase.Keypair.master(networkPassphrase);
-        const account = new StellarBase.Account(source.publicKey(), '7');
-        const destination =
-          'GDQERENWDDSQZS7R7WKHZI3BSOYMV3FSWR7TFUYFTKQ447PIX6NREOJM';
-        const amount = '2000.0000000';
-        const asset = StellarBase.Asset.native();
-
-        let tx = new StellarBase.TransactionBuilder(account, {
-          fee: '100',
-          networkPassphrase: networkPassphrase,
-          timebounds: {
-            minTime: 0,
-            maxTime: 0
-          },
-          v1: true
-        })
-          .addOperation(
-            StellarBase.Operation.payment({
-              destination,
-              asset,
-              amount
-            })
-          )
-          .addMemo(StellarBase.Memo.text('Happy birthday!'))
-          .build();
-
-        let med25519 = new StellarBase.xdr.MuxedAccountMed25519({
-          id: StellarBase.xdr.Uint64.fromString('0'),
-          ed25519: source.rawPublicKey()
-        });
-        let muxedAccount = StellarBase.xdr.MuxedAccount.keyTypeMuxedEd25519(
-          med25519
-        );
-
-        const envelope = tx.toEnvelope();
-        envelope
-          .v1()
-          .tx()
-          .sourceAccount(muxedAccount);
-        const txWithMuxedAccount = new StellarBase.Transaction(
-          envelope,
-          networkPassphrase
-        );
-
-        expect(txWithMuxedAccount.source).to.equal(tx.source);
-
-        let feeSource = StellarBase.Keypair.fromSecret(
-          'SB7ZMPZB3YMMK5CUWENXVLZWBK4KYX4YU5JBXQNZSK2DP2Q7V3LVTO5V'
-        );
-        const feeBumpTx = StellarBase.TransactionBuilder.buildFeeBumpTransaction(
-          feeSource,
-          '200',
-          txWithMuxedAccount,
-          networkPassphrase
-        );
-
-        expect(feeBumpTx.source).to.equal(txWithMuxedAccount.source);
-        expect(feeBumpTx.feeSource).to.equal(feeSource.publicKey());
-      });
+      expect(txWithMuxedAccount.source).to.equal(tx.source);
     });
   });
 });

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -152,6 +152,9 @@ describe('Transaction', function() {
     let rawSig = env.signatures()[0].signature();
     let verified = signer.verify(tx.hash(), rawSig);
     expect(verified).to.equal(true);
+
+    env.signatures().push({});
+    expect(tx.signatures.length).to.equal(1);
   });
 
   it('signs using hash preimage', function() {
@@ -510,7 +513,10 @@ describe('Transaction', function() {
         envelope,
         networkPassphrase
       );
-      expect(txWithMuxedAccount.source).to.equal(tx.source);
+      expect(txWithMuxedAccount.source).to.equal(
+        StellarBase.StrKey.encodeMuxedAccount(med25519.toXDR())
+      );
+      expect(tx.source).to.equal(source.publicKey());
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -504,30 +504,35 @@ export namespace StrKey {
   function decodeSha256Hash(data: string): Buffer;
 }
 
-export class Transaction<
-  TMemo extends Memo = Memo,
-  TOps extends Operation[] = Operation[]
-> {
-  constructor(envelope: string | xdr.TransactionEnvelope, networkPassphrase?: string);
+export class TransactionI {
   addSignature(publicKey: string, signature: string): void;
+  fee: string;
   getKeypairSignature(keypair: Keypair): string;
   hash(): Buffer;
-  isFeeBump(): boolean;
+  networkPassphrase: string;
   sign(...keypairs: Keypair[]): void;
   signatureBase(): Buffer;
+  signatures: xdr.DecoratedSignature[];
   signHashX(preimage: Buffer | string): void;
   toEnvelope(): xdr.TransactionEnvelope;
   toXDR(): string;
+}
+
+export class FeeBumpTransaction extends TransactionI {
+  constructor(envelope: string | xdr.TransactionEnvelope, networkPassphrase: string);
+  feeSource: string;
+  innerTransaction: Transaction;
+}
+
+export class Transaction<
+  TMemo extends Memo = Memo,
+  TOps extends Operation[] = Operation[]
+> extends TransactionI {
+  constructor(envelope: string | xdr.TransactionEnvelope, networkPassphrase?: string);
+  memo: TMemo;
   operations: TOps;
   sequence: string;
-  fee: string;
-  innerFee?: string;
   source: string;
-  feeSource?: string;
-  memo: TMemo;
-  networkPassphrase: string;
-  signatures: xdr.DecoratedSignature[];
-  innerSignatures?: xdr.DecoratedSignature[];
   timeBounds?: {
     minTime: string;
     maxTime: string;
@@ -547,7 +552,7 @@ export class TransactionBuilder {
   setTimeout(timeoutInSeconds: number): this;
   build(): Transaction;
   setNetworkPassphrase(networkPassphrase: string): this;
-  static buildFeeBumpTransaction(feeSource: Keypair, baseFee: string, innerTx: Transaction, networkPassphrase: string): Transaction;
+  static buildFeeBumpTransaction(feeSource: Keypair, baseFee: string, innerTx: Transaction, networkPassphrase: string): FeeBumpTransaction;
 }
 
 export namespace TransactionBuilder {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -553,6 +553,7 @@ export class TransactionBuilder {
   build(): Transaction;
   setNetworkPassphrase(networkPassphrase: string): this;
   static buildFeeBumpTransaction(feeSource: Keypair, baseFee: string, innerTx: Transaction, networkPassphrase: string): FeeBumpTransaction;
+  static fromXDR(envelope: string, networkPassphrase: string): Transaction|FeeBumpTransaction;
 }
 
 export namespace TransactionBuilder {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -553,7 +553,7 @@ export class TransactionBuilder {
   build(): Transaction;
   setNetworkPassphrase(networkPassphrase: string): this;
   static buildFeeBumpTransaction(feeSource: Keypair, baseFee: string, innerTx: Transaction, networkPassphrase: string): FeeBumpTransaction;
-  static fromXDR(envelope: string, networkPassphrase: string): Transaction|FeeBumpTransaction;
+  static fromXDR(envelope: string|xdr.TransactionEnvelope, networkPassphrase: string): Transaction|FeeBumpTransaction;
 }
 
 export namespace TransactionBuilder {

--- a/types/test.ts
+++ b/types/test.ts
@@ -20,6 +20,8 @@ const transactionFromXDR = new StellarSdk.Transaction(transaction.toEnvelope(), 
 transactionFromXDR.networkPassphrase; // $ExpectType string
 transactionFromXDR.networkPassphrase = "SDF";
 
+StellarSdk.TransactionBuilder.fromXDR(transaction.toXDR(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]> | FeeBumpTransaction
+
 const sig = StellarSdk.xdr.DecoratedSignature.fromXDR(Buffer.of(1, 2)); // $ExpectType DecoratedSignature
 sig.hint(); // $ExpectType Buffer
 sig.signature(); // $ExpectType Buffer
@@ -43,6 +45,8 @@ feeBumptransaction.fee; // $ExpectType string
 feeBumptransaction.toXDR(); // $ExpectType string
 feeBumptransaction.toEnvelope(); // $ExpectType TransactionEnvelope
 feeBumptransaction.hash(); // $ExpectType Buffer
+
+StellarSdk.TransactionBuilder.fromXDR(feeBumptransaction.toXDR(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]> | FeeBumpTransaction
 
 // P.S. don't use Memo constructor
 new StellarSdk.Memo(StellarSdk.MemoHash, 'asdf').value; // $ExpectType MemoValue

--- a/types/test.ts
+++ b/types/test.ts
@@ -35,6 +35,15 @@ StellarSdk.Memo.text('asdf').value; // $ExpectType string | Buffer
 StellarSdk.Memo.return('asdf').value; // $ExpectType Buffer
 StellarSdk.Memo.hash('asdf').value; // $ExpectType Buffer
 
+const feeBumptransaction = StellarSdk.TransactionBuilder.buildFeeBumpTransaction(masterKey, "120", transaction, StellarSdk.Networks.TESTNET); // $ExpectType FeeBumpTransaction
+
+feeBumptransaction.feeSource; // $ExpectType string
+feeBumptransaction.innerTransaction; // $ExpectType Transaction<Memo<MemoType>, Operation[]>
+feeBumptransaction.fee; // $ExpectType string
+feeBumptransaction.toXDR(); // $ExpectType string
+feeBumptransaction.toEnvelope(); // $ExpectType TransactionEnvelope
+feeBumptransaction.hash(); // $ExpectType Buffer
+
 // P.S. don't use Memo constructor
 new StellarSdk.Memo(StellarSdk.MemoHash, 'asdf').value; // $ExpectType MemoValue
 // (new StellarSdk.Memo(StellarSdk.MemoHash, 'asdf')).type; // $ExpectType MemoType  // TODO: Inspect what's wrong with linter.

--- a/types/test.ts
+++ b/types/test.ts
@@ -21,6 +21,7 @@ transactionFromXDR.networkPassphrase; // $ExpectType string
 transactionFromXDR.networkPassphrase = "SDF";
 
 StellarSdk.TransactionBuilder.fromXDR(transaction.toXDR(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]> | FeeBumpTransaction
+StellarSdk.TransactionBuilder.fromXDR(transaction.toEnvelope(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]> | FeeBumpTransaction
 
 const sig = StellarSdk.xdr.DecoratedSignature.fromXDR(Buffer.of(1, 2)); // $ExpectType DecoratedSignature
 sig.hint(); // $ExpectType Buffer
@@ -47,6 +48,7 @@ feeBumptransaction.toEnvelope(); // $ExpectType TransactionEnvelope
 feeBumptransaction.hash(); // $ExpectType Buffer
 
 StellarSdk.TransactionBuilder.fromXDR(feeBumptransaction.toXDR(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]> | FeeBumpTransaction
+StellarSdk.TransactionBuilder.fromXDR(feeBumptransaction.toEnvelope(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]> | FeeBumpTransaction
 
 // P.S. don't use Memo constructor
 new StellarSdk.Memo(StellarSdk.MemoHash, 'asdf').value; // $ExpectType MemoValue

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -440,7 +440,7 @@ struct TransactionV1Envelope
 
 struct FeeBumpTransaction
 {
-    AccountID feeSource;
+    MuxedAccount feeSource;
     int64 fee;
     union switch (EnvelopeType type)
     {


### PR DESCRIPTION
## What

Add the class `FeeBumpTransaction` to represent fee bump transactions.

## Why

This pull request updates some of the code introduced in #321,  creating a different class to represent fee bump transaction.

While having a single class could work, long term, having different classes to separate both type of transactions is less error prone and makes the interface on fee bump transactions more explicit.

When you create a new `FeeBumpTransaction` you can reach the inner transaction via `.innerTransaction`, this returns an instance of `Transaction` which gives access to all the properties on the inner transaction, like the original fee, sourceAccount, operations, and memo. 


