### PR TITLE
Fixes Typescript errors referencing the SetOptions auth flags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fix 
+- Update Typescript test for `SetOptions` to use authorization flags (e.g. `AuthRequiredFlag`) correctly ([#418](https://github.com/stellar/js-stellar-base/pull/418)).
+
 ## [v5.1.0](https://github.com/stellar/js-stellar-base/compare/v5.0.0..v5.1.0)
 
 ### Update

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -153,8 +153,8 @@ export namespace AuthFlag {
   type clawbackEnabled = typeof AuthClawbackEnabledFlag;
 }
 export type AuthFlag =
-  | AuthFlag.immutable
   | AuthFlag.required
+  | AuthFlag.immutable
   | AuthFlag.revocable
   | AuthFlag.clawbackEnabled;
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -107,8 +107,8 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
     })
   ).addOperation(
     StellarSdk.Operation.setOptions({
-      setFlags:   StellarSdk.AuthFlag.immutable | StellarSdk.AuthFlag.required,
-      clearFlags: StellarSdk.AuthFlag.revocable | StellarSdk.AuthFlag.clawbackEnabled
+      setFlags:   (StellarSdk.AuthImmutableFlag | StellarSdk.AuthRequiredFlag) as StellarSdk.AuthFlag,
+      clearFlags: (StellarSdk.AuthRevocableFlag | StellarSdk.AuthClawbackEnabledFlag) as StellarSdk.AuthFlag,
     })
   ).addMemo(new StellarSdk.Memo(StellarSdk.MemoText, 'memo'))
   .setTimeout(5)


### PR DESCRIPTION
The SDK uses the full name (i.e. `AuthClawbackEnabledFlag`) rather than going through the namespace (e.g. `AuthFlag.clawbackEnabled`), and the Typescript files have been updated accordingly to hint these types.

This should fix linter errors.