### PR TITLE
Add Claimant class wrapper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## Unreleased
 
+## Add
+- Add the `Claimant` class which helps the creation of claimable balances. ((#367)[https://github.com/stellar/js-stellar-base/pull/367]).
+The default behavior of this class it to create claimants with an unconditional predicate if none is passed:
+
+```
+const claimant = new StellarBase.Claimant(
+  'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+);
+```
+
+However, you can use any of the following helpers to create a predicate:
+
+```
+StellarBase.Claimant.predicateUnconditional();
+StellarBase.Claimant.predicateAnd(left, right);
+StellarBase.Claimant.predicateOr(left, right);
+StellarBase.Claimant.predicateNot(predicate);
+StellarBase.Claimant.predicateBeforeAbsoluteTime(unixEpoch);
+StellarBase.Claimant.predicateBeforeRelativeTime(seconds);
+```
+
+And then pass the predicate in the constructor:
+
+```
+const left = StellarBase.Claimant.predicateBeforeRelativeTime('800');
+const right = StellarBase.Claimant.predicateBeforeRelativeTime(
+  '1200'
+);
+const predicate = StellarBase.Claimant.predicateOr(left, right);
+const claimant = new StellarBase.Claimant(
+  'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+  predicate
+);
+```
+
 ### Breaking
 
 - The XDR generated in this code includes breaking changes on the internal XDR library since a bug was fixed which was causing incorrect code to be generated (see https://github.com/stellar/xdrgen/pull/52).

--- a/src/claimant.js
+++ b/src/claimant.js
@@ -1,0 +1,171 @@
+import xdr from './generated/stellar-xdr_generated';
+import { Keypair } from './keypair';
+import { StrKey } from './strkey';
+
+/**
+ * Claimant class represents an xdr.Claimant
+ *
+ * The claim predicate is optional, it defaults to unconditional if none is specified.
+ *
+ * @constructor
+ * @param {string} destination - The destination account ID.
+ * @param {xdr.ClaimPredicate} [predicate] - The claim predicate.
+ */
+export class Claimant {
+  constructor(destination, predicate) {
+    if (destination && !StrKey.isValidEd25519PublicKey(destination)) {
+      throw new Error('Destination is invalid');
+    }
+    this._destination = destination;
+
+    if (!predicate) {
+      this._predicate = xdr.ClaimPredicate.claimPredicateUnconditional();
+    } else if (predicate instanceof xdr.ClaimPredicate) {
+      this._predicate = predicate;
+    } else {
+      throw new Error('Predicate should be an xdr.ClaimPredicate');
+    }
+  }
+
+  /**
+   * Returns an unconditional claim predicate
+   * @Return {xdr.ClaimPredicate}
+   */
+  static claimPredicateUnconditional() {
+    return xdr.ClaimPredicate.claimPredicateUnconditional();
+  }
+
+  /**
+   * Returns an `and` claim predicate
+   * @param {xdr.ClaimPredicate} left an xdr.ClaimPredicate
+   * @param {xdr.ClaimPredicate} right an xdr.ClaimPredicate
+   * @Return {xdr.ClaimPredicate}
+   */
+  static claimPredicateAnd(left, right) {
+    if (!(left instanceof xdr.ClaimPredicate)) {
+      throw new Error('left Predicate should be an xdr.ClaimPredicate');
+    }
+    if (!(right instanceof xdr.ClaimPredicate)) {
+      throw new Error('right Predicate should be an xdr.ClaimPredicate');
+    }
+
+    return xdr.ClaimPredicate.claimPredicateAnd([left, right]);
+  }
+
+  /**
+   * Returns an `or` claim predicate
+   * @param {xdr.ClaimPredicate} left an xdr.ClaimPredicate
+   * @param {xdr.ClaimPredicate} right an xdr.ClaimPredicate
+   * @Return {xdr.ClaimPredicate}
+   */
+  static claimPredicateOr(left, right) {
+    if (!(left instanceof xdr.ClaimPredicate)) {
+      throw new Error('left Predicate should be an xdr.ClaimPredicate');
+    }
+    if (!(right instanceof xdr.ClaimPredicate)) {
+      throw new Error('right Predicate should be an xdr.ClaimPredicate');
+    }
+
+    return xdr.ClaimPredicate.claimPredicateOr([left, right]);
+  }
+
+  /**
+   * Returns a `not` claim predicate
+   * @param {xdr.ClaimPredicate} predicate an xdr.ClaimPredicate
+   * @Return {xdr.ClaimPredicate}
+   */
+  static claimPredicateNot(predicate) {
+    if (!(predicate instanceof xdr.ClaimPredicate)) {
+      throw new Error('right Predicate should be an xdr.ClaimPredicate');
+    }
+
+    return xdr.ClaimPredicate.claimPredicateNot(predicate);
+  }
+
+  /**
+   * Returns a `BeforeAbsoluteTime` claim predicate
+   *
+   * This predicate will be fulfilled if the closing time of the ledger that
+   * includes the CreateClaimableBalance operation is less than this (absolute) Unix timestamp.
+   *
+   * @param {string} absBefore Unix epoch as a string
+   * @Return {xdr.ClaimPredicate}
+   */
+  static claimPredicateBeforeAbsoluteTime(absBefore) {
+    return xdr.ClaimPredicate.claimPredicateBeforeAbsoluteTime(
+      xdr.Int64.fromString(absBefore)
+    );
+  }
+
+  /**
+   * Returns a `BeforeRelativeTime` claim predicate
+   *
+   * This predicate will be fulfilled if the closing time of the ledger that
+   * includes the CreateClaimableBalance operation plus this relative time delta
+   * (in seconds) is less than the current time.
+   *
+   * @param {strings} seconds seconds since closeTime of the ledger in which the ClaimableBalanceEntry was created (as string)
+   * @Return {xdr.ClaimPredicate}
+   */
+  static claimPredicateBeforeRelativeTime(seconds) {
+    return xdr.ClaimPredicate.claimPredicateBeforeRelativeTime(
+      xdr.Int64.fromString(seconds)
+    );
+  }
+
+  /**
+   * Returns a claimant object from its XDR object representation.
+   * @param {xdr.Claimant} claimantXdr - The claimant xdr object.
+   * @returns {Claimant}
+   */
+  static fromXDR(claimantXdr) {
+    let value;
+    switch (claimantXdr.switch()) {
+      case xdr.ClaimantType.claimantTypeV0():
+        value = claimantXdr.v0();
+        return new this(
+          StrKey.encodeEd25519PublicKey(value.destination().ed25519()),
+          value.predicate()
+        );
+      default:
+        throw new Error(`Invalid claimant type: ${claimantXdr.switch().name}`);
+    }
+  }
+
+  /**
+   * Returns the xdr object for this claimant.
+   * @returns {xdr.Claimant} XDR Claimant object
+   */
+  toXDRObject() {
+    const claimant = new xdr.ClaimantV0({
+      destination: Keypair.fromPublicKey(this._destination).xdrAccountId(),
+      predicate: this._predicate
+    });
+
+    return xdr.Claimant.claimantTypeV0(claimant);
+  }
+
+  /**
+   * @type {string}
+   * @readonly
+   */
+  get destination() {
+    return this._destination;
+  }
+
+  set destination(value) {
+    throw new Error('Claimant is immutable');
+  }
+
+  /**
+   * @type {xdr.ClaimPredicate}
+   * @readonly
+   */
+  get predicate() {
+    return this._predicate;
+  }
+
+  set predicate(value) {
+    throw new Error('Claimant is immutable');
+  }
+}

--- a/src/claimant.js
+++ b/src/claimant.js
@@ -31,7 +31,7 @@ export class Claimant {
    * Returns an unconditional claim predicate
    * @Return {xdr.ClaimPredicate}
    */
-  static claimPredicateUnconditional() {
+  static predicateUnconditional() {
     return xdr.ClaimPredicate.claimPredicateUnconditional();
   }
 
@@ -41,7 +41,7 @@ export class Claimant {
    * @param {xdr.ClaimPredicate} right an xdr.ClaimPredicate
    * @Return {xdr.ClaimPredicate}
    */
-  static claimPredicateAnd(left, right) {
+  static predicateAnd(left, right) {
     if (!(left instanceof xdr.ClaimPredicate)) {
       throw new Error('left Predicate should be an xdr.ClaimPredicate');
     }
@@ -58,7 +58,7 @@ export class Claimant {
    * @param {xdr.ClaimPredicate} right an xdr.ClaimPredicate
    * @Return {xdr.ClaimPredicate}
    */
-  static claimPredicateOr(left, right) {
+  static predicateOr(left, right) {
     if (!(left instanceof xdr.ClaimPredicate)) {
       throw new Error('left Predicate should be an xdr.ClaimPredicate');
     }
@@ -74,7 +74,7 @@ export class Claimant {
    * @param {xdr.ClaimPredicate} predicate an xdr.ClaimPredicate
    * @Return {xdr.ClaimPredicate}
    */
-  static claimPredicateNot(predicate) {
+  static predicateNot(predicate) {
     if (!(predicate instanceof xdr.ClaimPredicate)) {
       throw new Error('right Predicate should be an xdr.ClaimPredicate');
     }
@@ -91,7 +91,7 @@ export class Claimant {
    * @param {string} absBefore Unix epoch as a string
    * @Return {xdr.ClaimPredicate}
    */
-  static claimPredicateBeforeAbsoluteTime(absBefore) {
+  static predicateBeforeAbsoluteTime(absBefore) {
     return xdr.ClaimPredicate.claimPredicateBeforeAbsoluteTime(
       xdr.Int64.fromString(absBefore)
     );
@@ -107,7 +107,7 @@ export class Claimant {
    * @param {strings} seconds seconds since closeTime of the ledger in which the ClaimableBalanceEntry was created (as string)
    * @Return {xdr.ClaimPredicate}
    */
-  static claimPredicateBeforeRelativeTime(seconds) {
+  static predicateBeforeRelativeTime(seconds) {
     return xdr.ClaimPredicate.claimPredicateBeforeRelativeTime(
       xdr.Int64.fromString(seconds)
     );

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export {
 } from './operation';
 export * from './memo';
 export { Account } from './account';
+export { Claimant } from './claimant';
 export { Networks } from './network';
 export { StrKey } from './strkey';
 

--- a/test/unit/claimant_test.js
+++ b/test/unit/claimant_test.js
@@ -1,0 +1,176 @@
+const { expect } = require('chai');
+
+describe('Claimant', function() {
+  describe('constructor', function() {
+    it('throws an error when destination is invalid', function() {
+      expect(() => new StellarBase.Claimant('GCEZWKCA5', null)).to.throw(
+        /Destination is invalid/
+      );
+    });
+    it('defaults to unconditional if predicate is undefined', function() {
+      const claimant = new StellarBase.Claimant(
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      expect(claimant.predicate.switch()).to.equal(
+        StellarBase.xdr.ClaimPredicateType.claimPredicateUnconditional()
+      );
+    });
+    it('throws an error if predicate is not an xdr.ClaimPredicate', function() {
+      expect(
+        () =>
+          new StellarBase.Claimant(
+            'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+            3
+          )
+      ).to.throw(/Predicate should be an xdr.ClaimPredicate/);
+    });
+  });
+  describe('claimPredicateUnconditional()', function() {
+    it('returns an `unconditional` claim predicate', function() {
+      const predicate = StellarBase.Claimant.claimPredicateUnconditional();
+      expect(predicate.switch()).to.equal(
+        StellarBase.xdr.ClaimPredicateType.claimPredicateUnconditional()
+      );
+    });
+  });
+  describe('claimPredicateBeforeAbsoluteTime()', function() {
+    it('returns a `beforeAbsoluteTime` claim predicate', function() {
+      const time = '4102444800000';
+      const predicate = StellarBase.Claimant.claimPredicateBeforeAbsoluteTime(
+        time
+      );
+      expect(predicate.switch()).to.equal(
+        StellarBase.xdr.ClaimPredicateType.claimPredicateBeforeAbsoluteTime()
+      );
+      const value = predicate.absBefore();
+      expect(value.toString()).to.equal(time);
+    });
+  });
+  describe('claimPredicateBeforeRelativeTime()', function() {
+    it('returns a `beforeRelativeTime` claim predicate', function() {
+      const time = '86400';
+      const predicate = StellarBase.Claimant.claimPredicateBeforeRelativeTime(
+        time
+      );
+      expect(predicate.switch()).to.equal(
+        StellarBase.xdr.ClaimPredicateType.claimPredicateBeforeRelativeTime()
+      );
+      const value = predicate.relBefore();
+      expect(value.toString()).to.equal(time);
+    });
+  });
+  describe('claimPredicateNot()', function() {
+    it('returns a `not` claim predicate', function() {
+      const time = '86400';
+      const beforeRel = StellarBase.Claimant.claimPredicateBeforeRelativeTime(
+        time
+      );
+      const predicate = StellarBase.Claimant.claimPredicateNot(beforeRel);
+      expect(predicate.switch()).to.equal(
+        StellarBase.xdr.ClaimPredicateType.claimPredicateNot()
+      );
+      const value = predicate.notPredicate().value();
+      expect(value).to.not.be.null;
+      expect(value.toString()).to.equal(time);
+    });
+  });
+  describe('claimPredicateOr()', function() {
+    it('returns an `or` claim predicate', function() {
+      const left = StellarBase.Claimant.claimPredicateBeforeRelativeTime('800');
+      const right = StellarBase.Claimant.claimPredicateBeforeRelativeTime(
+        '1200'
+      );
+      const predicate = StellarBase.Claimant.claimPredicateOr(left, right);
+      expect(predicate.switch()).to.equal(
+        StellarBase.xdr.ClaimPredicateType.claimPredicateOr()
+      );
+      const predicates = predicate.orPredicates();
+      expect(predicates[0].value().toString()).to.equal('800');
+      expect(predicates[1].value().toString()).to.equal('1200');
+    });
+  });
+  describe('claimPredicateAnd()', function() {
+    it('returns an `and` predicate claim predicate', function() {
+      const left = StellarBase.Claimant.claimPredicateBeforeRelativeTime('800');
+      const right = StellarBase.Claimant.claimPredicateBeforeRelativeTime(
+        '1200'
+      );
+      const predicate = StellarBase.Claimant.claimPredicateAnd(left, right);
+      expect(predicate.switch()).to.equal(
+        StellarBase.xdr.ClaimPredicateType.claimPredicateAnd()
+      );
+      const predicates = predicate.andPredicates();
+      expect(predicates[0].value().toString()).to.equal('800');
+      expect(predicates[1].value().toString()).to.equal('1200');
+    });
+  });
+  describe('destination()', function() {
+    it('returns the destination accountID', function() {
+      const destination =
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      const claimant = new StellarBase.Claimant(destination);
+      expect(claimant.destination).to.equal(destination);
+    });
+    it('does not allow changes in accountID', function() {
+      const destination =
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      const claimant = new StellarBase.Claimant(destination);
+      expect(() => (claimant.destination = '32323')).to.throw(
+        /Claimant is immutable/
+      );
+    });
+  });
+  describe('predicate()', function() {
+    it('returns the predicate', function() {
+      const claimant = new StellarBase.Claimant(
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      expect(claimant.predicate.switch()).to.equal(
+        StellarBase.Claimant.claimPredicateUnconditional().switch()
+      );
+    });
+    it('does not allow changes in predicate', function() {
+      const destination =
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      const claimant = new StellarBase.Claimant(destination);
+      expect(() => (claimant.predicate = null)).to.throw(
+        /Claimant is immutable/
+      );
+    });
+  });
+  describe('toXDRObject()', function() {
+    it('returns a xdr.Claimant', function() {
+      const destination =
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      const claimant = new StellarBase.Claimant(destination);
+      const xdrClaimant = claimant.toXDRObject();
+      expect(xdrClaimant).to.be.an.instanceof(StellarBase.xdr.Claimant);
+      expect(xdrClaimant.switch()).to.equal(
+        StellarBase.xdr.ClaimantType.claimantTypeV0()
+      );
+      const value = xdrClaimant.value();
+      expect(
+        StellarBase.StrKey.encodeEd25519PublicKey(value.destination().ed25519())
+      ).to.equal(destination);
+      expect(value.predicate().switch()).to.equal(
+        StellarBase.Claimant.claimPredicateUnconditional().switch()
+      );
+
+      expect(() => xdrClaimant.toXDR()).to.not.throw();
+    });
+  });
+  describe('fromXDR()', function() {
+    it('returns a Claimant', function() {
+      const destination =
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      const claimant = new StellarBase.Claimant(destination);
+      const hex = claimant.toXDRObject().toXDR('hex');
+      const xdrClaimant = StellarBase.xdr.Claimant.fromXDR(hex, 'hex');
+      const fromXDR = StellarBase.Claimant.fromXDR(xdrClaimant);
+      expect(fromXDR.destination).to.equal(destination);
+      expect(fromXDR.predicate.switch()).to.equal(
+        StellarBase.Claimant.claimPredicateUnconditional().switch()
+      );
+    });
+  });
+});

--- a/test/unit/claimant_test.js
+++ b/test/unit/claimant_test.js
@@ -25,20 +25,18 @@ describe('Claimant', function() {
       ).to.throw(/Predicate should be an xdr.ClaimPredicate/);
     });
   });
-  describe('claimPredicateUnconditional()', function() {
+  describe('predicateUnconditional()', function() {
     it('returns an `unconditional` claim predicate', function() {
-      const predicate = StellarBase.Claimant.claimPredicateUnconditional();
+      const predicate = StellarBase.Claimant.predicateUnconditional();
       expect(predicate.switch()).to.equal(
         StellarBase.xdr.ClaimPredicateType.claimPredicateUnconditional()
       );
     });
   });
-  describe('claimPredicateBeforeAbsoluteTime()', function() {
+  describe('predicateBeforeAbsoluteTime()', function() {
     it('returns a `beforeAbsoluteTime` claim predicate', function() {
       const time = '4102444800000';
-      const predicate = StellarBase.Claimant.claimPredicateBeforeAbsoluteTime(
-        time
-      );
+      const predicate = StellarBase.Claimant.predicateBeforeAbsoluteTime(time);
       expect(predicate.switch()).to.equal(
         StellarBase.xdr.ClaimPredicateType.claimPredicateBeforeAbsoluteTime()
       );
@@ -46,12 +44,10 @@ describe('Claimant', function() {
       expect(value.toString()).to.equal(time);
     });
   });
-  describe('claimPredicateBeforeRelativeTime()', function() {
+  describe('predicateBeforeRelativeTime()', function() {
     it('returns a `beforeRelativeTime` claim predicate', function() {
       const time = '86400';
-      const predicate = StellarBase.Claimant.claimPredicateBeforeRelativeTime(
-        time
-      );
+      const predicate = StellarBase.Claimant.predicateBeforeRelativeTime(time);
       expect(predicate.switch()).to.equal(
         StellarBase.xdr.ClaimPredicateType.claimPredicateBeforeRelativeTime()
       );
@@ -59,13 +55,11 @@ describe('Claimant', function() {
       expect(value.toString()).to.equal(time);
     });
   });
-  describe('claimPredicateNot()', function() {
+  describe('predicateNot()', function() {
     it('returns a `not` claim predicate', function() {
       const time = '86400';
-      const beforeRel = StellarBase.Claimant.claimPredicateBeforeRelativeTime(
-        time
-      );
-      const predicate = StellarBase.Claimant.claimPredicateNot(beforeRel);
+      const beforeRel = StellarBase.Claimant.predicateBeforeRelativeTime(time);
+      const predicate = StellarBase.Claimant.predicateNot(beforeRel);
       expect(predicate.switch()).to.equal(
         StellarBase.xdr.ClaimPredicateType.claimPredicateNot()
       );
@@ -74,13 +68,11 @@ describe('Claimant', function() {
       expect(value.toString()).to.equal(time);
     });
   });
-  describe('claimPredicateOr()', function() {
+  describe('predicateOr()', function() {
     it('returns an `or` claim predicate', function() {
-      const left = StellarBase.Claimant.claimPredicateBeforeRelativeTime('800');
-      const right = StellarBase.Claimant.claimPredicateBeforeRelativeTime(
-        '1200'
-      );
-      const predicate = StellarBase.Claimant.claimPredicateOr(left, right);
+      const left = StellarBase.Claimant.predicateBeforeRelativeTime('800');
+      const right = StellarBase.Claimant.predicateBeforeRelativeTime('1200');
+      const predicate = StellarBase.Claimant.predicateOr(left, right);
       expect(predicate.switch()).to.equal(
         StellarBase.xdr.ClaimPredicateType.claimPredicateOr()
       );
@@ -89,13 +81,11 @@ describe('Claimant', function() {
       expect(predicates[1].value().toString()).to.equal('1200');
     });
   });
-  describe('claimPredicateAnd()', function() {
+  describe('predicateAnd()', function() {
     it('returns an `and` predicate claim predicate', function() {
-      const left = StellarBase.Claimant.claimPredicateBeforeRelativeTime('800');
-      const right = StellarBase.Claimant.claimPredicateBeforeRelativeTime(
-        '1200'
-      );
-      const predicate = StellarBase.Claimant.claimPredicateAnd(left, right);
+      const left = StellarBase.Claimant.predicateBeforeRelativeTime('800');
+      const right = StellarBase.Claimant.predicateBeforeRelativeTime('1200');
+      const predicate = StellarBase.Claimant.predicateAnd(left, right);
       expect(predicate.switch()).to.equal(
         StellarBase.xdr.ClaimPredicateType.claimPredicateAnd()
       );
@@ -126,7 +116,7 @@ describe('Claimant', function() {
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
       expect(claimant.predicate.switch()).to.equal(
-        StellarBase.Claimant.claimPredicateUnconditional().switch()
+        StellarBase.Claimant.predicateUnconditional().switch()
       );
     });
     it('does not allow changes in predicate', function() {
@@ -153,7 +143,7 @@ describe('Claimant', function() {
         StellarBase.StrKey.encodeEd25519PublicKey(value.destination().ed25519())
       ).to.equal(destination);
       expect(value.predicate().switch()).to.equal(
-        StellarBase.Claimant.claimPredicateUnconditional().switch()
+        StellarBase.Claimant.predicateUnconditional().switch()
       );
 
       expect(() => xdrClaimant.toXDR()).to.not.throw();
@@ -169,7 +159,7 @@ describe('Claimant', function() {
       const fromXDR = StellarBase.Claimant.fromXDR(xdrClaimant);
       expect(fromXDR.destination).to.equal(destination);
       expect(fromXDR.predicate.switch()).to.equal(
-        StellarBase.Claimant.claimPredicateUnconditional().switch()
+        StellarBase.Claimant.predicateUnconditional().switch()
       );
     });
   });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,6 +39,22 @@ export class Asset {
   issuer: string;
 }
 
+export class Claimant {
+  readonly destination: string;
+  readonly predicate: xdr.ClaimPredicate;
+  constructor(destination: string, predicate?: xdr.ClaimPredicate);
+
+  toXDRObject(): xdr.Claimant;
+
+  static fromXDR(claimantXdr: xdr.Claimant): Claimant;
+  static predicateUnconditional(): xdr.ClaimPredicate;
+  static predicateAnd(left: xdr.ClaimPredicate, right: xdr.ClaimPredicate): xdr.ClaimPredicate;
+  static predicateOr(left: xdr.ClaimPredicate, right: xdr.ClaimPredicate): xdr.ClaimPredicate;
+  static predicateNot(predicate: xdr.ClaimPredicate): xdr.ClaimPredicate;
+  static predicateBeforeAbsoluteTime(absBefore: string): xdr.ClaimPredicate;
+  static predicateBeforeRelativeTime(seconds: string): xdr.ClaimPredicate;
+}
+
 export const FastSigning: boolean;
 
 export type KeypairType = 'ed25519';

--- a/types/test.ts
+++ b/types/test.ts
@@ -133,3 +133,9 @@ StellarSdk.xdr.LedgerEntryChanges.fromXDR(raw); // $ExpectType LedgerEntryChange
 StellarSdk.xdr.Asset.assetTypeNative(); // $ExpectType Asset
 StellarSdk.xdr.InnerTransactionResultResult.txInternalError(); // $ExpectType InnerTransactionResultResult
 StellarSdk.xdr.TransactionV0Ext[0](); // $ExpectedType TransactionV0Ext
+
+StellarSdk.Claimant.predicateUnconditional(); // $ExpectType ClaimPredicate
+const claimant = new StellarSdk.Claimant(sourceKey.publicKey()); // $ExpectType Claimant
+claimant.toXDRObject(); // $ExpectType Claimant
+claimant.destination; // $ExpectType string
+claimant.predicate; // $ExpectType ClaimPredicate


### PR DESCRIPTION
Add a new helper class to make it easier to create `xdr.Claimant` which will be used  to create and read the `CreateClaimableBalance` operations. 

By default it will create a claimant with an unconditional predicate if none is passed:

```
const claimant = new StellarBase.Claimant(
  'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
);
```

But additionally, it offers some helpers to make it easier to build new claim predicates:

```
Claimant.predicateUnconditional();
Claimant.predicateAnd(left, right);
Claimant.predicateOr(left, right);
Claimant.predicateNot(predicate);
Claimant.predicateBeforeAbsoluteTime(unixEpoch);
Claimant.predicateBeforeRelativeTime(seconds);
```

The helpers above will appear in the documentation. The following is a simple snippet showing how to create a claimant with an `or` predicate:

```
const left = StellarBase.Claimant.predicateBeforeRelativeTime('800');
const right = StellarBase.Claimant.predicateBeforeRelativeTime(
  '1200'
);
const predicate = StellarBase.Claimant.predicateOr(left, right);
const claimant = new StellarBase.Claimant(
  'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
  predicate
);
```