### PR TITLE
Extend StrKey to handle xdr.MuxedAccount

### DIFF
--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -62,7 +62,7 @@ export class FeeBumpTransaction extends TransactionBase {
    * @readonly
    */
   get feeSource() {
-    return this._muxedToString(this.tx.feeSource());
+    return StrKey.encodeMuxedAccount(this.tx.feeSource().toXDR());
   }
 
   /**

--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -42,7 +42,7 @@ export class FeeBumpTransaction extends TransactionBase {
     const innerTxEnvelope = xdr.TransactionEnvelope.envelopeTypeTx(
       tx.innerTx().v1()
     );
-
+    this._feeSource = StrKey.encodeMuxedAccount(this.tx.feeSource().toXDR());
     this._innerTransaction = new Transaction(
       innerTxEnvelope,
       networkPassphrase
@@ -62,7 +62,7 @@ export class FeeBumpTransaction extends TransactionBase {
    * @readonly
    */
   get feeSource() {
-    return StrKey.encodeMuxedAccount(this.tx.feeSource().toXDR());
+    return this._feeSource;
   }
 
   /**

--- a/src/strkey.js
+++ b/src/strkey.js
@@ -6,6 +6,7 @@ import isUndefined from 'lodash/isUndefined';
 import isNull from 'lodash/isNull';
 import isString from 'lodash/isString';
 import { verifyChecksum } from './util/checksum';
+import xdr from './generated/stellar-xdr_generated';
 
 const versionBytes = {
   ed25519PublicKey: 6 << 3, // G
@@ -110,21 +111,43 @@ export class StrKey {
   }
 
   /**
-   * Encodes data to strkey muxed account.
-   * @param {Buffer} data data to encode
+   * Encodes data to strkey.
+   * @param {Buffer} data data to encode. It must represent a valid xdr.MuxedAccount
    * @returns {string}
    */
   static encodeMuxedAccount(data) {
-    return encodeCheck('muxedAccount', data);
+    const muxed = xdr.MuxedAccount.fromXDR(data);
+
+    if (muxed.switch() === xdr.CryptoKeyType.keyTypeEd25519()) {
+      return encodeCheck('ed25519PublicKey', muxed.ed25519());
+    }
+
+    return encodeCheck('muxedAccount', muxed.med25519().toXDR());
   }
 
   /**
-   * Decodes strkey muxed account to raw data.
+   * Decodes strkey muxed account to raw data. The raw data can be used to create a valid xdr.MuxedAccount
    * @param {string} data data to decode
    * @returns {Buffer}
    */
   static decodeMuxedAccount(data) {
-    return decodeCheck('muxedAccount', data);
+    let muxed;
+    switch (data.length) {
+      case 56:
+        muxed = xdr.MuxedAccount.keyTypeEd25519(
+          decodeCheck('ed25519PublicKey', data)
+        );
+        break;
+      case 69:
+        muxed = xdr.MuxedAccount.keyTypeMuxedEd25519(
+          xdr.MuxedAccountMed25519.fromXDR(decodeCheck('muxedAccount', data))
+        );
+        break;
+      default:
+        throw new Error('invalid encoded string');
+    }
+
+    return muxed.toXDR();
   }
 }
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -49,6 +49,19 @@ export class Transaction extends TransactionBase {
     this._memo = tx.memo();
     this._sequence = tx.seqNum().toString();
 
+    switch (this._envelopeType) {
+      case xdr.EnvelopeType.envelopeTypeTxV0():
+        this._source = StrKey.encodeEd25519PublicKey(
+          this.tx.sourceAccountEd25519()
+        );
+        break;
+      default:
+        this._source = StrKey.encodeMuxedAccount(
+          this.tx.sourceAccount().toXDR()
+        );
+        break;
+    }
+
     const timeBounds = tx.timeBounds();
     if (timeBounds) {
       this._timeBounds = {
@@ -91,19 +104,7 @@ export class Transaction extends TransactionBase {
    * @readonly
    */
   get source() {
-    const envelopeType = this._envelopeType;
-    let source;
-
-    switch (envelopeType) {
-      case xdr.EnvelopeType.envelopeTypeTxV0():
-        source = StrKey.encodeEd25519PublicKey(this.tx.sourceAccountEd25519());
-        break;
-      default:
-        source = StrKey.encodeMuxedAccount(this.tx.sourceAccount().toXDR());
-        break;
-    }
-
-    return source;
+    return this._source;
   }
 
   set source(value) {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -99,7 +99,7 @@ export class Transaction extends TransactionBase {
         source = StrKey.encodeEd25519PublicKey(this.tx.sourceAccountEd25519());
         break;
       default:
-        source = this._muxedToString(this.tx.sourceAccount());
+        source = StrKey.encodeMuxedAccount(this.tx.sourceAccount().toXDR());
         break;
     }
 

--- a/src/transaction_base.js
+++ b/src/transaction_base.js
@@ -200,12 +200,4 @@ export class TransactionBase {
       .toXDR()
       .toString('base64');
   }
-
-  _muxedToString(muxedAccount) {
-    if (muxedAccount.switch() === xdr.CryptoKeyType.keyTypeEd25519()) {
-      return StrKey.encodeEd25519PublicKey(muxedAccount.ed25519());
-    }
-
-    return StrKey.encodeMuxedAccount(muxedAccount.med25519().toXDR());
-  }
 }

--- a/src/transaction_base.js
+++ b/src/transaction_base.js
@@ -1,7 +1,6 @@
 import xdr from './generated/stellar-xdr_generated';
 import { hash } from './hashing';
 import { Keypair } from './keypair';
-import { StrKey } from './strkey';
 
 /**
  * @ignore

--- a/test/unit/fee_bump_transation_test.js
+++ b/test/unit/fee_bump_transation_test.js
@@ -333,7 +333,7 @@ describe('FeeBumpTransaction', function() {
       this.networkPassphrase
     );
     expect(txWithMuxedAccount.feeSource).to.equal(
-      StellarBase.StrKey.encodeMuxedAccount(med25519.toXDR())
+      StellarBase.StrKey.encodeMuxedAccount(muxedAccount.toXDR())
     );
   });
 });

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -106,16 +106,33 @@ describe('StrKey', function() {
     });
 
     describe('muxed account', function() {
-      it('decodes correctly', function() {
+      it('decodes med25519 correctly', function() {
         const med25519 = new StellarBase.xdr.MuxedAccountMed25519({
           id: StellarBase.xdr.Uint64.fromString('0'),
           ed25519: StellarBase.StrKey.decodeEd25519PublicKey(
             'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ'
           )
         });
-        let expectedBuffer = med25519.toXDR();
+        let expectedBuffer = StellarBase.xdr.MuxedAccount.keyTypeMuxedEd25519(
+          med25519
+        ).toXDR();
         let strkey =
           'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6';
+        expect(StellarBase.StrKey.decodeMuxedAccount(strkey)).to.eql(
+          expectedBuffer
+        );
+      });
+
+      it('decodes ed25519 correctly', function() {
+        const rawEd25519 = StellarBase.StrKey.decodeEd25519PublicKey(
+          'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ'
+        );
+        const expectedBuffer = StellarBase.xdr.MuxedAccount.keyTypeEd25519(
+          rawEd25519
+        ).toXDR();
+        const strkey =
+          'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ';
+
         expect(StellarBase.StrKey.decodeMuxedAccount(strkey)).to.eql(
           expectedBuffer
         );
@@ -214,16 +231,34 @@ describe('StrKey', function() {
     });
 
     describe('muxed account', function() {
-      it('encodes a buffer correctly', function() {
+      it('encodes med25519 accounts correctly', function() {
         const med25519 = new StellarBase.xdr.MuxedAccountMed25519({
           id: StellarBase.xdr.Uint64.fromString('0'),
           ed25519: StellarBase.StrKey.decodeEd25519PublicKey(
             'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ'
           )
         });
-        let buffer = med25519.toXDR();
+        const buffer = StellarBase.xdr.MuxedAccount.keyTypeMuxedEd25519(
+          med25519
+        ).toXDR();
+
         let expectedMuxedAccount =
           'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6';
+        expect(StellarBase.StrKey.encodeMuxedAccount(buffer)).to.eql(
+          expectedMuxedAccount
+        );
+      });
+      it('encodes ed25519 accounts correctly', function() {
+        const ed25519 = StellarBase.StrKey.decodeEd25519PublicKey(
+          'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ'
+        );
+
+        const buffer = StellarBase.xdr.MuxedAccount.keyTypeEd25519(
+          ed25519
+        ).toXDR();
+
+        let expectedMuxedAccount =
+          'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ';
         expect(StellarBase.StrKey.encodeMuxedAccount(buffer)).to.eql(
           expectedMuxedAccount
         );

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -550,7 +550,7 @@ describe('Transaction', function() {
         networkPassphrase
       );
       expect(txWithMuxedAccount.source).to.equal(
-        StellarBase.StrKey.encodeMuxedAccount(med25519.toXDR())
+        StellarBase.StrKey.encodeMuxedAccount(muxedAccount.toXDR())
       );
       expect(tx.source).to.equal(source.publicKey());
     });


### PR DESCRIPTION
The initial implementation was not compatible with an `xdr.MuxedAccount` but rather the `muxedEd25119` discriminant. 

This PR:

- Extends `encodeMuxedAccount` to handle the raw data for `xdr.MuxedAccount`, it can return a `G..` or `M...` account.
- Extends `decodeMuxedAccount` to handle `G..` or `M..` accounts, the result can be used to create a valid `xdr.MuxedAccount`.