### PR TITLE
Add Typescript definitions for CAP-35 operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,31 @@
 
 ## Unreleased
 
+## [v6.0.0](https://github.com/stellar/js-stellar-base/compare/v5.0.0..v6.0.0)
+
+### Update
+
+- The Typescript definitions have been updated to support CAP-35 ([#TODO](https://github.com/stellar/js-stellar-base/pull/TODO)). 
+
+- The `AllowTrust` flag type definitions (`TrustLineFlags`) have been renamed to match the XDR directly, since SetTrustLineFlags supercedes the now-deprecated `AllowTrustOp` ([#TODO](https://github.com/stellar/js-stellar-base/pull/TODO)).
+
+
 ## [v5.0.0](https://github.com/stellar/js-stellar-base/compare/v4.0.3..v5.0.0)
 
 ### Add
-- Introduced new CAP-35 operations, `ClawbackOp` and `ClawbackClaimableBalanceOp` ([#397](https://github.com/stellar/js-stellar-base/pull/397/)).
+
+- Introduced new CAP-35 operations, `ClawbackOp`, `ClawbackClaimableBalanceOp`, and `SetTrustLineFlagsOp` ([#397](https://github.com/stellar/js-stellar-base/pull/397/)).
 
 ### Update
 
 - Add an additional parameter check to `claimClaimableBalance` to fail faster ([#390](https://github.com/stellar/js-stellar-base/pull/390)).
 
-- The XDR & TS definitions have been updated to support CAP-35 ([#394](https://github.com/stellar/js-stellar-base/pull/394)).
+- The XDR definitions have been updated to support CAP-35 ([#394](https://github.com/stellar/js-stellar-base/pull/394)).
 
 ### Breaking
 
 - `AllowTrustOpAsset` has been renamed to `AssetCode` ([#394](https://github.com/stellar/js-stellar-base/pull/394))
+
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 ## Unreleased
 
-## [v6.0.0](https://github.com/stellar/js-stellar-base/compare/v5.0.0..v6.0.0)
-
 ### Update
 
-- The Typescript definitions have been updated to support CAP-35 ([#TODO](https://github.com/stellar/js-stellar-base/pull/TODO)). 
+- The Typescript definitions have been updated to support CAP-35 ([#407](https://github.com/stellar/js-stellar-base/pull/407)). 
 
-- The `AllowTrust` flag type definitions (`TrustLineFlags`) have been renamed to match the XDR directly, since SetTrustLineFlags supercedes the now-deprecated `AllowTrustOp` ([#TODO](https://github.com/stellar/js-stellar-base/pull/TODO)).
+- The `AllowTrust` flag type definitions (`TrustLineFlags`) have been renamed to match the XDR directly, since SetTrustLineFlags supercedes the now-deprecated `AllowTrustOp` ([#407](https://github.com/stellar/js-stellar-base/pull/407)).
 
 
 ## [v5.0.0](https://github.com/stellar/js-stellar-base/compare/v4.0.3..v5.0.0)

--- a/src/operation.js
+++ b/src/operation.js
@@ -62,7 +62,6 @@ export const AuthImmutableFlag = 1 << 2;
  * * `{@link Operation.bumpSequence}`
  * * `{@link Operation.createClaimableBalance}`
  * * `{@link Operation.claimClaimableBalance}`
- * * `{@link Operation.clawbackClaimableBalance}`
  * * `{@link Operation.beginSponsoringFutureReserves}`
  * * `{@link Operation.endSponsoringFutureReserves}`
  * * `{@link Operation.revokeAccountSponsorship}`
@@ -72,6 +71,7 @@ export const AuthImmutableFlag = 1 << 2;
  * * `{@link Operation.revokeClaimableBalanceSponsorship}`
  * * `{@link Operation.revokeSignerSponsorship}`
  * * `{@link Operation.clawback}`
+ * * `{@link Operation.clawbackClaimableBalance}`
  * * `{@link Operation.setTrustLineFlags}`
  *
  * @class Operation
@@ -276,11 +276,6 @@ export class Operation {
         result.balanceId = attrs.toXDR('hex');
         break;
       }
-      case 'clawbackClaimableBalance': {
-        result.type = 'clawbackClaimableBalance';
-        result.balanceId = attrs.toXDR('hex');
-        break;
-      }
       case 'beginSponsoringFutureReserves': {
         result.type = 'beginSponsoringFutureReserves';
         result.sponsoredId = accountIdtoAddress(attrs.sponsoredId());
@@ -299,6 +294,11 @@ export class Operation {
         result.amount = this._fromXDRAmount(attrs.amount());
         result.from = encodeMuxedAccountToAddress(attrs.from());
         result.asset = Asset.fromOperation(attrs.asset());
+        break;
+      }
+      case 'clawbackClaimableBalance': {
+        result.type = 'clawbackClaimableBalance';
+        result.balanceId = attrs.toXDR('hex');
         break;
       }
       case 'setTrustLineFlags': {

--- a/src/operations/set_trustline_flags.js
+++ b/src/operations/set_trustline_flags.js
@@ -18,16 +18,18 @@ import { Keypair } from '../keypair';
  * @param {string} opts.trustor     - the account whose trustline this is
  * @param {Asset}  opts.asset       - the asset on the trustline
  * @param {object} opts.flags       - the set of flags to modify
- * @param {bool}   opts.flags.authorized  - authorize account to perform transactions
- *     with its credit
- * @param {bool}   opts.flags.authorizedToMaintainLiabilities - authorize
- *     account to maintain and reduce liabilities for its credit
- * @param {bool}   opts.flags.clawbackEnabled - stop claimable balances on this
- *     trustlines from having clawbacks enabled (this flag can only be set to
- *     false!)
  *
+ * @param {bool}   [opts.flags.authorized]  - authorize account to perform
+ *     transactions with its credit
+ * @param {bool}   [opts.flags.authorizedToMaintainLiabilities] - authorize
+ *     account to maintain and reduce liabilities for its credit
+ * @param {bool}   [opts.flags.clawbackEnabled] - stop claimable balances on
+ *     this trustlines from having clawbacks enabled (this flag can only be set
+ *     to false!)
  * @param {string} [opts.source] - The source account for the operation.
  *                                 Defaults to the transaction's source account.
+ *
+ * @note You must include at least one flag.
  *
  * @return {xdr.SetTrustLineFlagsOp}
  *

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -391,9 +391,9 @@ export namespace OperationOptions {
     trustor: string;
     asset: Asset;
     flags: {
-      authorized?: boolean | undefined;
-      authorizedToMaintainLiabilities?: boolean | undefined;
-      clawbackEnabled?: boolean | undefined;
+      authorized?: boolean;
+      authorizedToMaintainLiabilities?: boolean;
+      clawbackEnabled?: boolean;
     };
   }
 }
@@ -668,9 +668,9 @@ export namespace Operation {
     trustor: string;
     asset: Asset;
     flags: {
-      authorized?: boolean | undefined;
-      authorizedToMaintainLiabilities?: boolean | undefined;
-      clawbackEnabled?: boolean | undefined;
+      authorized?: boolean;
+      authorizedToMaintainLiabilities?: boolean;
+      clawbackEnabled?: boolean;
     };
   }
   function setTrustLineFlags(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -159,11 +159,19 @@ export namespace TrustLineFlag {
   type deauthorize = 0;
   type authorize = 1;
   type authorizeToMaintainLiabilities = 2;
+  type enableTrustlineClawback = 4;
 }
 export type TrustLineFlag =
   | TrustLineFlag.deauthorize
   | TrustLineFlag.authorize
-  | TrustLineFlag.authorizeToMaintainLiabilities;
+  | TrustLineFlag.authorizeToMaintainLiabilities
+  | TrustLineFlag.enableTrustlineClawback;
+export type TrustLineFlagSet = {
+  deauthorize?: boolean | undefined;
+  authorize?: boolean | undefined;
+  authorizeToMaintainLiabilities?: boolean | undefined;
+  enableTrustlineClawback?: boolean | undefined;
+}
 
 export namespace Signer {
   interface Ed25519PublicKey {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -239,6 +239,9 @@ export namespace OperationType {
   type BeginSponsoringFutureReserves = 'beginSponsoringFutureReserves';
   type EndSponsoringFutureReserves = 'endSponsoringFutureReserves';
   type RevokeSponsorship = 'revokeSponsorship';
+  type Clawback = 'clawback';
+  type ClawbackClaimableBalance = 'clawbackClaimableBalance';
+  type SetTrustLineFlags = 'setTrustLineFlags';
 }
 export type OperationType =
   | OperationType.CreateAccount
@@ -259,7 +262,10 @@ export type OperationType =
   | OperationType.ClaimClaimableBalance
   | OperationType.BeginSponsoringFutureReserves
   | OperationType.EndSponsoringFutureReserves
-  | OperationType.RevokeSponsorship;
+  | OperationType.RevokeSponsorship
+  | OperationType.Clawback
+  | OperationType.ClawbackClaimableBalance
+  | OperationType.SetTrustLineFlags;
 
 export namespace OperationOptions {
   interface BaseOptions {
@@ -373,6 +379,23 @@ export namespace OperationOptions {
     account: string;
     signer: SignerKeyOptions;
   }
+  interface Clawback extends BaseOptions {
+    asset: Asset;
+    amount: string;
+    from: string;
+  }
+  interface ClawbackClaimableBalance extends BaseOptions {
+    balanceId: string;
+  }
+  interface SetTrustLineFlags extends BaseOptions {
+    trustor: string;
+    asset: Asset;
+    flags: {
+      authorized: boolean;
+      authorizedToMaintainLiabilities: boolean;
+      clawbackEnabled: boolean;
+    };
+  }
 }
 export type OperationOptions =
   | OperationOptions.CreateAccount
@@ -397,7 +420,10 @@ export type OperationOptions =
   | OperationOptions.RevokeOfferSponsorship
   | OperationOptions.RevokeDataSponsorship
   | OperationOptions.RevokeClaimableBalanceSponsorship
-  | OperationOptions.RevokeSignerSponsorship;
+  | OperationOptions.RevokeSignerSponsorship
+  | OperationOptions.Clawback
+  | OperationOptions.ClawbackClaimableBalance
+  | OperationOptions.SetTrustLineFlags;
 
 export namespace Operation {
   interface BaseOperation<T extends OperationType = OperationType> {
@@ -622,6 +648,35 @@ export namespace Operation {
     options: OperationOptions.RevokeSignerSponsorship
   ): xdr.Operation<RevokeSignerSponsorship>;
 
+  interface Clawback extends BaseOperation<OperationType.Clawback> {
+    asset: Asset;
+    amount: string;
+    from: string;
+  }
+  function clawback(
+    options: OperationOptions.Clawback
+  ): xdr.Operation<Clawback>;
+
+  interface ClawbackClaimableBalance extends BaseOperation<OperationType.ClawbackClaimableBalance> {
+    balanceId: string;
+  }
+  function clawbackClaimableBalance(
+    options: OperationOptions.ClawbackClaimableBalance
+  ): xdr.Operation<ClawbackClaimableBalance>;
+
+  interface SetTrustLineFlags extends BaseOperation<OperationType.SetTrustLineFlags> {
+    trustor: string;
+    asset: Asset;
+    flags: {
+      authorized: boolean;
+      authorizedToMaintainLiabilities: boolean;
+      clawbackEnabled: boolean;
+    };
+  }
+  function setTrustLineFlags(
+    options: OperationOptions.SetTrustLineFlags
+  ): xdr.Operation<SetTrustLineFlags>;
+
   function fromXDRObject<T extends Operation = Operation>(
     xdrOperation: xdr.Operation<T>
   ): T;
@@ -650,7 +705,10 @@ export type Operation =
   | Operation.RevokeOfferSponsorship
   | Operation.RevokeDataSponsorship
   | Operation.RevokeClaimableBalanceSponsorship
-  | Operation.RevokeSignerSponsorship;
+  | Operation.RevokeSignerSponsorship
+  | Operation.Clawback
+  | Operation.ClawbackClaimableBalance
+  | Operation.SetTrustLineFlags;
 
 export namespace StrKey {
   function encodeEd25519PublicKey(data: Buffer): string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -391,9 +391,9 @@ export namespace OperationOptions {
     trustor: string;
     asset: Asset;
     flags: {
-      authorized: boolean;
-      authorizedToMaintainLiabilities: boolean;
-      clawbackEnabled: boolean;
+      authorized?: boolean | undefined;
+      authorizedToMaintainLiabilities?: boolean | undefined;
+      clawbackEnabled?: boolean | undefined;
     };
   }
 }
@@ -668,9 +668,9 @@ export namespace Operation {
     trustor: string;
     asset: Asset;
     flags: {
-      authorized: boolean;
-      authorizedToMaintainLiabilities: boolean;
-      clawbackEnabled: boolean;
+      authorized?: boolean | undefined;
+      authorizedToMaintainLiabilities?: boolean | undefined;
+      clawbackEnabled?: boolean | undefined;
     };
   }
   function setTrustLineFlags(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -159,19 +159,11 @@ export namespace TrustLineFlag {
   type deauthorize = 0;
   type authorize = 1;
   type authorizeToMaintainLiabilities = 2;
-  type enableTrustlineClawback = 4;
 }
 export type TrustLineFlag =
   | TrustLineFlag.deauthorize
   | TrustLineFlag.authorize
-  | TrustLineFlag.authorizeToMaintainLiabilities
-  | TrustLineFlag.enableTrustlineClawback;
-export type TrustLineFlagSet = {
-  deauthorize?: boolean | undefined;
-  authorize?: boolean | undefined;
-  authorizeToMaintainLiabilities?: boolean | undefined;
-  enableTrustlineClawback?: boolean | undefined;
-}
+  | TrustLineFlag.authorizeToMaintainLiabilities;
 
 export namespace Signer {
   interface Ed25519PublicKey {

--- a/types/test.ts
+++ b/types/test.ts
@@ -78,6 +78,34 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
         preAuthTx: "da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
       }
     })
+  ).addOperation(
+    StellarSdk.Operation.clawback({
+      from: account.accountId(),
+      amount: "1000",
+      asset: usd,
+    })
+  ).addOperation(
+    StellarSdk.Operation.clawbackClaimableBalance({
+      balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
+    })
+  ).addOperation(
+    StellarSdk.Operation.setTrustLineFlags({
+      trustor: account.accountId(),
+      asset: usd,
+      flags: {
+        authorize: true,
+        authorizeToMaintainLiabilities: true,
+        enableTrustlineClawback: true,
+      },
+    })
+  ).addOperation(
+    StellarSdk.Operation.setTrustLineFlags({
+      trustor: account.accountId(),
+      asset: usd,
+      flags: {
+        authorize: true,
+      },
+    })
   ).addMemo(new StellarSdk.Memo(StellarSdk.MemoText, 'memo'))
   .setTimeout(5)
   .build(); // $ExpectType () => Transaction<Memo<MemoType>, Operation[]>
@@ -213,3 +241,35 @@ const claimant = new StellarSdk.Claimant(sourceKey.publicKey()); // $ExpectType 
 claimant.toXDRObject(); // $ExpectType Claimant
 claimant.destination; // $ExpectType string
 claimant.predicate; // $ExpectType ClaimPredicate
+
+const claw = StellarSdk.xdr.ClawbackOp.fromXDR(
+  // tslint:disable:max-line-length
+  'AAAAAAAAABMAAAABUkFORAAAAABX4bxZtGki6kctorbhhcn3lD09fT42k5RcSAkTvDPgLwAAAABX4bxZtGki6kctorbhhcn3lD09fT42k5RcSAkTvDPgLwAAAAJUC+QA',
+  'base64'
+);
+claw; // $ExpectType ClawbackOp
+
+// .addOperation(
+//     StellarSdk.Operation.clawbackClaimableBalance({
+//       balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
+//     })
+//   ).addOperation(
+//     StellarSdk.Operation.setTrustLineFlags({
+//       trustor: account.accountId(),
+//       asset: new StellarSdk.Asset("RAND", account.accountId()),
+//       flags: {
+//         deauthorize: true,
+//         authorize: true,
+//         authorizeToMaintainLiabilities: true,
+//         enableTrustlineClawback: true,
+//       },
+//     })
+//   ).addOperation(
+//     StellarSdk.Operation.setTrustLineFlags({
+//       trustor: account.accountId(),
+//       asset: new StellarSdk.Asset("RAND", account.accountId()),
+//       flags: {
+//         deauthorize: false,
+//         authorize: true,
+//       },
+//     }))

--- a/types/test.ts
+++ b/types/test.ts
@@ -93,9 +93,9 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
       trustor: account.accountId(),
       asset: usd,
       flags: {
-        authorize: true,
-        authorizeToMaintainLiabilities: true,
-        enableTrustlineClawback: true,
+        authorized: true,
+        authorizedToMaintainLiabilities: true,
+        clawbackEnabled: true,
       },
     })
   ).addOperation(
@@ -103,7 +103,7 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
       trustor: account.accountId(),
       asset: usd,
       flags: {
-        authorize: true,
+        authorized: true,
       },
     })
   ).addMemo(new StellarSdk.Memo(StellarSdk.MemoText, 'memo'))
@@ -244,32 +244,21 @@ claimant.predicate; // $ExpectType ClaimPredicate
 
 const claw = StellarSdk.xdr.ClawbackOp.fromXDR(
   // tslint:disable:max-line-length
-  'AAAAAAAAABMAAAABUkFORAAAAABX4bxZtGki6kctorbhhcn3lD09fT42k5RcSAkTvDPgLwAAAABX4bxZtGki6kctorbhhcn3lD09fT42k5RcSAkTvDPgLwAAAAJUC+QA',
+  'AAAAAAAAABMAAAABVVNEAAAAAADNTrgPO19O0EsnYjSc333yWGLKEVxLyu1kfKjCKOz9ewAAAADFTYDKyTn2O0DVUEycHKfvsnFWj91TVl0ut1kwg5nLigAAAAJUC+QA',
   'base64'
 );
 claw; // $ExpectType ClawbackOp
 
-// .addOperation(
-//     StellarSdk.Operation.clawbackClaimableBalance({
-//       balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
-//     })
-//   ).addOperation(
-//     StellarSdk.Operation.setTrustLineFlags({
-//       trustor: account.accountId(),
-//       asset: new StellarSdk.Asset("RAND", account.accountId()),
-//       flags: {
-//         deauthorize: true,
-//         authorize: true,
-//         authorizeToMaintainLiabilities: true,
-//         enableTrustlineClawback: true,
-//       },
-//     })
-//   ).addOperation(
-//     StellarSdk.Operation.setTrustLineFlags({
-//       trustor: account.accountId(),
-//       asset: new StellarSdk.Asset("RAND", account.accountId()),
-//       flags: {
-//         deauthorize: false,
-//         authorize: true,
-//       },
-//     }))
+const clawCb = StellarSdk.xdr.ClawbackClaimableBalanceOp.fromXDR(
+  // tslint:disable:max-line-length
+  'AAAAAAAAABUAAAAAxU2Aysk59jtA1VBMnByn77JxVo/dU1ZdLrdZMIOZy4oAAAABVVNEAAAAAADNTrgPO19O0EsnYjSc333yWGLKEVxLyu1kfKjCKOz9ewAAAAAAAAAH',
+  'base64'
+);
+clawCb; // $ExpectType ClawbackClaimableBalanceOp
+
+const trust = StellarSdk.xdr.SetTrustLineFlagsOp.fromXDR(
+  // tslint:disable:max-line-length
+  'AAAAAAAAABUAAAAAF1frB6QZRDTYW4dheEA3ZZLCjSWs9eQgzsyvqdUy2rgAAAABVVNEAAAAAADNTrgPO19O0EsnYjSc333yWGLKEVxLyu1kfKjCKOz9ewAAAAAAAAAB',
+  'base64'
+);
+trust; // $ExpectType SetTrustLineFlagsOp


### PR DESCRIPTION
This builds on @overcat's work in #406 (you can see the [branch diff here](https://github.com/overcat/js-stellar-base/compare/dev-types-cap35...stellar:cap35-hints)), introducing test cases for the type hints and allows certain flags to be left off.