### PR TITLE
Rollback SEP23 (Muxed Account strkeys) support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Remove
+
+- Rollback support for SEP23 (Muxed Account StrKey) ([#349](https://github.com/stellar/js-stellar-base/pull/349)).
+
 ## [v3.0.2](https://github.com/stellar/js-stellar-base/compare/v3.0.1..v3.0.2)
 
 ### Fix
@@ -20,7 +24,7 @@ This version brings protocol 13 support with backwards compatibility support for
 - Add `TransactionBuilder.buildFeeBumpTransaction` which makes it easy to create `FeeBumpTransaction` ([#321](https://github.com/stellar/js-stellar-base/pull/321)).
 - Adds a feature flag which allow consumers of this library to create V1 (protocol 13) transactions using the `TransactionBuilder` ([#321](https://github.com/stellar/js-stellar-base/pull/321)).
 - Add support for [CAP0027](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0027.md): First-class multiplexed accounts ([#325](https://github.com/stellar/js-stellar-base/pull/325)).
-- Add `Keypair.xdrMuxedAccount` which creates a new `xdr.MuxedAccount`([#325](https://github.com/stellar/js-stellar-base/pull/325)).
+- ~Add `Keypair.xdrMuxedAccount` which creates a new `xdr.MuxedAccount`([#325](https://github.com/stellar/js-stellar-base/pull/325)).~
 - Add `FeeBumpTransaction` which makes it easy to work with fee bump transactions ([#328](https://github.com/stellar/js-stellar-base/pull/328)).
 - Add `TransactionBuilder.fromXDR` which receives an xdr envelope and return a `Transaction` or `FeeBumpTransaction` ([#328](https://github.com/stellar/js-stellar-base/pull/328)).
 
@@ -28,27 +32,7 @@ This version brings protocol 13 support with backwards compatibility support for
 - Update XDR definitions with protocol 13 ([#317](https://github.com/stellar/js-stellar-base/pull/317)).
 - Extend `Transaction` to work with `TransactionV1Envelope` and `TransactionV0Envelope` ([#317](https://github.com/stellar/js-stellar-base/pull/317)).
 - Add backward compatibility support for [CAP0018](https://github.com/stellar/stellar-protocol/blob/f01c9354aaab1e8ca97a25cf888829749cadf36a/core/cap-0018.md) ([#317](https://github.com/stellar/js-stellar-base/pull/317)).
-- Update operations builder to support multiplexed accounts ([#337](https://github.com/stellar/js-stellar-base/pull/337)).
-
-  This allows you to specify an `M` account as the destination or source:
-  ```
-  var destination = 'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6';
-  var amount = '1000.0000000';
-  var asset = new StellarBase.Asset(
-    'USDUSD',
-    'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
-  );
-  var source =
-    'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6';
-  StellarBase.Operation.payment({
-    destination,
-    asset,
-    amount,
-    source
-  });
-  ```
-
-  **To use multiplexed accounts you need a Stellar network instance running Protocol 13 or higher**
+- ~Update operations builder to support multiplexed accounts ([#337](https://github.com/stellar/js-stellar-base/pull/337)).~
 
 ### Breaking changes
 

--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -1,9 +1,9 @@
 import xdr from './generated/stellar-xdr_generated';
 import { hash } from './hashing';
 
-import { StrKey } from './strkey';
 import { Transaction } from './transaction';
 import { TransactionBase } from './transaction_base';
+import { encodeMuxedAccountToAddress } from './util/decode_encode_muxed_account';
 
 /**
  * Use {@link TransactionBuilder.buildFeeBumpTransaction} to build a
@@ -42,7 +42,7 @@ export class FeeBumpTransaction extends TransactionBase {
     const innerTxEnvelope = xdr.TransactionEnvelope.envelopeTypeTx(
       tx.innerTx().v1()
     );
-    this._feeSource = StrKey.encodeMuxedAccount(this.tx.feeSource().toXDR());
+    this._feeSource = encodeMuxedAccountToAddress(this.tx.feeSource());
     this._innerTransaction = new Transaction(
       innerTxEnvelope,
       networkPassphrase

--- a/src/operation.js
+++ b/src/operation.js
@@ -12,7 +12,10 @@ import { Asset } from './asset';
 import { StrKey } from './strkey';
 import xdr from './generated/stellar-xdr_generated';
 import * as ops from './operations/index';
-import { decodeAddress } from './util/decode_encode_address';
+import {
+  decodeAddress,
+  encodeMuxedAccountToAddress
+} from './util/decode_encode_address';
 
 const ONE = 10000000;
 const MAX_INT64 = '9223372036854775807';
@@ -80,13 +83,10 @@ export class Operation {
     function accountIdtoAddress(accountId) {
       return StrKey.encodeEd25519PublicKey(accountId.ed25519());
     }
-    function muxedAccounttoAddress(accountId) {
-      return StrKey.encodeMuxedAccount(accountId.toXDR());
-    }
 
     const result = {};
     if (operation.sourceAccount()) {
-      result.source = muxedAccounttoAddress(operation.sourceAccount());
+      result.source = encodeMuxedAccountToAddress(operation.sourceAccount());
     }
 
     const attrs = operation.body().value();
@@ -101,7 +101,7 @@ export class Operation {
       }
       case 'payment': {
         result.type = 'payment';
-        result.destination = muxedAccounttoAddress(attrs.destination());
+        result.destination = encodeMuxedAccountToAddress(attrs.destination());
         result.asset = Asset.fromOperation(attrs.asset());
         result.amount = this._fromXDRAmount(attrs.amount());
         break;
@@ -110,7 +110,7 @@ export class Operation {
         result.type = 'pathPaymentStrictReceive';
         result.sendAsset = Asset.fromOperation(attrs.sendAsset());
         result.sendMax = this._fromXDRAmount(attrs.sendMax());
-        result.destination = muxedAccounttoAddress(attrs.destination());
+        result.destination = encodeMuxedAccountToAddress(attrs.destination());
         result.destAsset = Asset.fromOperation(attrs.destAsset());
         result.destAmount = this._fromXDRAmount(attrs.destAmount());
         result.path = [];
@@ -127,7 +127,7 @@ export class Operation {
         result.type = 'pathPaymentStrictSend';
         result.sendAsset = Asset.fromOperation(attrs.sendAsset());
         result.sendAmount = this._fromXDRAmount(attrs.sendAmount());
-        result.destination = muxedAccounttoAddress(attrs.destination());
+        result.destination = encodeMuxedAccountToAddress(attrs.destination());
         result.destAsset = Asset.fromOperation(attrs.destAsset());
         result.destMin = this._fromXDRAmount(attrs.destMin());
         result.path = [];
@@ -232,7 +232,7 @@ export class Operation {
       }
       case 'accountMerge': {
         result.type = 'accountMerge';
-        result.destination = muxedAccounttoAddress(attrs);
+        result.destination = encodeMuxedAccountToAddress(attrs);
         break;
       }
       case 'manageDatum': {

--- a/src/operation.js
+++ b/src/operation.js
@@ -12,6 +12,7 @@ import { Asset } from './asset';
 import { StrKey } from './strkey';
 import xdr from './generated/stellar-xdr_generated';
 import * as ops from './operations/index';
+import { decodeAddress } from './util/decode_encode_address';
 
 const ONE = 10000000;
 const MAX_INT64 = '9223372036854775807';
@@ -62,9 +63,7 @@ export class Operation {
   static setSourceAccount(opAttributes, opts) {
     if (opts.source) {
       try {
-        opAttributes.sourceAccount = xdr.MuxedAccount.fromXDR(
-          StrKey.decodeMuxedAccount(opts.source)
-        );
+        opAttributes.sourceAccount = decodeAddress(opts.source);
       } catch (e) {
         throw new Error('Source address is invalid');
       }

--- a/src/operation.js
+++ b/src/operation.js
@@ -13,9 +13,9 @@ import { StrKey } from './strkey';
 import xdr from './generated/stellar-xdr_generated';
 import * as ops from './operations/index';
 import {
-  decodeAddress,
+  decodeAddressToMuxedAccount,
   encodeMuxedAccountToAddress
-} from './util/decode_encode_address';
+} from './util/decode_encode_muxed_account';
 
 const ONE = 10000000;
 const MAX_INT64 = '9223372036854775807';
@@ -66,7 +66,7 @@ export class Operation {
   static setSourceAccount(opAttributes, opts) {
     if (opts.source) {
       try {
-        opAttributes.sourceAccount = decodeAddress(opts.source);
+        opAttributes.sourceAccount = decodeAddressToMuxedAccount(opts.source);
       } catch (e) {
         throw new Error('Source address is invalid');
       }

--- a/src/operations/account_merge.js
+++ b/src/operations/account_merge.js
@@ -1,5 +1,5 @@
 import xdr from '../generated/stellar-xdr_generated';
-import { decodeAddress } from '../util/decode_encode_address';
+import { decodeAddressToMuxedAccount } from '../util/decode_encode_muxed_account';
 
 /**
  * Transfers native balance to destination account.
@@ -14,7 +14,7 @@ export function accountMerge(opts) {
   const opAttributes = {};
   try {
     opAttributes.body = xdr.OperationBody.accountMerge(
-      decodeAddress(opts.destination)
+      decodeAddressToMuxedAccount(opts.destination)
     );
   } catch (e) {
     throw new Error('destination is invalid');

--- a/src/operations/account_merge.js
+++ b/src/operations/account_merge.js
@@ -1,5 +1,5 @@
 import xdr from '../generated/stellar-xdr_generated';
-import { StrKey } from '../strkey';
+import { decodeAddress } from '../util/decode_encode_address';
 
 /**
  * Transfers native balance to destination account.
@@ -14,7 +14,7 @@ export function accountMerge(opts) {
   const opAttributes = {};
   try {
     opAttributes.body = xdr.OperationBody.accountMerge(
-      xdr.MuxedAccount.fromXDR(StrKey.decodeMuxedAccount(opts.destination))
+      decodeAddress(opts.destination)
     );
   } catch (e) {
     throw new Error('destination is invalid');

--- a/src/operations/path_payment_strict_receive.js
+++ b/src/operations/path_payment_strict_receive.js
@@ -1,5 +1,5 @@
 import xdr from '../generated/stellar-xdr_generated';
-import { decodeAddress } from '../util/decode_encode_address';
+import { decodeAddressToMuxedAccount } from '../util/decode_encode_muxed_account';
 
 /**
  * Returns a XDR PathPaymentStrictReceiveOp. A `PathPaymentStrictReceive` operation send the specified amount to the
@@ -36,7 +36,7 @@ export function pathPaymentStrictReceive(opts) {
   attributes.sendMax = this._toXDRAmount(opts.sendMax);
 
   try {
-    attributes.destination = decodeAddress(opts.destination);
+    attributes.destination = decodeAddressToMuxedAccount(opts.destination);
   } catch (e) {
     throw new Error('destination is invalid');
   }

--- a/src/operations/path_payment_strict_receive.js
+++ b/src/operations/path_payment_strict_receive.js
@@ -1,5 +1,5 @@
 import xdr from '../generated/stellar-xdr_generated';
-import { StrKey } from '../strkey';
+import { decodeAddress } from '../util/decode_encode_address';
 
 /**
  * Returns a XDR PathPaymentStrictReceiveOp. A `PathPaymentStrictReceive` operation send the specified amount to the
@@ -36,9 +36,7 @@ export function pathPaymentStrictReceive(opts) {
   attributes.sendMax = this._toXDRAmount(opts.sendMax);
 
   try {
-    attributes.destination = xdr.MuxedAccount.fromXDR(
-      StrKey.decodeMuxedAccount(opts.destination)
-    );
+    attributes.destination = decodeAddress(opts.destination);
   } catch (e) {
     throw new Error('destination is invalid');
   }

--- a/src/operations/path_payment_strict_send.js
+++ b/src/operations/path_payment_strict_send.js
@@ -1,5 +1,5 @@
 import xdr from '../generated/stellar-xdr_generated';
-import { StrKey } from '../strkey';
+import { decodeAddress } from '../util/decode_encode_address';
 
 /**
  * Returns a XDR PathPaymentStrictSendOp. A `PathPaymentStrictSend` operation send the specified amount to the
@@ -35,9 +35,7 @@ export function pathPaymentStrictSend(opts) {
   attributes.sendAsset = opts.sendAsset.toXDRObject();
   attributes.sendAmount = this._toXDRAmount(opts.sendAmount);
   try {
-    attributes.destination = xdr.MuxedAccount.fromXDR(
-      StrKey.decodeMuxedAccount(opts.destination)
-    );
+    attributes.destination = decodeAddress(opts.destination);
   } catch (e) {
     throw new Error('destination is invalid');
   }

--- a/src/operations/path_payment_strict_send.js
+++ b/src/operations/path_payment_strict_send.js
@@ -1,5 +1,5 @@
 import xdr from '../generated/stellar-xdr_generated';
-import { decodeAddress } from '../util/decode_encode_address';
+import { decodeAddressToMuxedAccount } from '../util/decode_encode_muxed_account';
 
 /**
  * Returns a XDR PathPaymentStrictSendOp. A `PathPaymentStrictSend` operation send the specified amount to the
@@ -35,7 +35,7 @@ export function pathPaymentStrictSend(opts) {
   attributes.sendAsset = opts.sendAsset.toXDRObject();
   attributes.sendAmount = this._toXDRAmount(opts.sendAmount);
   try {
-    attributes.destination = decodeAddress(opts.destination);
+    attributes.destination = decodeAddressToMuxedAccount(opts.destination);
   } catch (e) {
     throw new Error('destination is invalid');
   }

--- a/src/operations/payment.js
+++ b/src/operations/payment.js
@@ -1,5 +1,5 @@
 import xdr from '../generated/stellar-xdr_generated';
-import { decodeAddress } from '../util/decode_encode_address';
+import { decodeAddressToMuxedAccount } from '../util/decode_encode_muxed_account';
 
 /**
  * Create a payment operation.
@@ -22,7 +22,7 @@ export function payment(opts) {
 
   const attributes = {};
   try {
-    attributes.destination = decodeAddress(opts.destination);
+    attributes.destination = decodeAddressToMuxedAccount(opts.destination);
   } catch (e) {
     throw new Error('destination is invalid');
   }

--- a/src/operations/payment.js
+++ b/src/operations/payment.js
@@ -1,5 +1,5 @@
 import xdr from '../generated/stellar-xdr_generated';
-import { StrKey } from '../strkey';
+import { decodeAddress } from '../util/decode_encode_address';
 
 /**
  * Create a payment operation.
@@ -22,9 +22,7 @@ export function payment(opts) {
 
   const attributes = {};
   try {
-    attributes.destination = xdr.MuxedAccount.fromXDR(
-      StrKey.decodeMuxedAccount(opts.destination)
-    );
+    attributes.destination = decodeAddress(opts.destination);
   } catch (e) {
     throw new Error('destination is invalid');
   }

--- a/src/strkey.js
+++ b/src/strkey.js
@@ -6,14 +6,12 @@ import isUndefined from 'lodash/isUndefined';
 import isNull from 'lodash/isNull';
 import isString from 'lodash/isString';
 import { verifyChecksum } from './util/checksum';
-import xdr from './generated/stellar-xdr_generated';
 
 const versionBytes = {
   ed25519PublicKey: 6 << 3, // G
   ed25519SecretSeed: 18 << 3, // S
   preAuthTx: 19 << 3, // T
-  sha256Hash: 23 << 3, // X
-  muxedAccount: 12 << 3 // M
+  sha256Hash: 23 << 3 // X
 };
 
 /**
@@ -108,46 +106,6 @@ export class StrKey {
    */
   static decodeSha256Hash(data) {
     return decodeCheck('sha256Hash', data);
-  }
-
-  /**
-   * Encodes data to strkey.
-   * @param {Buffer} data data to encode. It must represent a valid xdr.MuxedAccount
-   * @returns {string}
-   */
-  static encodeMuxedAccount(data) {
-    const muxed = xdr.MuxedAccount.fromXDR(data);
-
-    if (muxed.switch() === xdr.CryptoKeyType.keyTypeEd25519()) {
-      return encodeCheck('ed25519PublicKey', muxed.ed25519());
-    }
-
-    return encodeCheck('muxedAccount', muxed.med25519().toXDR());
-  }
-
-  /**
-   * Decodes strkey muxed account to raw data. The raw data can be used to create a valid xdr.MuxedAccount
-   * @param {string} data data to decode
-   * @returns {Buffer}
-   */
-  static decodeMuxedAccount(data) {
-    let muxed;
-    switch (data.length) {
-      case 56:
-        muxed = xdr.MuxedAccount.keyTypeEd25519(
-          decodeCheck('ed25519PublicKey', data)
-        );
-        break;
-      case 69:
-        muxed = xdr.MuxedAccount.keyTypeMuxedEd25519(
-          xdr.MuxedAccountMed25519.fromXDR(decodeCheck('muxedAccount', data))
-        );
-        break;
-      default:
-        throw new Error('invalid encoded string');
-    }
-
-    return muxed.toXDR();
   }
 }
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -6,6 +6,7 @@ import { StrKey } from './strkey';
 import { Operation } from './operation';
 import { Memo } from './memo';
 import { TransactionBase } from './transaction_base';
+import { encodeMuxedAccountToAddress } from './util/decode_encode_muxed_account';
 
 /**
  * Use {@link TransactionBuilder} to build a transaction object. If you have
@@ -56,9 +57,7 @@ export class Transaction extends TransactionBase {
         );
         break;
       default:
-        this._source = StrKey.encodeMuxedAccount(
-          this.tx.sourceAccount().toXDR()
-        );
+        this._source = encodeMuxedAccountToAddress(this.tx.sourceAccount());
         break;
     }
 

--- a/src/util/decode_encode_address.js
+++ b/src/util/decode_encode_address.js
@@ -12,3 +12,20 @@ export function decodeAddress(address) {
     StrKey.decodeEd25519PublicKey(address)
   );
 }
+
+/**
+ * Converts an xdr.MuxedAccount to its string representation, forcing the ed25519 representation.
+ * @function
+ * @param {xdr.MuxedAccount} muxedAccount .
+ * @returns {string} address
+ */
+export function encodeMuxedAccountToAddress(muxedAccount) {
+  let ed25519;
+  if (muxedAccount.switch() === xdr.CryptoKeyType.keyTypeEd25519()) {
+    ed25519 = muxedAccount.ed25519();
+  } else {
+    ed25519 = muxedAccount.med25519().ed25519();
+  }
+
+  return StrKey.encodeEd25519PublicKey(ed25519);
+}

--- a/src/util/decode_encode_address.js
+++ b/src/util/decode_encode_address.js
@@ -1,0 +1,14 @@
+import xdr from '../generated/stellar-xdr_generated';
+import { StrKey } from '../strkey';
+
+/**
+ * Returns a XDR.MuxedAccount forcing the ed25519 discriminant.
+ * @function
+ * @param {string} address address to encode to XDR.
+ * @returns {xdr.MuxedAccount} MuxedAccount with ed25519 discriminant.
+ */
+export function decodeAddress(address) {
+  return xdr.MuxedAccount.keyTypeEd25519(
+    StrKey.decodeEd25519PublicKey(address)
+  );
+}

--- a/src/util/decode_encode_muxed_account.js
+++ b/src/util/decode_encode_muxed_account.js
@@ -7,7 +7,7 @@ import { StrKey } from '../strkey';
  * @param {string} address address to encode to XDR.
  * @returns {xdr.MuxedAccount} MuxedAccount with ed25519 discriminant.
  */
-export function decodeAddress(address) {
+export function decodeAddressToMuxedAccount(address) {
   return xdr.MuxedAccount.keyTypeEd25519(
     StrKey.decodeEd25519PublicKey(address)
   );

--- a/test/unit/fee_bump_transation_test.js
+++ b/test/unit/fee_bump_transation_test.js
@@ -332,9 +332,7 @@ describe('FeeBumpTransaction', function() {
       envelope,
       this.networkPassphrase
     );
-    expect(txWithMuxedAccount.feeSource).to.equal(
-      StellarBase.StrKey.encodeMuxedAccount(muxedAccount.toXDR())
-    );
+    expect(txWithMuxedAccount.feeSource).to.equal(this.feeSource.publicKey());
   });
 });
 

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -80,7 +80,7 @@ describe('Operation', function() {
       expect(obj.type).to.be.equal('payment');
       expect(obj.destination).to.be.equal(destination);
     });
-    it('supports muxed accounts', function() {
+    it('does not support muxed accounts', function() {
       var destination =
         'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6';
       var amount = '1000.0000000';
@@ -90,20 +90,15 @@ describe('Operation', function() {
       );
       var source =
         'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6';
-      let op = StellarBase.Operation.payment({
-        destination,
-        asset,
-        amount,
-        source
-      });
-      var xdr = op.toXDR('hex');
-      var operation = StellarBase.xdr.Operation.fromXDR(
-        Buffer.from(xdr, 'hex')
-      );
-      var obj = StellarBase.Operation.fromXDRObject(operation);
-      expect(obj.type).to.be.equal('payment');
-      expect(obj.destination).to.be.equal(destination);
-      expect(obj.source).to.be.equal(source);
+
+      expect(() => {
+        StellarBase.Operation.payment({
+          destination,
+          asset,
+          amount,
+          source
+        });
+      }).to.throw(/destination is invalid/);
     });
 
     it('fails to create payment operation with an invalid destination address', function() {
@@ -195,7 +190,7 @@ describe('Operation', function() {
         'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
       );
     });
-    it('supports muxed accounts', function() {
+    it('does not support muxed accounts', function() {
       var sendAsset = new StellarBase.Asset(
         'USD',
         'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
@@ -220,22 +215,17 @@ describe('Operation', function() {
           'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
         )
       ];
-      let op = StellarBase.Operation.pathPaymentStrictReceive({
-        sendAsset,
-        sendMax,
-        destination,
-        destAsset,
-        destAmount,
-        path,
-        source
-      });
-      var xdr = op.toXDR('hex');
-      var operation = StellarBase.xdr.Operation.fromXDR(
-        Buffer.from(xdr, 'hex')
-      );
-      var obj = StellarBase.Operation.fromXDRObject(operation);
-      expect(obj.destination).to.be.equal(destination);
-      expect(obj.source).to.be.equal(destination);
+      expect(() => {
+        StellarBase.Operation.pathPaymentStrictReceive({
+          sendAsset,
+          sendMax,
+          destination,
+          destAsset,
+          destAmount,
+          path,
+          source
+        });
+      }).to.throw(/destination is invalid/);
     });
     it('fails to create path payment operation with an invalid destination address', function() {
       let opts = {
@@ -352,7 +342,7 @@ describe('Operation', function() {
         'GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL'
       );
     });
-    it('supports muxed accounts', function() {
+    it('does not support muxed accounts', function() {
       var sendAsset = new StellarBase.Asset(
         'USD',
         'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
@@ -373,23 +363,17 @@ describe('Operation', function() {
           'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
         )
       ];
-      let op = StellarBase.Operation.pathPaymentStrictSend({
-        sendAsset,
-        sendAmount,
-        destination,
-        destAsset,
-        destMin,
-        path,
-        source
-      });
-      var xdr = op.toXDR('hex');
-      var operation = StellarBase.xdr.Operation.fromXDR(
-        Buffer.from(xdr, 'hex')
-      );
-      var obj = StellarBase.Operation.fromXDRObject(operation);
-      expect(obj.type).to.be.equal('pathPaymentStrictSend');
-      expect(obj.destination).to.be.equal(destination);
-      expect(obj.source).to.be.equal(source);
+      expect(() => {
+        StellarBase.Operation.pathPaymentStrictSend({
+          sendAsset,
+          sendAmount,
+          destination,
+          destAsset,
+          destMin,
+          path,
+          source
+        });
+      }).to.throw(/destination is invalid/);
     });
     it('fails to create path payment operation with an invalid destination address', function() {
       let opts = {
@@ -1537,21 +1521,15 @@ describe('Operation', function() {
       expect(obj.type).to.be.equal('accountMerge');
       expect(obj.destination).to.be.equal(opts.destination);
     });
-    it('supports muxed accounts', function() {
+    it('does not support muxed accounts', function() {
       var opts = {};
       opts.destination =
         'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6';
       opts.source =
         'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6';
-      let op = StellarBase.Operation.accountMerge(opts);
-      var xdr = op.toXDR('hex');
-      var operation = StellarBase.xdr.Operation.fromXDR(
-        Buffer.from(xdr, 'hex')
-      );
-      var obj = StellarBase.Operation.fromXDRObject(operation);
-      expect(obj.type).to.be.equal('accountMerge');
-      expect(obj.destination).to.be.equal(opts.destination);
-      expect(obj.source).to.be.equal(opts.source);
+      expect(() => {
+        StellarBase.Operation.accountMerge(opts);
+      }).to.throw(/destination is invalid/);
     });
     it('fails to create accountMerge operation with an invalid destination address', function() {
       let opts = {

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -100,82 +100,6 @@ describe('StrKey', function() {
         )
       ).to.throw(/invalid checksum/);
     });
-
-    describe('muxed account', function() {
-      it('decodes med25519 correctly', function() {
-        const med25519 = new StellarBase.xdr.MuxedAccountMed25519({
-          id: StellarBase.xdr.Uint64.fromString('0'),
-          ed25519: StellarBase.StrKey.decodeEd25519PublicKey(
-            'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ'
-          )
-        });
-        let expectedBuffer = StellarBase.xdr.MuxedAccount.keyTypeMuxedEd25519(
-          med25519
-        ).toXDR();
-        let strkey =
-          'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6';
-        expect(StellarBase.StrKey.decodeMuxedAccount(strkey)).to.eql(
-          expectedBuffer
-        );
-      });
-
-      it('decodes ed25519 correctly', function() {
-        const rawEd25519 = StellarBase.StrKey.decodeEd25519PublicKey(
-          'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ'
-        );
-        const expectedBuffer = StellarBase.xdr.MuxedAccount.keyTypeEd25519(
-          rawEd25519
-        ).toXDR();
-        const strkey =
-          'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ';
-
-        expect(StellarBase.StrKey.decodeMuxedAccount(strkey)).to.eql(
-          expectedBuffer
-        );
-      });
-
-      it('throws an error: unused trailing bit must be zero in the encoding of the last three bytes (24 bits) as five base-32 symbols (25 bits)', function() {
-        // unused trailing bit must be zero in the encoding of the last three bytes (24 bits) as five base-32 symbols (25 bits)
-        expect(() =>
-          StellarBase.StrKey.decodeMuxedAccount(
-            'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL7'
-          )
-        ).to.throw(/invalid encoded string/);
-      });
-
-      it('throws an error if strkey has an invalid algorithm', function() {
-        // Invalid algorithm (low 3 bits of version byte are 7)
-        expect(() =>
-          StellarBase.StrKey.decodeMuxedAccount(
-            'M4AAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITIU2K'
-          )
-        ).to.throw(/invalid version byte/);
-      });
-
-      it('throws an error if strkey has an invalid length', function() {
-        expect(() =>
-          StellarBase.StrKey.decodeMuxedAccount(
-            'MCAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITKNOGA'
-          )
-        ).to.throw(/invalid encoded string/);
-      });
-
-      it('throws an error with if strkey has padding bytes ', function() {
-        expect(() =>
-          StellarBase.StrKey.decodeMuxedAccount(
-            'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6==='
-          )
-        ).to.throw(/invalid encoded string/);
-      });
-
-      it('throws an error with an invalid checksum', function() {
-        expect(() =>
-          StellarBase.StrKey.decodeMuxedAccount(
-            'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL4'
-          )
-        ).to.throw(/invalid checksum/);
-      });
-    });
   });
 
   describe('#encodeCheck', function() {
@@ -224,41 +148,6 @@ describe('StrKey', function() {
       expect(() => StellarBase.StrKey.encodeEd25519PublicKey(null)).to.throw(
         /null data/
       );
-    });
-
-    describe('muxed account', function() {
-      it('encodes med25519 accounts correctly', function() {
-        const med25519 = new StellarBase.xdr.MuxedAccountMed25519({
-          id: StellarBase.xdr.Uint64.fromString('0'),
-          ed25519: StellarBase.StrKey.decodeEd25519PublicKey(
-            'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ'
-          )
-        });
-        const buffer = StellarBase.xdr.MuxedAccount.keyTypeMuxedEd25519(
-          med25519
-        ).toXDR();
-
-        let expectedMuxedAccount =
-          'MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6';
-        expect(StellarBase.StrKey.encodeMuxedAccount(buffer)).to.eql(
-          expectedMuxedAccount
-        );
-      });
-      it('encodes ed25519 accounts correctly', function() {
-        const ed25519 = StellarBase.StrKey.decodeEd25519PublicKey(
-          'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ'
-        );
-
-        const buffer = StellarBase.xdr.MuxedAccount.keyTypeEd25519(
-          ed25519
-        ).toXDR();
-
-        let expectedMuxedAccount =
-          'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ';
-        expect(StellarBase.StrKey.encodeMuxedAccount(buffer)).to.eql(
-          expectedMuxedAccount
-        );
-      });
     });
   });
 

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -565,9 +565,7 @@ describe('Transaction', function() {
         envelope,
         networkPassphrase
       );
-      expect(txWithMuxedAccount.source).to.equal(
-        StellarBase.StrKey.encodeMuxedAccount(muxedAccount.toXDR())
-      );
+      expect(txWithMuxedAccount.source).to.equal(source.publicKey());
       expect(tx.source).to.equal(source.publicKey());
       var operation = txWithMuxedAccount.operations[0];
       expect(operation.destination).to.be.equal(destination);

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -561,7 +561,6 @@ describe('Transaction', function() {
         .value()
         .destination(destMuxedAccount);
 
-      console.log(envelope.toXDR('base64'));
       const txWithMuxedAccount = new StellarBase.Transaction(
         envelope,
         networkPassphrase

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -545,6 +545,23 @@ describe('Transaction', function() {
         .v1()
         .tx()
         .sourceAccount(muxedAccount);
+
+      let destMed25519 = new StellarBase.xdr.MuxedAccountMed25519({
+        id: StellarBase.xdr.Uint64.fromString('0'),
+        ed25519: StellarBase.StrKey.decodeEd25519PublicKey(destination)
+      });
+      let destMuxedAccount = StellarBase.xdr.MuxedAccount.keyTypeMuxedEd25519(
+        destMed25519
+      );
+      envelope
+        .v1()
+        .tx()
+        .operations()[0]
+        .body()
+        .value()
+        .destination(destMuxedAccount);
+
+      console.log(envelope.toXDR('base64'));
       const txWithMuxedAccount = new StellarBase.Transaction(
         envelope,
         networkPassphrase
@@ -553,6 +570,8 @@ describe('Transaction', function() {
         StellarBase.StrKey.encodeMuxedAccount(muxedAccount.toXDR())
       );
       expect(tx.source).to.equal(source.publicKey());
+      var operation = txWithMuxedAccount.operations[0];
+      expect(operation.destination).to.be.equal(destination);
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -487,9 +487,6 @@ export namespace StrKey {
 
   function encodeSha256Hash(data: Buffer): string;
   function decodeSha256Hash(data: string): Buffer;
-
-  function encodeMuxedAccount(data: Buffer): string;
-  function decodeMuxedAccount(data: string): Buffer;
 }
 
 export class TransactionI {


### PR DESCRIPTION
Remove SEP23 (Muxed Account StrKeys) support until SEP23 moves from a `draft` to `accepted`. 

Fix #348 