### PR TITLE
Add non-breaking muxed account support to fee-bump transactions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
+
 ## Unreleased
+
+### Add
+- **Opt-in support for muxed accounts.** In addition to the support introduced in [v5.2.0](https://github.com/stellar/js-stellar-base/releases/v5.2.0), this completes support for muxed accounts by enabling them for fee-bump transactions. Pass the muxing ID as the (new, optional) last parameter to `TransactionBuilder.buildFeeBumpTransaction` to make the `feeSource` a fully-muxed account instance ([#434](https://github.com/stellar/js-stellar-base/pull/434)).
 
 
 ## [v5.2.0](https://github.com/stellar/js-stellar-base/compare/v5.1.0..v5.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## Unreleased
 
 ### Add
-- **Opt-in support for muxed accounts.** In addition to the support introduced in [v5.2.0](https://github.com/stellar/js-stellar-base/releases/v5.2.0), this completes support for muxed accounts by enabling them for fee-bump transactions. Pass the muxing ID as the (new, optional) last parameter to `TransactionBuilder.buildFeeBumpTransaction` to make the `feeSource` a fully-muxed account instance ([#434](https://github.com/stellar/js-stellar-base/pull/434)).
+- **Opt-in support for muxed accounts.** In addition to the support introduced in [v5.2.0](https://github.com/stellar/js-stellar-base/releases/v5.2.0), this completes support for muxed accounts by enabling them for fee-bump transactions. Pass a muxed account address (in the `M...` form) as the first parameter (and opting-in to muxing by passing `true` as the last parameter) to `TransactionBuilder.buildFeeBumpTransaction` to make the `feeSource` a fully-muxed account instance ([#434](https://github.com/stellar/js-stellar-base/pull/434)).
 
 
 ## [v5.2.0](https://github.com/stellar/js-stellar-base/compare/v5.1.0..v5.2.0)

--- a/src/account.js
+++ b/src/account.js
@@ -151,6 +151,9 @@ export class MuxedAccount {
 
   /**
    * A helper method to turn an M-address into its underlying G-address.
+   *
+   * @param   {string} mAddress - muxed address to convert
+   * @returns {string} underlying G-address
    */
   static parseBaseAddress(mAddress) {
     const muxedAccount = decodeAddressToMuxedAccount(mAddress, true);

--- a/src/account.js
+++ b/src/account.js
@@ -150,6 +150,14 @@ export class MuxedAccount {
   }
 
   /**
+   * A helper method to turn an M-address into its underlying G-address.
+   */
+  static parseBaseAddress(mAddress) {
+    const muxedAccount = decodeAddressToMuxedAccount(mAddress, true);
+    return encodeMuxedAccountToAddress(muxedAccount, false);
+  }
+
+  /**
    * @return {Account} the underlying account object shared among all muxed
    *     accounts with this Stellar address
    */
@@ -193,6 +201,16 @@ export class MuxedAccount {
    */
   incrementSequenceNumber() {
     return this.account.incrementSequenceNumber();
+  }
+
+  /**
+   * Creates another muxed "sub"account from the base with a new ID set
+   *
+   * @param  {string} id - the ID of the new muxed account
+   * @return {MuxedAccount} a new instance w/ the specified parameters
+   */
+  createSubaccount(id) {
+    return new MuxedAccount(this.account, id);
   }
 
   /**

--- a/src/account.js
+++ b/src/account.js
@@ -150,17 +150,6 @@ export class MuxedAccount {
   }
 
   /**
-   * A helper method to turn an M-address into its underlying G-address.
-   *
-   * @param   {string} mAddress - muxed address to convert
-   * @returns {string} underlying G-address
-   */
-  static parseBaseAddress(mAddress) {
-    const muxedAccount = decodeAddressToMuxedAccount(mAddress, true);
-    return encodeMuxedAccountToAddress(muxedAccount, false);
-  }
-
-  /**
    * @return {Account} the underlying account object shared among all muxed
    *     accounts with this Stellar address
    */

--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -13,12 +13,19 @@ import { encodeMuxedAccountToAddress } from './util/decode_encode_muxed_account'
  * Once a {@link FeeBumpTransaction} has been created, its attributes and operations
  * should not be changed. You should only add signatures (using {@link FeeBumpTransaction#sign}) before
  * submitting to the network or forwarding on to additional signers.
- * @param {string|xdr.TransactionEnvelope} envelope - The transaction envelope object or base64 encoded string.
- * @param {string} networkPassphrase passphrase of the target stellar network (e.g. "Public Global Stellar Network ; September 2015").
+ *
+ * @param {string|xdr.TransactionEnvelope} envelope - transaction envelope
+ *     object or base64 encoded string.
+ * @param {string} networkPassphrase - passphrase of the target Stellar network
+ *     (e.g. "Public Global Stellar Network ; September 2015").
+ * @param {bool}    [opts.withMuxing] - indicates that the fee source of this
+ *     transaction is a proper muxed account (i.e. coming from an M... address).
+ *     By default, this option is disabled until muxed accounts are mature.
+ *
  * @extends TransactionBase
  */
 export class FeeBumpTransaction extends TransactionBase {
-  constructor(envelope, networkPassphrase) {
+  constructor(envelope, networkPassphrase, withMuxing) {
     if (typeof envelope === 'string') {
       const buffer = Buffer.from(envelope, 'base64');
       envelope = xdr.TransactionEnvelope.fromXDR(buffer);
@@ -42,7 +49,10 @@ export class FeeBumpTransaction extends TransactionBase {
     const innerTxEnvelope = xdr.TransactionEnvelope.envelopeTypeTx(
       tx.innerTx().v1()
     );
-    this._feeSource = encodeMuxedAccountToAddress(this.tx.feeSource());
+    this._feeSource = encodeMuxedAccountToAddress(
+      this.tx.feeSource(),
+      withMuxing
+    );
     this._innerTransaction = new Transaction(
       innerTxEnvelope,
       networkPassphrase

--- a/src/keypair.js
+++ b/src/keypair.js
@@ -1,8 +1,12 @@
 import nacl from 'tweetnacl';
+import isUndefined from 'lodash/isUndefined';
+import isString from 'lodash/isString';
+
 import { sign, verify, generate } from './signing';
 import { StrKey } from './strkey';
-import xdr from './generated/stellar-xdr_generated';
 import { hash } from './hashing';
+
+import xdr from './generated/stellar-xdr_generated';
 
 /**
  * `Keypair` represents public (and secret) keys of the account.
@@ -121,7 +125,31 @@ export class Keypair {
     return new xdr.PublicKey.publicKeyTypeEd25519(this._publicKey);
   }
 
-  xdrMuxedAccount() {
+  /**
+   * Creates a {@link xdr.MuxedAccount} object from the public key.
+   *
+   * You will get a different type of muxed account depending on whether or not
+   * you pass an ID.
+   *
+   * @param  {string} [id] - stringified integer indicating the underlying muxed
+   *     ID of the new account object
+   *
+   * @return {xdr.MuxedAccount}
+   */
+  xdrMuxedAccount(id) {
+    if (!isUndefined(id)) {
+      if (!isString(id)) {
+        throw new TypeError(`expected string for ID, got ${typeof id}`);
+      }
+
+      return xdr.MuxedAccount.keyTypeMuxedEd25519(
+        new xdr.MuxedAccountMed25519({
+          id: xdr.Uint64.fromString(id),
+          ed25519: this._publicKey
+        })
+      );
+    }
+
     return new xdr.MuxedAccount.keyTypeEd25519(this._publicKey);
   }
 

--- a/src/operations/payment.js
+++ b/src/operations/payment.js
@@ -35,7 +35,7 @@ export function payment(opts) {
       opts.withMuxing
     );
   } catch (e) {
-    throw new Error('destination is invalid');
+    throw new Error('destination is invalid; did you forget to enable muxing?');
   }
 
   attributes.asset = opts.asset.toXDRObject();

--- a/test/unit/muxed_account_test.js
+++ b/test/unit/muxed_account_test.js
@@ -82,6 +82,9 @@ describe('muxed account abstraction works', function() {
     const mux1 = new StellarBase.MuxedAccount.fromAddress(MPUBKEY_ZERO, '123');
     expect(mux1.id()).to.equal('0');
     expect(mux1.accountId()).to.equal(MPUBKEY_ZERO);
+    expect(mux1.baseAccount().accountId()).to.equal(
+      'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ'
+    );
     expect(mux1.sequenceNumber()).to.equal('123');
   });
 });

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -762,10 +762,12 @@ describe('TransactionBuilder', function() {
         networkPassphrase: networkPassphrase
       });
 
+      const muxed = new StellarBase.MuxedAccount.fromAddress(destination, '0');
+      const gAddress = muxed.baseAccount().accountId();
       builder.addOperation(
         StellarBase.Operation.payment({
           source: source.baseAccount().accountId(),
-          destination: StellarBase.MuxedAccount.parseBaseAddress(destination),
+          destination: gAddress,
           amount: amount,
           asset: asset
         })

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -774,15 +774,12 @@ describe('TransactionBuilder', function() {
       let tx = builder.build();
       tx.sign(signer);
 
-      const kp = StellarBase.Keypair.fromPublicKey(
-        source.baseAccount().accountId()
-      );
       const feeTx = StellarBase.TransactionBuilder.buildFeeBumpTransaction(
-        kp,
+        source.accountId(),
         '1000',
         tx,
         networkPassphrase,
-        '2'
+        true
       );
 
       expect(feeTx).to.be.an.instanceof(StellarBase.FeeBumpTransaction);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -808,11 +808,11 @@ export class TransactionBuilder {
   build(): Transaction;
   setNetworkPassphrase(networkPassphrase: string): this;
   static buildFeeBumpTransaction(
-    feeSource: Keypair,
+    feeSource: Keypair | string,
     baseFee: string,
     innerTx: Transaction,
     networkPassphrase: string,
-    id?: string
+    withMuxing?: boolean
   ): FeeBumpTransaction;
   static fromXDR(
     envelope: string | xdr.TransactionEnvelope,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,6 +16,7 @@ export class Account {
 export class MuxedAccount {
   constructor(account: Account, sequence: string);
   static fromAddress(mAddress: string, sequenceNum: string): MuxedAccount;
+  static parseBaseAddress(mAddress: string): string;
 
   /* Modeled after Account, above */
   accountId(): string;
@@ -100,7 +101,10 @@ export class Keypair {
   signDecorated(data: Buffer): xdr.DecoratedSignature;
   signatureHint(): Buffer;
   verify(data: Buffer, signature: Buffer): boolean;
+
   xdrAccountId(): xdr.AccountId;
+  xdrPublicKey(): xdr.PublicKey;
+  xdrMuxedAccount(id: string): xdr.MuxedAccount;
 }
 
 export const MemoNone = 'none';
@@ -764,7 +768,8 @@ export class TransactionI {
 export class FeeBumpTransaction extends TransactionI {
   constructor(
     envelope: string | xdr.TransactionEnvelope,
-    networkPassphrase: string
+    networkPassphrase: string,
+    withMuxing?: boolean
   );
   feeSource: string;
   innerTransaction: Transaction;
@@ -776,7 +781,8 @@ export class Transaction<
 > extends TransactionI {
   constructor(
     envelope: string | xdr.TransactionEnvelope,
-    networkPassphrase: string
+    networkPassphrase: string,
+    withMuxing?: boolean
   );
   memo: TMemo;
   operations: TOps;
@@ -805,12 +811,15 @@ export class TransactionBuilder {
     feeSource: Keypair,
     baseFee: string,
     innerTx: Transaction,
-    networkPassphrase: string
+    networkPassphrase: string,
+    id?: string
   ): FeeBumpTransaction;
   static fromXDR(
     envelope: string | xdr.TransactionEnvelope,
     networkPassphrase: string
   ): Transaction | FeeBumpTransaction;
+
+  supportMuxedAccounts: boolean;
 }
 
 export namespace TransactionBuilder {
@@ -823,6 +832,7 @@ export namespace TransactionBuilder {
     memo?: Memo;
     networkPassphrase?: string;
     v1?: boolean;
+    withMuxing?: boolean;
   }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,6 +21,7 @@ export class MuxedAccount {
   accountId(): string;
   sequenceNumber(): string;
   incrementSequenceNumber(): void;
+  createSubaccount(id: string): MuxedAccount;
 
   baseAccount(): Account;
   id(): string;

--- a/types/test.ts
+++ b/types/test.ts
@@ -6,6 +6,8 @@ const destKey = StellarSdk.Keypair.random();
 const usd = new StellarSdk.Asset('USD', 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'); // $ExpectType Asset
 const account = new StellarSdk.Account(sourceKey.publicKey(), '1'); // $ExpectType Account
 const muxedAccount = new StellarSdk.MuxedAccount(account, '123'); // $ExpectType MuxedAccount
+const muxedConforms: StellarSdk.Account = muxedAccount; // $ExpectType Account
+
 const transaction = new StellarSdk.TransactionBuilder(account, {
   fee: "100",
   networkPassphrase: StellarSdk.Networks.TESTNET

--- a/types/test.ts
+++ b/types/test.ts
@@ -6,7 +6,7 @@ const destKey = StellarSdk.Keypair.random();
 const usd = new StellarSdk.Asset('USD', 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'); // $ExpectType Asset
 const account = new StellarSdk.Account(sourceKey.publicKey(), '1'); // $ExpectType Account
 const muxedAccount = new StellarSdk.MuxedAccount(account, '123'); // $ExpectType MuxedAccount
-const muxedConforms: StellarSdk.Account = muxedAccount; // $ExpectType Account
+const muxedConforms = muxedAccount as StellarSdk.Account; // $ExpectType Account
 
 const transaction = new StellarSdk.TransactionBuilder(account, {
   fee: "100",


### PR DESCRIPTION
To avoid a breaking change, I've introduced a way to set the source of a fee-bump transaction via account strings (in both `G...` and `M...` form). To enable proper muxed accounts, you pass `withMuxing: true` as the last parameter of `TransactionBuilder.buildFeeBumpTransaction()` just like everywhere else to explicitly opt-in. Namely,

```js
const feeTx = StellarBase.TransactionBuilder.buildFeeBumpTransaction(
  feeSourceMAddress,
  bumpedFee,
  innerTx,
  networkPassphrase,
  true // optionally parses the source as a true muxed address
);
```