### PR TITLE
Add CAP-35 support to the SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,22 @@
 
 ## Unreleased
 
+### Add
+- Introduced new CAP-35 operations, `ClawbackOp` and `ClawbackClaimableBalanceOp` ([#asdf]()).
+
 ### Update
 
 - Add an additional parameter check to `claimClaimableBalance` to fail faster ([#390](https://github.com/stellar/js-stellar-base/pull/390)).
 
-- The XDR & TS definitions have been updated to support CAP-35 ([#394](https://github.com/stellar/js-stellar-base/pull/394))
+- The XDR & TS definitions have been updated to support CAP-35 ([#394](https://github.com/stellar/js-stellar-base/pull/394)).
 
 ### Breaking
+
 - `AllowTrustOpAsset` has been renamed to `AssetCode` ([#394](https://github.com/stellar/js-stellar-base/pull/394))
+
+### Deprecated
+
+- `AllowTrustOp` is now a deprecated operation.
 
 ## [v4.0.3](https://github.com/stellar/js-stellar-base/compare/v4.0.2..v4.0.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Add
-- Introduced new CAP-35 operations, `ClawbackOp` and `ClawbackClaimableBalanceOp` ([#asdf]()).
+- Introduced new CAP-35 operations, `ClawbackOp` and `ClawbackClaimableBalanceOp` ([#397](https://github.com/stellar/js-stellar-base/pull/397/)).
 
 ### Update
 

--- a/README.md
+++ b/README.md
@@ -12,20 +12,27 @@ implementation in JavaScript that can be used on either Node.js or web browsers.
 
 - **[API Reference](https://stellar.github.io/js-stellar-base/)**
 
-> **Warning!** Node version of this package is using [`sodium-native`](https://www.npmjs.com/package/sodium-native) package, a native implementation of [Ed25519](https://ed25519.cr.yp.to/) in Node.js, as an [optional dependency](https://docs.npmjs.com/files/package.json#optionaldependencies).
-> This means that if for any reason installation of this package fails, `stellar-base` will fallback to the much slower implementation contained in [`tweetnacl`](https://www.npmjs.com/package/tweetnacl).
+> **Warning!** Node version of this package is using
+> [`sodium-native`](https://www.npmjs.com/package/sodium-native) package, a
+> native implementation of [Ed25519](https://ed25519.cr.yp.to/) in Node.js, as
+> an
+> [optional dependency](https://docs.npmjs.com/files/package.json#optionaldependencies).
+> This means that if for any reason installation of this package fails,
+> `stellar-base` will fallback to the much slower implementation contained in
+> [`tweetnacl`](https://www.npmjs.com/package/tweetnacl).
 >
-> If you are using `stellar-base` in a browser you can ignore this. However, for production backend deployments you should definitely be using `sodium-native`.
+> If you are using `stellar-base` in a browser you can ignore this. However, for
+> production backend deployments you should definitely be using `sodium-native`.
 > If `sodium-native` is successfully installed and working
 > `StellarBase.FastSigning` variable will be equal `true`. Otherwise it will be
 > `false`.
 
 ## Quick start
 
-Using yarn to include js-stellar-base in your own project:
+Using npm to include js-stellar-base in your own project:
 
 ```shell
-yarn add stellar-base
+npm install --save stellar-base
 ```
 
 For browsers, [use Bower to install it](#to-use-in-the-browser). It exports a
@@ -43,10 +50,10 @@ relative to your html file.
 
 ### To use as a module in a Node.js project
 
-1. Install it using yarn:
+1. Install it using npm:
 
 ```shell
-yarn add stellar-base
+npm install --save stellar-base
 ```
 
 2. require/import it in your JavaScript:
@@ -98,9 +105,11 @@ Make sure that you are using the latest version number. They can be found on the
 
 1. Install Node 10.16.3
 
-Because we support earlier versions of Node, please install and develop on Node 10.16.3 so you don't get surprised when your code works locally but breaks in CI.
+Because we support earlier versions of Node, please install and develop on Node
+10.16.3 so you don't get surprised when your code works locally but breaks in CI.
 
-If you work on several projects that use different Node versions, you might find helpful to install a nodejs version manager.
+If you work on several projects that use different Node versions, you might find
+helpful to install a nodejs version manager.
 
 - https://github.com/creationix/nvm
 - https://github.com/wbyoung/avn
@@ -108,7 +117,9 @@ If you work on several projects that use different Node versions, you might find
 
 2. Install Yarn
 
-This project uses [Yarn](https://yarnpkg.com/) to manages its dependencies. To install Yarn, follow the project instructions available at https://yarnpkg.com/en/docs/install.
+This project uses [Yarn](https://yarnpkg.com/) to manages its dependencies. To
+install Yarn, follow the project instructions available at
+https://yarnpkg.com/en/docs/install.
 
 3. Clone the repo
 
@@ -120,7 +131,7 @@ git clone https://github.com/stellar/js-stellar-base.git
 
 ```shell
 cd js-stellar-base
-yarn
+yarn install
 ```
 
 5. Observe the project's code style
@@ -149,27 +160,14 @@ versions.)
 
 2. Install [Bundler](https://bundler.io).
 3. Install all dependencies.
+
+```shell
+bundle install
+```
+
 4. Copy xdr files from
    https://github.com/stellar/stellar-core/tree/master/src/xdr to `./xdr`.
-5. Run `yarn xdr` from the js-stellar-base folder.
-6. Transform the newly-generated JS into TypeScript using [dts-xdr](https://github.com/stellar/dts-xdr):
-
-To "scriptify" the above instructions, here are the steps one by one:
-
-```bash
-git clone https://github.com/stellar/js-stellar-base
-cd js-stellar-base
-bundle install
-yarn
-yarn xdr
-
-# If src/generated/stellar-xdr_generated.js changed, then:
-git clone https://github.com/stellar/dts-xdr
-cd dts-xdr
-stellar-xdr_generated.d.ts npx jscodeshift -t src/transform.js ../src/generated/stellar-xdr_generated.js
-cp stellar-xdr_generated.d.ts ../types/xdr.d.ts
-cd .. && rm -rf dts-xdr
-```
+5. Run `yarn xdr` js-stellar-base folder.
 
 ## Usage
 
@@ -190,8 +188,6 @@ To run a specific set of tests:
 gulp test:node
 gulp test:browser
 ```
-
-You can also run `yarn test` for a simpler subset of the test cases.
 
 Tests are also run on the
 [Travis CI js-stellar-base project](https://travis-ci.org/stellar/js-stellar-base)

--- a/README.md
+++ b/README.md
@@ -12,27 +12,20 @@ implementation in JavaScript that can be used on either Node.js or web browsers.
 
 - **[API Reference](https://stellar.github.io/js-stellar-base/)**
 
-> **Warning!** Node version of this package is using
-> [`sodium-native`](https://www.npmjs.com/package/sodium-native) package, a
-> native implementation of [Ed25519](https://ed25519.cr.yp.to/) in Node.js, as
-> an
-> [optional dependency](https://docs.npmjs.com/files/package.json#optionaldependencies).
-> This means that if for any reason installation of this package fails,
-> `stellar-base` will fallback to the much slower implementation contained in
-> [`tweetnacl`](https://www.npmjs.com/package/tweetnacl).
+> **Warning!** Node version of this package is using [`sodium-native`](https://www.npmjs.com/package/sodium-native) package, a native implementation of [Ed25519](https://ed25519.cr.yp.to/) in Node.js, as an [optional dependency](https://docs.npmjs.com/files/package.json#optionaldependencies).
+> This means that if for any reason installation of this package fails, `stellar-base` will fallback to the much slower implementation contained in [`tweetnacl`](https://www.npmjs.com/package/tweetnacl).
 >
-> If you are using `stellar-base` in a browser you can ignore this. However, for
-> production backend deployments you should definitely be using `sodium-native`.
+> If you are using `stellar-base` in a browser you can ignore this. However, for production backend deployments you should definitely be using `sodium-native`.
 > If `sodium-native` is successfully installed and working
 > `StellarBase.FastSigning` variable will be equal `true`. Otherwise it will be
 > `false`.
 
 ## Quick start
 
-Using npm to include js-stellar-base in your own project:
+Using yarn to include js-stellar-base in your own project:
 
 ```shell
-npm install --save stellar-base
+yarn add stellar-base
 ```
 
 For browsers, [use Bower to install it](#to-use-in-the-browser). It exports a
@@ -50,10 +43,10 @@ relative to your html file.
 
 ### To use as a module in a Node.js project
 
-1. Install it using npm:
+1. Install it using yarn:
 
 ```shell
-npm install --save stellar-base
+yarn add stellar-base
 ```
 
 2. require/import it in your JavaScript:
@@ -105,11 +98,9 @@ Make sure that you are using the latest version number. They can be found on the
 
 1. Install Node 10.16.3
 
-Because we support earlier versions of Node, please install and develop on Node
-10.16.3 so you don't get surprised when your code works locally but breaks in CI.
+Because we support earlier versions of Node, please install and develop on Node 10.16.3 so you don't get surprised when your code works locally but breaks in CI.
 
-If you work on several projects that use different Node versions, you might find
-helpful to install a nodejs version manager.
+If you work on several projects that use different Node versions, you might find helpful to install a nodejs version manager.
 
 - https://github.com/creationix/nvm
 - https://github.com/wbyoung/avn
@@ -117,9 +108,7 @@ helpful to install a nodejs version manager.
 
 2. Install Yarn
 
-This project uses [Yarn](https://yarnpkg.com/) to manages its dependencies. To
-install Yarn, follow the project instructions available at
-https://yarnpkg.com/en/docs/install.
+This project uses [Yarn](https://yarnpkg.com/) to manages its dependencies. To install Yarn, follow the project instructions available at https://yarnpkg.com/en/docs/install.
 
 3. Clone the repo
 
@@ -131,7 +120,7 @@ git clone https://github.com/stellar/js-stellar-base.git
 
 ```shell
 cd js-stellar-base
-yarn install
+yarn
 ```
 
 5. Observe the project's code style
@@ -160,14 +149,27 @@ versions.)
 
 2. Install [Bundler](https://bundler.io).
 3. Install all dependencies.
-
-```shell
-bundle install
-```
-
 4. Copy xdr files from
    https://github.com/stellar/stellar-core/tree/master/src/xdr to `./xdr`.
-5. Run `yarn xdr` js-stellar-base folder.
+5. Run `yarn xdr` from the js-stellar-base folder.
+6. Transform the newly-generated JS into TypeScript using [dts-xdr](https://github.com/stellar/dts-xdr):
+
+To "scriptify" the above instructions, here are the steps one by one:
+
+```bash
+git clone https://github.com/stellar/js-stellar-base
+cd js-stellar-base
+bundle install
+yarn
+yarn xdr
+
+# If src/generated/stellar-xdr_generated.js changed, then:
+git clone https://github.com/stellar/dts-xdr
+cd dts-xdr
+stellar-xdr_generated.d.ts npx jscodeshift -t src/transform.js ../src/generated/stellar-xdr_generated.js
+cp stellar-xdr_generated.d.ts ../types/xdr.d.ts
+cd .. && rm -rf dts-xdr
+```
 
 ## Usage
 
@@ -188,6 +190,8 @@ To run a specific set of tests:
 gulp test:node
 gulp test:browser
 ```
+
+You can also run `yarn test` for a simpler subset of the test cases.
 
 Tests are also run on the
 [Travis CI js-stellar-base project](https://travis-ci.org/stellar/js-stellar-base)

--- a/src/generated/stellar-xdr_generated.js
+++ b/src/generated/stellar-xdr_generated.js
@@ -1,4 +1,4 @@
-// Automatically generated on 2021-03-18T14:48:21-07:00
+// Automatically generated on 2021-03-19T18:40:30-07:00
 // DO NOT EDIT or your changes may be overwritten
 
 /* jshint maxstatements:2147483647  */
@@ -2869,7 +2869,8 @@ xdr.struct("DecoratedSignature", [
 //       END_SPONSORING_FUTURE_RESERVES = 17,
 //       REVOKE_SPONSORSHIP = 18,
 //       CLAWBACK = 19,
-//       CLAWBACK_CLAIMABLE_BALANCE = 20
+//       CLAWBACK_CLAIMABLE_BALANCE = 20,
+//       SET_TRUST_LINE_FLAGS = 21
 //   };
 //
 // ===========================================================================
@@ -2895,6 +2896,7 @@ xdr.enum("OperationType", {
   revokeSponsorship: 18,
   clawback: 19,
   clawbackClaimableBalance: 20,
+  setTrustLineFlags: 21,
 });
 
 // === xdr source ============================================================
@@ -3263,6 +3265,25 @@ xdr.struct("ClawbackClaimableBalanceOp", [
 
 // === xdr source ============================================================
 //
+//   struct SetTrustLineFlagsOp
+//   {
+//       AccountID trustor;
+//       Asset asset;
+//   
+//       uint32 clearFlags; // which flags to clear
+//       uint32 setFlags;   // which flags to set
+//   };
+//
+// ===========================================================================
+xdr.struct("SetTrustLineFlagsOp", [
+  ["trustor", xdr.lookup("AccountId")],
+  ["asset", xdr.lookup("Asset")],
+  ["clearFlags", xdr.lookup("Uint32")],
+  ["setFlags", xdr.lookup("Uint32")],
+]);
+
+// === xdr source ============================================================
+//
 //   union switch (OperationType type)
 //       {
 //       case CREATE_ACCOUNT:
@@ -3307,6 +3328,8 @@ xdr.struct("ClawbackClaimableBalanceOp", [
 //           ClawbackOp clawbackOp;
 //       case CLAWBACK_CLAIMABLE_BALANCE:
 //           ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
+//       case SET_TRUST_LINE_FLAGS:
+//           SetTrustLineFlagsOp setTrustLineFlagsOp;
 //       }
 //
 // ===========================================================================
@@ -3335,6 +3358,7 @@ xdr.union("OperationBody", {
     ["revokeSponsorship", "revokeSponsorshipOp"],
     ["clawback", "clawbackOp"],
     ["clawbackClaimableBalance", "clawbackClaimableBalanceOp"],
+    ["setTrustLineFlags", "setTrustLineFlagsOp"],
   ],
   arms: {
     createAccountOp: xdr.lookup("CreateAccountOp"),
@@ -3356,6 +3380,7 @@ xdr.union("OperationBody", {
     revokeSponsorshipOp: xdr.lookup("RevokeSponsorshipOp"),
     clawbackOp: xdr.lookup("ClawbackOp"),
     clawbackClaimableBalanceOp: xdr.lookup("ClawbackClaimableBalanceOp"),
+    setTrustLineFlagsOp: xdr.lookup("SetTrustLineFlagsOp"),
   },
 });
 
@@ -3412,6 +3437,8 @@ xdr.union("OperationBody", {
 //           ClawbackOp clawbackOp;
 //       case CLAWBACK_CLAIMABLE_BALANCE:
 //           ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
+//       case SET_TRUST_LINE_FLAGS:
+//           SetTrustLineFlagsOp setTrustLineFlagsOp;
 //       }
 //       body;
 //   };
@@ -5018,6 +5045,51 @@ xdr.union("ClawbackClaimableBalanceResult", {
 
 // === xdr source ============================================================
 //
+//   enum SetTrustLineFlagsResultCode
+//   {
+//       // codes considered as "success" for the operation
+//       SET_TRUST_LINE_FLAGS_SUCCESS = 0,
+//   
+//       // codes considered as "failure" for the operation
+//       SET_TRUST_LINE_FLAGS_MALFORMED = -1,
+//       SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
+//       SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
+//       SET_TRUST_LINE_FLAGS_INVALID_STATE = -4
+//   };
+//
+// ===========================================================================
+xdr.enum("SetTrustLineFlagsResultCode", {
+  setTrustLineFlagsSuccess: 0,
+  setTrustLineFlagsMalformed: -1,
+  setTrustLineFlagsNoTrustLine: -2,
+  setTrustLineFlagsCantRevoke: -3,
+  setTrustLineFlagsInvalidState: -4,
+});
+
+// === xdr source ============================================================
+//
+//   union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
+//   {
+//   case SET_TRUST_LINE_FLAGS_SUCCESS:
+//       void;
+//   default:
+//       void;
+//   };
+//
+// ===========================================================================
+xdr.union("SetTrustLineFlagsResult", {
+  switchOn: xdr.lookup("SetTrustLineFlagsResultCode"),
+  switchName: "code",
+  switches: [
+    ["setTrustLineFlagsSuccess", xdr.void()],
+  ],
+  arms: {
+  },
+  defaultArm: xdr.void(),
+});
+
+// === xdr source ============================================================
+//
 //   enum OperationResultCode
 //   {
 //       opINNER = 0, // inner object result is valid
@@ -5087,6 +5159,8 @@ xdr.enum("OperationResultCode", {
 //           ClawbackResult clawbackResult;
 //       case CLAWBACK_CLAIMABLE_BALANCE:
 //           ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
+//       case SET_TRUST_LINE_FLAGS:
+//           SetTrustLineFlagsResult setTrustLineFlagsResult;
 //       }
 //
 // ===========================================================================
@@ -5115,6 +5189,7 @@ xdr.union("OperationResultTr", {
     ["revokeSponsorship", "revokeSponsorshipResult"],
     ["clawback", "clawbackResult"],
     ["clawbackClaimableBalance", "clawbackClaimableBalanceResult"],
+    ["setTrustLineFlags", "setTrustLineFlagsResult"],
   ],
   arms: {
     createAccountResult: xdr.lookup("CreateAccountResult"),
@@ -5138,6 +5213,7 @@ xdr.union("OperationResultTr", {
     revokeSponsorshipResult: xdr.lookup("RevokeSponsorshipResult"),
     clawbackResult: xdr.lookup("ClawbackResult"),
     clawbackClaimableBalanceResult: xdr.lookup("ClawbackClaimableBalanceResult"),
+    setTrustLineFlagsResult: xdr.lookup("SetTrustLineFlagsResult"),
   },
 });
 
@@ -5190,6 +5266,8 @@ xdr.union("OperationResultTr", {
 //           ClawbackResult clawbackResult;
 //       case CLAWBACK_CLAIMABLE_BALANCE:
 //           ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
+//       case SET_TRUST_LINE_FLAGS:
+//           SetTrustLineFlagsResult setTrustLineFlagsResult;
 //       }
 //       tr;
 //   default:

--- a/src/operation.js
+++ b/src/operation.js
@@ -62,6 +62,7 @@ export const AuthImmutableFlag = 1 << 2;
  * * `{@link Operation.bumpSequence}`
  * * `{@link Operation.createClaimableBalance}`
  * * `{@link Operation.claimClaimableBalance}`
+ * * `{@link Operation.clawbackClaimableBalance}`
  * * `{@link Operation.beginSponsoringFutureReserves}`
  * * `{@link Operation.endSponsoringFutureReserves}`
  * * `{@link Operation.revokeAccountSponsorship}`
@@ -270,6 +271,11 @@ export class Operation {
       }
       case 'claimClaimableBalance': {
         result.type = 'claimClaimableBalance';
+        result.balanceId = attrs.toXDR('hex');
+        break;
+      }
+      case 'clawbackClaimableBalance': {
+        result.type = 'clawbackClaimableBalance';
         result.balanceId = attrs.toXDR('hex');
         break;
       }
@@ -517,6 +523,7 @@ Operation.changeTrust = ops.changeTrust;
 Operation.createAccount = ops.createAccount;
 Operation.createClaimableBalance = ops.createClaimableBalance;
 Operation.claimClaimableBalance = ops.claimClaimableBalance;
+Operation.clawbackClaimableBalance = ops.clawbackClaimableBalance;
 Operation.createPassiveSellOffer = ops.createPassiveSellOffer;
 Operation.inflation = ops.inflation;
 Operation.manageData = ops.manageData;

--- a/src/operation.js
+++ b/src/operation.js
@@ -305,9 +305,35 @@ export class Operation {
         result.type = 'setTrustLineFlags';
         result.asset = Asset.fromOperation(attrs.asset());
         result.trustor = accountIdtoAddress(attrs.trustor());
-        result.clearFlags = attrs.clearFlags();
-        result.setFlags = attrs.setFlags();
-        // TODO: Finish the flags ^
+
+        // Convert from the integer bitwised flag into a sensible object that
+        // indicates true/false for each flag that's on/off.
+        const clears = attrs.clearFlags();
+        const sets = attrs.setFlags();
+
+        const mapping = {
+          authorized: xdr.TrustLineFlags.authorizedFlag(),
+          maintainLiabilities: xdr.TrustLineFlags.authorizedToMaintainLiabilitiesFlag(),
+          clawbackEnabled: xdr.TrustLineFlags.trustlineClawbackEnabledFlag()
+        };
+
+        const getFlagValue = (key) => {
+          const bit = mapping[key].value;
+          if (sets & bit) {
+            return true;
+          }
+          if (clears & bit) {
+            return false;
+          }
+          return undefined;
+        };
+
+        result.flags = {
+          authorized: getFlagValue('authorized'),
+          maintainLiabilities: getFlagValue('maintainLiabilities'),
+          clawbackEnabled: getFlagValue('clawbackEnabled')
+        };
+
         break;
       }
       default: {

--- a/src/operation.js
+++ b/src/operation.js
@@ -72,6 +72,7 @@ export const AuthImmutableFlag = 1 << 2;
  * * `{@link Operation.revokeClaimableBalanceSponsorship}`
  * * `{@link Operation.revokeSignerSponsorship}`
  * * `{@link Operation.clawback}`
+ * * `{@link Operation.setTrustLineFlags}`
  *
  * @class Operation
  */
@@ -300,8 +301,13 @@ export class Operation {
         result.asset = Asset.fromOperation(attrs.asset());
         break;
       }
-      case 'setTrustlineFlags': {
-        result.type = 'setTrustlineFlags';
+      case 'setTrustLineFlags': {
+        result.type = 'setTrustLineFlags';
+        result.asset = Asset.fromOperation(attrs.asset());
+        result.trustor = accountIdtoAddress(attrs.trustor());
+        result.clearFlags = attrs.clearFlags();
+        result.setFlags = attrs.setFlags();
+        // TODO: Finish the flags ^
         break;
       }
       default: {
@@ -555,4 +561,4 @@ Operation.revokeClaimableBalanceSponsorship =
   ops.revokeClaimableBalanceSponsorship;
 Operation.revokeSignerSponsorship = ops.revokeSignerSponsorship;
 Operation.clawback = ops.clawback;
-Operation.setTrustlineFlags = ops.setTrustlineFlags;
+Operation.setTrustLineFlags = ops.setTrustLineFlags;

--- a/src/operation.js
+++ b/src/operation.js
@@ -306,14 +306,14 @@ export class Operation {
         result.asset = Asset.fromOperation(attrs.asset());
         result.trustor = accountIdtoAddress(attrs.trustor());
 
-        // Convert from the integer bitwised flag into a sensible object that
+        // Convert from the integer-bitwised flag into a sensible object that
         // indicates true/false for each flag that's on/off.
         const clears = attrs.clearFlags();
         const sets = attrs.setFlags();
 
         const mapping = {
           authorized: xdr.TrustLineFlags.authorizedFlag(),
-          maintainLiabilities: xdr.TrustLineFlags.authorizedToMaintainLiabilitiesFlag(),
+          authorizedToMaintainLiabilities: xdr.TrustLineFlags.authorizedToMaintainLiabilitiesFlag(),
           clawbackEnabled: xdr.TrustLineFlags.trustlineClawbackEnabledFlag()
         };
 
@@ -328,11 +328,10 @@ export class Operation {
           return undefined;
         };
 
-        result.flags = {
-          authorized: getFlagValue('authorized'),
-          maintainLiabilities: getFlagValue('maintainLiabilities'),
-          clawbackEnabled: getFlagValue('clawbackEnabled')
-        };
+        result.flags = {};
+        Object.keys(mapping).forEach((flagName) => {
+          result.flags[flagName] = getFlagValue(flagName);
+        });
 
         break;
       }

--- a/src/operation.js
+++ b/src/operation.js
@@ -71,6 +71,7 @@ export const AuthImmutableFlag = 1 << 2;
  * * `{@link Operation.revokeDataSponsorship}`
  * * `{@link Operation.revokeClaimableBalanceSponsorship}`
  * * `{@link Operation.revokeSignerSponsorship}`
+ * * `{@link Operation.clawback}`
  *
  * @class Operation
  */
@@ -290,6 +291,13 @@ export class Operation {
       }
       case 'revokeSponsorship': {
         extractRevokeSponshipDetails(attrs, result);
+        break;
+      }
+      case 'clawback': {
+        result.type = 'clawback';
+        result.amount = this._fromXDRAmount(attrs.amount());
+        result.from = encodeMuxedAccountToAddress(attrs.from());
+        result.asset = Asset.fromOperation(attrs.asset());
         break;
       }
       default: {
@@ -542,3 +550,4 @@ Operation.revokeDataSponsorship = ops.revokeDataSponsorship;
 Operation.revokeClaimableBalanceSponsorship =
   ops.revokeClaimableBalanceSponsorship;
 Operation.revokeSignerSponsorship = ops.revokeSignerSponsorship;
+Operation.clawback = ops.clawback;

--- a/src/operation.js
+++ b/src/operation.js
@@ -300,6 +300,10 @@ export class Operation {
         result.asset = Asset.fromOperation(attrs.asset());
         break;
       }
+      case 'setTrustlineFlags': {
+        result.type = 'setTrustlineFlags';
+        break;
+      }
       default: {
         throw new Error(`Unknown operation: ${operationName}`);
       }
@@ -551,3 +555,4 @@ Operation.revokeClaimableBalanceSponsorship =
   ops.revokeClaimableBalanceSponsorship;
 Operation.revokeSignerSponsorship = ops.revokeSignerSponsorship;
 Operation.clawback = ops.clawback;
+Operation.setTrustlineFlags = ops.setTrustlineFlags;

--- a/src/operations/allow_trust.js
+++ b/src/operations/allow_trust.js
@@ -4,15 +4,20 @@ import { Keypair } from '../keypair';
 import { StrKey } from '../strkey';
 
 /**
+ * @deprecated since v5.0
+ *
  * Returns an XDR AllowTrustOp. An "allow trust" operation authorizes another
  * account to hold your account's credit for a given asset.
+ *
  * @function
  * @alias Operation.allowTrust
+ *
  * @param {object} opts Options object
  * @param {string} opts.trustor - The trusting account (the one being authorized)
  * @param {string} opts.assetCode - The asset code being authorized.
  * @param {(0|1|2)} opts.authorize - `1` to authorize, `2` to authorize to maintain liabilities, and `0` to deauthorize.
  * @param {string} [opts.source] - The source account (defaults to transaction source).
+ *
  * @returns {xdr.AllowTrustOp} Allow Trust operation
  */
 export function allowTrust(opts) {

--- a/src/operations/claim_claimable_balance.js
+++ b/src/operations/claim_claimable_balance.js
@@ -20,8 +20,9 @@ export function claimClaimableBalance(opts = {}) {
     typeof opts.balanceId !== 'string' ||
     opts.balanceId.length !== 8 + 64 /* 8b discriminant + 64b string */
   ) {
-    throw new Error('must provide a valid claimable balance Id');
+    throw new Error('must provide a valid claimable balance id');
   }
+
   const attributes = {};
   attributes.balanceId = xdr.ClaimableBalanceId.fromXDR(opts.balanceId, 'hex');
   const claimClaimableBalanceOp = new xdr.ClaimClaimableBalanceOp(attributes);

--- a/src/operations/claim_claimable_balance.js
+++ b/src/operations/claim_claimable_balance.js
@@ -16,12 +16,7 @@ import xdr from '../generated/stellar-xdr_generated';
  *
  */
 export function claimClaimableBalance(opts = {}) {
-  if (
-    typeof opts.balanceId !== 'string' ||
-    opts.balanceId.length !== 8 + 64 /* 8b discriminant + 64b string */
-  ) {
-    throw new Error('must provide a valid claimable balance id');
-  }
+  validateClaimableBalanceId(opts.balanceId);
 
   const attributes = {};
   attributes.balanceId = xdr.ClaimableBalanceId.fromXDR(opts.balanceId, 'hex');
@@ -34,4 +29,13 @@ export function claimClaimableBalance(opts = {}) {
   this.setSourceAccount(opAttributes, opts);
 
   return new xdr.Operation(opAttributes);
+}
+
+export function validateClaimableBalanceId(balanceId) {
+  if (
+    typeof balanceId !== 'string' ||
+    balanceId.length !== 8 + 64 /* 8b discriminant + 64b string */
+  ) {
+    throw new Error('must provide a valid claimable balance id');
+  }
 }

--- a/src/operations/clawback.js
+++ b/src/operations/clawback.js
@@ -1,0 +1,42 @@
+import xdr from '../generated/stellar-xdr_generated';
+import { decodeAddressToMuxedAccount } from '../util/decode_encode_muxed_account';
+
+/**
+ * Creates a clawback operation.
+ *
+ * @function
+ * @alias Operation.clawback
+ *
+ * @param {object} opts - Options object
+ * @param {Asset}  opts.asset - The asset being clawed back.
+ * @param {string} opts.amount - The amount of the asset to claw back.
+ * @param {string} opts.from - The public key of the (muxed) account to claw back from.
+ *
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ *
+ * @return {xdr.ClawbackOp}
+ *
+ * @example
+ * const op = Operation.clawback({
+ *   balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
+ * });
+ *
+ * @link https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#clawback-operation
+ */
+export function clawback(opts = {}) {
+  const attributes = {};
+
+  if (!this.isValidAmount(opts.amount)) {
+    throw new TypeError(this.constructAmountRequirementsError('amount'));
+  }
+  attributes.amount = this._toXDRAmount(opts.amount);
+  attributes.asset = opts.asset.toXDRObject();
+  attributes.from = decodeAddressToMuxedAccount(opts.from);
+
+  const opAttributes = {
+    body: xdr.OperationBody.clawback(new xdr.ClawbackOp(attributes))
+  };
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/clawback.js
+++ b/src/operations/clawback.js
@@ -16,11 +16,6 @@ import { decodeAddressToMuxedAccount } from '../util/decode_encode_muxed_account
  *
  * @return {xdr.ClawbackOp}
  *
- * @example
- * const op = Operation.clawback({
- *   balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
- * });
- *
  * @link https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#clawback-operation
  */
 export function clawback(opts = {}) {

--- a/src/operations/clawback_claimable_balance.js
+++ b/src/operations/clawback_claimable_balance.js
@@ -1,0 +1,41 @@
+import xdr from '../generated/stellar-xdr_generated';
+
+/**
+ * Creates a clawback operation for a claimable balance.
+ *
+ * @function
+ * @alias Operation.clawbackClaimableBalance
+ * @param {object} opts - Options object
+ * @param {string} opts.balanceId - The claimable balance ID to be clawed back.
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ *
+ * @return {xdr.Operation} Clawback claimable balance operation
+ *
+ * @example
+ * const op = Operation.clawbackClaimableBalance({
+ *   balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
+ * });
+ *
+ * @link https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#clawback-claimable-balance-operation
+ */
+export function clawbackClaimableBalance(opts = {}) {
+  if (
+    typeof opts.balanceId !== 'string' ||
+    opts.balanceId.length !== 8 + 64 /* 8b discriminant + 64b string */
+  ) {
+    throw new Error('must provide a valid claimable balance id');
+  }
+
+  const attributes = {
+    balanceId: xdr.ClaimableBalanceId.fromXDR(opts.balanceId, 'hex')
+  };
+
+  const opAttributes = {
+    body: xdr.OperationBody.clawbackClaimableBalance(
+      new xdr.ClawbackClaimableBalanceOp(attributes)
+    )
+  };
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/clawback_claimable_balance.js
+++ b/src/operations/clawback_claimable_balance.js
@@ -9,7 +9,7 @@ import xdr from '../generated/stellar-xdr_generated';
  * @param {string} opts.balanceId - The claimable balance ID to be clawed back.
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
  *
- * @return {xdr.Operation} Clawback claimable balance operation
+ * @return {xdr.ClawbackClaimableBalanceOp}
  *
  * @example
  * const op = Operation.clawbackClaimableBalance({

--- a/src/operations/clawback_claimable_balance.js
+++ b/src/operations/clawback_claimable_balance.js
@@ -1,4 +1,5 @@
 import xdr from '../generated/stellar-xdr_generated';
+import { validateClaimableBalanceId } from './claim_claimable_balance';
 
 /**
  * Creates a clawback operation for a claimable balance.
@@ -19,12 +20,7 @@ import xdr from '../generated/stellar-xdr_generated';
  * @link https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#clawback-claimable-balance-operation
  */
 export function clawbackClaimableBalance(opts = {}) {
-  if (
-    typeof opts.balanceId !== 'string' ||
-    opts.balanceId.length !== 8 + 64 /* 8b discriminant + 64b string */
-  ) {
-    throw new Error('must provide a valid claimable balance id');
-  }
+  validateClaimableBalanceId(opts.balanceId);
 
   const attributes = {
     balanceId: xdr.ClaimableBalanceId.fromXDR(opts.balanceId, 'hex')

--- a/src/operations/create_claimable_balance.js
+++ b/src/operations/create_claimable_balance.js
@@ -3,13 +3,16 @@ import { Asset } from '../asset';
 
 /**
  * Create a new claimable balance operation.
+ *
  * @function
  * @alias Operation.createClaimableBalance
+ *
  * @param {object} opts Options object
  * @param {Asset} opts.asset - The asset for the claimable balance.
  * @param {string} opts.amount - Amount.
  * @param {Claimant[]} opts.claimants - An array of Claimants
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ *
  * @returns {xdr.Operation} Create claimable balance operation
  *
  * @example
@@ -51,6 +54,7 @@ export function createClaimableBalance(opts) {
   attributes.asset = opts.asset.toXDRObject();
   attributes.amount = this._toXDRAmount(opts.amount);
   attributes.claimants = opts.claimants.map((c) => c.toXDRObject());
+
   const createClaimableBalanceOp = new xdr.CreateClaimableBalanceOp(attributes);
 
   const opAttributes = {};

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -26,3 +26,4 @@ export {
   revokeSignerSponsorship
 } from './revoke_sponsorship';
 export { clawback } from './clawback';
+export { setTrustlineFlags } from './set_trustline_flags';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -25,3 +25,4 @@ export {
   revokeClaimableBalanceSponsorship,
   revokeSignerSponsorship
 } from './revoke_sponsorship';
+export { clawback } from './clawback';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -26,4 +26,4 @@ export {
   revokeSignerSponsorship
 } from './revoke_sponsorship';
 export { clawback } from './clawback';
-export { setTrustlineFlags } from './set_trustline_flags';
+export { setTrustLineFlags } from './set_trustline_flags';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -7,6 +7,7 @@ export { changeTrust } from './change_trust';
 export { createAccount } from './create_account';
 export { createClaimableBalance } from './create_claimable_balance';
 export { claimClaimableBalance } from './claim_claimable_balance';
+export { clawbackClaimableBalance } from './clawback_claimable_balance';
 export { inflation } from './inflation';
 export { manageData } from './manage_data';
 export { manageBuyOffer } from './manage_buy_offer';

--- a/src/operations/set_trustline_flags.js
+++ b/src/operations/set_trustline_flags.js
@@ -1,21 +1,59 @@
-//
-// Not implemented until https://github.com/stellar/stellar-core/pull/2918 merges.
-//
-// import xdr from '../generated/stellar-xdr_generated';
+import xdr from '../generated/stellar-xdr_generated';
+import { Keypair } from '../keypair';
 
 /**
- * Creates a trustline flag setting operation.
+ * Creates a trustline flag configuring operation.
  *
  * @function
- * @alias Operation.setTrustlineFlags
+ * @alias Operation.setTrustLineFlags
  *
  * @param {object} opts - Options object
- * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ * @param {string} opts.trustor     - the account whose trustline this is
+ * @param {Asset}  opts.asset       - the asset on the trustline
+ * @param {[xdr.TrustLineFlags]} opts.clearFlags - the flags to clear
+ * @param {[xdr.TrustLineFlags]} opts.setFlags   - the flags to set
  *
- * @return {xdr.SetTrustlineFlagsOp}
+ * @param {string} [opts.source] - The source account for the operation.
+ *                                 Defaults to the transaction's source account.
+ *
+ * @return {xdr.SetTrustLineFlagsOp}
  *
  * @link https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#set-trustline-flags-operation
  */
-export function setTrustlineFlags(opts = {}) {
-  throw new Error('Not implemented.', opts);
+export function setTrustLineFlags(opts = {}) {
+  const attributes = {};
+
+  /* eslint no-bitwise: "off" */
+
+  let clearFlag = 0;
+  if (opts.clearFlags instanceof Array) {
+    opts.clearFlags.forEach((x) => {
+      clearFlag |= x.value;
+    });
+  } else if (opts.clearFlags !== undefined) {
+    throw new Error('clearFlags should be an array of xdr.TrustLineFlags');
+  }
+
+  let setFlag = 0;
+  if (opts.setFlags instanceof Array) {
+    opts.setFlags.forEach((x) => {
+      setFlag |= x.value;
+    });
+  } else {
+    throw new Error('setFlags should be an array of xdr.TrustLineFlags');
+  }
+
+  attributes.trustor = Keypair.fromPublicKey(opts.trustor).xdrAccountId();
+  attributes.asset = opts.asset.toXDRObject();
+  attributes.clearFlags = clearFlag;
+  attributes.setFlags = setFlag;
+
+  const opAttributes = {
+    body: xdr.OperationBody.setTrustLineFlags(
+      new xdr.SetTrustLineFlagsOp(attributes)
+    )
+  };
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
 }

--- a/src/operations/set_trustline_flags.js
+++ b/src/operations/set_trustline_flags.js
@@ -4,44 +4,68 @@ import { Keypair } from '../keypair';
 /**
  * Creates a trustline flag configuring operation.
  *
+ * For the flags, set them to true to enable them and false to disable them. Any
+ * unmodified operations will be marked `undefined` in the result.
+ *
+ * Note that you can only **clear** the clawbackEnabled flag set; it must be set
+ * account-wide via operations.SetOptions (setting
+ * xdr.AccountFlags.clawbackEnabled).
+ *
  * @function
  * @alias Operation.setTrustLineFlags
  *
  * @param {object} opts - Options object
  * @param {string} opts.trustor     - the account whose trustline this is
  * @param {Asset}  opts.asset       - the asset on the trustline
- * @param {[xdr.TrustLineFlags]} opts.clearFlags - the flags to clear
- * @param {[xdr.TrustLineFlags]} opts.setFlags   - the flags to set
+ * @param {object} opts.flags       - the set of flags to modify
+ * @param {bool}   opts.flags.authorized  - authorize account to perform transactions
+ *     with its credit
+ * @param {bool}   opts.flags.maintainLiabilities - authorize account to
+ *     maintain and reduce liabilities for its credit
+ * @param {bool}   opts.flags.clawbackEnabled - stop claimable balances on this
+ *     trustlines from having clawbacks enabled (this flag can only be set to
+ *     false!)
  *
  * @param {string} [opts.source] - The source account for the operation.
  *                                 Defaults to the transaction's source account.
  *
  * @return {xdr.SetTrustLineFlagsOp}
  *
- * @link https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#set-trustline-flags-operation
+ * @link xdr.AccountFlags
+ * @link xdr.TrustLineFlags
+ * @see https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#set-trustline-flags-operation
+ * @see https://developers.stellar.org/docs/start/list-of-operations/#set-options
  */
 export function setTrustLineFlags(opts = {}) {
   const attributes = {};
 
+  if (typeof opts.flags !== 'object' || Object.keys(opts.flags).length === 0) {
+    throw new Error('opts.flags must be an map of boolean flags to modify');
+  }
+
+  const mapping = {
+    authorized: xdr.TrustLineFlags.authorizedFlag(),
+    maintainLiabilities: xdr.TrustLineFlags.authorizedToMaintainLiabilitiesFlag(),
+    clawbackEnabled: xdr.TrustLineFlags.trustlineClawbackEnabledFlag()
+  };
+
   /* eslint no-bitwise: "off" */
-
   let clearFlag = 0;
-  if (opts.clearFlags instanceof Array) {
-    opts.clearFlags.forEach((x) => {
-      clearFlag |= x.value;
-    });
-  } else if (opts.clearFlags !== undefined) {
-    throw new Error('clearFlags should be an array of xdr.TrustLineFlags');
-  }
-
   let setFlag = 0;
-  if (opts.setFlags instanceof Array) {
-    opts.setFlags.forEach((x) => {
-      setFlag |= x.value;
-    });
-  } else {
-    throw new Error('setFlags should be an array of xdr.TrustLineFlags');
-  }
+
+  Object.keys(opts.flags).forEach((flagName) => {
+    if (!Object.prototype.hasOwnProperty.call(mapping, flagName)) {
+      throw new Error(`unsupported flag name specified: ${flagName}`);
+    }
+
+    const flagValue = opts.flags[flagName];
+    const bit = mapping[flagName].value;
+    if (flagValue === true) {
+      setFlag |= bit;
+    } else if (flagValue === false) {
+      clearFlag |= bit;
+    }
+  });
 
   attributes.trustor = Keypair.fromPublicKey(opts.trustor).xdrAccountId();
   attributes.asset = opts.asset.toXDRObject();

--- a/src/operations/set_trustline_flags.js
+++ b/src/operations/set_trustline_flags.js
@@ -20,8 +20,8 @@ import { Keypair } from '../keypair';
  * @param {object} opts.flags       - the set of flags to modify
  * @param {bool}   opts.flags.authorized  - authorize account to perform transactions
  *     with its credit
- * @param {bool}   opts.flags.maintainLiabilities - authorize account to
- *     maintain and reduce liabilities for its credit
+ * @param {bool}   opts.flags.authorizedToMaintainLiabilities - authorize
+ *     account to maintain and reduce liabilities for its credit
  * @param {bool}   opts.flags.clawbackEnabled - stop claimable balances on this
  *     trustlines from having clawbacks enabled (this flag can only be set to
  *     false!)
@@ -45,7 +45,7 @@ export function setTrustLineFlags(opts = {}) {
 
   const mapping = {
     authorized: xdr.TrustLineFlags.authorizedFlag(),
-    maintainLiabilities: xdr.TrustLineFlags.authorizedToMaintainLiabilitiesFlag(),
+    authorizedToMaintainLiabilities: xdr.TrustLineFlags.authorizedToMaintainLiabilitiesFlag(),
     clawbackEnabled: xdr.TrustLineFlags.trustlineClawbackEnabledFlag()
   };
 

--- a/src/operations/set_trustline_flags.js
+++ b/src/operations/set_trustline_flags.js
@@ -1,0 +1,21 @@
+//
+// Not implemented until https://github.com/stellar/stellar-core/pull/2918 merges.
+//
+// import xdr from '../generated/stellar-xdr_generated';
+
+/**
+ * Creates a trustline flag setting operation.
+ *
+ * @function
+ * @alias Operation.setTrustlineFlags
+ *
+ * @param {object} opts - Options object
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ *
+ * @return {xdr.SetTrustlineFlagsOp}
+ *
+ * @link https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#set-trustline-flags-operation
+ */
+export function setTrustlineFlags(opts = {}) {
+  throw new Error('Not implemented.', opts);
+}

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2218,7 +2218,7 @@ describe('Operation', function() {
         asset: asset,
         flags: {
           authorized: false,
-          maintainLiabilities: true,
+          authorizedToMaintainLiabilities: true,
           clawbackEnabled: false
         }
       });
@@ -2235,7 +2235,7 @@ describe('Operation', function() {
       expect(obj.asset.equals(asset)).to.be.true;
       expect(obj.trustor).to.be.equal(account);
       expect(obj.flags.authorized).to.be.false;
-      expect(obj.flags.maintainLiabilities).to.be.true;
+      expect(obj.flags.authorizedToMaintainLiabilities).to.be.true;
       expect(obj.flags.clawbackEnabled).to.be.false;
     });
     it('leaves unmodified flags as undefined', function() {
@@ -2278,7 +2278,7 @@ describe('Operation', function() {
       expect(obj.asset.equals(asset)).to.be.true;
       expect(obj.trustor).to.be.equal(account);
       expect(obj.flags.authorized).to.be.true;
-      expect(obj.flags.maintainLiabilities).to.be.undefined;
+      expect(obj.flags.authorizedToMaintainLiabilities).to.be.undefined;
       expect(obj.flags.clawbackEnabled).to.be.undefined;
     });
     it('fails with invalid flags', function() {

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2201,7 +2201,7 @@ describe('Operation', function() {
       );
       var obj = StellarBase.Operation.fromXDRObject(operation);
       expect(obj.type).to.be.equal('clawback');
-      // expect(obj.asset).to.be.equal(asset);
+      expect(obj.asset.equals(asset)).to.be.true;
     });
   });
 

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2204,6 +2204,14 @@ describe('Operation', function() {
     });
   });
 
+  describe('setTrustlineFlags()', function() {
+    it('creates a SetTrustlineFlagOp', function() {
+      expect(() => {
+        StellarBase.Operation.setTrustlineFlags({});
+      }).to.throw();
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2184,13 +2184,11 @@ describe('Operation', function() {
       }).to.throw();
     });
     it('returns a clawback()', function() {
-      let asset = new StellarBase.Asset(
-        'GCOIN',
-        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
-      );
+      let account = 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
+      let asset = new StellarBase.Asset('GCOIN', account);
       const amount = '100.0000000';
       const op = StellarBase.Operation.clawback({
-        from: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7',
+        from: account,
         amount: amount,
         asset: asset
       });
@@ -2202,16 +2200,14 @@ describe('Operation', function() {
       var obj = StellarBase.Operation.fromXDRObject(operation);
       expect(obj.type).to.be.equal('clawback');
       expect(obj.asset.equals(asset)).to.be.true;
+      expect(obj.from).to.be.equal(account);
     });
   });
 
   describe('setTrustLineFlags()', function() {
     it('creates a SetTrustLineFlagsOp', function() {
       let account = 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
-      let asset = new StellarBase.Asset(
-        'GCOIN',
-        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
-      );
+      let asset = new StellarBase.Asset('GCOIN', account);
 
       const op = StellarBase.Operation.setTrustLineFlags({
         trustor: account,
@@ -2240,10 +2236,7 @@ describe('Operation', function() {
     });
     it('leaves unmodified flags as undefined', function() {
       let account = 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
-      let asset = new StellarBase.Asset(
-        'GCOIN',
-        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
-      );
+      let asset = new StellarBase.Asset('GCOIN', account);
 
       expect(() =>
         StellarBase.Operation.setTrustLineFlags({

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2160,6 +2160,50 @@ describe('Operation', function() {
     });
   });
 
+  describe('clawback()', function() {
+    it('requires asset, amount, account', function() {
+      let asset = new StellarBase.Asset(
+        'GCOIN',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      const amount = '100.0000000';
+
+      expect(() => {
+        StellarBase.Operation.clawback({
+          from: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        });
+      }).to.throw();
+      expect(() => {
+        StellarBase.Operation.clawback({ amount });
+      }).to.throw();
+      expect(() => {
+        StellarBase.Operation.clawback({ asset });
+      }).to.throw();
+      expect(() => {
+        StellarBase.Operation.clawback({});
+      }).to.throw();
+    });
+    it('returns a clawback()', function() {
+      let asset = new StellarBase.Asset(
+        'GCOIN',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      const amount = '100.0000000';
+      const op = StellarBase.Operation.clawback({
+        from: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7',
+        amount: amount,
+        asset: asset
+      });
+
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('clawback');
+    });
+  });
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -1841,9 +1841,7 @@ describe('Operation', function() {
       const balanceId =
         '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be';
 
-      const op = StellarBase.Operation.claimClaimableBalance({
-        balanceId
-      });
+      const op = StellarBase.Operation.claimClaimableBalance({ balanceId });
       var xdr = op.toXDR('hex');
       var operation = StellarBase.xdr.Operation.fromXDR(
         Buffer.from(xdr, 'hex')
@@ -1854,7 +1852,7 @@ describe('Operation', function() {
     });
     it('throws an error when balanceId is not present', function() {
       expect(() => StellarBase.Operation.claimClaimableBalance({})).to.throw(
-        /must provide a valid claimable balance Id/
+        /must provide a valid claimable balance id/
       );
     });
     it('throws an error for invalid balanceIds', function() {
@@ -1862,7 +1860,37 @@ describe('Operation', function() {
         StellarBase.Operation.claimClaimableBalance({
           balanceId: 'badc0ffee'
         })
-      ).to.throw(/must provide a valid claimable balance Id/);
+      ).to.throw(/must provide a valid claimable balance id/);
+    });
+  });
+
+  describe('clawbackClaimableBalance()', function() {
+    it('creates a clawbackClaimableBalanceOp', function() {
+      const balanceId =
+        '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be';
+
+      const op = StellarBase.Operation.clawbackClaimableBalance({
+        balanceId: balanceId
+      });
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('clawbackClaimableBalance');
+      expect(obj.balanceId).to.equal(balanceId);
+    });
+    it('throws an error when balanceId is not present', function() {
+      expect(() => StellarBase.Operation.clawbackClaimableBalance({})).to.throw(
+        /must provide a valid claimable balance id/
+      );
+    });
+    it('throws an error for invalid balanceIds', function() {
+      expect(() =>
+        StellarBase.Operation.clawbackClaimableBalance({
+          balanceId: 'badc0ffee'
+        })
+      ).to.throw(/must provide a valid claimable balance id/);
     });
   });
 

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2201,14 +2201,41 @@ describe('Operation', function() {
       );
       var obj = StellarBase.Operation.fromXDRObject(operation);
       expect(obj.type).to.be.equal('clawback');
+      // expect(obj.asset).to.be.equal(asset);
     });
   });
 
-  describe('setTrustlineFlags()', function() {
-    it('creates a SetTrustlineFlagOp', function() {
+  describe('setTrustLineFlags()', function() {
+    it('creates a SetTrustLineFlagsOp', function() {
       expect(() => {
-        StellarBase.Operation.setTrustlineFlags({});
+        StellarBase.Operation.setTrustLineFlags({});
       }).to.throw();
+
+      let account = 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
+      let asset = new StellarBase.Asset(
+        'GCOIN',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      const op = StellarBase.Operation.setTrustLineFlags({
+        trustor: account,
+        asset: asset,
+        clearFlags: [StellarBase.xdr.TrustLineFlags.authorizedFlag()],
+        setFlags: [
+          StellarBase.xdr.TrustLineFlags.authorizedToMaintainLiabilitiesFlag(),
+          StellarBase.xdr.TrustLineFlags.trustlineClawbackEnabledFlag()
+        ]
+      });
+
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('setTrustLineFlags');
+      expect(obj.asset.equals(asset)).to.be.true;
+      expect(obj.trustor).to.be.equal(account);
+      expect(obj.setFlags).to.be.equal(2 | 4);
+      expect(obj.clearFlags).to.be.equal(1);
     });
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // TypeScript Version: 2.9
 
 /// <reference types="node" />
-import xdr from './xdr';
+import { xdr } from './xdr';
 
 export { xdr };
 

--- a/types/xdr.d.ts
+++ b/types/xdr.d.ts
@@ -4,6 +4,8 @@
 
 import { Operation } from './index';
 
+export {}
+
 // Hidden namespace as hack to work around name collision.
 declare namespace xdrHidden {
   // tslint:disable-line:strict-export-declare-modifiers
@@ -39,7 +41,7 @@ declare namespace xdrHidden {
   }
 }
 
-declare namespace xdr {
+export namespace xdr {
   export import Operation = xdrHidden.Operation2; // tslint:disable-line:strict-export-declare-modifiers
 
   interface SignedInt {

--- a/types/xdr.d.ts
+++ b/types/xdr.d.ts
@@ -4,7 +4,7 @@
 
 import { Operation } from './index';
 
-export {}
+export {};
 
 // Hidden namespace as hack to work around name collision.
 declare namespace xdrHidden {

--- a/types/xdr.d.ts
+++ b/types/xdr.d.ts
@@ -40,7 +40,7 @@ declare namespace xdrHidden {
 }
 
 declare namespace xdr {
-  export import Operation = xdrHidden.Operation2; // tslint:disable-line:strict-export-declare-modifiers
+    export import Operation = xdrHidden.Operation2; // tslint:disable-line:strict-export-declare-modifiers
 
   interface SignedInt {
     readonly MAX_VALUE: 2147483647;

--- a/types/xdr.d.ts
+++ b/types/xdr.d.ts
@@ -40,7 +40,7 @@ declare namespace xdrHidden {
 }
 
 declare namespace xdr {
-    export import Operation = xdrHidden.Operation2; // tslint:disable-line:strict-export-declare-modifiers
+  export import Operation = xdrHidden.Operation2; // tslint:disable-line:strict-export-declare-modifiers
 
   interface SignedInt {
     readonly MAX_VALUE: 2147483647;

--- a/types/xdr.d.ts
+++ b/types/xdr.d.ts
@@ -1,4 +1,4 @@
-// The type definitions inside the namespace xdr were automatically generated on 2020-11-13T19:52:42Z
+// The type definitions inside the namespace xdr were automatically generated on 2021-03-19T18:40:30Z
 // using https://github.com/stellar/dts-xdr.
 // DO NOT EDIT definitions inside the xdr namespace or your changes may be overwritten
 
@@ -600,7 +600,8 @@ declare namespace xdr {
       | 'endSponsoringFutureReserves'
       | 'revokeSponsorship'
       | 'clawback'
-      | 'clawbackClaimableBalance';
+      | 'clawbackClaimableBalance'
+      | 'setTrustLineFlags';
 
     readonly value:
       | 0
@@ -623,7 +624,8 @@ declare namespace xdr {
       | 17
       | 18
       | 19
-      | 20;
+      | 20
+      | 21;
 
     static createAccount(): OperationType;
 
@@ -666,6 +668,8 @@ declare namespace xdr {
     static clawback(): OperationType;
 
     static clawbackClaimableBalance(): OperationType;
+
+    static setTrustLineFlags(): OperationType;
   }
 
   class RevokeSponsorshipType {
@@ -1297,6 +1301,27 @@ declare namespace xdr {
     static clawbackClaimableBalanceNotIssuer(): ClawbackClaimableBalanceResultCode;
 
     static clawbackClaimableBalanceNotClawbackEnabled(): ClawbackClaimableBalanceResultCode;
+  }
+
+  class SetTrustLineFlagsResultCode {
+    readonly name:
+      | 'setTrustLineFlagsSuccess'
+      | 'setTrustLineFlagsMalformed'
+      | 'setTrustLineFlagsNoTrustLine'
+      | 'setTrustLineFlagsCantRevoke'
+      | 'setTrustLineFlagsInvalidState';
+
+    readonly value: 0 | -1 | -2 | -3 | -4;
+
+    static setTrustLineFlagsSuccess(): SetTrustLineFlagsResultCode;
+
+    static setTrustLineFlagsMalformed(): SetTrustLineFlagsResultCode;
+
+    static setTrustLineFlagsNoTrustLine(): SetTrustLineFlagsResultCode;
+
+    static setTrustLineFlagsCantRevoke(): SetTrustLineFlagsResultCode;
+
+    static setTrustLineFlagsInvalidState(): SetTrustLineFlagsResultCode;
   }
 
   class OperationResultCode {
@@ -4356,6 +4381,46 @@ declare namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class SetTrustLineFlagsOp {
+    constructor(attributes: {
+      trustor: AccountId;
+      asset: Asset;
+      clearFlags: number;
+      setFlags: number;
+    });
+
+    trustor(value?: AccountId): AccountId;
+
+    asset(value?: Asset): Asset;
+
+    clearFlags(value?: number): number;
+
+    setFlags(value?: number): number;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): SetTrustLineFlagsOp;
+
+    static write(value: SetTrustLineFlagsOp, io: Buffer): void;
+
+    static isValid(value: SetTrustLineFlagsOp): boolean;
+
+    static toXDR(value: SetTrustLineFlagsOp): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): SetTrustLineFlagsOp;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): SetTrustLineFlagsOp;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class OperationIdId {
     constructor(attributes: {
       sourceAccount: MuxedAccount;
@@ -6542,6 +6607,8 @@ declare namespace xdr {
       value?: ClawbackClaimableBalanceOp
     ): ClawbackClaimableBalanceOp;
 
+    setTrustLineFlagsOp(value?: SetTrustLineFlagsOp): SetTrustLineFlagsOp;
+
     static createAccount(value: CreateAccountOp): OperationBody;
 
     static payment(value: PaymentOp): OperationBody;
@@ -6594,6 +6661,8 @@ declare namespace xdr {
       value: ClawbackClaimableBalanceOp
     ): OperationBody;
 
+    static setTrustLineFlags(value: SetTrustLineFlagsOp): OperationBody;
+
     value():
       | CreateAccountOp
       | PaymentOp
@@ -6614,6 +6683,7 @@ declare namespace xdr {
       | RevokeSponsorshipOp
       | ClawbackOp
       | ClawbackClaimableBalanceOp
+      | SetTrustLineFlagsOp
       | void;
 
     toXDR(format?: 'raw'): Buffer;
@@ -7611,6 +7681,37 @@ declare namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class SetTrustLineFlagsResult {
+    switch(): SetTrustLineFlagsResultCode;
+
+    static setTrustLineFlagsSuccess(): SetTrustLineFlagsResult;
+
+    value(): void;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): SetTrustLineFlagsResult;
+
+    static write(value: SetTrustLineFlagsResult, io: Buffer): void;
+
+    static isValid(value: SetTrustLineFlagsResult): boolean;
+
+    static toXDR(value: SetTrustLineFlagsResult): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): SetTrustLineFlagsResult;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): SetTrustLineFlagsResult;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class OperationResultTr {
     switch(): OperationType;
 
@@ -7674,6 +7775,10 @@ declare namespace xdr {
       value?: ClawbackClaimableBalanceResult
     ): ClawbackClaimableBalanceResult;
 
+    setTrustLineFlagsResult(
+      value?: SetTrustLineFlagsResult
+    ): SetTrustLineFlagsResult;
+
     static createAccount(value: CreateAccountResult): OperationResultTr;
 
     static payment(value: PaymentResult): OperationResultTr;
@@ -7732,6 +7837,8 @@ declare namespace xdr {
       value: ClawbackClaimableBalanceResult
     ): OperationResultTr;
 
+    static setTrustLineFlags(value: SetTrustLineFlagsResult): OperationResultTr;
+
     value():
       | CreateAccountResult
       | PaymentResult
@@ -7753,7 +7860,8 @@ declare namespace xdr {
       | EndSponsoringFutureReservesResult
       | RevokeSponsorshipResult
       | ClawbackResult
-      | ClawbackClaimableBalanceResult;
+      | ClawbackClaimableBalanceResult
+      | SetTrustLineFlagsResult;
 
     toXDR(format?: 'raw'): Buffer;
 
@@ -8042,5 +8150,3 @@ declare namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 }
-
-export default xdr;

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -48,7 +48,8 @@ enum OperationType
     END_SPONSORING_FUTURE_RESERVES = 17,
     REVOKE_SPONSORSHIP = 18,
     CLAWBACK = 19,
-    CLAWBACK_CLAIMABLE_BALANCE = 20
+    CLAWBACK_CLAIMABLE_BALANCE = 20,
+    SET_TRUST_LINE_FLAGS = 21
 };
 
 /* CreateAccount
@@ -390,6 +391,24 @@ struct ClawbackClaimableBalanceOp
     ClaimableBalanceID balanceID;
 };
 
+/* SetTrustLineFlagsOp
+
+   Updates the flags of an existing trust line.
+   This is called by the issuer of the related asset.
+
+   Threshold: low
+
+   Result: SetTrustLineFlagsResult
+*/
+struct SetTrustLineFlagsOp
+{
+    AccountID trustor;
+    Asset asset;
+
+    uint32 clearFlags; // which flags to clear
+    uint32 setFlags;   // which flags to set
+};
+
 /* An operation is the lowest unit of work that a transaction does */
 struct Operation
 {
@@ -442,6 +461,8 @@ struct Operation
         ClawbackOp clawbackOp;
     case CLAWBACK_CLAIMABLE_BALANCE:
         ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
+    case SET_TRUST_LINE_FLAGS:
+        SetTrustLineFlagsOp setTrustLineFlagsOp;
     }
     body;
 };
@@ -1186,6 +1207,28 @@ default:
     void;
 };
 
+/******* SetTrustLineFlags Result ********/
+
+enum SetTrustLineFlagsResultCode
+{
+    // codes considered as "success" for the operation
+    SET_TRUST_LINE_FLAGS_SUCCESS = 0,
+
+    // codes considered as "failure" for the operation
+    SET_TRUST_LINE_FLAGS_MALFORMED = -1,
+    SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
+    SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
+    SET_TRUST_LINE_FLAGS_INVALID_STATE = -4
+};
+
+union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
+{
+case SET_TRUST_LINE_FLAGS_SUCCESS:
+    void;
+default:
+    void;
+};
+
 /* High level Operation Result */
 enum OperationResultCode
 {
@@ -1246,6 +1289,8 @@ case opINNER:
         ClawbackResult clawbackResult;
     case CLAWBACK_CLAIMABLE_BALANCE:
         ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
+    case SET_TRUST_LINE_FLAGS:
+        SetTrustLineFlagsResult setTrustLineFlagsResult;
     }
     tr;
 default:


### PR DESCRIPTION
Fulfills creation the [list of CAP-35 features](https://gist.github.com/2opremio/89c4775104635382d51b6f5e41cbf6d5#new-operations):

## New operations
 
- `clawback` with the following fields:
    - Asset fields (identical to the asset fields in the Change Trust, Allow Trust and Set Trustline Flags operations)
        - `asset_type`
        - `asset_code`
        - `asset_issuer`
    - `from` - account from which the asset is clawed back
    - `amount` - asset amount clawed back

- `clawback_claimable_balance`, with the following field:
    - `balance_id` - claimable balance identifer of the claimable balance to be clawed back

- `set_trust_line_flags`, with the following fields:
  - Asset fields (identical to the asset fields in the Change Trust, Allow Trust and Set Trustline Flags operations)
    - `asset_type`
    - `asset_code`
    - `asset_issuer`
  - `trustor` - account whose trustline is affected by this operation
  - flag fields, with the same scheme as the Set Options operation (note that CAP-35 introduces the new `AUTH_CLAWBACK_ENABLED_FLAG` flag)

Related to #395.