### PR TITLE
Stop trying to guess if ed25519 keys are actually med25519 keys.

### DIFF
--- a/src/strkey.js
+++ b/src/strkey.js
@@ -24,18 +24,10 @@ export class StrKey {
   /**
    * Encodes `data` to strkey ed25519 public key.
    *
-   * If the parameter is a muxed account, it will extract the underlying public
-   * key.
-   *
    * @param   {Buffer} data   raw data to encode
    * @returns {string}        "G..." representation of the key
    */
   static encodeEd25519PublicKey(data) {
-    if (data && data[0] === versionBytes.med25519PublicKey) {
-      const medKey = encodeCheck('med25519PublicKey', data);
-      return this.encodeEd25519PublicKey(medKey.ed25519());
-    }
-
     return encodeCheck('ed25519PublicKey', data);
   }
 

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -746,12 +746,12 @@ describe('TransactionBuilder', function() {
     });
   });
 
-  describe('does not regress Issue #646', function() {
-    // expect(() => {
-    StellarBase.TransactionBuilder.fromXDR(
-      'AAAAAgAAAABg/GhKJU5ut52ih6Klx0ymGvsac1FPJig1CHYqyesIHQAAJxACBmMCAAAADgAAAAAAAAABAAAAATMAAAAAAAABAAAAAQAAAABg/GhKJU5ut52ih6Klx0ymGvsac1FPJig1CHYqyesIHQAAAAAAAAAAqdkSiA5dzNXstOtkPkHd6dAMPMA+MSXwK8OlrAGCKasAAAAAAcnDgAAAAAAAAAAByesIHQAAAEAuLrTfW6D+HYlUD9y+JolF1qrb40hIRATzsQaQjchKJuhOZJjLO0d7oaTD3JZ4UL4vVKtV7TvV17rQgCQnuz8F',
-      'Public Global Stellar Network ; September 2015'
-    );
-    // }).to.not.throw();
+  describe('does not regress js-stellar-sdk#646', function() {
+    expect(() => {
+      StellarBase.TransactionBuilder.fromXDR(
+        'AAAAAgAAAABg/GhKJU5ut52ih6Klx0ymGvsac1FPJig1CHYqyesIHQAAJxACBmMCAAAADgAAAAAAAAABAAAAATMAAAAAAAABAAAAAQAAAABg/GhKJU5ut52ih6Klx0ymGvsac1FPJig1CHYqyesIHQAAAAAAAAAAqdkSiA5dzNXstOtkPkHd6dAMPMA+MSXwK8OlrAGCKasAAAAAAcnDgAAAAAAAAAAByesIHQAAAEAuLrTfW6D+HYlUD9y+JolF1qrb40hIRATzsQaQjchKJuhOZJjLO0d7oaTD3JZ4UL4vVKtV7TvV17rQgCQnuz8F',
+        'Public Global Stellar Network ; September 2015'
+      );
+    }).to.not.throw();
   });
 });

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -744,14 +744,14 @@ describe('TransactionBuilder', function() {
       expect(source.sequenceNumber()).to.equal('1235');
       expect(source.baseAccount().sequenceNumber()).to.equal('1235');
     });
-  });
 
-  describe('does not regress js-stellar-sdk#646', function() {
-    expect(() => {
-      StellarBase.TransactionBuilder.fromXDR(
-        'AAAAAgAAAABg/GhKJU5ut52ih6Klx0ymGvsac1FPJig1CHYqyesIHQAAJxACBmMCAAAADgAAAAAAAAABAAAAATMAAAAAAAABAAAAAQAAAABg/GhKJU5ut52ih6Klx0ymGvsac1FPJig1CHYqyesIHQAAAAAAAAAAqdkSiA5dzNXstOtkPkHd6dAMPMA+MSXwK8OlrAGCKasAAAAAAcnDgAAAAAAAAAAByesIHQAAAEAuLrTfW6D+HYlUD9y+JolF1qrb40hIRATzsQaQjchKJuhOZJjLO0d7oaTD3JZ4UL4vVKtV7TvV17rQgCQnuz8F',
-        'Public Global Stellar Network ; September 2015'
-      );
-    }).to.not.throw();
+    it('does not regress js-stellar-sdk#646', function() {
+      expect(() => {
+        StellarBase.TransactionBuilder.fromXDR(
+          'AAAAAgAAAABg/GhKJU5ut52ih6Klx0ymGvsac1FPJig1CHYqyesIHQAAJxACBmMCAAAADgAAAAAAAAABAAAAATMAAAAAAAABAAAAAQAAAABg/GhKJU5ut52ih6Klx0ymGvsac1FPJig1CHYqyesIHQAAAAAAAAAAqdkSiA5dzNXstOtkPkHd6dAMPMA+MSXwK8OlrAGCKasAAAAAAcnDgAAAAAAAAAAByesIHQAAAEAuLrTfW6D+HYlUD9y+JolF1qrb40hIRATzsQaQjchKJuhOZJjLO0d7oaTD3JZ4UL4vVKtV7TvV17rQgCQnuz8F',
+          'Public Global Stellar Network ; September 2015'
+        );
+      }).to.not.throw();
+    });
   });
 });

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -745,4 +745,13 @@ describe('TransactionBuilder', function() {
       expect(source.baseAccount().sequenceNumber()).to.equal('1235');
     });
   });
+
+  describe('does not regress Issue #646', function() {
+    // expect(() => {
+    StellarBase.TransactionBuilder.fromXDR(
+      'AAAAAgAAAABg/GhKJU5ut52ih6Klx0ymGvsac1FPJig1CHYqyesIHQAAJxACBmMCAAAADgAAAAAAAAABAAAAATMAAAAAAAABAAAAAQAAAABg/GhKJU5ut52ih6Klx0ymGvsac1FPJig1CHYqyesIHQAAAAAAAAAAqdkSiA5dzNXstOtkPkHd6dAMPMA+MSXwK8OlrAGCKasAAAAAAcnDgAAAAAAAAAAByesIHQAAAEAuLrTfW6D+HYlUD9y+JolF1qrb40hIRATzsQaQjchKJuhOZJjLO0d7oaTD3JZ4UL4vVKtV7TvV17rQgCQnuz8F',
+      'Public Global Stellar Network ; September 2015'
+    );
+    // }).to.not.throw();
+  });
 });


### PR DESCRIPTION
A regression was introduced in 8.1.1 where raw muxed accounts were interpreted as M-addresses by `StrKey.encodeEd25519PublicKey` as a convenience, but this behavior is incorrect.

This closes stellar/js-stellar-sdk#646.