### PR TITLE
Expose the AuthClawbackEnabled flag for use with the SetOptionsOp

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ export {
   Operation,
   AuthRequiredFlag,
   AuthRevocableFlag,
-  AuthImmutableFlag
+  AuthImmutableFlag,
+  AuthClawbackEnabledFlag
 } from './operation';
 export * from './memo';
 export { Account } from './account';

--- a/src/operation.js
+++ b/src/operation.js
@@ -22,26 +22,40 @@ const ONE = 10000000;
 const MAX_INT64 = '9223372036854775807';
 
 /**
- * When set using `{@link Operation.setOptions}` option, requires the issuing account to
- * give other accounts permission before they can hold the issuing account’s credit.
+ * When set using `{@link Operation.setOptions}` option, requires the issuing
+ * account to give other accounts permission before they can hold the issuing
+ * account’s credit.
+ *
  * @constant
  * @see [Account flags](https://www.stellar.org/developers/guides/concepts/accounts.html#flags)
  */
 export const AuthRequiredFlag = 1 << 0;
 /**
- * When set using `{@link Operation.setOptions}` option, allows the issuing account to
- * revoke its credit held by other accounts.
+ * When set using `{@link Operation.setOptions}` option, allows the issuing
+ * account to revoke its credit held by other accounts.
+ *
  * @constant
  * @see [Account flags](https://www.stellar.org/developers/guides/concepts/accounts.html#flags)
  */
 export const AuthRevocableFlag = 1 << 1;
 /**
- * When set using `{@link Operation.setOptions}` option, then none of the authorization flags
- * can be set and the account can never be deleted.
+ * When set using `{@link Operation.setOptions}` option, then none of the
+ * authorization flags can be set and the account can never be deleted.
+ *
  * @constant
  * @see [Account flags](https://www.stellar.org/developers/guides/concepts/accounts.html#flags)
  */
 export const AuthImmutableFlag = 1 << 2;
+
+/**
+ * When set using `{@link Operation.setOptions}` option, then any trustlines
+ * created by this account can have a ClawbackOp operation submitted for the
+ * corresponding asset.
+ *
+ * @constant
+ * @see [Account flags](https://www.stellar.org/developers/guides/concepts/accounts.html#flags)
+ */
+export const AuthClawbackEnabledFlag = 1 << 3;
 
 /**
  * `Operation` class represents [operations](https://www.stellar.org/developers/guides/concepts/operations.html) in Stellar network.

--- a/src/operations/set_options.js
+++ b/src/operations/set_options.js
@@ -21,10 +21,13 @@ function weightCheckFunction(value, name) {
  *   - `{@link AuthRequiredFlag}`
  *   - `{@link AuthRevocableFlag}`
  *   - `{@link AuthImmutableFlag}`
+ *   - `{@link AuthClawbackEnabledFlag}`
  *
  * It's possible to set/clear multiple flags at once using logical or.
+ *
  * @function
  * @alias Operation.setOptions
+ *
  * @param {object} opts Options object
  * @param {string} [opts.inflationDest] - Set this account ID as the account's inflation destination.
  * @param {(number|string)} [opts.clearFlags] - Bitmap integer for which account flags to clear.
@@ -41,6 +44,7 @@ function weightCheckFunction(value, name) {
  * @param {number|string} [opts.signer.weight] - The weight of the new signer (0 to delete or 1-255)
  * @param {string} [opts.homeDomain] - sets the home domain used for reverse federation lookup.
  * @param {string} [opts.source] - The source account (defaults to transaction source).
+ *
  * @returns {xdr.SetOptionsOp}  XDR operation
  * @see [Account flags](https://www.stellar.org/developers/guides/concepts/accounts.html#flags)
  */

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -551,6 +551,7 @@ describe('Operation', function() {
       expect(StellarBase.AuthRequiredFlag).to.be.equal(1);
       expect(StellarBase.AuthRevocableFlag).to.be.equal(2);
       expect(StellarBase.AuthImmutableFlag).to.be.equal(4);
+      expect(StellarBase.AuthClawbackEnabledFlag).to.be.equal(8);
     });
 
     it('creates a setOptionsOp', function() {
@@ -559,7 +560,8 @@ describe('Operation', function() {
         'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
       opts.clearFlags =
         StellarBase.AuthRevocableFlag | StellarBase.AuthImmutableFlag;
-      opts.setFlags = StellarBase.AuthRequiredFlag;
+      opts.setFlags =
+        StellarBase.AuthRequiredFlag | StellarBase.AuthClawbackEnabledFlag;
       opts.masterWeight = 0;
       opts.lowThreshold = 1;
       opts.medThreshold = 2;
@@ -581,7 +583,7 @@ describe('Operation', function() {
       expect(obj.type).to.be.equal('setOptions');
       expect(obj.inflationDest).to.be.equal(opts.inflationDest);
       expect(obj.clearFlags).to.be.equal(6);
-      expect(obj.setFlags).to.be.equal(1);
+      expect(obj.setFlags).to.be.equal(9);
       expect(obj.masterWeight).to.be.equal(opts.masterWeight);
       expect(obj.lowThreshold).to.be.equal(opts.lowThreshold);
       expect(obj.medThreshold).to.be.equal(opts.medThreshold);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -145,15 +145,18 @@ export enum Networks {
 export const AuthRequiredFlag: 1;
 export const AuthRevocableFlag: 2;
 export const AuthImmutableFlag: 4;
+export const AuthClawbackEnabledFlag: 8;
 export namespace AuthFlag {
   type immutable = typeof AuthImmutableFlag;
   type required = typeof AuthRequiredFlag;
   type revocable = typeof AuthRevocableFlag;
+  type clawbackEnabled = typeof AuthClawbackEnabledFlag;
 }
 export type AuthFlag =
   | AuthFlag.immutable
   | AuthFlag.required
-  | AuthFlag.revocable;
+  | AuthFlag.revocable
+  | AuthFlag.clawbackEnabled;
 
 export namespace TrustLineFlag {
   type deauthorize = 0;

--- a/types/test.ts
+++ b/types/test.ts
@@ -14,8 +14,7 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
       sponsoredId: account.accountId(),
       source: masterKey.publicKey()
     })
-  )
-  .addOperation(
+  ).addOperation(
     StellarSdk.Operation.accountMerge({ destination: destKey.publicKey() }),
   ).addOperation(
     StellarSdk.Operation.createClaimableBalance({
@@ -105,6 +104,11 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
       flags: {
         authorized: true,
       },
+    })
+  ).addOperation(
+    StellarSdk.Operation.setOptions({
+      setFlags:   StellarSdk.AuthFlag.immutable | StellarSdk.AuthFlag.required,
+      clearFlags: StellarSdk.AuthFlag.revocable | StellarSdk.AuthFlag.clawbackEnabled
     })
   ).addMemo(new StellarSdk.Memo(StellarSdk.MemoText, 'memo'))
   .setTimeout(5)


### PR DESCRIPTION
This should allow library consumers to do things like:

```js
const op = StellarSdk.Operation.setOptions({ 
    setFlags: StellarSdk.AuthFlag.clawbackEnabled,
});
```