### PR TITLE
Release v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## Unreleased
 
+## [v5.1.0](https://github.com/stellar/js-stellar-base/compare/v5.0.0..v5.1.0)
+
 ### Update
 
 - The Typescript definitions have been updated to support CAP-35 ([#407](https://github.com/stellar/js-stellar-base/pull/407)). 
-
-- The `AllowTrust` flag type definitions (`TrustLineFlags`) have been renamed to match the XDR directly, since SetTrustLineFlags supercedes the now-deprecated `AllowTrustOp` ([#407](https://github.com/stellar/js-stellar-base/pull/407)).
-
 
 ## [v5.0.0](https://github.com/stellar/js-stellar-base/compare/v4.0.3..v5.0.0)
 


### PR DESCRIPTION
I was originally going to introduce a breaking change but finagled around it; we'll revisit it once `AllowTrustOp` goes beyond its deprecation period.