### PR TITLE
Fix XDR gen instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ yarn xdr
 # If src/generated/stellar-xdr_generated.js changed, then:
 git clone https://github.com/stellar/dts-xdr
 cd dts-xdr
-stellar-xdr_generated.d.ts npx jscodeshift -t src/transform.js ../src/generated/stellar-xdr_generated.js
+npm install
+OUT=stellar-xdr_generated.d.ts npx jscodeshift -t src/transform.js ../src/generated/stellar-xdr_generated.js
 cp stellar-xdr_generated.d.ts ../types/xdr.d.ts
 cd .. && rm -rf dts-xdr
 ```


### PR DESCRIPTION
### What
Add an npm install and missing env var setting to the xdr generation instructions.

### Why
I needed to add them to get the process to work.