### PR TITLE
Document new authorize to maintain liabilities functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This version brings protocol 13 support with backwards compatibility support for
 - Update XDR definitions with protocol 13 ([#317](https://github.com/stellar/js-stellar-base/pull/317)).
 - Extend `Transaction` to work with `TransactionV1Envelope` and `TransactionV0Envelope` ([#317](https://github.com/stellar/js-stellar-base/pull/317)).
 - Add backward compatibility support for [CAP0018](https://github.com/stellar/stellar-protocol/blob/f01c9354aaab1e8ca97a25cf888829749cadf36a/core/cap-0018.md) ([#317](https://github.com/stellar/js-stellar-base/pull/317)).     
-  CAP0018 provides issuers with a level of authorization between unauthorized and fully authorized. The changes in this release allow you to use the new   authorization level and provides backward compatible support for Protocol 12.
+  CAP0018 provides issuers with a new level of authorization between unauthorized and fully authorized, called "authorized to maintain liabilities". The changes in this release allow you to use the new authorization level and provides backward compatible support for Protocol 12.
 
   Before Protocol 13, the argument `authorize` in the `AllowTrust` operation was of type `boolean` where `true` was authorize and `false` deauthorize. Starting in Protocol 13, this value is now a `number` where `0` is deauthorize, `1` is authorize, and `2` is authorize to maintain liabilities.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,23 @@ This version brings protocol 13 support with backwards compatibility support for
 ### Update
 - Update XDR definitions with protocol 13 ([#317](https://github.com/stellar/js-stellar-base/pull/317)).
 - Extend `Transaction` to work with `TransactionV1Envelope` and `TransactionV0Envelope` ([#317](https://github.com/stellar/js-stellar-base/pull/317)).
-- Add backward compatibility support for [CAP0018](https://github.com/stellar/stellar-protocol/blob/f01c9354aaab1e8ca97a25cf888829749cadf36a/core/cap-0018.md) ([#317](https://github.com/stellar/js-stellar-base/pull/317)).
+- Add backward compatibility support for [CAP0018](https://github.com/stellar/stellar-protocol/blob/f01c9354aaab1e8ca97a25cf888829749cadf36a/core/cap-0018.md) ([#317](https://github.com/stellar/js-stellar-base/pull/317)).     
+  CAP0018 provides issuers with a level of authorization between unauthorized and fully authorized. The changes in this release allow you to use the new   authorization level and provides backward compatible support for Protocol 12.
+
+  Before Protocol 13, the argument `authorize` in the `AllowTrust` operation was of type `boolean` where `true` was authorize and `false` deauthorize. Starting in Protocol 13, this value is now a `number` where `0` is deauthorize, `1` is authorize, and `2` is authorize to maintain liabilities.
+
+  The syntax for authorizing a trustline is still the same, but the authorize parameter is now a `number`.
+
+    ```js
+    Operation.allowTrust({
+      trustor: trustor.publicKey(),
+      assetCode: "COP",
+      authorize: 1
+    });
+    ```
+
+  You can use still use a `boolean`; however, we recommend you update your code to pass a `number` instead. Finally,  using the value `2` for authorize to maintain liabilities will only be valid if Stellar Core is running on Protocol 13; otherwise, you'll get an error.
+
 - ~Update operations builder to support multiplexed accounts ([#337](https://github.com/stellar/js-stellar-base/pull/337)).~
 
 ### Breaking changes

--- a/src/operations/allow_trust.js
+++ b/src/operations/allow_trust.js
@@ -11,7 +11,7 @@ import { StrKey } from '../strkey';
  * @param {object} opts Options object
  * @param {string} opts.trustor - The trusting account (the one being authorized)
  * @param {string} opts.assetCode - The asset code being authorized.
- * @param {boolean|number} opts.authorize - True to authorize the line, false to deauthorize.
+ * @param {(0|1|2)} opts.authorize - `1` to authorize, `2` to authorize to maintain liabilities, and `0` to deauthorize.
  * @param {string} [opts.source] - The source account (defaults to transaction source).
  * @returns {xdr.AllowTrustOp} Allow Trust operation
  */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,9 +3,7 @@
 /// <reference types="node" />
 import xdr from './xdr';
 
-export {
-  xdr
-};
+export { xdr };
 
 export class Account {
   constructor(accountId: string, sequence: string);
@@ -141,6 +139,16 @@ export type AuthFlag =
   | AuthFlag.required
   | AuthFlag.revocable;
 
+export namespace TrustLineFlag {
+  type deauthorize = 0;
+  type authorize = 1;
+  type authorizeToMaintainLiabilities = 2;
+}
+export type TrustLineFlag =
+  | TrustLineFlag.deauthorize
+  | TrustLineFlag.authorize
+  | TrustLineFlag.authorizeToMaintainLiabilities;
+
 export namespace Signer {
   interface Ed25519PublicKey {
     ed25519PublicKey: string;
@@ -221,7 +229,7 @@ export namespace OperationOptions {
   interface AllowTrust extends BaseOptions {
     trustor: string;
     assetCode: string;
-    authorize?: boolean | number;
+    authorize?: boolean | TrustLineFlag;
   }
   interface ChangeTrust extends BaseOptions {
     asset: Asset;
@@ -324,7 +332,7 @@ export namespace Operation {
     trustor: string;
     assetCode: string;
     // this is a boolean or a number so that it can support protocol 12 or 13
-    authorize: boolean | number | undefined;
+    authorize: boolean | TrustLineFlag | undefined;
   }
   function allowTrust(
     options: OperationOptions.AllowTrust
@@ -393,7 +401,8 @@ export namespace Operation {
     options: OperationOptions.ManageBuyOffer
   ): xdr.Operation<ManageBuyOffer>;
 
-  interface PathPaymentStrictReceive extends BaseOperation<OperationType.PathPaymentStrictReceive> {
+  interface PathPaymentStrictReceive
+    extends BaseOperation<OperationType.PathPaymentStrictReceive> {
     sendAsset: Asset;
     sendMax: string;
     destination: string;
@@ -405,7 +414,8 @@ export namespace Operation {
     options: OperationOptions.PathPaymentStrictReceive
   ): xdr.Operation<PathPaymentStrictReceive>;
 
-  interface PathPaymentStrictSend extends BaseOperation<OperationType.PathPaymentStrictSend> {
+  interface PathPaymentStrictSend
+    extends BaseOperation<OperationType.PathPaymentStrictSend> {
     sendAsset: Asset;
     sendAmount: string;
     destination: string;
@@ -504,7 +514,10 @@ export class TransactionI {
 }
 
 export class FeeBumpTransaction extends TransactionI {
-  constructor(envelope: string | xdr.TransactionEnvelope, networkPassphrase: string);
+  constructor(
+    envelope: string | xdr.TransactionEnvelope,
+    networkPassphrase: string
+  );
   feeSource: string;
   innerTransaction: Transaction;
 }
@@ -513,7 +526,10 @@ export class Transaction<
   TMemo extends Memo = Memo,
   TOps extends Operation[] = Operation[]
 > extends TransactionI {
-  constructor(envelope: string | xdr.TransactionEnvelope, networkPassphrase: string);
+  constructor(
+    envelope: string | xdr.TransactionEnvelope,
+    networkPassphrase: string
+  );
   memo: TMemo;
   operations: TOps;
   sequence: string;
@@ -524,7 +540,7 @@ export class Transaction<
   };
 }
 
-export const BASE_FEE = "100";
+export const BASE_FEE = '100';
 export const TimeoutInfinite = 0;
 
 export class TransactionBuilder {
@@ -537,8 +553,16 @@ export class TransactionBuilder {
   setTimeout(timeoutInSeconds: number): this;
   build(): Transaction;
   setNetworkPassphrase(networkPassphrase: string): this;
-  static buildFeeBumpTransaction(feeSource: Keypair, baseFee: string, innerTx: Transaction, networkPassphrase: string): FeeBumpTransaction;
-  static fromXDR(envelope: string|xdr.TransactionEnvelope, networkPassphrase: string): Transaction|FeeBumpTransaction;
+  static buildFeeBumpTransaction(
+    feeSource: Keypair,
+    baseFee: string,
+    innerTx: Transaction,
+    networkPassphrase: string
+  ): FeeBumpTransaction;
+  static fromXDR(
+    envelope: string | xdr.TransactionEnvelope,
+    networkPassphrase: string
+  ): Transaction | FeeBumpTransaction;
 }
 
 export namespace TransactionBuilder {


### PR DESCRIPTION
I forgot to include proper documentation for this functionality. This PR update the TypeScript types for better linting, update the `jsdocs`, and the changelog.

<img width="2297" alt="Screen Shot 2020-06-12 at 10 05 44 AM" src="https://user-images.githubusercontent.com/21772/84518925-0577d500-ac97-11ea-9a0d-b0ebdc74e472.png">

Fix #557.