### PR TITLE
Stop linting MemoValue incorrectly so CI passes

### DIFF
--- a/test/unit/crypto_test.js
+++ b/test/unit/crypto_test.js
@@ -1,8 +1,8 @@
 import crypto from 'crypto';
 
 function expectBuffersToBeEqual(left, right) {
-  let leftHex = left.toString('hex');
-  let rightHex = right.toString('hex');
+  const leftHex = left.toString('hex');
+  const rightHex = right.toString('hex');
   expect(leftHex).to.eql(rightHex);
 }
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -117,9 +117,16 @@ feeBumptransaction.hash(); // $ExpectType Buffer
 StellarSdk.TransactionBuilder.fromXDR(feeBumptransaction.toXDR(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]> | FeeBumpTransaction
 StellarSdk.TransactionBuilder.fromXDR(feeBumptransaction.toEnvelope(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]> | FeeBumpTransaction
 
-// P.S. don't use Memo constructor
-new StellarSdk.Memo(StellarSdk.MemoHash, 'asdf').value; // $ExpectType MemoValue
-// (new StellarSdk.Memo(StellarSdk.MemoHash, 'asdf')).type; // $ExpectType MemoType  // TODO: Inspect what's wrong with linter.
+// P.S. You shouldn't be using the Memo constructor
+//
+// Unfortunately, it appears that type aliases aren't unwrapped by the linter,
+// causing the following lines to fail unnecessarily:
+//
+// new StellarSdk.Memo(StellarSdk.MemoHash, 'asdf').value; // $ExpectType MemoValue
+// new StellarSdk.Memo(StellarSdk.MemoHash, 'asdf').type; // $ExpectType MemoType
+//
+// This is because the linter just does a raw string comparison on type names:
+// https://github.com/Microsoft/dtslint/issues/57#issuecomment-451666294
 
 const noSignerXDR = StellarSdk.Operation.setOptions({ lowThreshold: 1 });
 StellarSdk.Operation.fromXDRObject(noSignerXDR).signer; // $ExpectType never


### PR DESCRIPTION
From what I can gather, this linting error is due to the fact that `MemoValue` is [not expanded](https://github.com/Microsoft/dtslint/issues/57#issuecomment-451666294) into its constituent types (`string | Buffer | null`, from index.d.ts:106) by the linter. It's not an actual error, obviously, since the passed parameter is a string. 

Since there's no resolution aside from the [issue being resolved](https://github.com/Microsoft/dtslint/issues/57#issuecomment-451666294), it doesn't make sense to perpetually allow CI to false-positive every PR because of it.