### PR TITLE
Add helpers to create CAP23 operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## Add
-- Add the `Claimant` class which helps the creation of claimable balances. ((#367)[https://github.com/stellar/js-stellar-base/pull/367]).
+- Add the `Claimant` class which helps the creation of claimable balances. ([#367](https://github.com/stellar/js-stellar-base/pull/367)).
 The default behavior of this class it to create claimants with an unconditional predicate if none is passed:
 
 ```
@@ -35,6 +35,38 @@ const claimant = new StellarBase.Claimant(
   'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
   predicate
 );
+```
+
+- Add `Operation.createClaimableBalance` ([#368](https://github.com/stellar/js-stellar-base/pull/368))
+Extend the operation class with a new helper to create claimable balance operations.
+
+```js
+const asset = new Asset(
+  'USD',
+  'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+);
+const amount = '100.0000000';
+const claimants = [
+  new Claimant(
+    'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+     Claimant.predicateBeforeAbsoluteTime("4102444800000")
+  )
+];
+
+const op = Operation.createClaimableBalance({
+  asset,
+  amount,
+  claimants
+});
+```
+
+- Add `Operation.claimClaimableBalance` ([#368](https://github.com/stellar/js-stellar-base/pull/368))
+Extend the operation class with a new helper to create claim claimable balance operations. It receives the `balanceId` as exposed by Horizon in the `/claimable_balances` end-point.
+
+```js
+const op = Operation.createClaimableBalance({
+  balanceId: '0da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
+});
 ```
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Extend the operation class with a new helper to create claim claimable balance o
 
 ```js
 const op = Operation.createClaimableBalance({
-  balanceId: '0da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
+  balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
 });
 ```
 

--- a/src/operation.js
+++ b/src/operation.js
@@ -266,17 +266,7 @@ export class Operation {
       }
       case 'claimClaimableBalance': {
         result.type = 'claimClaimableBalance';
-        // the first character of the balanceId represents xdr type discriminant and the rest is the body value in hex.
-        // Use toString(16) since value is a number
-        result.balanceId = attrs
-          .balanceId()
-          .switch()
-          .value.toString(16);
-        // Use toString('hex') because value is a buffer
-        result.balanceId += attrs
-          .balanceId()
-          .value()
-          .toString('hex');
+        result.balanceId = attrs.toXDR('hex');
         break;
       }
       default: {

--- a/src/operation.js
+++ b/src/operation.js
@@ -9,6 +9,7 @@ import isNumber from 'lodash/isNumber';
 import isFinite from 'lodash/isFinite';
 import { best_r } from './util/continued_fraction';
 import { Asset } from './asset';
+import { Claimant } from './claimant';
 import { StrKey } from './strkey';
 import xdr from './generated/stellar-xdr_generated';
 import * as ops from './operations/index';
@@ -59,6 +60,7 @@ export const AuthImmutableFlag = 1 << 2;
  * * `{@link Operation.inflation}`
  * * `{@link Operation.manageData}`
  * * `{@link Operation.bumpSequence}`
+ * * `{@link Operation.createClaimableBalance}`
  *
  * @class Operation
  */
@@ -251,6 +253,16 @@ export class Operation {
         result.bumpTo = attrs.bumpTo().toString();
         break;
       }
+      case 'createClaimableBalance': {
+        result.type = 'createClaimableBalance';
+        result.asset = Asset.fromOperation(attrs.asset());
+        result.amount = this._fromXDRAmount(attrs.amount());
+        result.claimants = [];
+        attrs.claimants().forEach((claimant) => {
+          result.claimants.push(Claimant.fromXDR(claimant));
+        });
+        break;
+      }
       default: {
         throw new Error(`Unknown operation: ${operationName}`);
       }
@@ -389,6 +401,7 @@ Operation.allowTrust = ops.allowTrust;
 Operation.bumpSequence = ops.bumpSequence;
 Operation.changeTrust = ops.changeTrust;
 Operation.createAccount = ops.createAccount;
+Operation.createClaimableBalance = ops.createClaimableBalance;
 Operation.createPassiveSellOffer = ops.createPassiveSellOffer;
 Operation.inflation = ops.inflation;
 Operation.manageData = ops.manageData;

--- a/src/operation.js
+++ b/src/operation.js
@@ -61,6 +61,7 @@ export const AuthImmutableFlag = 1 << 2;
  * * `{@link Operation.manageData}`
  * * `{@link Operation.bumpSequence}`
  * * `{@link Operation.createClaimableBalance}`
+ * * `{@link Operation.claimClaimableBalance}`
  *
  * @class Operation
  */
@@ -263,6 +264,21 @@ export class Operation {
         });
         break;
       }
+      case 'claimClaimableBalance': {
+        result.type = 'claimClaimableBalance';
+        // the first character of the balanceId represents xdr type discriminant and the rest is the body value in hex.
+        // Use toString(16) since value is a number
+        result.balanceId = attrs
+          .balanceId()
+          .switch()
+          .value.toString(16);
+        // Use toString('hex') because value is a buffer
+        result.balanceId += attrs
+          .balanceId()
+          .value()
+          .toString('hex');
+        break;
+      }
       default: {
         throw new Error(`Unknown operation: ${operationName}`);
       }
@@ -402,6 +418,7 @@ Operation.bumpSequence = ops.bumpSequence;
 Operation.changeTrust = ops.changeTrust;
 Operation.createAccount = ops.createAccount;
 Operation.createClaimableBalance = ops.createClaimableBalance;
+Operation.claimClaimableBalance = ops.claimClaimableBalance;
 Operation.createPassiveSellOffer = ops.createPassiveSellOffer;
 Operation.inflation = ops.inflation;
 Operation.manageData = ops.manageData;

--- a/src/operations/claim_claimable_balance.js
+++ b/src/operations/claim_claimable_balance.js
@@ -1,0 +1,43 @@
+import xdr from '../generated/stellar-xdr_generated';
+
+/**
+ * Create a new claim claimable balance operation.
+ * @function
+ * @alias Operation.claimClaimableBalance
+ * @param {object} opts Options object
+ * @param {string} opts.claimableBalanceId - The claimable balance id to be claimed.
+ * @returns {xdr.ClaimClaimableBalanceOp} Claim claimable balance operation
+ *
+ * @example
+ * const op = Operation.claimClaimableBalance({
+ *   balanceId: '0da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
+ * });
+ *
+ */
+export function claimClaimableBalance(opts) {
+  if (typeof opts.balanceId !== 'string' || opts.balanceId.length < 2) {
+    throw new Error('must provide a valid claimable balance Id');
+  }
+
+  const discriminant = opts.balanceId.slice(0, 1);
+  if (discriminant !== '0') {
+    throw new Error(
+      `invalid claimable balance Id: ${discriminant} is not a valid type`
+    );
+  }
+  const hexHash = opts.balanceId.slice(1);
+
+  const attributes = {};
+  attributes.balanceId = xdr.ClaimableBalanceId.claimableBalanceIdTypeV0(
+    xdr.Hash.fromXDR(hexHash, 'hex')
+  );
+  const claimClaimableBalanceOp = new xdr.ClaimClaimableBalanceOp(attributes);
+
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.claimClaimableBalance(
+    claimClaimableBalanceOp
+  );
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/claim_claimable_balance.js
+++ b/src/operations/claim_claimable_balance.js
@@ -5,7 +5,7 @@ import xdr from '../generated/stellar-xdr_generated';
  * @function
  * @alias Operation.claimClaimableBalance
  * @param {object} opts Options object
- * @param {string} opts.claimableBalanceId - The claimable balance id to be claimed.
+ * @param {string} opts.balanceId - The claimable balance id to be claimed.
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
  * @returns {xdr.Operation} Claim claimable balance operation
  *
@@ -15,8 +15,8 @@ import xdr from '../generated/stellar-xdr_generated';
  * });
  *
  */
-export function claimClaimableBalance(opts) {
-  if (typeof opts.balanceId !== 'string' || opts.balanceId.length < 2) {
+export function claimClaimableBalance(opts = {}) {
+  if (typeof opts.balanceId !== 'string') {
     throw new Error('must provide a valid claimable balance Id');
   }
   const attributes = {};

--- a/src/operations/claim_claimable_balance.js
+++ b/src/operations/claim_claimable_balance.js
@@ -7,7 +7,7 @@ import xdr from '../generated/stellar-xdr_generated';
  * @param {object} opts Options object
  * @param {string} opts.claimableBalanceId - The claimable balance id to be claimed.
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
- * @returns {xdr.ClaimClaimableBalanceOp} Claim claimable balance operation
+ * @returns {xdr.Operation} Claim claimable balance operation
  *
  * @example
  * const op = Operation.claimClaimableBalance({

--- a/src/operations/claim_claimable_balance.js
+++ b/src/operations/claim_claimable_balance.js
@@ -6,6 +6,7 @@ import xdr from '../generated/stellar-xdr_generated';
  * @alias Operation.claimClaimableBalance
  * @param {object} opts Options object
  * @param {string} opts.claimableBalanceId - The claimable balance id to be claimed.
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
  * @returns {xdr.ClaimClaimableBalanceOp} Claim claimable balance operation
  *
  * @example

--- a/src/operations/claim_claimable_balance.js
+++ b/src/operations/claim_claimable_balance.js
@@ -10,7 +10,7 @@ import xdr from '../generated/stellar-xdr_generated';
  *
  * @example
  * const op = Operation.claimClaimableBalance({
- *   balanceId: '0da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
+ *   balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
  * });
  *
  */
@@ -18,19 +18,8 @@ export function claimClaimableBalance(opts) {
   if (typeof opts.balanceId !== 'string' || opts.balanceId.length < 2) {
     throw new Error('must provide a valid claimable balance Id');
   }
-
-  const discriminant = opts.balanceId.slice(0, 1);
-  if (discriminant !== '0') {
-    throw new Error(
-      `invalid claimable balance Id: ${discriminant} is not a valid type`
-    );
-  }
-  const hexHash = opts.balanceId.slice(1);
-
   const attributes = {};
-  attributes.balanceId = xdr.ClaimableBalanceId.claimableBalanceIdTypeV0(
-    xdr.Hash.fromXDR(hexHash, 'hex')
-  );
+  attributes.balanceId = xdr.ClaimableBalanceId.fromXDR(opts.balanceId, 'hex');
   const claimClaimableBalanceOp = new xdr.ClaimClaimableBalanceOp(attributes);
 
   const opAttributes = {};

--- a/src/operations/create_claimable_balance.js
+++ b/src/operations/create_claimable_balance.js
@@ -9,6 +9,7 @@ import { Asset } from '../asset';
  * @param {Asset} opts.asset - The asset for the claimable balance.
  * @param {string} opts.amount - Amount.
  * @param {Claimant[]} opts.claimants - An array of Claimants
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
  * @returns {xdr.CreateClaimableBalanceOp} Create claimable balance operation
  *
  * @example

--- a/src/operations/create_claimable_balance.js
+++ b/src/operations/create_claimable_balance.js
@@ -10,7 +10,7 @@ import { Asset } from '../asset';
  * @param {string} opts.amount - Amount.
  * @param {Claimant[]} opts.claimants - An array of Claimants
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
- * @returns {xdr.CreateClaimableBalanceOp} Create claimable balance operation
+ * @returns {xdr.Operation} Create claimable balance operation
  *
  * @example
  * const asset = new Asset(

--- a/src/operations/create_claimable_balance.js
+++ b/src/operations/create_claimable_balance.js
@@ -43,7 +43,7 @@ export function createClaimableBalance(opts) {
     throw new TypeError(this.constructAmountRequirementsError('amount'));
   }
 
-  if (!opts.claimants || (opts.claimants && opts.claimants.length === 0)) {
+  if (!Array.isArray(opts.claimants) || opts.claimants.length === 0) {
     throw new Error('must provide at least one claimant');
   }
 

--- a/src/operations/create_claimable_balance.js
+++ b/src/operations/create_claimable_balance.js
@@ -1,0 +1,62 @@
+import xdr from '../generated/stellar-xdr_generated';
+import { Asset } from '../asset';
+
+/**
+ * Create a new claimable balance operation.
+ * @function
+ * @alias Operation.createClaimableBalance
+ * @param {object} opts Options object
+ * @param {Asset} opts.asset - The asset for the claimable balance.
+ * @param {string} opts.amount - Amount.
+ * @param {Claimant[]} opts.claimants - An array of Claimants
+ * @returns {xdr.CreateClaimableBalanceOp} Create claimable balance operation
+ *
+ * @example
+ * const asset = new Asset(
+ *   'USD',
+ *   'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+ * );
+ * const amount = '100.0000000';
+ * const claimants = [
+ *   new Claimant(
+ *     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+ *      Claimant.predicateBeforeAbsoluteTime("4102444800000")
+ *   )
+ * ];
+ *
+ * const op = Operation.createClaimableBalance({
+ *   asset,
+ *   amount,
+ *   claimants
+ * });
+ *
+ */
+export function createClaimableBalance(opts) {
+  if (!(opts.asset instanceof Asset)) {
+    throw new Error(
+      'must provide an asset for create claimable balance operation'
+    );
+  }
+
+  if (!this.isValidAmount(opts.amount)) {
+    throw new TypeError(this.constructAmountRequirementsError('amount'));
+  }
+
+  if (!opts.claimants || (opts.claimants && opts.claimants.length === 0)) {
+    throw new Error('must provide at least one claimant');
+  }
+
+  const attributes = {};
+  attributes.asset = opts.asset.toXDRObject();
+  attributes.amount = this._toXDRAmount(opts.amount);
+  attributes.claimants = opts.claimants.map((c) => c.toXDRObject());
+  const createClaimableBalanceOp = new xdr.CreateClaimableBalanceOp(attributes);
+
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.createClaimableBalance(
+    createClaimableBalanceOp
+  );
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -6,6 +6,7 @@ export { bumpSequence } from './bump_sequence';
 export { changeTrust } from './change_trust';
 export { createAccount } from './create_account';
 export { createClaimableBalance } from './create_claimable_balance';
+export { claimClaimableBalance } from './claim_claimable_balance';
 export { inflation } from './inflation';
 export { manageData } from './manage_data';
 export { manageBuyOffer } from './manage_buy_offer';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -5,6 +5,7 @@ export { allowTrust } from './allow_trust';
 export { bumpSequence } from './bump_sequence';
 export { changeTrust } from './change_trust';
 export { createAccount } from './create_account';
+export { createClaimableBalance } from './create_claimable_balance';
 export { inflation } from './inflation';
 export { manageData } from './manage_data';
 export { manageBuyOffer } from './manage_buy_offer';

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1730,6 +1730,101 @@ describe('Operation', function() {
     });
   });
 
+  describe('createClaimableBalance()', function() {
+    it('creates a CreateClaimableBalanceOp', function() {
+      const asset = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      const amount = '100.0000000';
+      const claimants = [
+        new StellarBase.Claimant(
+          'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+        )
+      ];
+
+      const op = StellarBase.Operation.createClaimableBalance({
+        asset,
+        amount,
+        claimants
+      });
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('createClaimableBalance');
+      expect(obj.asset.toString()).to.equal(asset.toString());
+      expect(obj.amount).to.be.equal(amount);
+      expect(obj.claimants).to.have.lengthOf(1);
+      expect(obj.claimants[0].toXDRObject().toXDR('hex')).to.equal(
+        claimants[0].toXDRObject().toXDR('hex')
+      );
+    });
+    it('throws an error when asset is not present', function() {
+      const amount = '100.0000000';
+      const claimants = [
+        new StellarBase.Claimant(
+          'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+        )
+      ];
+
+      const attrs = {
+        amount,
+        claimants
+      };
+
+      expect(() =>
+        StellarBase.Operation.createClaimableBalance(attrs)
+      ).to.throw(
+        /must provide an asset for create claimable balance operation/
+      );
+    });
+    it('throws an error when amount is not present', function() {
+      const asset = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      const claimants = [
+        new StellarBase.Claimant(
+          'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+        )
+      ];
+
+      const attrs = {
+        asset,
+        claimants
+      };
+
+      expect(() =>
+        StellarBase.Operation.createClaimableBalance(attrs)
+      ).to.throw(
+        /amount argument must be of type String, represent a positive number and have at most 7 digits after the decimal/
+      );
+    });
+    it('throws an error when claimants is empty or not present', function() {
+      const asset = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      const amount = '100.0000';
+
+      const attrs = {
+        asset,
+        amount
+      };
+
+      expect(() =>
+        StellarBase.Operation.createClaimableBalance(attrs)
+      ).to.throw(/must provide at least one claimant/);
+
+      attrs.claimants = [];
+      expect(() =>
+        StellarBase.Operation.createClaimableBalance(attrs)
+      ).to.throw(/must provide at least one claimant/);
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1828,7 +1828,7 @@ describe('Operation', function() {
   describe('claimClaimableBalance()', function() {
     it('creates a claimClaimableBalanceOp', function() {
       const balanceId =
-        '0da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be';
+        '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be';
 
       const op = StellarBase.Operation.claimClaimableBalance({
         balanceId
@@ -1841,7 +1841,7 @@ describe('Operation', function() {
       expect(obj.type).to.be.equal('claimClaimableBalance');
       expect(obj.balanceId).to.equal(balanceId);
     });
-    it('throws an error when balanceId is not present or length higher than 2', function() {
+    it('throws an error when balanceId is invalid', function() {
       expect(() => StellarBase.Operation.claimClaimableBalance({})).to.throw(
         /must provide a valid claimable balance Id/
       );
@@ -1855,13 +1855,6 @@ describe('Operation', function() {
           balanceId: '0'
         })
       ).to.throw(/must provide a valid claimable balance Id/);
-    });
-    it('throws an error when balanceId does not start with 0', function() {
-      expect(() =>
-        StellarBase.Operation.claimClaimableBalance({
-          balanceId: '10'
-        })
-      ).to.throw(/invalid claimable balance Id: 1 is not a valid type/);
     });
   });
 

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1825,6 +1825,46 @@ describe('Operation', function() {
     });
   });
 
+  describe('claimClaimableBalance()', function() {
+    it('creates a claimClaimableBalanceOp', function() {
+      const balanceId =
+        '0da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be';
+
+      const op = StellarBase.Operation.claimClaimableBalance({
+        balanceId
+      });
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('claimClaimableBalance');
+      expect(obj.balanceId).to.equal(balanceId);
+    });
+    it('throws an error when balanceId is not present or length higher than 2', function() {
+      expect(() => StellarBase.Operation.claimClaimableBalance({})).to.throw(
+        /must provide a valid claimable balance Id/
+      );
+      expect(() =>
+        StellarBase.Operation.claimClaimableBalance({
+          balanceId: ''
+        })
+      ).to.throw(/must provide a valid claimable balance Id/);
+      expect(() =>
+        StellarBase.Operation.claimClaimableBalance({
+          balanceId: '0'
+        })
+      ).to.throw(/must provide a valid claimable balance Id/);
+    });
+    it('throws an error when balanceId does not start with 0', function() {
+      expect(() =>
+        StellarBase.Operation.claimClaimableBalance({
+          balanceId: '10'
+        })
+      ).to.throw(/invalid claimable balance Id: 1 is not a valid type/);
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1841,20 +1841,10 @@ describe('Operation', function() {
       expect(obj.type).to.be.equal('claimClaimableBalance');
       expect(obj.balanceId).to.equal(balanceId);
     });
-    it('throws an error when balanceId is invalid', function() {
+    it('throws an error when balanceId is not present', function() {
       expect(() => StellarBase.Operation.claimClaimableBalance({})).to.throw(
         /must provide a valid claimable balance Id/
       );
-      expect(() =>
-        StellarBase.Operation.claimClaimableBalance({
-          balanceId: ''
-        })
-      ).to.throw(/must provide a valid claimable balance Id/);
-      expect(() =>
-        StellarBase.Operation.claimClaimableBalance({
-          balanceId: '0'
-        })
-      ).to.throw(/must provide a valid claimable balance Id/);
     });
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -218,6 +218,8 @@ export namespace OperationType {
   type Inflation = 'inflation';
   type ManageData = 'manageData';
   type BumpSequence = 'bumpSequence';
+  type CreateClaimableBalance = 'createClaimableBalance';
+  type ClaimClaimableBalance = 'claimClaimableBalance';
 }
 export type OperationType =
   | OperationType.CreateAccount
@@ -233,7 +235,9 @@ export type OperationType =
   | OperationType.AccountMerge
   | OperationType.Inflation
   | OperationType.ManageData
-  | OperationType.BumpSequence;
+  | OperationType.BumpSequence
+  | OperationType.CreateClaimableBalance
+  | OperationType.ClaimClaimableBalance;
 
 export namespace OperationOptions {
   interface BaseOptions {
@@ -314,6 +318,14 @@ export namespace OperationOptions {
   interface BumpSequence extends BaseOptions {
     bumpTo: string;
   }
+  interface CreateClaimableBalance extends BaseOptions {
+    asset: Asset;
+    amount: string;
+    claimants: Claimant[];
+  }
+  interface ClaimClaimableBalance extends BaseOptions {
+    balanceId: string;
+  }
 }
 export type OperationOptions =
   | OperationOptions.CreateAccount
@@ -329,7 +341,9 @@ export type OperationOptions =
   | OperationOptions.AccountMerge
   | OperationOptions.Inflation
   | OperationOptions.ManageData
-  | OperationOptions.BumpSequence;
+  | OperationOptions.BumpSequence
+  | OperationOptions.CreateClaimableBalance
+  | OperationOptions.ClaimClaimableBalance;
 
 export namespace Operation {
   interface BaseOperation<T extends OperationType = OperationType> {
@@ -479,6 +493,22 @@ export namespace Operation {
     options: OperationOptions.BumpSequence
   ): xdr.Operation<BumpSequence>;
 
+  interface CreateClaimableBalance extends BaseOperation<OperationType.CreateClaimableBalance> {
+    amount: string;
+    asset: Asset;
+    claimants: Claimant[];
+  }
+  function createClaimableBalance(
+    options: OperationOptions.CreateClaimableBalance
+  ): xdr.Operation<CreateClaimableBalance>;
+
+  interface ClaimClaimableBalance extends BaseOperation<OperationType.ClaimClaimableBalance> {
+    balanceId: string;
+  }
+  function claimClaimableBalance(
+    options: OperationOptions.ClaimClaimableBalance
+  ): xdr.Operation<ClaimClaimableBalance>;
+
   function fromXDRObject<T extends Operation = Operation>(
     xdrOperation: xdr.Operation<T>
   ): T;
@@ -497,7 +527,9 @@ export type Operation =
   | Operation.AccountMerge
   | Operation.Inflation
   | Operation.ManageData
-  | Operation.BumpSequence;
+  | Operation.BumpSequence
+  | Operation.CreateClaimableBalance
+  | Operation.ClaimClaimableBalance;
 
 export namespace StrKey {
   function encodeEd25519PublicKey(data: Buffer): string;

--- a/types/test.ts
+++ b/types/test.ts
@@ -9,9 +9,20 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
   networkPassphrase: StellarSdk.Networks.TESTNET
 })
   .addOperation(
-    StellarSdk.Operation.accountMerge({ destination: destKey.publicKey() })
-  )
-  .addMemo(new StellarSdk.Memo(StellarSdk.MemoText, 'memo'))
+    StellarSdk.Operation.accountMerge({ destination: destKey.publicKey() }),
+  ).addOperation(
+    StellarSdk.Operation.createClaimableBalance({
+      amount: "10",
+      asset: StellarSdk.Asset.native(),
+      claimants: [
+        new StellarSdk.Claimant(account.accountId())
+      ]
+    }),
+  ).addOperation(
+    StellarSdk.Operation.claimClaimableBalance({
+      balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
+    }),
+  ).addMemo(new StellarSdk.Memo(StellarSdk.MemoText, 'memo'))
   .setTimeout(5)
   .build(); // $ExpectType () => Transaction<Memo<MemoType>, Operation[]>
 


### PR DESCRIPTION
Extend the `Operation` class with two new helpers which allow the creation of CAP23 related operations:

- Add `Operation.createClaimableBalance`.
Extend the operation class with a new helper to create claimable balance operations.

```js
const asset = new Asset(
  'USD',
  'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
);
const amount = '100.0000000';
const claimants = [
  new Claimant(
    'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
     Claimant.predicateBeforeAbsoluteTime("4102444800000")
  )
];

const op = Operation.createClaimableBalance({
  asset,
  amount,
  claimants
});
```

- Add `Operation.claimClaimableBalance`.
Extend the operation class with a new helper to create claim claimable balance operations. It receives the `balanceId` as exposed by Horizon in the `/claimable_balances` end-point.

```js
const op = Operation.createClaimableBalance({
  balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
});
```