### PR TITLE
Release v5.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fix
-- Update various dependencies to more-secure versions. Most are developer dependencies which means no or minimal downstream effects; the only non-developer dependency upgrade is a patch version bump to `lodash` ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428))..
+- Update various dependencies to more-secure versions. Most are developer dependencies which means no or minimal downstream effects; the only non-developer dependency upgrade is a patch version bump to `lodash` ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428)).
 
 
 ## [v5.3.1](https://github.com/stellar/js-stellar-base/compare/v5.3.0..v5.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fix
-- Update various dependencies to more-secure versions. Most are developer dependencies which means no or minimal downstream effects; the only non-developer dependency upgrade is a patch version bump to `lodash` ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447)).
+- Update various dependencies to more-secure versions. Most are developer dependencies which means no or minimal downstream effects; the only non-developer dependency upgrade is a patch version bump to `lodash` ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428))..
 
 
 ## [v5.3.1](https://github.com/stellar/js-stellar-base/compare/v5.3.0..v5.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fix
-- Update various dependencies to more-secure versions. Most are developer dependencies which means no or minimal downstream effects; the only non-developer dependency upgrade is a patch version bump to `lodash` ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428), [#449](https://github.com/stellar/js-stellar-base/pull/449)).
+- Update various dependencies to secure versions. Most are developer dependencies which means no or minimal downstream effects ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428)); the only non-developer dependency upgrade is a patch version bump to `lodash` ([#449](https://github.com/stellar/js-stellar-base/pull/449)).
 
 
 ## [v5.3.1](https://github.com/stellar/js-stellar-base/compare/v5.3.0..v5.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fix
-- Update various dependencies to more-secure versions. Most are developer dependencies which means no or minimal downstream effects; the only non-developer dependency upgrade is a patch version bump to `lodash` ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428)).
+- Update various dependencies to more-secure versions. Most are developer dependencies which means no or minimal downstream effects; the only non-developer dependency upgrade is a patch version bump to `lodash` ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428), [#449](https://github.com/stellar/js-stellar-base/pull/449)).
 
 
 ## [v5.3.1](https://github.com/stellar/js-stellar-base/compare/v5.3.0..v5.3.1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Low level stellar support library",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
This release involves dependency updates for security purposes. 
It should be low impact, but refer to the PRs linked in the CHANGELOG for details.