### PR TITLE
Add support for Sponsored Reserves (CAP33).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,99 @@ const op = Operation.createClaimableBalance({
   balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
 });
 ```
+- Add support for Sponsored Reserves (CAP33)([#369](https://github.com/stellar/js-stellar-base/pull/369/))
+
+Extend the operation class with helpers that allow sponsoring reserves and also revoke sponsorships.
+
+To start sponsoring reserves for an account use:
+- `Operation.beginSponsoringFutureReserves`
+- `Operation.endSponsoringFutureReserves`
+
+To revoke a sponsorship after it has been created use any of the following helpers:
+
+- `Operation.revokeAccountSponsorship`
+- `Operation.revokeTrustlineSponsorship`
+- `Operation.revokeOfferSponsorship`
+- `Operation.revokeDataSponsorship`
+- `Operation.revokeClaimableBalanceSponsorship`
+- `Operation.revokeSignerSponsorship`
+
+The following example contains a transaction which sponsors operations for an account and then revoke some sponsorships.
+
+```
+const transaction = new StellarSdk.TransactionBuilder(account, {
+  fee: "100",
+  networkPassphrase: StellarSdk.Networks.TESTNET
+})
+  .addOperation(
+    StellarSdk.Operation.beginSponsoringFutureReserves({
+      sponsoredId: account.accountId(),
+      source: masterKey.publicKey()
+    })
+  )
+  .addOperation(
+    StellarSdk.Operation.accountMerge({ destination: destKey.publicKey() }),
+  ).addOperation(
+    StellarSdk.Operation.createClaimableBalance({
+      amount: "10",
+      asset: StellarSdk.Asset.native(),
+      claimants: [
+        new StellarSdk.Claimant(account.accountId())
+      ]
+    }),
+  ).addOperation(
+    StellarSdk.Operation.claimClaimableBalance({
+      balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
+    }),
+  ).addOperation(
+    StellarSdk.Operation.endSponsoringFutureReserves({
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeAccountSponsorship({
+      account: account.accountId(),
+    })
+  ).addOperation(
+      StellarSdk.Operation.revokeTrustlineSponsorship({
+        account: account.accountId(),
+        asset: usd,
+      })
+  ).addOperation(
+    StellarSdk.Operation.revokeOfferSponsorship({
+      seller: account.accountId(),
+      offerId: '12345'
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeDataSponsorship({
+      account: account.accountId(),
+      name: 'foo'
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeClaimableBalanceSponsorship({
+      balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeSignerSponsorship({
+      account: account.accountId(),
+      signer: {
+        ed25519PublicKey: sourceKey.publicKey()
+      }
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeSignerSponsorship({
+      account: account.accountId(),
+      signer: {
+        sha256Hash: "da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
+      }
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeSignerSponsorship({
+      account: account.accountId(),
+      signer: {
+        preAuthTx: "da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
+      }
+    })
+  ).build();
+```
 
 ### Breaking
 

--- a/src/operation.js
+++ b/src/operation.js
@@ -440,6 +440,11 @@ function extractRevokeSponshipDetails(attrs, result) {
         }
         case xdr.LedgerEntryType.data().name: {
           result.type = 'revokeDataSponsorship';
+          result.account = accountIdtoAddress(ledgerKey.data().accountId());
+          result.name = ledgerKey
+            .data()
+            .dataName()
+            .toString('ascii');
           break;
         }
         case xdr.LedgerEntryType.claimableBalance().name: {
@@ -488,3 +493,4 @@ Operation.endSponsoringFutureReserves = ops.endSponsoringFutureReserves;
 Operation.revokeAccountSponsorship = ops.revokeAccountSponsorship;
 Operation.revokeTrustlineSponsorship = ops.revokeTrustlineSponsorship;
 Operation.revokeOfferSponsorship = ops.revokeOfferSponsorship;
+Operation.revokeDataSponsorship = ops.revokeDataSponsorship;

--- a/src/operation.js
+++ b/src/operation.js
@@ -423,6 +423,10 @@ function extractRevokeSponshipDetails(attrs, result) {
         }
         case xdr.LedgerEntryType.trustline().name: {
           result.type = 'revokeTrustlineSponsorship';
+          result.account = accountIdtoAddress(
+            ledgerKey.trustLine().accountId()
+          );
+          result.asset = Asset.fromOperation(ledgerKey.trustLine().asset());
           break;
         }
         case xdr.LedgerEntryType.offer().name: {
@@ -477,3 +481,4 @@ Operation.setOptions = ops.setOptions;
 Operation.beginSponsoringFutureReserves = ops.beginSponsoringFutureReserves;
 Operation.endSponsoringFutureReserves = ops.endSponsoringFutureReserves;
 Operation.revokeAccountSponsorship = ops.revokeAccountSponsorship;
+Operation.revokeTrustlineSponsorship = ops.revokeTrustlineSponsorship;

--- a/src/operation.js
+++ b/src/operation.js
@@ -449,6 +449,10 @@ function extractRevokeSponshipDetails(attrs, result) {
         }
         case xdr.LedgerEntryType.claimableBalance().name: {
           result.type = 'revokeClaimableBalanceSponsorship';
+          result.balanceId = ledgerKey
+            .claimableBalance()
+            .balanceId()
+            .toXDR('hex');
           break;
         }
         default: {
@@ -494,3 +498,5 @@ Operation.revokeAccountSponsorship = ops.revokeAccountSponsorship;
 Operation.revokeTrustlineSponsorship = ops.revokeTrustlineSponsorship;
 Operation.revokeOfferSponsorship = ops.revokeOfferSponsorship;
 Operation.revokeDataSponsorship = ops.revokeDataSponsorship;
+Operation.revokeClaimableBalanceSponsorship =
+  ops.revokeClaimableBalanceSponsorship;

--- a/src/operation.js
+++ b/src/operation.js
@@ -463,12 +463,39 @@ function extractRevokeSponshipDetails(attrs, result) {
     }
     case 'revokeSponsorshipSigner': {
       result.type = 'revokeSignerSponsorship';
+      result.account = accountIdtoAddress(attrs.signer().accountId());
+      result.signer = convertXDRSignerKeyToObject(attrs.signer().signerKey());
       break;
     }
     default: {
       throw new Error(`Unknown revokeSponsorship: ${attrs.switch().name}`);
     }
   }
+}
+
+function convertXDRSignerKeyToObject(signerKey) {
+  const attrs = {};
+  switch (signerKey.switch().name) {
+    case xdr.SignerKeyType.signerKeyTypeEd25519().name: {
+      attrs.ed25519PublicKey = StrKey.encodeEd25519PublicKey(
+        signerKey.ed25519()
+      );
+      break;
+    }
+    case xdr.SignerKeyType.signerKeyTypePreAuthTx().name: {
+      attrs.preAuthTx = signerKey.preAuthTx().toString('hex');
+      break;
+    }
+    case xdr.SignerKeyType.signerKeyTypeHashX().name: {
+      attrs.sha256Hash = signerKey.hashX().toString('hex');
+      break;
+    }
+    default: {
+      throw new Error(`Unknown signerKey: ${signerKey.switch().name}`);
+    }
+  }
+
+  return attrs;
 }
 
 function accountIdtoAddress(accountId) {
@@ -500,3 +527,4 @@ Operation.revokeOfferSponsorship = ops.revokeOfferSponsorship;
 Operation.revokeDataSponsorship = ops.revokeDataSponsorship;
 Operation.revokeClaimableBalanceSponsorship =
   ops.revokeClaimableBalanceSponsorship;
+Operation.revokeSignerSponsorship = ops.revokeSignerSponsorship;

--- a/src/operation.js
+++ b/src/operation.js
@@ -275,6 +275,10 @@ export class Operation {
         result.sponsoredId = accountIdtoAddress(attrs.sponsoredId());
         break;
       }
+      case 'endSponsoringFutureReserves': {
+        result.type = 'endSponsoringFutureReserves';
+        break;
+      }
       default: {
         throw new Error(`Unknown operation: ${operationName}`);
       }
@@ -425,3 +429,4 @@ Operation.pathPaymentStrictSend = ops.pathPaymentStrictSend;
 Operation.payment = ops.payment;
 Operation.setOptions = ops.setOptions;
 Operation.beginSponsoringFutureReserves = ops.beginSponsoringFutureReserves;
+Operation.endSponsoringFutureReserves = ops.endSponsoringFutureReserves;

--- a/src/operation.js
+++ b/src/operation.js
@@ -431,6 +431,11 @@ function extractRevokeSponshipDetails(attrs, result) {
         }
         case xdr.LedgerEntryType.offer().name: {
           result.type = 'revokeOfferSponsorship';
+          result.seller = accountIdtoAddress(ledgerKey.offer().sellerId());
+          result.offerId = ledgerKey
+            .offer()
+            .offerId()
+            .toString();
           break;
         }
         case xdr.LedgerEntryType.data().name: {
@@ -482,3 +487,4 @@ Operation.beginSponsoringFutureReserves = ops.beginSponsoringFutureReserves;
 Operation.endSponsoringFutureReserves = ops.endSponsoringFutureReserves;
 Operation.revokeAccountSponsorship = ops.revokeAccountSponsorship;
 Operation.revokeTrustlineSponsorship = ops.revokeTrustlineSponsorship;
+Operation.revokeOfferSponsorship = ops.revokeOfferSponsorship;

--- a/src/operation.js
+++ b/src/operation.js
@@ -63,6 +63,13 @@ export const AuthImmutableFlag = 1 << 2;
  * * `{@link Operation.createClaimableBalance}`
  * * `{@link Operation.claimClaimableBalance}`
  * * `{@link Operation.beginSponsoringFutureReserves}`
+ * * `{@link Operation.endSponsoringFutureReserves}`
+ * * `{@link Operation.revokeAccountSponsorship}`
+ * * `{@link Operation.revokeTrustlineSponsorship}`
+ * * `{@link Operation.revokeOfferSponsorship}`
+ * * `{@link Operation.revokeDataSponsorship}`
+ * * `{@link Operation.revokeClaimableBalanceSponsorship}`
+ * * `{@link Operation.revokeSignerSponsorship}`
  *
  * @class Operation
  */

--- a/src/operation.js
+++ b/src/operation.js
@@ -62,6 +62,7 @@ export const AuthImmutableFlag = 1 << 2;
  * * `{@link Operation.bumpSequence}`
  * * `{@link Operation.createClaimableBalance}`
  * * `{@link Operation.claimClaimableBalance}`
+ * * `{@link Operation.beginSponsoringFutureReserves}`
  *
  * @class Operation
  */
@@ -269,6 +270,11 @@ export class Operation {
         result.balanceId = attrs.toXDR('hex');
         break;
       }
+      case 'beginSponsoringFutureReserves': {
+        result.type = 'beginSponsoringFutureReserves';
+        result.sponsoredId = accountIdtoAddress(attrs.sponsoredId());
+        break;
+      }
       default: {
         throw new Error(`Unknown operation: ${operationName}`);
       }
@@ -418,3 +424,4 @@ Operation.pathPaymentStrictReceive = ops.pathPaymentStrictReceive;
 Operation.pathPaymentStrictSend = ops.pathPaymentStrictSend;
 Operation.payment = ops.payment;
 Operation.setOptions = ops.setOptions;
+Operation.beginSponsoringFutureReserves = ops.beginSponsoringFutureReserves;

--- a/src/operations/begin_sponsoring_future_reserves.js
+++ b/src/operations/begin_sponsoring_future_reserves.js
@@ -1,0 +1,33 @@
+import xdr from '../generated/stellar-xdr_generated';
+import { StrKey } from '../strkey';
+import { Keypair } from '../keypair';
+
+/**
+ * Create a begin sponsoring future reserves operation.
+ * @function
+ * @alias Operation.beginSponsoringFutureReserves
+ * @param {object} opts Options object
+ * @param {string} opts.sponsoredId - The sponsored account id.
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ * @returns {xdr.Operation} xdr operation
+ *
+ * @example
+ * const op = Operation.beginSponsoringFutureReserves({
+ *   sponsoredId: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+ * });
+ *
+ */
+export function beginSponsoringFutureReserves(opts) {
+  if (!StrKey.isValidEd25519PublicKey(opts.sponsoredId)) {
+    throw new Error('sponsoredId is invalid');
+  }
+  const op = new xdr.BeginSponsoringFutureReservesOp({
+    sponsoredId: Keypair.fromPublicKey(opts.sponsoredId).xdrAccountId()
+  });
+
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.beginSponsoringFutureReserves(op);
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/begin_sponsoring_future_reserves.js
+++ b/src/operations/begin_sponsoring_future_reserves.js
@@ -17,7 +17,7 @@ import { Keypair } from '../keypair';
  * });
  *
  */
-export function beginSponsoringFutureReserves(opts) {
+export function beginSponsoringFutureReserves(opts = {}) {
   if (!StrKey.isValidEd25519PublicKey(opts.sponsoredId)) {
     throw new Error('sponsoredId is invalid');
   }

--- a/src/operations/begin_sponsoring_future_reserves.js
+++ b/src/operations/begin_sponsoring_future_reserves.js
@@ -3,7 +3,7 @@ import { StrKey } from '../strkey';
 import { Keypair } from '../keypair';
 
 /**
- * Create a begin sponsoring future reserves operation.
+ * Create a "begin sponsoring future reserves" operation.
  * @function
  * @alias Operation.beginSponsoringFutureReserves
  * @param {object} opts Options object

--- a/src/operations/end_sponsoring_future_reserves.js
+++ b/src/operations/end_sponsoring_future_reserves.js
@@ -1,0 +1,21 @@
+import xdr from '../generated/stellar-xdr_generated';
+
+/**
+ * Create a end sponsoring future reserves operation.
+ * @function
+ * @alias Operation.endSponsoringFutureReserves
+ * @param {object} opts Options object
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ * @returns {xdr.Operation} xdr operation
+ *
+ * @example
+ * const op = Operation.endSponsoringFutureReserves();
+ *
+ */
+export function endSponsoringFutureReserves(opts = {}) {
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.endSponsoringFutureReserves();
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/end_sponsoring_future_reserves.js
+++ b/src/operations/end_sponsoring_future_reserves.js
@@ -1,7 +1,7 @@
 import xdr from '../generated/stellar-xdr_generated';
 
 /**
- * Create a end sponsoring future reserves operation.
+ * Create an "end sponsoring future reserves" operation.
  * @function
  * @alias Operation.endSponsoringFutureReserves
  * @param {object} opts Options object

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -19,5 +19,6 @@ export { endSponsoringFutureReserves } from './end_sponsoring_future_reserves';
 export {
   revokeAccountSponsorship,
   revokeTrustlineSponsorship,
-  revokeOfferSponsorship
+  revokeOfferSponsorship,
+  revokeDataSponsorship
 } from './revoke_sponsorship';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -16,3 +16,4 @@ export { payment } from './payment';
 export { setOptions } from './set_options';
 export { beginSponsoringFutureReserves } from './begin_sponsoring_future_reserves';
 export { endSponsoringFutureReserves } from './end_sponsoring_future_reserves';
+export { revokeAccountSponsorship } from './revoke_sponsorship';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -18,5 +18,6 @@ export { beginSponsoringFutureReserves } from './begin_sponsoring_future_reserve
 export { endSponsoringFutureReserves } from './end_sponsoring_future_reserves';
 export {
   revokeAccountSponsorship,
-  revokeTrustlineSponsorship
+  revokeTrustlineSponsorship,
+  revokeOfferSponsorship
 } from './revoke_sponsorship';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -14,3 +14,4 @@ export { pathPaymentStrictReceive } from './path_payment_strict_receive';
 export { pathPaymentStrictSend } from './path_payment_strict_send';
 export { payment } from './payment';
 export { setOptions } from './set_options';
+export { beginSponsoringFutureReserves } from './begin_sponsoring_future_reserves';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -15,3 +15,4 @@ export { pathPaymentStrictSend } from './path_payment_strict_send';
 export { payment } from './payment';
 export { setOptions } from './set_options';
 export { beginSponsoringFutureReserves } from './begin_sponsoring_future_reserves';
+export { endSponsoringFutureReserves } from './end_sponsoring_future_reserves';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -20,5 +20,6 @@ export {
   revokeAccountSponsorship,
   revokeTrustlineSponsorship,
   revokeOfferSponsorship,
-  revokeDataSponsorship
+  revokeDataSponsorship,
+  revokeClaimableBalanceSponsorship
 } from './revoke_sponsorship';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -16,4 +16,7 @@ export { payment } from './payment';
 export { setOptions } from './set_options';
 export { beginSponsoringFutureReserves } from './begin_sponsoring_future_reserves';
 export { endSponsoringFutureReserves } from './end_sponsoring_future_reserves';
-export { revokeAccountSponsorship } from './revoke_sponsorship';
+export {
+  revokeAccountSponsorship,
+  revokeTrustlineSponsorship
+} from './revoke_sponsorship';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -21,5 +21,6 @@ export {
   revokeTrustlineSponsorship,
   revokeOfferSponsorship,
   revokeDataSponsorship,
-  revokeClaimableBalanceSponsorship
+  revokeClaimableBalanceSponsorship,
+  revokeSignerSponsorship
 } from './revoke_sponsorship';

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -1,0 +1,37 @@
+import xdr from '../generated/stellar-xdr_generated';
+import { StrKey } from '../strkey';
+import { Keypair } from '../keypair';
+
+/**
+ * Create a revoke sponsorship operation for an account.
+ * 
+  * @function
+ 
+ * @param {object} opts Options object
+ * @param {string} opts.account - The sponsored account ID.
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ * @returns {xdr.Operation} xdr operation
+ *
+ * @example
+ * const op = Operation.revokeAccountSponsorship({
+ *   account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7
+ * });
+ *
+ */
+export function revokeAccountSponsorship(opts = {}) {
+  if (!StrKey.isValidEd25519PublicKey(opts.account)) {
+    throw new Error('account is invalid');
+  }
+
+  const ledgerKey = xdr.LedgerKey.account(
+    new xdr.LedgerKeyAccount({
+      accountId: Keypair.fromPublicKey(opts.account).xdrAccountId()
+    })
+  );
+  const op = xdr.RevokeSponsorshipOp.revokeSponsorshipLedgerEntry(ledgerKey);
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.revokeSponsorship(op);
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -1,6 +1,7 @@
 import xdr from '../generated/stellar-xdr_generated';
 import { StrKey } from '../strkey';
 import { Keypair } from '../keypair';
+import { Asset } from '../asset';
 
 /**
  * Create a revoke sponsorship operation for an account.
@@ -26,6 +27,49 @@ export function revokeAccountSponsorship(opts = {}) {
   const ledgerKey = xdr.LedgerKey.account(
     new xdr.LedgerKeyAccount({
       accountId: Keypair.fromPublicKey(opts.account).xdrAccountId()
+    })
+  );
+  const op = xdr.RevokeSponsorshipOp.revokeSponsorshipLedgerEntry(ledgerKey);
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.revokeSponsorship(op);
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}
+
+/**
+ * Create a revoke sponsorship operation for a trustline.
+ * 
+  * @function
+ 
+ * @param {object} opts Options object
+ * @param {string} opts.account - The account ID which owns the trustline.
+ * @param {Asset} opts.asset - The asset in the trustline.
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ * @returns {xdr.Operation} xdr operation
+ *
+ * @example
+ * const op = Operation.revokeTrustlineSponsorship({
+ *   account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7
+ *   asset: new StellarBase.Asset(
+ *     'USDUSD', 
+ *     'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+ *   )
+ * });
+ *
+ */
+export function revokeTrustlineSponsorship(opts = {}) {
+  if (!StrKey.isValidEd25519PublicKey(opts.account)) {
+    throw new Error('account is invalid');
+  }
+  if (!(opts.asset instanceof Asset)) {
+    throw new Error('asset is invalid');
+  }
+
+  const ledgerKey = xdr.LedgerKey.trustline(
+    new xdr.LedgerKeyTrustLine({
+      accountId: Keypair.fromPublicKey(opts.account).xdrAccountId(),
+      asset: opts.asset.toXDRObject()
     })
   );
   const op = xdr.RevokeSponsorshipOp.revokeSponsorshipLedgerEntry(ledgerKey);

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -79,3 +79,43 @@ export function revokeTrustlineSponsorship(opts = {}) {
 
   return new xdr.Operation(opAttributes);
 }
+
+/**
+ * Create a revoke sponsorship operation for an offer
+ * 
+  * @function
+ 
+ * @param {object} opts Options object
+ * @param {string} opts.seller - The account ID which created the offer.
+ * @param {string} opts.offerId - The offer ID.
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ * @returns {xdr.Operation} xdr operation
+ *
+ * @example
+ * const op = Operation.revokeOfferSponsorship({
+ *   seller: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7
+ *   offerId: '1234'
+ * });
+ *
+ */
+export function revokeOfferSponsorship(opts = {}) {
+  if (!StrKey.isValidEd25519PublicKey(opts.seller)) {
+    throw new Error('seller is invalid');
+  }
+  if (typeof opts.offerId !== 'string') {
+    throw new Error('offerId is invalid');
+  }
+
+  const ledgerKey = xdr.LedgerKey.offer(
+    new xdr.LedgerKeyOffer({
+      sellerId: Keypair.fromPublicKey(opts.seller).xdrAccountId(),
+      offerId: xdr.Int64.fromString(opts.offerId)
+    })
+  );
+  const op = xdr.RevokeSponsorshipOp.revokeSponsorshipLedgerEntry(ledgerKey);
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.revokeSponsorship(op);
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -1,3 +1,4 @@
+import isString from 'lodash/isString';
 import xdr from '../generated/stellar-xdr_generated';
 import { StrKey } from '../strkey';
 import { Keypair } from '../keypair';
@@ -5,9 +6,8 @@ import { Asset } from '../asset';
 
 /**
  * Create a revoke sponsorship operation for an account.
- * 
-  * @function
- 
+ *
+ * @function
  * @param {object} opts Options object
  * @param {string} opts.account - The sponsored account ID.
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
@@ -39,9 +39,8 @@ export function revokeAccountSponsorship(opts = {}) {
 
 /**
  * Create a revoke sponsorship operation for a trustline.
- * 
-  * @function
- 
+ *
+ * @function
  * @param {object} opts Options object
  * @param {string} opts.account - The account ID which owns the trustline.
  * @param {Asset} opts.asset - The asset in the trustline.
@@ -52,7 +51,7 @@ export function revokeAccountSponsorship(opts = {}) {
  * const op = Operation.revokeTrustlineSponsorship({
  *   account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7
  *   asset: new StellarBase.Asset(
- *     'USDUSD', 
+ *     'USDUSD',
  *     'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
  *   )
  * });
@@ -82,9 +81,8 @@ export function revokeTrustlineSponsorship(opts = {}) {
 
 /**
  * Create a revoke sponsorship operation for an offer
- * 
-  * @function
- 
+ *
+ * @function
  * @param {object} opts Options object
  * @param {string} opts.seller - The account ID which created the offer.
  * @param {string} opts.offerId - The offer ID.
@@ -102,7 +100,7 @@ export function revokeOfferSponsorship(opts = {}) {
   if (!StrKey.isValidEd25519PublicKey(opts.seller)) {
     throw new Error('seller is invalid');
   }
-  if (typeof opts.offerId !== 'string') {
+  if (!isString(opts.offerId)) {
     throw new Error('offerId is invalid');
   }
 
@@ -110,6 +108,45 @@ export function revokeOfferSponsorship(opts = {}) {
     new xdr.LedgerKeyOffer({
       sellerId: Keypair.fromPublicKey(opts.seller).xdrAccountId(),
       offerId: xdr.Int64.fromString(opts.offerId)
+    })
+  );
+  const op = xdr.RevokeSponsorshipOp.revokeSponsorshipLedgerEntry(ledgerKey);
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.revokeSponsorship(op);
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}
+
+/**
+ * Create a revoke sponsorship operation for a data entry.
+ *
+ * @function
+ * @param {object} opts Options object
+ * @param {string} opts.account - The account ID which owns the data entry.
+ * @param {string} opts.name - The name of the data entry
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ * @returns {xdr.Operation} xdr operation
+ *
+ * @example
+ * const op = Operation.revokeDataSponsorship({
+ *   account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7
+ *   name: 'foo'
+ * });
+ *
+ */
+export function revokeDataSponsorship(opts = {}) {
+  if (!StrKey.isValidEd25519PublicKey(opts.account)) {
+    throw new Error('account is invalid');
+  }
+  if (!isString(opts.name) || opts.name.length > 64) {
+    throw new Error('name must be a string, up to 64 characters');
+  }
+
+  const ledgerKey = xdr.LedgerKey.data(
+    new xdr.LedgerKeyData({
+      accountId: Keypair.fromPublicKey(opts.account).xdrAccountId(),
+      dataName: opts.name
     })
   );
   const op = xdr.RevokeSponsorshipOp.revokeSponsorshipLedgerEntry(ledgerKey);

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -156,3 +156,36 @@ export function revokeDataSponsorship(opts = {}) {
 
   return new xdr.Operation(opAttributes);
 }
+
+/**
+ * Create a revoke sponsorship operation for a claimable balance.
+ *
+ * @function
+ * @param {object} opts Options object
+ * @param {string} opts.balanceId - The sponsored claimable balance ID.
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ * @returns {xdr.Operation} xdr operation
+ *
+ * @example
+ * const op = Operation.revokeClaimableBalanceSponsorship({
+ *   balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
+ * });
+ *
+ */
+export function revokeClaimableBalanceSponsorship(opts = {}) {
+  if (!isString(opts.balanceId)) {
+    throw new Error('balanceId is invalid');
+  }
+
+  const ledgerKey = xdr.LedgerKey.claimableBalance(
+    new xdr.LedgerKeyClaimableBalance({
+      balanceId: xdr.ClaimableBalanceId.fromXDR(opts.balanceId, 'hex')
+    })
+  );
+  const op = xdr.RevokeSponsorshipOp.revokeSponsorshipLedgerEntry(ledgerKey);
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.revokeSponsorship(op);
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -5,7 +5,7 @@ import { Keypair } from '../keypair';
 import { Asset } from '../asset';
 
 /**
- * Create a revoke sponsorship operation for an account.
+ * Create a "revoke sponsorship" operation for an account.
  *
  * @function
  * @alias Operation.revokeAccountSponsorship
@@ -39,7 +39,7 @@ export function revokeAccountSponsorship(opts = {}) {
 }
 
 /**
- * Create a revoke sponsorship operation for a trustline.
+ * Create a "revoke sponsorship" operation for a trustline.
  *
  * @function
  * @alias Operation.revokeTrustlineSponsorship
@@ -82,7 +82,7 @@ export function revokeTrustlineSponsorship(opts = {}) {
 }
 
 /**
- * Create a revoke sponsorship operation for an offer
+ * Create a "revoke sponsorship" operation for an offer.
  *
  * @function
  * @alias Operation.revokeOfferSponsorship
@@ -122,7 +122,7 @@ export function revokeOfferSponsorship(opts = {}) {
 }
 
 /**
- * Create a revoke sponsorship operation for a data entry.
+ * Create a "revoke sponsorship" operation for a data entry.
  *
  * @function
  * @alias Operation.revokeDataSponsorship
@@ -162,7 +162,7 @@ export function revokeDataSponsorship(opts = {}) {
 }
 
 /**
- * Create a revoke sponsorship operation for a claimable balance.
+ * Create a "revoke sponsorship" operation for a claimable balance.
  *
  * @function
  * @alias Operation.revokeClaimableBalanceSponsorship
@@ -196,7 +196,7 @@ export function revokeClaimableBalanceSponsorship(opts = {}) {
 }
 
 /**
- * Create a revoke sponsorship operation for a signer.
+ * Create a "revoke sponsorship" operation for a signer.
  *
  * @function
  * @alias Operation.revokeSignerSponsorship

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -8,6 +8,7 @@ import { Asset } from '../asset';
  * Create a revoke sponsorship operation for an account.
  *
  * @function
+ * @alias Operation.revokeAccountSponsorship
  * @param {object} opts Options object
  * @param {string} opts.account - The sponsored account ID.
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
@@ -41,6 +42,7 @@ export function revokeAccountSponsorship(opts = {}) {
  * Create a revoke sponsorship operation for a trustline.
  *
  * @function
+ * @alias Operation.revokeTrustlineSponsorship
  * @param {object} opts Options object
  * @param {string} opts.account - The account ID which owns the trustline.
  * @param {Asset} opts.asset - The asset in the trustline.
@@ -83,6 +85,7 @@ export function revokeTrustlineSponsorship(opts = {}) {
  * Create a revoke sponsorship operation for an offer
  *
  * @function
+ * @alias Operation.revokeOfferSponsorship
  * @param {object} opts Options object
  * @param {string} opts.seller - The account ID which created the offer.
  * @param {string} opts.offerId - The offer ID.
@@ -122,6 +125,7 @@ export function revokeOfferSponsorship(opts = {}) {
  * Create a revoke sponsorship operation for a data entry.
  *
  * @function
+ * @alias Operation.revokeDataSponsorship
  * @param {object} opts Options object
  * @param {string} opts.account - The account ID which owns the data entry.
  * @param {string} opts.name - The name of the data entry
@@ -161,6 +165,7 @@ export function revokeDataSponsorship(opts = {}) {
  * Create a revoke sponsorship operation for a claimable balance.
  *
  * @function
+ * @alias Operation.revokeClaimableBalanceSponsorship
  * @param {object} opts Options object
  * @param {string} opts.balanceId - The sponsored claimable balance ID.
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
@@ -194,6 +199,7 @@ export function revokeClaimableBalanceSponsorship(opts = {}) {
  * Create a revoke sponsorship operation for a signer.
  *
  * @function
+ * @alias Operation.revokeSignerSponsorship
  * @param {object} opts Options object
  * @param {string} opts.account - The account ID where the signer sponsorship is being removed from.
  * @param {object} opts.signer - The signer whose sponsorship is being removed.

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1920,7 +1920,7 @@ describe('Operation', function() {
   });
 
   describe('revokeTrustlineSponsorship()', function() {
-    it('creates a revokeAccountSponsorshipOp', function() {
+    it('creates a revokeTrustlineSponsorship', function() {
       const account =
         'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
       var asset = new StellarBase.Asset(
@@ -1957,43 +1957,39 @@ describe('Operation', function() {
     });
   });
 
-  describe('revokeTrustlineSponsorship()', function() {
-    it('creates a revokeAccountSponsorshipOp', function() {
-      const account =
-        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
-      var asset = new StellarBase.Asset(
-        'USDUSD',
-        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
-      );
-      const op = StellarBase.Operation.revokeTrustlineSponsorship({
-        account,
-        asset
+  describe('revokeOfferSponsorship()', function() {
+    it('creates a revokeOfferSponsorship', function() {
+      const seller = 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
+      var offerId = '1234';
+      const op = StellarBase.Operation.revokeOfferSponsorship({
+        seller,
+        offerId
       });
       var xdr = op.toXDR('hex');
 
       var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
       expect(operation.body().switch().name).to.equal('revokeSponsorship');
       var obj = StellarBase.Operation.fromXDRObject(operation);
-      expect(obj.type).to.be.equal('revokeTrustlineSponsorship');
-      expect(obj.account).to.be.equal(account);
-      expect(obj.asset.toString()).to.be.equal(asset.toString());
+      expect(obj.type).to.be.equal('revokeOfferSponsorship');
+      expect(obj.seller).to.be.equal(seller);
+      expect(obj.offerId).to.be.equal(offerId);
     });
-    it('throws an error when account is invalid', function() {
+    it('throws an error when seller is invalid', function() {
+      expect(() => StellarBase.Operation.revokeOfferSponsorship({})).to.throw(
+        /seller is invalid/
+      );
       expect(() =>
-        StellarBase.Operation.revokeTrustlineSponsorship({})
-      ).to.throw(/account is invalid/);
-      expect(() =>
-        StellarBase.Operation.revokeTrustlineSponsorship({
-          account: 'GBAD'
+        StellarBase.Operation.revokeOfferSponsorship({
+          seller: 'GBAD'
         })
-      ).to.throw(/account is invalid/);
+      ).to.throw(/seller is invalid/);
     });
-    it('throws an error when asset is invalid', function() {
+    it('throws an error when asset offerId is not included', function() {
       expect(() =>
-        StellarBase.Operation.revokeTrustlineSponsorship({
-          account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        StellarBase.Operation.revokeOfferSponsorship({
+          seller: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
         })
-      ).to.throw(/asset is invalid/);
+      ).to.throw(/offerId is invalid/);
     });
   });
 

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1993,6 +1993,43 @@ describe('Operation', function() {
     });
   });
 
+  describe('revokeDataSponsorship()', function() {
+    it('creates a revokeDataSponsorship', function() {
+      const account =
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
+      var name = 'foo';
+      const op = StellarBase.Operation.revokeDataSponsorship({
+        account,
+        name
+      });
+      var xdr = op.toXDR('hex');
+
+      var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      expect(operation.body().switch().name).to.equal('revokeSponsorship');
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeDataSponsorship');
+      expect(obj.account).to.be.equal(account);
+      expect(obj.name).to.be.equal(name);
+    });
+    it('throws an error when account is invalid', function() {
+      expect(() => StellarBase.Operation.revokeDataSponsorship({})).to.throw(
+        /account is invalid/
+      );
+      expect(() =>
+        StellarBase.Operation.revokeDataSponsorship({
+          account: 'GBAD'
+        })
+      ).to.throw(/account is invalid/);
+    });
+    it('throws an error when data name is not included', function() {
+      expect(() =>
+        StellarBase.Operation.revokeDataSponsorship({
+          account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        })
+      ).to.throw(/name must be a string, up to 64 characters/);
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1878,6 +1878,20 @@ describe('Operation', function() {
     });
   });
 
+  describe('endSponsoringFutureReserves()', function() {
+    it('creates a endSponsoringFutureReservesOp', function() {
+      const op = StellarBase.Operation.endSponsoringFutureReserves();
+      var xdr = op.toXDR('hex');
+
+      var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      expect(operation.body().switch().name).to.equal(
+        'endSponsoringFutureReserves'
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('endSponsoringFutureReserves');
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1848,6 +1848,36 @@ describe('Operation', function() {
     });
   });
 
+  describe('beginSponsoringFutureReserves()', function() {
+    it('creates a beginSponsoringFutureReservesOp', function() {
+      const sponsoredId =
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
+
+      const op = StellarBase.Operation.beginSponsoringFutureReserves({
+        sponsoredId
+      });
+      var xdr = op.toXDR('hex');
+
+      var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      expect(operation.body().switch().name).to.equal(
+        'beginSponsoringFutureReserves'
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('beginSponsoringFutureReserves');
+      expect(obj.sponsoredId).to.equal(sponsoredId);
+    });
+    it('throws an error when sponsoredId is invalid', function() {
+      expect(() =>
+        StellarBase.Operation.beginSponsoringFutureReserves({})
+      ).to.throw(/sponsoredId is invalid/);
+      expect(() =>
+        StellarBase.Operation.beginSponsoringFutureReserves({
+          sponsoredId: 'GBAD'
+        })
+      ).to.throw(/sponsoredId is invalid/);
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2052,6 +2052,68 @@ describe('Operation', function() {
     });
   });
 
+  describe('revokeSignerSponsorship()', function() {
+    it('creates a revokeSignerSponsorship', function() {
+      const account =
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
+      let signer = {
+        ed25519PublicKey:
+          'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      };
+      let op = StellarBase.Operation.revokeSignerSponsorship({
+        account,
+        signer
+      });
+      let xdr = op.toXDR('hex');
+
+      let operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      expect(operation.body().switch().name).to.equal('revokeSponsorship');
+      let obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeSignerSponsorship');
+      expect(obj.account).to.be.equal(account);
+      expect(obj.signer.ed25519PublicKey).to.be.equal(signer.ed25519PublicKey);
+
+      // preAuthTx signer
+      signer = {
+        preAuthTx: StellarBase.hash('Tx hash').toString('hex')
+      };
+      op = StellarBase.Operation.revokeSignerSponsorship({
+        account,
+        signer
+      });
+      operation = StellarBase.xdr.Operation.fromXDR(op.toXDR('hex'), 'hex');
+      obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeSignerSponsorship');
+      expect(obj.account).to.be.equal(account);
+      expect(obj.signer.preAuthTx).to.be.equal(signer.preAuthTx);
+
+      // sha256Hash signer
+      signer = {
+        sha256Hash: StellarBase.hash('Hash Preimage').toString('hex')
+      };
+      op = StellarBase.Operation.revokeSignerSponsorship({
+        account,
+        signer
+      });
+      operation = StellarBase.xdr.Operation.fromXDR(op.toXDR('hex'), 'hex');
+      obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeSignerSponsorship');
+      expect(obj.account).to.be.equal(account);
+      expect(obj.signer.sha256Hash).to.be.equal(signer.sha256Hash);
+    });
+    it('throws an error when account is invalid', function() {
+      const signer = {
+        ed25519PublicKey:
+          'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      };
+      expect(() =>
+        StellarBase.Operation.revokeSignerSponsorship({
+          signer
+        })
+      ).to.throw(/account is invalid/);
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1919,6 +1919,84 @@ describe('Operation', function() {
     });
   });
 
+  describe('revokeTrustlineSponsorship()', function() {
+    it('creates a revokeAccountSponsorshipOp', function() {
+      const account =
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
+      var asset = new StellarBase.Asset(
+        'USDUSD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      const op = StellarBase.Operation.revokeTrustlineSponsorship({
+        account,
+        asset
+      });
+      var xdr = op.toXDR('hex');
+
+      var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      expect(operation.body().switch().name).to.equal('revokeSponsorship');
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeTrustlineSponsorship');
+    });
+    it('throws an error when account is invalid', function() {
+      expect(() =>
+        StellarBase.Operation.revokeTrustlineSponsorship({})
+      ).to.throw(/account is invalid/);
+      expect(() =>
+        StellarBase.Operation.revokeTrustlineSponsorship({
+          account: 'GBAD'
+        })
+      ).to.throw(/account is invalid/);
+    });
+    it('throws an error when asset is invalid', function() {
+      expect(() =>
+        StellarBase.Operation.revokeTrustlineSponsorship({
+          account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        })
+      ).to.throw(/asset is invalid/);
+    });
+  });
+
+  describe('revokeTrustlineSponsorship()', function() {
+    it('creates a revokeAccountSponsorshipOp', function() {
+      const account =
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
+      var asset = new StellarBase.Asset(
+        'USDUSD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      const op = StellarBase.Operation.revokeTrustlineSponsorship({
+        account,
+        asset
+      });
+      var xdr = op.toXDR('hex');
+
+      var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      expect(operation.body().switch().name).to.equal('revokeSponsorship');
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeTrustlineSponsorship');
+      expect(obj.account).to.be.equal(account);
+      expect(obj.asset.toString()).to.be.equal(asset.toString());
+    });
+    it('throws an error when account is invalid', function() {
+      expect(() =>
+        StellarBase.Operation.revokeTrustlineSponsorship({})
+      ).to.throw(/account is invalid/);
+      expect(() =>
+        StellarBase.Operation.revokeTrustlineSponsorship({
+          account: 'GBAD'
+        })
+      ).to.throw(/account is invalid/);
+    });
+    it('throws an error when asset is invalid', function() {
+      expect(() =>
+        StellarBase.Operation.revokeTrustlineSponsorship({
+          account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        })
+      ).to.throw(/asset is invalid/);
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1892,6 +1892,33 @@ describe('Operation', function() {
     });
   });
 
+  describe('revokeAccountSponsorship()', function() {
+    it('creates a revokeAccountSponsorshipOp', function() {
+      const account =
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
+      const op = StellarBase.Operation.revokeAccountSponsorship({
+        account
+      });
+      var xdr = op.toXDR('hex');
+
+      var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      expect(operation.body().switch().name).to.equal('revokeSponsorship');
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeAccountSponsorship');
+      expect(obj.account).to.be.equal(account);
+    });
+    it('throws an error when account is invalid', function() {
+      expect(() => StellarBase.Operation.revokeAccountSponsorship({})).to.throw(
+        /account is invalid/
+      );
+      expect(() =>
+        StellarBase.Operation.revokeAccountSponsorship({
+          account: 'GBAD'
+        })
+      ).to.throw(/account is invalid/);
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2030,6 +2030,28 @@ describe('Operation', function() {
     });
   });
 
+  describe('revokeClaimableBalanceSponsorship()', function() {
+    it('creates a revokeClaimableBalanceSponsorship', function() {
+      const balanceId =
+        '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be';
+      const op = StellarBase.Operation.revokeClaimableBalanceSponsorship({
+        balanceId
+      });
+      var xdr = op.toXDR('hex');
+
+      var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      expect(operation.body().switch().name).to.equal('revokeSponsorship');
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeClaimableBalanceSponsorship');
+      expect(obj.balanceId).to.be.equal(balanceId);
+    });
+    it('throws an error when balanceId is invalid', function() {
+      expect(() =>
+        StellarBase.Operation.revokeClaimableBalanceSponsorship({})
+      ).to.throw(/balanceId is invalid/);
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -220,6 +220,7 @@ export namespace OperationType {
   type BumpSequence = 'bumpSequence';
   type CreateClaimableBalance = 'createClaimableBalance';
   type ClaimClaimableBalance = 'claimClaimableBalance';
+  type BeginSponsoringFutureReserves = 'beginSponsoringFutureReserves';
 }
 export type OperationType =
   | OperationType.CreateAccount
@@ -237,7 +238,8 @@ export type OperationType =
   | OperationType.ManageData
   | OperationType.BumpSequence
   | OperationType.CreateClaimableBalance
-  | OperationType.ClaimClaimableBalance;
+  | OperationType.ClaimClaimableBalance
+  | OperationType.BeginSponsoringFutureReserves;
 
 export namespace OperationOptions {
   interface BaseOptions {
@@ -326,6 +328,9 @@ export namespace OperationOptions {
   interface ClaimClaimableBalance extends BaseOptions {
     balanceId: string;
   }
+  interface BeginSponsoringFutureReserves extends BaseOptions {
+    sponsoredId: string;
+  }
 }
 export type OperationOptions =
   | OperationOptions.CreateAccount
@@ -343,7 +348,8 @@ export type OperationOptions =
   | OperationOptions.ManageData
   | OperationOptions.BumpSequence
   | OperationOptions.CreateClaimableBalance
-  | OperationOptions.ClaimClaimableBalance;
+  | OperationOptions.ClaimClaimableBalance
+  | OperationOptions.BeginSponsoringFutureReserves;
 
 export namespace Operation {
   interface BaseOperation<T extends OperationType = OperationType> {
@@ -509,6 +515,13 @@ export namespace Operation {
     options: OperationOptions.ClaimClaimableBalance
   ): xdr.Operation<ClaimClaimableBalance>;
 
+  interface BeginSponsoringFutureReserves extends BaseOperation<OperationType.BeginSponsoringFutureReserves> {
+    sponsoredId: string;
+  }
+  function beginSponsoringFutureReserves(
+    options: OperationOptions.BeginSponsoringFutureReserves
+  ): xdr.Operation<BeginSponsoringFutureReserves>;
+
   function fromXDRObject<T extends Operation = Operation>(
     xdrOperation: xdr.Operation<T>
   ): T;
@@ -529,7 +542,8 @@ export type Operation =
   | Operation.ManageData
   | Operation.BumpSequence
   | Operation.CreateClaimableBalance
-  | Operation.ClaimClaimableBalance;
+  | Operation.ClaimClaimableBalance
+  | Operation.BeginSponsoringFutureReserves;
 
 export namespace StrKey {
   function encodeEd25519PublicKey(data: Buffer): string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -179,10 +179,26 @@ export namespace Signer {
     weight: number | undefined;
   }
 }
+export namespace SignerKeyOptions {
+  interface Ed25519PublicKey {
+    ed25519PublicKey: string;
+  }
+  interface Sha256Hash {
+    sha256Hash: Buffer | string;
+  }
+  interface PreAuthTx {
+    preAuthTx: Buffer | string;
+  }
+}
 export type Signer =
   | Signer.Ed25519PublicKey
   | Signer.Sha256Hash
   | Signer.PreAuthTx;
+
+export type SignerKeyOptions =
+  | SignerKeyOptions.Ed25519PublicKey
+  | SignerKeyOptions.Sha256Hash
+  | SignerKeyOptions.PreAuthTx;
 
 export namespace SignerOptions {
   interface Ed25519PublicKey {
@@ -222,6 +238,7 @@ export namespace OperationType {
   type ClaimClaimableBalance = 'claimClaimableBalance';
   type BeginSponsoringFutureReserves = 'beginSponsoringFutureReserves';
   type EndSponsoringFutureReserves = 'endSponsoringFutureReserves';
+  type RevokeSponsorship = 'revokeSponsorship';
 }
 export type OperationType =
   | OperationType.CreateAccount
@@ -241,7 +258,8 @@ export type OperationType =
   | OperationType.CreateClaimableBalance
   | OperationType.ClaimClaimableBalance
   | OperationType.BeginSponsoringFutureReserves
-  | OperationType.EndSponsoringFutureReserves;
+  | OperationType.EndSponsoringFutureReserves
+  | OperationType.RevokeSponsorship;
 
 export namespace OperationOptions {
   interface BaseOptions {
@@ -333,6 +351,28 @@ export namespace OperationOptions {
   interface BeginSponsoringFutureReserves extends BaseOptions {
     sponsoredId: string;
   }
+  interface RevokeAccountSponsorship extends BaseOptions {
+    account: string;
+  }
+  interface RevokeTrustlineSponsorship extends BaseOptions {
+    account: string;
+    asset: Asset;
+  }
+  interface RevokeOfferSponsorship extends BaseOptions {
+    seller: string;
+    offerId: string;
+  }
+  interface RevokeDataSponsorship extends BaseOptions {
+    account: string;
+    name: string;
+  }
+  interface RevokeClaimableBalanceSponsorship extends BaseOptions {
+    balanceId: string;
+  }
+  interface RevokeSignerSponsorship extends BaseOptions {
+    account: string;
+    signer: SignerKeyOptions;
+  }
 }
 export type OperationOptions =
   | OperationOptions.CreateAccount
@@ -351,7 +391,13 @@ export type OperationOptions =
   | OperationOptions.BumpSequence
   | OperationOptions.CreateClaimableBalance
   | OperationOptions.ClaimClaimableBalance
-  | OperationOptions.BeginSponsoringFutureReserves;
+  | OperationOptions.BeginSponsoringFutureReserves
+  | OperationOptions.RevokeAccountSponsorship
+  | OperationOptions.RevokeTrustlineSponsorship
+  | OperationOptions.RevokeOfferSponsorship
+  | OperationOptions.RevokeDataSponsorship
+  | OperationOptions.RevokeClaimableBalanceSponsorship
+  | OperationOptions.RevokeSignerSponsorship;
 
 export namespace Operation {
   interface BaseOperation<T extends OperationType = OperationType> {
@@ -530,6 +576,52 @@ export namespace Operation {
     options: OperationOptions.BaseOptions
   ): xdr.Operation<EndSponsoringFutureReserves>;
 
+  interface RevokeAccountSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+    account: string;
+  }
+  function revokeAccountSponsorship(
+    options: OperationOptions.RevokeAccountSponsorship
+  ): xdr.Operation<RevokeAccountSponsorship>;
+
+  interface RevokeTrustlineSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+    account: string;
+    asset: Asset;
+  }
+  function revokeTrustlineSponsorship(
+    options: OperationOptions.RevokeTrustlineSponsorship
+  ): xdr.Operation<RevokeTrustlineSponsorship>;
+
+  interface RevokeOfferSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+    seller: string;
+    offerId: string;
+  }
+  function revokeOfferSponsorship(
+    options: OperationOptions.RevokeOfferSponsorship
+  ): xdr.Operation<RevokeOfferSponsorship>;
+
+  interface RevokeDataSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+    account: string;
+    name: string;
+  }
+  function revokeDataSponsorship(
+    options: OperationOptions.RevokeDataSponsorship
+  ): xdr.Operation<RevokeDataSponsorship>;
+
+  interface RevokeClaimableBalanceSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+    balanceId: string;
+  }
+  function revokeClaimableBalanceSponsorship(
+    options: OperationOptions.RevokeClaimableBalanceSponsorship
+  ): xdr.Operation<RevokeClaimableBalanceSponsorship>;
+
+  interface RevokeSignerSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+    account: string;
+    signer: SignerKeyOptions;
+  }
+  function revokeSignerSponsorship(
+    options: OperationOptions.RevokeSignerSponsorship
+  ): xdr.Operation<RevokeSignerSponsorship>;
+
   function fromXDRObject<T extends Operation = Operation>(
     xdrOperation: xdr.Operation<T>
   ): T;
@@ -552,7 +644,13 @@ export type Operation =
   | Operation.CreateClaimableBalance
   | Operation.ClaimClaimableBalance
   | Operation.BeginSponsoringFutureReserves
-  | Operation.EndSponsoringFutureReserves;
+  | Operation.EndSponsoringFutureReserves
+  | Operation.RevokeAccountSponsorship
+  | Operation.RevokeTrustlineSponsorship
+  | Operation.RevokeOfferSponsorship
+  | Operation.RevokeDataSponsorship
+  | Operation.RevokeClaimableBalanceSponsorship
+  | Operation.RevokeSignerSponsorship;
 
 export namespace StrKey {
   function encodeEd25519PublicKey(data: Buffer): string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -221,6 +221,7 @@ export namespace OperationType {
   type CreateClaimableBalance = 'createClaimableBalance';
   type ClaimClaimableBalance = 'claimClaimableBalance';
   type BeginSponsoringFutureReserves = 'beginSponsoringFutureReserves';
+  type EndSponsoringFutureReserves = 'endSponsoringFutureReserves';
 }
 export type OperationType =
   | OperationType.CreateAccount
@@ -239,7 +240,8 @@ export type OperationType =
   | OperationType.BumpSequence
   | OperationType.CreateClaimableBalance
   | OperationType.ClaimClaimableBalance
-  | OperationType.BeginSponsoringFutureReserves;
+  | OperationType.BeginSponsoringFutureReserves
+  | OperationType.EndSponsoringFutureReserves;
 
 export namespace OperationOptions {
   interface BaseOptions {
@@ -522,6 +524,12 @@ export namespace Operation {
     options: OperationOptions.BeginSponsoringFutureReserves
   ): xdr.Operation<BeginSponsoringFutureReserves>;
 
+  interface EndSponsoringFutureReserves extends BaseOperation<OperationType.EndSponsoringFutureReserves> {
+  }
+  function endSponsoringFutureReserves(
+    options: OperationOptions.BaseOptions
+  ): xdr.Operation<EndSponsoringFutureReserves>;
+
   function fromXDRObject<T extends Operation = Operation>(
     xdrOperation: xdr.Operation<T>
   ): T;
@@ -543,7 +551,8 @@ export type Operation =
   | Operation.BumpSequence
   | Operation.CreateClaimableBalance
   | Operation.ClaimClaimableBalance
-  | Operation.BeginSponsoringFutureReserves;
+  | Operation.BeginSponsoringFutureReserves
+  | Operation.EndSponsoringFutureReserves;
 
 export namespace StrKey {
   function encodeEd25519PublicKey(data: Buffer): string;

--- a/types/test.ts
+++ b/types/test.ts
@@ -22,6 +22,10 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
     StellarSdk.Operation.claimClaimableBalance({
       balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
     }),
+  ).addOperation(
+    StellarSdk.Operation.beginSponsoringFutureReserves({
+      sponsoredId: account.accountId()
+    })
   ).addMemo(new StellarSdk.Memo(StellarSdk.MemoText, 'memo'))
   .setTimeout(5)
   .build(); // $ExpectType () => Transaction<Memo<MemoType>, Operation[]>

--- a/types/test.ts
+++ b/types/test.ts
@@ -26,6 +26,8 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
     StellarSdk.Operation.beginSponsoringFutureReserves({
       sponsoredId: account.accountId()
     })
+  ).addOperation(
+    StellarSdk.Operation.endSponsoringFutureReserves({})
   ).addMemo(new StellarSdk.Memo(StellarSdk.MemoText, 'memo'))
   .setTimeout(5)
   .build(); // $ExpectType () => Transaction<Memo<MemoType>, Operation[]>

--- a/types/test.ts
+++ b/types/test.ts
@@ -3,11 +3,18 @@ import * as StellarSdk from 'stellar-base';
 const masterKey = StellarSdk.Keypair.master(StellarSdk.Networks.TESTNET); // $ExpectType Keypair
 const sourceKey = StellarSdk.Keypair.random(); // $ExpectType Keypair
 const destKey = StellarSdk.Keypair.random();
+const usd = new StellarSdk.Asset('USD', 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'); // $ExpectType Asset
 const account = new StellarSdk.Account(sourceKey.publicKey(), '1');
 const transaction = new StellarSdk.TransactionBuilder(account, {
   fee: "100",
   networkPassphrase: StellarSdk.Networks.TESTNET
 })
+  .addOperation(
+    StellarSdk.Operation.beginSponsoringFutureReserves({
+      sponsoredId: account.accountId(),
+      source: masterKey.publicKey()
+    })
+  )
   .addOperation(
     StellarSdk.Operation.accountMerge({ destination: destKey.publicKey() }),
   ).addOperation(
@@ -23,11 +30,54 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
       balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
     }),
   ).addOperation(
-    StellarSdk.Operation.beginSponsoringFutureReserves({
-      sponsoredId: account.accountId()
+    StellarSdk.Operation.endSponsoringFutureReserves({
     })
   ).addOperation(
     StellarSdk.Operation.endSponsoringFutureReserves({})
+  ).addOperation(
+    StellarSdk.Operation.revokeAccountSponsorship({
+      account: account.accountId(),
+    })
+  ).addOperation(
+      StellarSdk.Operation.revokeTrustlineSponsorship({
+        account: account.accountId(),
+        asset: usd,
+      })
+  ).addOperation(
+    StellarSdk.Operation.revokeOfferSponsorship({
+      seller: account.accountId(),
+      offerId: '12345'
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeDataSponsorship({
+      account: account.accountId(),
+      name: 'foo'
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeClaimableBalanceSponsorship({
+      balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeSignerSponsorship({
+      account: account.accountId(),
+      signer: {
+        ed25519PublicKey: sourceKey.publicKey()
+      }
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeSignerSponsorship({
+      account: account.accountId(),
+      signer: {
+        sha256Hash: "da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
+      }
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeSignerSponsorship({
+      account: account.accountId(),
+      signer: {
+        preAuthTx: "da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
+      }
+    })
   ).addMemo(new StellarSdk.Memo(StellarSdk.MemoText, 'memo'))
   .setTimeout(5)
   .build(); // $ExpectType () => Transaction<Memo<MemoType>, Operation[]>

--- a/types/xdr.d.ts
+++ b/types/xdr.d.ts
@@ -21,13 +21,13 @@ declare namespace xdrHidden {
 
     toXDR(format: 'hex' | 'base64'): string;
 
-    static read(io: Buffer): Operation;
+    static read(io: Buffer): xdr.Operation;
 
-    static write(value: Operation2, io: Buffer): void;
+    static write(value: xdr.Operation, io: Buffer): void;
 
-    static isValid(value: Operation2): boolean;
+    static isValid(value: xdr.Operation): boolean;
 
-    static toXDR(value: Operation2): Buffer;
+    static toXDR(value: xdr.Operation): Buffer;
 
     static fromXDR(input: Buffer, format?: 'raw'): xdr.Operation;
 


### PR DESCRIPTION
Extend the operation class with helpers that allow sponsoring reserves and also revoke sponsorships.

To start sponsoring reserves for an account use:
- `Operation.beginSponsoringFutureReserves`
- `Operation.endSponsoringFutureReserves`

To revoke a sponsorship after it has been created use any of the following helpers:

- `Operation.revokeAccountSponsorship`
- `Operation.revokeTrustlineSponsorship`
- `Operation.revokeOfferSponsorship`
- `Operation.revokeDataSponsorship`
- `Operation.revokeClaimableBalanceSponsorship`
- `Operation.revokeSignerSponsorship`

The following example contains a transaction which sponsors operations for an account and then revoke some sponsorships.

```js
const transaction = new StellarSdk.TransactionBuilder(account, {
  fee: "100",
  networkPassphrase: StellarSdk.Networks.TESTNET
})
  .addOperation(
    StellarSdk.Operation.beginSponsoringFutureReserves({
      sponsoredId: account.accountId(),
      source: masterKey.publicKey()
    })
  )
  .addOperation(
    StellarSdk.Operation.accountMerge({ destination: destKey.publicKey() }),
  ).addOperation(
    StellarSdk.Operation.createClaimableBalance({
      amount: "10",
      asset: StellarSdk.Asset.native(),
      claimants: [
        new StellarSdk.Claimant(account.accountId())
      ]
    }),
  ).addOperation(
    StellarSdk.Operation.claimClaimableBalance({
      balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
    }),
  ).addOperation(
    StellarSdk.Operation.endSponsoringFutureReserves({
    })
  ).addOperation(
    StellarSdk.Operation.revokeAccountSponsorship({
      account: account.accountId(),
    })
  ).addOperation(
      StellarSdk.Operation.revokeTrustlineSponsorship({
        account: account.accountId(),
        asset: usd,
      })
  ).addOperation(
    StellarSdk.Operation.revokeOfferSponsorship({
      seller: account.accountId(),
      offerId: '12345'
    })
  ).addOperation(
    StellarSdk.Operation.revokeDataSponsorship({
      account: account.accountId(),
      name: 'foo'
    })
  ).addOperation(
    StellarSdk.Operation.revokeClaimableBalanceSponsorship({
      balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
    })
  ).addOperation(
    StellarSdk.Operation.revokeSignerSponsorship({
      account: account.accountId(),
      signer: {
        ed25519PublicKey: sourceKey.publicKey()
      }
    })
  ).addOperation(
    StellarSdk.Operation.revokeSignerSponsorship({
      account: account.accountId(),
      signer: {
        sha256Hash: "da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
      }
    })
  ).addOperation(
    StellarSdk.Operation.revokeSignerSponsorship({
      account: account.accountId(),
      signer: {
        preAuthTx: "da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
      }
    })
  ).build();
```