### PR TITLE
Enforce claimable balance IDs to be 72-byte strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Update
+
+- Add an additional parameter check to `claimClaimableBalance` to fail faster ([#390](https://github.com/stellar/js-stellar-base/pull/390)).
+
 ## [v4.0.3](https://github.com/stellar/js-stellar-base/compare/v4.0.2..v4.0.3)
 
 ## Update

--- a/src/operations/claim_claimable_balance.js
+++ b/src/operations/claim_claimable_balance.js
@@ -16,7 +16,10 @@ import xdr from '../generated/stellar-xdr_generated';
  *
  */
 export function claimClaimableBalance(opts = {}) {
-  if (typeof opts.balanceId !== 'string') {
+  if (
+    typeof opts.balanceId !== 'string' ||
+    opts.balanceId.length !== 8 + 64 /* 8b discriminant + 64b string */
+  ) {
     throw new Error('must provide a valid claimable balance Id');
   }
   const attributes = {};

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1857,6 +1857,13 @@ describe('Operation', function() {
         /must provide a valid claimable balance Id/
       );
     });
+    it('throws an error for invalid balanceIds', function() {
+      expect(() =>
+        StellarBase.Operation.claimClaimableBalance({
+          balanceId: 'badc0ffee'
+        })
+      ).to.throw(/must provide a valid claimable balance Id/);
+    });
   });
 
   describe('beginSponsoringFutureReserves()', function() {


### PR DESCRIPTION
Closes #388.