### PR TITLE
Stops G-addresses from being forcefully turned into fully-muxed objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fix
+- Creating operations with both muxed and unmuxed properties resulted in unintuitive XDR. Specifically, the unmuxed property would be transformed into the equivalent property with an ID of 0 ([#441](https://github.com/stellar/js-stellar-base/pull/441)). 
+
 
 ## [v5.3.0](https://github.com/stellar/js-stellar-base/compare/v5.2.1..v5.3.0)
 

--- a/src/account.js
+++ b/src/account.js
@@ -5,7 +5,8 @@ import xdr from './generated/stellar-xdr_generated';
 import { StrKey } from './strkey';
 import {
   decodeAddressToMuxedAccount,
-  encodeMuxedAccountToAddress
+  encodeMuxedAccountToAddress,
+  encodeMuxedAccount
 } from './util/decode_encode_muxed_account';
 
 /**
@@ -97,11 +98,11 @@ export class Account {
  *   4: MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAAQLQQ
  *
  * This object makes it easy to create muxed accounts from regular accounts,
- * duplicate them, retrieve the underlying IDs, etc. without mucking around with
+ * duplicate them, get/set the underlying IDs, etc. without mucking around with
  * the raw XDR.
  *
  * Because muxed accounts are purely an off-chain convention, they all share the
- * sequence number tied to the underlying G... account. Thus, this object
+ * sequence number tied to their underlying G... account. Thus, this object
  * *requires* an {@link Account} instance to be passed in, so that muxed
  * instances of an account can collectively modify the sequence number whenever
  * a muxed account is used as the source of a @{link Transaction} with {@link
@@ -110,9 +111,11 @@ export class Account {
  * @constructor
  *
  * @param {Account}   account - the @{link Account} instance representing the
- *     underlying G... address
+ *                              underlying G... address
  * @param {string}    id      - a stringified uint64 value that represents the
- *     ID of the muxed account
+ *                              ID of the muxed account
+ *
+ * @link https://developers.stellar.org/docs/glossary/muxed-accounts/
  */
 export class MuxedAccount {
   constructor(baseAccount, id) {
@@ -122,9 +125,9 @@ export class MuxedAccount {
     }
 
     this.account = baseAccount;
-    this._muxedXdr = decodeAddressToMuxedAccount(accountId, true);
+    this._muxedXdr = encodeMuxedAccount(accountId, id);
     this._mAddress = encodeMuxedAccountToAddress(this._muxedXdr, true);
-    this.setId(id);
+    this._id = id;
   }
 
   /**

--- a/src/operations/account_merge.js
+++ b/src/operations/account_merge.js
@@ -9,9 +9,10 @@ import { decodeAddressToMuxedAccount } from '../util/decode_encode_muxed_account
  *
  * @param {object} opts - options object
  * @param {string} opts.destination - destination to merge the source account into
- * @param {bool}  [opts.withMuxing] - indicates that opts.destination is an
- *     M... address and should be interpreted fully as a muxed account. By
- *     default, this option is disabled until muxed accounts are mature.*
+ * @param {bool}  [opts.withMuxing] - indicates that some parameters in the
+ *     operation are M... addresses that should be interpreted fully as a muxed
+ *     account. By default, this option is disabled until muxed accounts are
+ *     mature.
  * @param {string} [opts.source]    - operation source account (defaults to
  *     transaction source)
  * @returns {xdr.Operation} an Account Merge operation (xdr.AccountMergeOp)

--- a/src/operations/path_payment_strict_receive.js
+++ b/src/operations/path_payment_strict_receive.js
@@ -21,9 +21,10 @@ import { decodeAddressToMuxedAccount } from '../util/decode_encode_muxed_account
  * @param {Asset}   opts.destAsset    - asset the destination will receive
  * @param {string}  opts.destAmount   - amount the destination receives
  * @param {Asset[]} opts.path         - array of Asset objects to use as the path
- * @param {bool}    [opts.withMuxing] - Indicates that opts.destination is an
- *     M... address and should be interpreted fully as a muxed account. By
- *     default, this option is disabled until muxed accounts are mature.
+ * @param {bool}    [opts.withMuxing] - indicates that some parameters in the
+ *     operation are M... addresses that should be interpreted fully as a muxed
+ *     account. By default, this option is disabled until muxed accounts are
+ *     mature.
  * @param {string}  [opts.source]     - The source account for the payment.
  *     Defaults to the transaction's source account.
  *

--- a/src/operations/path_payment_strict_send.js
+++ b/src/operations/path_payment_strict_send.js
@@ -20,9 +20,10 @@ import { decodeAddressToMuxedAccount } from '../util/decode_encode_muxed_account
  * @param {Asset}   opts.destAsset    - asset the destination will receive
  * @param {string}  opts.destMin      - minimum amount of destAsset to be receive
  * @param {Asset[]} opts.path         - array of Asset objects to use as the path
- * @param {bool}    [opts.withMuxing] - Indicates that opts.destination is an
- *     M... address and should be interpreted fully as a muxed account. By
- *     default, this option is disabled until muxed accounts are mature.
+ * @param {bool}    [opts.withMuxing] - indicates that some parameters in the
+ *     operation are M... addresses that should be interpreted fully as a muxed
+ *     account. By default, this option is disabled until muxed accounts are
+ *     mature.
  * @param {string}  [opts.source]     - The source account for the payment.
  *     Defaults to the transaction's source account.
  *

--- a/src/operations/payment.js
+++ b/src/operations/payment.js
@@ -12,9 +12,10 @@ import { decodeAddressToMuxedAccount } from '../util/decode_encode_muxed_account
  * @param {string}  opts.destination  - The destination account ID.
  * @param {Asset}   opts.asset        - The asset to send.
  * @param {string}  opts.amount       - The amount to send.
- * @param {bool}    [opts.withMuxing] - Indicates that opts.destination is an
- *     M... address and should be interpreted fully as a muxed account. By
- *     default, this option is disabled until muxed accounts are mature.
+ * @param {bool}    [opts.withMuxing] - Indicates that some parameters (either
+ *     the `destination` or `source`, in this case) are M... addresses that
+ *     should be interpreted fully as a muxed account. By default, this option
+ *     is disabled until muxed accounts are mature.
  * @param {string}  [opts.source]     - The source account for the payment.
  *     Defaults to the transaction's source account.
  *

--- a/src/util/decode_encode_muxed_account.js
+++ b/src/util/decode_encode_muxed_account.js
@@ -20,20 +20,13 @@ import { StrKey } from '../strkey';
  *
  * @returns {xdr.MuxedAccount}  a muxed account object for this address string
  *
- * @note     If you pass a G... address and DO specify supportMuxing=true, then
- *           this will return an xdr.MuxedAccount with an ID of zero.
+ * @note     If you pass a G... address, `supportMuxing` will be ignored.
  * @warning  If you pass an M... address and do NOT specify supportMuxing=true,
  *           then this function will throw an error.
  */
 export function decodeAddressToMuxedAccount(address, supportMuxing) {
-  if (supportMuxing) {
-    if (StrKey.isValidMed25519PublicKey(address)) {
-      return _decodeAddressFullyToMuxedAccount(address);
-    }
-
-    if (StrKey.isValidEd25519PublicKey(address)) {
-      return encodeMuxedAccount(address, '0');
-    }
+  if (supportMuxing && StrKey.isValidMed25519PublicKey(address)) {
+    return _decodeAddressFullyToMuxedAccount(address);
   }
 
   return xdr.MuxedAccount.keyTypeEd25519(
@@ -52,7 +45,7 @@ export function decodeAddressToMuxedAccount(address, supportMuxing) {
  * @param   {xdr.MuxedAccount} muxedAccount   account to stringify
  * @param   {bool}            [supportMuxing] converts the object into its full,
  *     proper M... address, encoding both the underlying G... address and the
- *     Muxing ID
+ *     muxing ID, but *ONLY* when the ID is present.
  *
  * @returns {string}  stringified G... (corresponding to the underlying pubkey)
  *     or M... address (corresponding to both the key and the muxed ID)

--- a/test/unit/muxed_account_test.js
+++ b/test/unit/muxed_account_test.js
@@ -61,7 +61,7 @@ describe('muxed account abstraction works', function() {
     expect(mux2.sequenceNumber()).to.equal('12348');
   });
 
-  it('lets subaccounts be created', function() {
+  it('lets virtual accounts be created', function() {
     let baseAccount = new StellarBase.Account(PUBKEY, '12345');
     const mux1 = new StellarBase.MuxedAccount(baseAccount, '1');
 

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -282,24 +282,20 @@ describe('StrKey', function() {
         StellarBase.StrKey.decodeMed25519PublicKey(MPUBKEY).equals(RAW_MPUBKEY)
       ).to.be.true;
     });
-    it('decodes to an empty muxed account when given a G...', function() {
-      const emptyMux = StellarBase.decodeAddressToMuxedAccount(PUBKEY, true);
-      const ZERO = StellarBase.xdr.Uint64.fromString('0');
 
-      expect(StellarBase.xdr.MuxedAccount.isValid(emptyMux)).to.be.true;
-      expect(emptyMux.switch()).to.equal(
-        StellarBase.xdr.CryptoKeyType.keyTypeMuxedEd25519()
+    it('lets G... accounts pass through (unmuxed)', function() {
+      const unmuxed = StellarBase.decodeAddressToMuxedAccount(PUBKEY, true);
+
+      expect(StellarBase.xdr.MuxedAccount.isValid(unmuxed)).to.be.true;
+      expect(unmuxed.switch()).to.equal(
+        StellarBase.xdr.CryptoKeyType.keyTypeEd25519()
       );
       expect(
-        emptyMux
-          .med25519()
+        unmuxed
           .ed25519()
           .equals(StellarBase.StrKey.decodeEd25519PublicKey(PUBKEY))
       ).to.be.true;
-      expect(emptyMux.med25519().id()).to.eql(ZERO);
-      expect(StellarBase.encodeMuxedAccountToAddress(emptyMux)).to.equal(
-        PUBKEY
-      );
+      expect(StellarBase.encodeMuxedAccountToAddress(unmuxed)).to.equal(PUBKEY);
     });
     it('decodes underlying G... address correctly', function() {
       expect(
@@ -308,9 +304,7 @@ describe('StrKey', function() {
         )
       ).to.equal(PUBKEY);
     });
-  });
 
-  describe('#muxedAccounts', function() {
     const RAW_PUBKEY = StellarBase.StrKey.decodeEd25519PublicKey(PUBKEY);
     const unmuxed = StellarBase.xdr.MuxedAccount.keyTypeEd25519(RAW_PUBKEY);
 


### PR DESCRIPTION
**TL;DR:** Building operations with both muxed and unmuxed properties is broken without this PR.

Currently, if you called

```js
decodeAddressToMuxedAccount("G...", true)
```

you would get a `xdr.MuxedAccount(pubkey=G..., ID=0)` object (where the `G...` is the XDR-encoded public key bytes not the string, to be clear) in return. In other words, we always force G... to be fully-muxed w/ ID=0 if you opt-in to muxing. 

This behavior is broken for two reasons:
 - it isn't faithful to user's expectations, and, more importantly 
 - it doesn't work when you mix muxed and unmuxed parameters in operations.

For example, if you create a payment operation with a muxed destination and an unmuxed source account, it will result in XDR containing a muxed source account with an ID of zero, because you must pass `withMuxing: true`. This isn't faithful to API expectations, since the XDR would be identical in the case where you created a payment with a muxed destination and an *actual* muxed source with id=0 set explicitly.

**This PR stops this behavior,** and makes muxing support more "transparent": if you pass a `G`, you get a `G`; if you pass an `M`, you get an `M`, but only if you opt-in to muxing. 

The new tests: `supports mixing muxed and unmuxed properties` and `lets G... accounts pass through` will fail without the changes in this PR, and the `decodes to an empty muxed account` is no longer expected behavior.