### PR TITLE
Update minimum versions in Karma-Sauce for JavaScript compatibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fix 
 - Update Typescript test for `SetOptions` to use authorization flags (e.g. `AuthRequiredFlag`) correctly ([#418](https://github.com/stellar/js-stellar-base/pull/418)).
 
+### Update
+- Modernize the minimum-supported browser versions for the library ([#419](https://github.com/stellar/js-stellar-base/pull/419)).
+
 ## [v5.1.0](https://github.com/stellar/js-stellar-base/compare/v5.0.0..v5.1.0)
 
 ### Update

--- a/karma-sauce.conf.js
+++ b/karma-sauce.conf.js
@@ -7,17 +7,19 @@ module.exports = function(config) {
     sl_chrome: {
       base: 'SauceLabs',
       browserName: 'chrome',
-      version: '44'
+      version: '49'
     },
     sl_firefox: {
       base: 'SauceLabs',
       browserName: 'firefox',
-      version: '39'
+      platform: 'Windows 8.1',
+      version: '44'
     },
     sl_ie_11: {
       base: 'SauceLabs',
       browserName: 'internet explorer',
-      version: '11'
+      platform: 'Windows 8.1',
+      version: 'latest'
     }
   };
 

--- a/karma-sauce.conf.js
+++ b/karma-sauce.conf.js
@@ -7,6 +7,7 @@ module.exports = function(config) {
     sl_chrome: {
       base: 'SauceLabs',
       browserName: 'chrome',
+      platform: 'Windows 8.1',
       version: '49'
     },
     sl_firefox: {


### PR DESCRIPTION
Updates the following minimum compatibilities to prevent build errors:
 - The platform has been bumped to Windows 8.1, since Windows 7 is [EOL](https://www.microsoft.com/en-ww/microsoft-365/windows/end-of-windows-7-support).
 - Firefox and Chrome have been bumped to versions 44 and 49, respectively, which are the [minimum versions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#browser_compatibility) that support the `let` identifier.

As you can see, the builds finally pass.