### PR TITLE
[v6.0.0] Update XDR to include CAP-38 definitions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,26 @@
 
 ## Unreleased
 
-- The XDR definitions have been updated to support CAP-38 ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
-- The `TrustLineAsset` and `ChangeTrustAsset` objects have been included to interact with both assets and liquidity pools ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
-- Added helper `Operation.revokeLiquidityPoolSponsorship` ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
-- Introduced new CAP-38 operations `LiquidityPoolDepositOp` and `LiquidityPoolWithdrawOp` ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
+## [v6.0.0](https://github.com/stellar/js-stellar-base/compare/v5.3.2..v6.0.0)
+
+### Add
+
+- Introduced new CAP-38 operations `LiquidityPoolDepositOp` and `LiquidityPoolWithdrawOp`.
+- Introduced two new types of assets, `TrustLineAsset` and `ChangeTrustAsset`.
+
+### Update
+
+- The XDR definitions have been updated to support CAP-38.
+- Extended `Operation` class with the `Operation.revokeLiquidityPoolSponsorship` helper that allows revoking a liquidity pool sponsorship.
+- Asset types now include `AssetType.liquidityPoolShares`.
+
+### Breaking
+
+- Must use `TrustLineAsset` instead of `Asset` in the function `Operation.revokeTrustlineSponsorship` and the XDR objects `TrustLineEntry` and `LedgerKeyTrustLine`.
+- Must use `ChangeTrustAsset` instead of `Asset` in the function `Operation.changeTrust` and the XDR object `ChangeTrustOp`.
+- The `AssetAlphaNum4` and `AssetAlphaNum12` objects were renamed to `AlphaNum4` and `AlphaNum12` respectively.
+
+## [v5.3.2](https://github.com/stellar/js-stellar-base/compare/v5.3.1..v5.3.2)
 
 ### Fix
 - Update various dependencies to secure versions. Most are developer dependencies which means no or minimal downstream effects ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428)); the only non-developer dependency upgrade is a patch version bump to `lodash` ([#449](https://github.com/stellar/js-stellar-base/pull/449)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - The XDR definitions have been updated to support CAP-38 ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
 - The `TrustLineAsset` and `ChangeTrustAsset` objects have been included to interact with both assets and liquidity pools ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
 - Added helper `Operation.revokeLiquidityPoolSponsorship` ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
-- Introduced new CAP-38 operation `LiquidityPoolDepositOp` ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
+- Introduced new CAP-38 operations `LiquidityPoolDepositOp` and `LiquidityPoolWithdrawOp` ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
 
 ### Fix
 - Update various dependencies to secure versions. Most are developer dependencies which means no or minimal downstream effects ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428)); the only non-developer dependency upgrade is a patch version bump to `lodash` ([#449](https://github.com/stellar/js-stellar-base/pull/449)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-- The `TrustLineAsset` and `ChangeTrustAsset` objects have been included to interact with both assets and liquidity pools ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
 - The XDR definitions have been updated to support CAP-38 ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
-- Add helper `Operation.revokeLiquidityPoolSponsorship`.
+- The `TrustLineAsset` and `ChangeTrustAsset` objects have been included to interact with both assets and liquidity pools ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
+- Added helper `Operation.revokeLiquidityPoolSponsorship` ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
+- Introduced new CAP-38 operation `LiquidityPoolDepositOp` ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
 
 ### Fix
 - Update various dependencies to secure versions. Most are developer dependencies which means no or minimal downstream effects ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428)); the only non-developer dependency upgrade is a patch version bump to `lodash` ([#449](https://github.com/stellar/js-stellar-base/pull/449)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `TrustLineAsset` and `ChangeTrustAsset` objects have been included to interact with both assets and liquidity pools ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
 - The XDR definitions have been updated to support CAP-38 ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
+- Add helper `Operation.revokeLiquidityPoolSponsorship`.
 
 ### Fix
 - Update various dependencies to secure versions. Most are developer dependencies which means no or minimal downstream effects ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428)); the only non-developer dependency upgrade is a patch version bump to `lodash` ([#449](https://github.com/stellar/js-stellar-base/pull/449)).
@@ -255,6 +256,10 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
   ).addOperation(
     StellarSdk.Operation.revokeClaimableBalanceSponsorship({
       balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
+    })
+  ).addOperation(
+    StellarSdk.Operation.revokeLiquidityPoolSponsorship({
+      liquidityPoolId: "dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7",
     })
   ).addOperation(
     StellarSdk.Operation.revokeSignerSponsorship({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- The `TrustLineAsset` object has been included to handle both Liquidity Pools and regular Assets in the trustline ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
+- The XDR definitions have been updated to support CAP-38 ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
+
 ### Fix
 - Update various dependencies to secure versions. Most are developer dependencies which means no or minimal downstream effects ([#446](https://github.com/stellar/js-stellar-base/pull/446), [#447](https://github.com/stellar/js-stellar-base/pull/447), [#392](https://github.com/stellar/js-stellar-base/pull/392), [#428](https://github.com/stellar/js-stellar-base/pull/428)); the only non-developer dependency upgrade is a patch version bump to `lodash` ([#449](https://github.com/stellar/js-stellar-base/pull/449)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- The `TrustLineAsset` object has been included to handle both Liquidity Pools and regular Assets in the trustline ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
+- The `TrustLineAsset` and `ChangeTrustAsset` objects have been included to interact with both assets and liquidity pools ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
 - The XDR definitions have been updated to support CAP-38 ([#451](https://github.com/stellar/js-stellar-base/pull/451)).
 
 ### Fix

--- a/src/asset.js
+++ b/src/asset.js
@@ -79,10 +79,10 @@ export class Asset {
     let xdrType;
     let xdrTypeString;
     if (this.code.length <= 4) {
-      xdrType = xdr.AssetAlphaNum4;
+      xdrType = xdr.AlphaNum4;
       xdrTypeString = 'assetTypeCreditAlphanum4';
     } else {
-      xdrType = xdr.AssetAlphaNum12;
+      xdrType = xdr.AlphaNum12;
       xdrTypeString = 'assetTypeCreditAlphanum12';
     }
 

--- a/src/change_trust_asset.js
+++ b/src/change_trust_asset.js
@@ -1,0 +1,253 @@
+import clone from 'lodash/clone';
+import padEnd from 'lodash/padEnd';
+import trimEnd from 'lodash/trimEnd';
+import { Asset } from './asset';
+import xdr from './generated/stellar-xdr_generated';
+import { Keypair } from './keypair';
+import { LiquidityPoolFeeV18, liquidityPoolId } from './liquidity_pool_id';
+import { StrKey } from './strkey';
+
+// TODO: ChangeTrustAsset
+// - [ ] ChangeTrustOp -> Asset to ChangeTrustAsset
+
+/**
+ * ChangeTrustAsset class represents a trustline change to either a liquidity
+ * pool or an issued asset with an asset code / issuer account ID pair.
+ *
+ * The change trust asset can either represent a trustline change to the an
+ * issued asset or to a liquidity pool. For an issued asset, the code and issuer
+ * will be valid and liquidityPool parameters will be empty. For liquidity
+ * pools, the liquidityPool parameters will all be valid while the code and
+ * issuer will be empty.
+ *
+ * @constructor
+ * @param {string} code - The asset code.
+ * @param {string} issuer - The account ID of the asset issuer.
+ * @param {LiquidityPoolParams.ConstantProduct} liquidityPoolParams – the
+ * liquidity pool parameters.
+ * @param {Asset} liquidityPoolParams.asseta – the first asset in the Pool, it
+ * must respect the rule assetA < assetB.
+ * @param {Asset} liquidityPoolParams.assetB – the second asset in the Pool, it
+ * must respect the rule assetA < assetB.
+ * @param {number} liquidityPoolParams.fee – the liquidity pool fee. For now the
+ * only fee supported is `30`.
+ */
+export class ChangeTrustAsset {
+  constructor(code, issuer, liquidityPoolParams) {
+    if (!code && !issuer && !liquidityPoolParams) {
+      throw new Error(
+        'Must provide either code, issuer or liquidityPoolParams'
+      );
+    }
+
+    // Validate code & issuer.
+    if ((code || issuer) && !/^[a-zA-Z0-9]{1,12}$/.test(code)) {
+      throw new Error(
+        'Asset code is invalid (maximum alphanumeric, 12 characters at max)'
+      );
+    }
+    if (code && String(code).toLowerCase() !== 'xlm' && !issuer) {
+      throw new Error('Issuer cannot be null');
+    }
+    if (issuer && !StrKey.isValidEd25519PublicKey(issuer)) {
+      throw new Error('Issuer is invalid');
+    }
+
+    // Validate liquidity pool params.
+    if (!code && !issuer) {
+      if (!liquidityPoolParams) {
+        throw new Error('Must provide liquidityPoolParams or code & issuer');
+      }
+      const { asseta, assetB, fee } = liquidityPoolParams;
+      if (!asseta || !(asseta instanceof Asset)) {
+        throw new Error('asseta is invalid');
+      }
+      if (!assetB || !(assetB instanceof Asset)) {
+        throw new Error('assetB is invalid');
+      }
+      if (!fee || fee !== LiquidityPoolFeeV18) {
+        throw new Error('fee is invalid');
+      }
+    }
+
+    this.code = code;
+    this.issuer = issuer;
+    this.liquidityPoolParams = liquidityPoolParams;
+  }
+
+  /**
+   * Returns a trustline asset object for the native asset.
+   * @returns {ChangeTrustAsset}
+   */
+  static native() {
+    return new ChangeTrustAsset('XLM');
+  }
+
+  /**
+   * Returns a change trust asset object from its XDR object representation.
+   * @param {xdr.ChangeTrustAsset} ctAssetXdr - The asset xdr object.
+   * @returns {ChangeTrustAsset}
+   */
+  static fromOperation(ctAssetXdr) {
+    let anum;
+    let code;
+    let issuer;
+    let liquidityPoolParams;
+    switch (ctAssetXdr.switch()) {
+      case xdr.AssetType.assetTypeNative():
+        return this.native();
+      case xdr.AssetType.assetTypeCreditAlphanum4():
+        anum = ctAssetXdr.alphaNum4();
+      /* falls through */
+      case xdr.AssetType.assetTypeCreditAlphanum12():
+        anum = anum || ctAssetXdr.alphaNum12();
+        issuer = StrKey.encodeEd25519PublicKey(anum.issuer().ed25519());
+        code = trimEnd(anum.assetCode(), '\0');
+        return new this(code, issuer);
+      case xdr.AssetType.assetTypePoolShare():
+        // TODO: review if this is correct
+        liquidityPoolParams = ctAssetXdr.liquidityPool().constantProduct();
+        return new this(null, null, {
+          asseta: liquidityPoolParams.asseta(),
+          assetB: liquidityPoolParams.assetB(),
+          fee: liquidityPoolParams.fee()
+        });
+      default:
+        throw new Error(`Invalid asset type: ${ctAssetXdr.switch().name}`);
+    }
+  }
+
+  /**
+   * Returns the xdr object for this asset.
+   * @returns {xdr.ChangeTrustAsset} XDR ChangeTrustAsset object
+   */
+  toXDRObject() {
+    if (this.isNative()) {
+      return xdr.ChangeTrustAsset.assetTypeNative();
+    }
+
+    if (this.isLiquidityPool()) {
+      // TODO: review if this is correct
+      const lpConstantProductParamsXdr = new xdr.LiquidityPoolConstantProductParameters(
+        this.getLiquidityPoolParams()
+      );
+      const lpParamsXdr = new xdr.LiquidityPoolParameters(
+        'liquidityPoolConstantProduct',
+        lpConstantProductParamsXdr
+      );
+      return new xdr.ChangeTrustAsset('assetTypePoolShare', lpParamsXdr);
+    }
+
+    let xdrType;
+    let xdrTypeString;
+    if (this.code.length <= 4) {
+      xdrType = xdr.AlphaNum4;
+      xdrTypeString = 'assetTypeCreditAlphanum4';
+    } else {
+      xdrType = xdr.AlphaNum12;
+      xdrTypeString = 'assetTypeCreditAlphanum12';
+    }
+
+    // pad code with null bytes if necessary
+    const padLength = this.code.length <= 4 ? 4 : 12;
+    const paddedCode = padEnd(this.code, padLength, '\0');
+
+    // eslint-disable-next-line new-cap
+    const assetType = new xdrType({
+      assetCode: paddedCode,
+      issuer: Keypair.fromPublicKey(this.issuer).xdrAccountId()
+    });
+
+    return new xdr.ChangeTrustAsset(xdrTypeString, assetType);
+  }
+
+  /**
+   * @returns {string} Asset code
+   */
+  getCode() {
+    return clone(this.code);
+  }
+
+  /**
+   * @returns {string} Asset issuer
+   */
+  getIssuer() {
+    return clone(this.issuer);
+  }
+
+  /**
+   * @returns {string} Liquidity pool ID
+   */
+  getLiquidityPoolParams() {
+    return clone(this.liquidityPoolParams);
+  }
+
+  /**
+   * @see [Assets concept](https://www.stellar.org/developers/guides/concepts/assets.html)
+   * @returns {string} Asset type. Can be one of following types:
+   *
+   * * `native`
+   * * `credit_alphanum4`
+   * * `credit_alphanum12`
+   * * `liquidity_pool_shares`
+   */
+  getAssetType() {
+    if (this.isNative()) {
+      return 'native';
+    }
+    if (this.isLiquidityPool()) {
+      return 'liquidity_pool_shares';
+    }
+    if (this.code.length >= 1 && this.code.length <= 4) {
+      return 'credit_alphanum4';
+    }
+    if (this.code.length >= 5 && this.code.length <= 12) {
+      return 'credit_alphanum12';
+    }
+
+    return null;
+  }
+
+  /**
+   * @returns {boolean}  true if this trustline asset object is the native asset.
+   */
+  isNative() {
+    return this.code && !this.issuer;
+  }
+
+  /**
+   * @returns {boolean} true if this trustline asset object is a liquidity pool.
+   */
+  isLiquidityPool() {
+    return !!this.liquidityPoolParams;
+  }
+
+  /**
+   * @param {ChangeTrustAsset} asset Asset to compare
+   * @returns {boolean} true if this asset equals the given asset.
+   */
+  equals(asset) {
+    return (
+      this.code === asset.getCode() &&
+      this.issuer === asset.getIssuer() &&
+      this.liquidityPoolParams === asset.getLiquidityPoolParams()
+    );
+  }
+
+  toString() {
+    if (this.isNative()) {
+      return 'native';
+    }
+
+    if (this.isLiquidityPool()) {
+      const poolId = liquidityPoolId(
+        xdr.LiquidityPoolType.liquidityPoolConstantProduct(),
+        this.getLiquidityPoolParams()
+      ).toString('hex');
+      // TODO: review if this is correct
+      return `liquidity_pool:${poolId}`;
+    }
+
+    return `${this.getCode()}:${this.getIssuer()}`;
+  }
+}

--- a/src/change_trust_asset.js
+++ b/src/change_trust_asset.js
@@ -108,8 +108,8 @@ export class ChangeTrustAsset {
         // TODO: review if this is correct
         liquidityPoolParams = ctAssetXdr.liquidityPool().constantProduct();
         return new this(null, null, {
-          asseta: liquidityPoolParams.asseta(),
-          assetB: liquidityPoolParams.assetB(),
+          asseta: Asset.fromOperation(liquidityPoolParams.asseta()),
+          assetB: Asset.fromOperation(liquidityPoolParams.assetB()),
           fee: liquidityPoolParams.fee()
         });
       default:
@@ -128,8 +128,13 @@ export class ChangeTrustAsset {
 
     if (this.isLiquidityPool()) {
       // TODO: review if this is correct
+      const { asseta, assetB, fee } = this.getLiquidityPoolParams();
       const lpConstantProductParamsXdr = new xdr.LiquidityPoolConstantProductParameters(
-        this.getLiquidityPoolParams()
+        {
+          asseta: asseta.toXDRObject(),
+          assetB: assetB.toXDRObject(),
+          fee
+        }
       );
       const lpParamsXdr = new xdr.LiquidityPoolParameters(
         'liquidityPoolConstantProduct',

--- a/src/generated/stellar-xdr_generated.js
+++ b/src/generated/stellar-xdr_generated.js
@@ -1,4 +1,4 @@
-// Automatically generated on 2021-08-11T18:06:04-03:00
+// Automatically generated on 2021-08-12T17:10:08-03:00
 // DO NOT EDIT or your changes may be overwritten
 
 /* jshint maxstatements:2147483647  */
@@ -969,12 +969,14 @@ xdr.union("Claimant", {
 //
 //   enum ClaimableBalanceIDType
 //   {
-//       CLAIMABLE_BALANCE_ID_TYPE_V0 = 0
+//       CLAIMABLE_BALANCE_ID_TYPE_V0 = 0,
+//       CLAIMABLE_BALANCE_ID_TYPE_FROM_POOL_REVOKE = 1
 //   };
 //
 // ===========================================================================
 xdr.enum("ClaimableBalanceIdType", {
   claimableBalanceIdTypeV0: 0,
+  claimableBalanceIdTypeFromPoolRevoke: 1,
 });
 
 // === xdr source ============================================================
@@ -983,6 +985,8 @@ xdr.enum("ClaimableBalanceIdType", {
 //   {
 //   case CLAIMABLE_BALANCE_ID_TYPE_V0:
 //       Hash v0;
+//   case CLAIMABLE_BALANCE_ID_TYPE_FROM_POOL_REVOKE:
+//       Hash fromPoolRevoke;
 //   };
 //
 // ===========================================================================
@@ -991,9 +995,11 @@ xdr.union("ClaimableBalanceId", {
   switchName: "type",
   switches: [
     ["claimableBalanceIdTypeV0", "v0"],
+    ["claimableBalanceIdTypeFromPoolRevoke", "fromPoolRevoke"],
   ],
   arms: {
     v0: xdr.lookup("Hash"),
+    fromPoolRevoke: xdr.lookup("Hash"),
   },
 });
 
@@ -1506,7 +1512,8 @@ xdr.union("LedgerKey", {
 //       ENVELOPE_TYPE_AUTH = 3,
 //       ENVELOPE_TYPE_SCPVALUE = 4,
 //       ENVELOPE_TYPE_TX_FEE_BUMP = 5,
-//       ENVELOPE_TYPE_OP_ID = 6
+//       ENVELOPE_TYPE_OP_ID = 6,
+//       ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7
 //   };
 //
 // ===========================================================================
@@ -1518,6 +1525,7 @@ xdr.enum("EnvelopeType", {
   envelopeTypeScpvalue: 4,
   envelopeTypeTxFeeBump: 5,
   envelopeTypeOpId: 6,
+  envelopeTypePoolRevokeOpId: 7,
 });
 
 // === xdr source ============================================================
@@ -1589,7 +1597,7 @@ xdr.union("StellarValueExt", {
 //       // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
 //       // unknown steps during consensus if needed.
 //       // see notes below on 'LedgerUpgrade' for more detail
-//       // max size is dictated by number of upgrade types (+ room for future)
+//       // max size is dictated by number of upgrade types ( room for future)
 //       UpgradeType upgrades<6>;
 //   
 //       // reserved for future use
@@ -1613,10 +1621,75 @@ xdr.struct("StellarValue", [
 
 // === xdr source ============================================================
 //
+//   const MASK_LEDGERHEADER_FLAGS = 0x7;
+//
+// ===========================================================================
+xdr.const("MASK_LEDGERHEADER_FLAGS", 0x7);
+
+// === xdr source ============================================================
+//
+//   enum LedgerHeaderFlags
+//   { // masks for each flag
+//   
+//       DISABLE_LIQUIDITY_POOL_TRADING_FLAG = 0x1,
+//       DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG = 0x2,
+//       DISABLE_LIQUIDITY_POOL_WITHDRAWAL_FLAG = 0x4
+//   };
+//
+// ===========================================================================
+xdr.enum("LedgerHeaderFlags", {
+  disableLiquidityPoolTradingFlag: 1,
+  disableLiquidityPoolDepositFlag: 2,
+  disableLiquidityPoolWithdrawalFlag: 4,
+});
+
+// === xdr source ============================================================
+//
 //   union switch (int v)
 //       {
 //       case 0:
 //           void;
+//       }
+//
+// ===========================================================================
+xdr.union("LedgerHeaderExtensionV1Ext", {
+  switchOn: xdr.int(),
+  switchName: "v",
+  switches: [
+    [0, xdr.void()],
+  ],
+  arms: {
+  },
+});
+
+// === xdr source ============================================================
+//
+//   struct LedgerHeaderExtensionV1
+//   {
+//       uint32 flags; // UpgradeFlags
+//   
+//       union switch (int v)
+//       {
+//       case 0:
+//           void;
+//       }
+//       ext;
+//   };
+//
+// ===========================================================================
+xdr.struct("LedgerHeaderExtensionV1", [
+  ["flags", xdr.lookup("Uint32")],
+  ["ext", xdr.lookup("LedgerHeaderExtensionV1Ext")],
+]);
+
+// === xdr source ============================================================
+//
+//   union switch (int v)
+//       {
+//       case 0:
+//           void;
+//       case 1:
+//           LedgerHeaderExtensionV1 v1;
 //       }
 //
 // ===========================================================================
@@ -1625,8 +1698,10 @@ xdr.union("LedgerHeaderExt", {
   switchName: "v",
   switches: [
     [0, xdr.void()],
+    [1, "v1"],
   ],
   arms: {
+    v1: xdr.lookup("LedgerHeaderExtensionV1"),
   },
 });
 
@@ -1666,6 +1741,8 @@ xdr.union("LedgerHeaderExt", {
 //       {
 //       case 0:
 //           void;
+//       case 1:
+//           LedgerHeaderExtensionV1 v1;
 //       }
 //       ext;
 //   };
@@ -1696,7 +1773,8 @@ xdr.struct("LedgerHeader", [
 //       LEDGER_UPGRADE_VERSION = 1,
 //       LEDGER_UPGRADE_BASE_FEE = 2,
 //       LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3,
-//       LEDGER_UPGRADE_BASE_RESERVE = 4
+//       LEDGER_UPGRADE_BASE_RESERVE = 4,
+//       LEDGER_UPGRADE_FLAGS = 5
 //   };
 //
 // ===========================================================================
@@ -1705,6 +1783,7 @@ xdr.enum("LedgerUpgradeType", {
   ledgerUpgradeBaseFee: 2,
   ledgerUpgradeMaxTxSetSize: 3,
   ledgerUpgradeBaseReserve: 4,
+  ledgerUpgradeFlags: 5,
 });
 
 // === xdr source ============================================================
@@ -1719,6 +1798,8 @@ xdr.enum("LedgerUpgradeType", {
 //       uint32 newMaxTxSetSize; // update maxTxSetSize
 //   case LEDGER_UPGRADE_BASE_RESERVE:
 //       uint32 newBaseReserve; // update baseReserve
+//   case LEDGER_UPGRADE_FLAGS:
+//       uint32 newFlags; // update flags
 //   };
 //
 // ===========================================================================
@@ -1730,12 +1811,14 @@ xdr.union("LedgerUpgrade", {
     ["ledgerUpgradeBaseFee", "newBaseFee"],
     ["ledgerUpgradeMaxTxSetSize", "newMaxTxSetSize"],
     ["ledgerUpgradeBaseReserve", "newBaseReserve"],
+    ["ledgerUpgradeFlags", "newFlags"],
   ],
   arms: {
     newLedgerVersion: xdr.lookup("Uint32"),
     newBaseFee: xdr.lookup("Uint32"),
     newMaxTxSetSize: xdr.lookup("Uint32"),
     newBaseReserve: xdr.lookup("Uint32"),
+    newFlags: xdr.lookup("Uint32"),
   },
 });
 
@@ -3803,6 +3886,26 @@ xdr.struct("OperationIdId", [
 
 // === xdr source ============================================================
 //
+//   struct
+//       {
+//           AccountID sourceAccount;
+//           SequenceNumber seqNum;
+//           uint32 opNum;
+//           PoolID liquidityPoolID;
+//           Asset asset;
+//       }
+//
+// ===========================================================================
+xdr.struct("OperationIdRevokeId", [
+  ["sourceAccount", xdr.lookup("AccountId")],
+  ["seqNum", xdr.lookup("SequenceNumber")],
+  ["opNum", xdr.lookup("Uint32")],
+  ["liquidityPoolId", xdr.lookup("PoolId")],
+  ["asset", xdr.lookup("Asset")],
+]);
+
+// === xdr source ============================================================
+//
 //   union OperationID switch (EnvelopeType type)
 //   {
 //   case ENVELOPE_TYPE_OP_ID:
@@ -3812,6 +3915,15 @@ xdr.struct("OperationIdId", [
 //           SequenceNumber seqNum;
 //           uint32 opNum;
 //       } id;
+//   case ENVELOPE_TYPE_POOL_REVOKE_OP_ID:
+//       struct
+//       {
+//           AccountID sourceAccount;
+//           SequenceNumber seqNum;
+//           uint32 opNum;
+//           PoolID liquidityPoolID;
+//           Asset asset;
+//       } revokeId;
 //   };
 //
 // ===========================================================================
@@ -3820,9 +3932,11 @@ xdr.union("OperationId", {
   switchName: "type",
   switches: [
     ["envelopeTypeOpId", "id"],
+    ["envelopeTypePoolRevokeOpId", "revokeId"],
   ],
   arms: {
     id: xdr.lookup("OperationIdId"),
+    revokeId: xdr.lookup("OperationIdRevokeId"),
   },
 });
 
@@ -4204,13 +4318,15 @@ xdr.struct("TransactionSignaturePayload", [
 //   enum ClaimAtomType
 //   {
 //       CLAIM_ATOM_TYPE_V0 = 0,
-//       CLAIM_ATOM_TYPE_ORDER_BOOK = 1
+//       CLAIM_ATOM_TYPE_ORDER_BOOK = 1,
+//       CLAIM_ATOM_TYPE_LIQUIDITY_POOL = 2
 //   };
 //
 // ===========================================================================
 xdr.enum("ClaimAtomType", {
   claimAtomTypeV0: 0,
   claimAtomTypeOrderBook: 1,
+  claimAtomTypeLiquidityPool: 2,
 });
 
 // === xdr source ============================================================
@@ -4269,12 +4385,38 @@ xdr.struct("ClaimOfferAtom", [
 
 // === xdr source ============================================================
 //
+//   struct ClaimLiquidityAtom
+//   {
+//       PoolID liquidityPoolID;
+//   
+//       // amount and asset taken from the pool
+//       Asset assetSold;
+//       int64 amountSold;
+//   
+//       // amount and asset sent to the pool
+//       Asset assetBought;
+//       int64 amountBought;
+//   };
+//
+// ===========================================================================
+xdr.struct("ClaimLiquidityAtom", [
+  ["liquidityPoolId", xdr.lookup("PoolId")],
+  ["assetSold", xdr.lookup("Asset")],
+  ["amountSold", xdr.lookup("Int64")],
+  ["assetBought", xdr.lookup("Asset")],
+  ["amountBought", xdr.lookup("Int64")],
+]);
+
+// === xdr source ============================================================
+//
 //   union ClaimAtom switch (ClaimAtomType type)
 //   {
 //   case CLAIM_ATOM_TYPE_V0:
 //       ClaimOfferAtomV0 v0;
 //   case CLAIM_ATOM_TYPE_ORDER_BOOK:
 //       ClaimOfferAtom orderBook;
+//   case CLAIM_ATOM_TYPE_LIQUIDITY_POOL:
+//       ClaimLiquidityAtom liquidityPool;
 //   };
 //
 // ===========================================================================
@@ -4284,10 +4426,12 @@ xdr.union("ClaimAtom", {
   switches: [
     ["claimAtomTypeV0", "v0"],
     ["claimAtomTypeOrderBook", "orderBook"],
+    ["claimAtomTypeLiquidityPool", "liquidityPool"],
   ],
   arms: {
     v0: xdr.lookup("ClaimOfferAtomV0"),
     orderBook: xdr.lookup("ClaimOfferAtom"),
+    liquidityPool: xdr.lookup("ClaimLiquidityAtom"),
   },
 });
 
@@ -4917,7 +5061,9 @@ xdr.union("ChangeTrustResult", {
 //                                       // source account does not require trust
 //       ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
 //       ALLOW_TRUST_CANT_REVOKE = -4,     // source account can't revoke trust,
-//       ALLOW_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
+//       ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
+//       ALLOW_TRUST_LOW_RESERVE = -6 // claimable balances can't be created
+//                                    // on revoke due to low reserves 
 //   };
 //
 // ===========================================================================
@@ -4928,6 +5074,7 @@ xdr.enum("AllowTrustResultCode", {
   allowTrustTrustNotRequired: -3,
   allowTrustCantRevoke: -4,
   allowTrustSelfNotAllowed: -5,
+  allowTrustLowReserve: -6,
 });
 
 // === xdr source ============================================================
@@ -5463,7 +5610,9 @@ xdr.union("ClawbackClaimableBalanceResult", {
 //       SET_TRUST_LINE_FLAGS_MALFORMED = -1,
 //       SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
 //       SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
-//       SET_TRUST_LINE_FLAGS_INVALID_STATE = -4
+//       SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
+//       SET_TRUST_LINE_FLAGS_LOW_RESERVE = -5 // claimable balances can't be created
+//                                             // on revoke due to low reserves
 //   };
 //
 // ===========================================================================
@@ -5473,6 +5622,7 @@ xdr.enum("SetTrustLineFlagsResultCode", {
   setTrustLineFlagsNoTrustLine: -2,
   setTrustLineFlagsCantRevoke: -3,
   setTrustLineFlagsInvalidState: -4,
+  setTrustLineFlagsLowReserve: -5,
 });
 
 // === xdr source ============================================================

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ export { xdr };
 export { hash } from './hashing';
 export { sign, verify, FastSigning } from './signing';
 export {
-  liquidityPoolId,
+  getLiquidityPoolId,
   LiquidityPoolFeeV18,
   validateLexicographicalAssetsOrder
 } from './liquidity_pool_id';

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export {
   BASE_FEE
 } from './transaction_builder';
 export { Asset } from './asset';
+export { TrustLineAsset } from './trustline_asset';
 export {
   Operation,
   AuthRequiredFlag,

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ export {
   BASE_FEE
 } from './transaction_builder';
 export { Asset } from './asset';
+export { ChangeTrustAsset } from './change_trust_asset';
 export { TrustLineAsset } from './trustline_asset';
 export {
   Operation,

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,11 @@ import xdr from './generated/stellar-xdr_generated';
 export { xdr };
 export { hash } from './hashing';
 export { sign, verify, FastSigning } from './signing';
+export {
+  liquidityPoolId,
+  LiquidityPoolFeeV18,
+  validateLexicographicalAssetsOrder
+} from './liquidity_pool_id';
 export { Keypair } from './keypair';
 export { UnsignedHyper, Hyper } from 'js-xdr';
 export { TransactionBase } from './transaction_base';

--- a/src/liquidity_pool_id.js
+++ b/src/liquidity_pool_id.js
@@ -20,10 +20,8 @@ import { hash } from './hashing';
  * @return {Buffer} the Pool ID buffer. It can be stringfied with
  * `toString('hex')`.
  */
-export function liquidityPoolId(liquidityPoolType, liquidityPoolParams) {
-  if (
-    liquidityPoolType !== xdr.LiquidityPoolType.liquidityPoolConstantProduct()
-  ) {
+export function getLiquidityPoolId(liquidityPoolType, liquidityPoolParams) {
+  if (liquidityPoolType !== 'constant_product') {
     throw new Error('liquidityPoolType is invalid');
   }
 

--- a/src/liquidity_pool_id.js
+++ b/src/liquidity_pool_id.js
@@ -21,10 +21,6 @@ import { hash } from './hashing';
  * `toString('hex')`.
  */
 export function liquidityPoolId(liquidityPoolType, liquidityPoolParams) {
-  if (!liquidityPoolType) {
-    liquidityPoolType = 0;
-  }
-
   if (
     liquidityPoolType !== xdr.LiquidityPoolType.liquidityPoolConstantProduct()
   ) {
@@ -34,7 +30,6 @@ export function liquidityPoolId(liquidityPoolType, liquidityPoolParams) {
   if (!liquidityPoolParams) {
     throw new Error('liquidityPoolParams cannot be empty');
   }
-
   const { asseta, assetB, fee } = liquidityPoolParams;
   if (!asseta || !(asseta instanceof Asset)) {
     throw new Error('asseta is invalid');

--- a/src/liquidity_pool_id.js
+++ b/src/liquidity_pool_id.js
@@ -1,0 +1,121 @@
+import xdr from './generated/stellar-xdr_generated';
+import { Asset } from './asset';
+import { hash } from './hashing';
+
+/**
+ * Compute the Pool ID for a given set of assets, fee and pool type.
+ * @see [stellar-core getPoolID](https://github.com/stellar/stellar-core/blob/9f3a48c6a8f1aa77b6043a055d0638661f718080/src/ledger/test/LedgerTxnTests.cpp#L3746-L3751)
+ *
+ * @export
+ * @param {LiquidityPoolType} liquidityPoolType – a number representing the
+ * liquidity pool type. It defaults to `0` for constant product type.
+ * @param {LiquidityPoolParams.ConstantProduct} liquidityPoolParams – the
+ * liquidity pool parameters.
+ * @param {Asset} liquidityPoolParams.asseta – the first asset in the Pool, it
+ * must respect the rule assetA < assetB.
+ * @param {Asset} liquidityPoolParams.assetB – the second asset in the Pool, it
+ * must respect the rule assetA < assetB.
+ * @param {number} liquidityPoolParams.fee – the liquidity pool fee. For now the
+ * only fee supported is `30`.
+ * @return {Buffer} the Pool ID buffer. It can be stringfied with `toString('hex')`.
+ */
+
+export function liquidityPoolId(liquidityPoolType, liquidityPoolParams) {
+  if (!liquidityPoolType) {
+    liquidityPoolType = 0;
+  }
+
+  if (
+    liquidityPoolType !== xdr.LiquidityPoolType.liquidityPoolConstantProduct()
+  ) {
+    throw new Error('liquidityPoolType is invalid');
+  }
+
+  if (!liquidityPoolParams) {
+    throw new Error('liquidityPoolParams cannot be empty');
+  }
+
+  const { asseta, assetB, fee } = liquidityPoolParams;
+  if (!asseta || !(asseta instanceof Asset)) {
+    throw new Error('asseta is invalid');
+  }
+  if (!assetB || !(assetB instanceof Asset)) {
+    throw new Error('assetB is invalid');
+  }
+  if (!fee || fee != LiquidityPoolFeeV18) {
+    throw new Error('fee is invalid');
+  }
+
+  if (!validateLexicographicalAssetsOrder(asseta, assetB)) {
+    throw new Error('assets are not in lexicografichal order');
+  }
+
+  const lpTypeData = xdr.LiquidityPoolType.liquidityPoolConstantProduct().toXDR();
+  const lpParamsData = new xdr.LiquidityPoolConstantProductParameters({
+    asseta: asseta.toXDRObject(),
+    assetB: assetB.toXDRObject(),
+    fee
+  }).toXDR();
+  const payload = Buffer.concat([lpTypeData, lpParamsData]);
+  const poolId = hash(payload);
+
+  return poolId;
+}
+
+/**
+ * Validates if assetA < assetB:
+ * 1. First compare the type (eg. native before alphanum4 before alphanum12).
+ * 2. If the types are equal, compare the assets codes.
+ * 3. If the asset codes are equal, compare the issuers.
+ *
+ * @param {Asset} assetA
+ * @param {Asset} assetB
+ * @return {boolean} true if assetA < assetB.
+ */
+export function validateLexicographicalAssetsOrder(assetA, assetB) {
+  if (!assetA || !(assetA instanceof Asset)) {
+    throw new Error('assetA is invalid');
+  }
+  if (!assetB || !(assetB instanceof Asset)) {
+    throw new Error('assetB is invalid');
+  }
+
+  if (assetA === assetB) {
+    return false;
+  }
+
+  // Compare asset types.
+  switch (assetA.getAssetType()) {
+    case 'native':
+      return true;
+    case 'credit_alphanum4':
+      if (assetB.getAssetType() === 'native') {
+        return false;
+      }
+      if (assetB.getAssetType() === 'credit_alphanum12') {
+        return true;
+      }
+      break;
+    case 'credit_alphanum12':
+      if (assetB.getAssetType() !== 'credit_alphanum12') {
+        return false;
+      }
+    default:
+      throw new Error('Unexpected asset type');
+  }
+
+  // Compare asset codes.
+  switch (assetA.getCode().localeCompare(assetB.getCode())) {
+    case -1: // assetA < assetB
+      return true;
+    case 1: // assetA > assetB
+      return false;
+    default:
+      break;
+  }
+
+  // Compare asset issuers.
+  return assetA.getIssuer().localeCompare(assetB.getIssuer()) < 0;
+}
+
+export const LiquidityPoolFeeV18 = 30;

--- a/src/liquidity_pool_id.js
+++ b/src/liquidity_pool_id.js
@@ -17,9 +17,9 @@ import { hash } from './hashing';
  * must respect the rule assetA < assetB.
  * @param {number} liquidityPoolParams.fee – the liquidity pool fee. For now the
  * only fee supported is `30`.
- * @return {Buffer} the Pool ID buffer. It can be stringfied with `toString('hex')`.
+ * @return {Buffer} the Pool ID buffer. It can be stringfied with
+ * `toString('hex')`.
  */
-
 export function liquidityPoolId(liquidityPoolType, liquidityPoolParams) {
   if (!liquidityPoolType) {
     liquidityPoolType = 0;
@@ -42,7 +42,7 @@ export function liquidityPoolId(liquidityPoolType, liquidityPoolParams) {
   if (!assetB || !(assetB instanceof Asset)) {
     throw new Error('assetB is invalid');
   }
-  if (!fee || fee != LiquidityPoolFeeV18) {
+  if (!fee || fee !== LiquidityPoolFeeV18) {
     throw new Error('fee is invalid');
   }
 
@@ -68,8 +68,8 @@ export function liquidityPoolId(liquidityPoolType, liquidityPoolParams) {
  * 2. If the types are equal, compare the assets codes.
  * 3. If the asset codes are equal, compare the issuers.
  *
- * @param {Asset} assetA
- * @param {Asset} assetB
+ * @param {Asset} assetA - the first asset in the lexicographical order.
+ * @param {Asset} assetB - the second asset in the lexicographical order.
  * @return {boolean} true if assetA < assetB.
  */
 export function validateLexicographicalAssetsOrder(assetA, assetB) {
@@ -100,6 +100,7 @@ export function validateLexicographicalAssetsOrder(assetA, assetB) {
       if (assetB.getAssetType() !== 'credit_alphanum12') {
         return false;
       }
+      break;
     default:
       throw new Error('Unexpected asset type');
   }

--- a/src/operation.js
+++ b/src/operation.js
@@ -90,6 +90,8 @@ export const AuthClawbackEnabledFlag = 1 << 3;
  * * `{@link Operation.clawback}`
  * * `{@link Operation.clawbackClaimableBalance}`
  * * `{@link Operation.setTrustLineFlags}`
+ * * `{@link Operation.liquidityPoolDepositOp}`
+ * * `{@link Operation.liquidityPoolWithdrawOp}`
  *
  * @class Operation
  */
@@ -373,6 +375,16 @@ export class Operation {
 
         break;
       }
+      case 'liquidityPoolDeposit': {
+        result.type = 'liquidityPoolDeposit';
+        result.liquidityPoolId = attrs.liquidityPoolId().toString('hex');
+        result.maxAmounta = this._fromXDRAmount(attrs.maxAmounta());
+        result.maxAmountB = this._fromXDRAmount(attrs.maxAmountB());
+        result.minPrice = this._fromXDRPrice(attrs.minPrice());
+        result.maxPrice = this._fromXDRPrice(attrs.maxPrice());
+        break;
+      }
+      // TODO: liquidityPoolWithdrawOp
       default: {
         throw new Error(`Unknown operation: ${operationName}`);
       }
@@ -636,3 +648,5 @@ Operation.revokeLiquidityPoolSponsorship = ops.revokeLiquidityPoolSponsorship;
 Operation.revokeSignerSponsorship = ops.revokeSignerSponsorship;
 Operation.clawback = ops.clawback;
 Operation.setTrustLineFlags = ops.setTrustLineFlags;
+Operation.liquidityPoolDeposit = ops.liquidityPoolDeposit;
+// Operation.liquidityPoolWithdrawOp = ops.liquidityPoolWithdrawOp;

--- a/src/operation.js
+++ b/src/operation.js
@@ -11,6 +11,7 @@ import { best_r } from './util/continued_fraction';
 import { Asset } from './asset';
 import { Claimant } from './claimant';
 import { StrKey } from './strkey';
+import { TrustLineAsset } from './trustline_asset';
 import xdr from './generated/stellar-xdr_generated';
 import * as ops from './operations/index';
 import {
@@ -517,7 +518,9 @@ function extractRevokeSponshipDetails(attrs, result) {
           result.account = accountIdtoAddress(
             ledgerKey.trustLine().accountId()
           );
-          result.asset = Asset.fromOperation(ledgerKey.trustLine().asset());
+          result.asset = TrustLineAsset.fromOperation(
+            ledgerKey.trustLine().asset()
+          );
           break;
         }
         case xdr.LedgerEntryType.offer().name: {

--- a/src/operation.js
+++ b/src/operation.js
@@ -9,6 +9,7 @@ import isNumber from 'lodash/isNumber';
 import isFinite from 'lodash/isFinite';
 import { best_r } from './util/continued_fraction';
 import { Asset } from './asset';
+import { ChangeTrustAsset } from './change_trust_asset';
 import { Claimant } from './claimant';
 import { StrKey } from './strkey';
 import { TrustLineAsset } from './trustline_asset';
@@ -188,7 +189,7 @@ export class Operation {
       }
       case 'changeTrust': {
         result.type = 'changeTrust';
-        result.line = Asset.fromOperation(attrs.line());
+        result.line = ChangeTrustAsset.fromOperation(attrs.line());
         result.limit = this._fromXDRAmount(attrs.limit());
         break;
       }

--- a/src/operation.js
+++ b/src/operation.js
@@ -90,8 +90,8 @@ export const AuthClawbackEnabledFlag = 1 << 3;
  * * `{@link Operation.clawback}`
  * * `{@link Operation.clawbackClaimableBalance}`
  * * `{@link Operation.setTrustLineFlags}`
- * * `{@link Operation.liquidityPoolDepositOp}`
- * * `{@link Operation.liquidityPoolWithdrawOp}`
+ * * `{@link Operation.liquidityPoolDeposit}`
+ * * `{@link Operation.liquidityPoolWithdraw}`
  *
  * @class Operation
  */
@@ -384,7 +384,14 @@ export class Operation {
         result.maxPrice = this._fromXDRPrice(attrs.maxPrice());
         break;
       }
-      // TODO: liquidityPoolWithdrawOp
+      case 'liquidityPoolWithdraw': {
+        result.type = 'liquidityPoolWithdraw';
+        result.liquidityPoolId = attrs.liquidityPoolId().toString('hex');
+        result.amount = this._fromXDRAmount(attrs.amount());
+        result.minAmounta = this._fromXDRAmount(attrs.minAmounta());
+        result.minAmountB = this._fromXDRAmount(attrs.minAmountB());
+        break;
+      }
       default: {
         throw new Error(`Unknown operation: ${operationName}`);
       }
@@ -649,4 +656,4 @@ Operation.revokeSignerSponsorship = ops.revokeSignerSponsorship;
 Operation.clawback = ops.clawback;
 Operation.setTrustLineFlags = ops.setTrustLineFlags;
 Operation.liquidityPoolDeposit = ops.liquidityPoolDeposit;
-// Operation.liquidityPoolWithdrawOp = ops.liquidityPoolWithdrawOp;
+Operation.liquidityPoolWithdraw = ops.liquidityPoolWithdraw;

--- a/src/operation.js
+++ b/src/operation.js
@@ -85,6 +85,7 @@ export const AuthClawbackEnabledFlag = 1 << 3;
  * * `{@link Operation.revokeOfferSponsorship}`
  * * `{@link Operation.revokeDataSponsorship}`
  * * `{@link Operation.revokeClaimableBalanceSponsorship}`
+ * * `{@link Operation.revokeLiquidityPoolSponsorship}`
  * * `{@link Operation.revokeSignerSponsorship}`
  * * `{@link Operation.clawback}`
  * * `{@link Operation.clawbackClaimableBalance}`
@@ -550,6 +551,14 @@ function extractRevokeSponshipDetails(attrs, result) {
             .toXDR('hex');
           break;
         }
+        case xdr.LedgerEntryType.liquidityPool().name: {
+          result.type = 'revokeLiquidityPoolSponsorship';
+          result.liquidityPoolId = ledgerKey
+            .liquidityPool()
+            .liquidityPoolId()
+            .toString('hex');
+          break;
+        }
         default: {
           throw new Error(`Unknown ledgerKey: ${attrs.switch().name}`);
         }
@@ -623,6 +632,7 @@ Operation.revokeOfferSponsorship = ops.revokeOfferSponsorship;
 Operation.revokeDataSponsorship = ops.revokeDataSponsorship;
 Operation.revokeClaimableBalanceSponsorship =
   ops.revokeClaimableBalanceSponsorship;
+Operation.revokeLiquidityPoolSponsorship = ops.revokeLiquidityPoolSponsorship;
 Operation.revokeSignerSponsorship = ops.revokeSignerSponsorship;
 Operation.clawback = ops.clawback;
 Operation.setTrustLineFlags = ops.setTrustLineFlags;

--- a/src/operations/change_trust.js
+++ b/src/operations/change_trust.js
@@ -8,11 +8,11 @@ const MAX_INT64 = '9223372036854775807';
 /**
  * Returns an XDR ChangeTrustOp. A "change trust" operation adds, removes, or updates a
  * trust line for a given asset from the source account to another. The issuer being
- * trusted and the asset code are in the given Asset object.
+ * trusted and the asset code are in the given ChangeTrustAsset object.
  * @function
  * @alias Operation.changeTrust
  * @param {object} opts Options object
- * @param {Asset} opts.asset - The asset for the trust line.
+ * @param {ChangeTrustAsset} opts.asset - The change trust asset for the trust line.
  * @param {string} [opts.limit] - The limit for the asset, defaults to max int64.
  *                                If the limit is set to "0" it deletes the trustline.
  * @param {string} [opts.source] - The source account (defaults to transaction source).

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -28,3 +28,12 @@ export {
 } from './revoke_sponsorship';
 export { clawback } from './clawback';
 export { setTrustLineFlags } from './set_trustline_flags';
+export { liquidityPoolDeposit } from './liquidity_pool_deposit';
+// TODO: add LIQUIDITY_POOL_WITHDRAW
+// struct LiquidityPoolWithdrawOp
+// {
+//     PoolID liquidityPoolID;
+//     int64 amount;         // amount of pool shares to withdraw
+//     int64 minAmountA;     // minimum amount of first asset to withdraw
+//     int64 minAmountB;     // minimum amount of second asset to withdraw
+// };

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -23,6 +23,7 @@ export {
   revokeOfferSponsorship,
   revokeDataSponsorship,
   revokeClaimableBalanceSponsorship,
+  revokeLiquidityPoolSponsorship,
   revokeSignerSponsorship
 } from './revoke_sponsorship';
 export { clawback } from './clawback';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -29,11 +29,4 @@ export {
 export { clawback } from './clawback';
 export { setTrustLineFlags } from './set_trustline_flags';
 export { liquidityPoolDeposit } from './liquidity_pool_deposit';
-// TODO: add LIQUIDITY_POOL_WITHDRAW
-// struct LiquidityPoolWithdrawOp
-// {
-//     PoolID liquidityPoolID;
-//     int64 amount;         // amount of pool shares to withdraw
-//     int64 minAmountA;     // minimum amount of first asset to withdraw
-//     int64 minAmountB;     // minimum amount of second asset to withdraw
-// };
+export { liquidityPoolWithdraw } from './liquidity_pool_withdraw';

--- a/src/operations/liquidity_pool_deposit.js
+++ b/src/operations/liquidity_pool_deposit.js
@@ -2,7 +2,7 @@ import isUndefined from 'lodash/isUndefined';
 import xdr from '../generated/stellar-xdr_generated';
 
 /**
- * Create a liquidity pool deposit operation.
+ * Creates a liquidity pool deposit operation.
  *
  * @function
  * @alias Operation.liquidityPoolDeposit
@@ -10,24 +10,19 @@ import xdr from '../generated/stellar-xdr_generated';
  *
  * @param {object} opts - Options object
  * @param {string} opts.liquidityPoolId - The liquidity pool ID.
- * @param {string} opts.maxAmounta      - Maximum amount of first asset to deposit.
- * @param {string} opts.maxAmountB      - Maximum amount of second asset to deposit.
+ * @param {string} opts.maxAmounta - Maximum amount of first asset to deposit.
+ * @param {string} opts.maxAmountB - Maximum amount of second asset to deposit.
  * @param {number|string|BigNumber|Object} opts.minPrice -  Minimum depositA/depositB price.
  * @param {number} opts.minPrice.n - If `opts.minPrice` is an object: the price numerator
  * @param {number} opts.minPrice.d - If `opts.minPrice` is an object: the price denominator
  * @param {number|string|BigNumber|Object} opts.maxPrice -  Maximum depositA/depositB price.
  * @param {number} opts.maxPrice.n - If `opts.maxPrice` is an object: the price numerator
  * @param {number} opts.maxPrice.d - If `opts.maxPrice` is an object: the price denominator
- * @param {string} [opts.source]        - The source account for the operation.
- *     Defaults to the transaction's source account.
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
  *
- * @returns {xdr.Operation}   The resulting operation (xdr.LiquidityPoolDepositOp).
+ * @returns {xdr.Operation} The resulting operation (xdr.LiquidityPoolDepositOp).
  */
-export function liquidityPoolDeposit(opts) {
-  if (!opts) {
-    throw new TypeError('opts cannot be empty');
-  }
-
+export function liquidityPoolDeposit(opts = {}) {
   const attributes = {};
   if (!opts.liquidityPoolId) {
     throw new TypeError('liquidityPoolId argument is required');

--- a/src/operations/liquidity_pool_deposit.js
+++ b/src/operations/liquidity_pool_deposit.js
@@ -1,0 +1,64 @@
+import isUndefined from 'lodash/isUndefined';
+import xdr from '../generated/stellar-xdr_generated';
+
+/**
+ * Create a liquidity pool deposit operation.
+ *
+ * @function
+ * @alias Operation.liquidityPoolDeposit
+ * @see https://developers.stellar.org/docs/start/list-of-operations/#liquidity-pool-deposit
+ *
+ * @param {object} opts - Options object
+ * @param {string} opts.liquidityPoolId - The liquidity pool ID.
+ * @param {string} opts.maxAmounta      - Maximum amount of first asset to deposit.
+ * @param {string} opts.maxAmountB      - Maximum amount of second asset to deposit.
+ * @param {number|string|BigNumber|Object} opts.minPrice -  Minimum depositA/depositB price.
+ * @param {number} opts.minPrice.n - If `opts.minPrice` is an object: the price numerator
+ * @param {number} opts.minPrice.d - If `opts.minPrice` is an object: the price denominator
+ * @param {number|string|BigNumber|Object} opts.maxPrice -  Maximum depositA/depositB price.
+ * @param {number} opts.maxPrice.n - If `opts.maxPrice` is an object: the price numerator
+ * @param {number} opts.maxPrice.d - If `opts.maxPrice` is an object: the price denominator
+ * @param {string} [opts.source]        - The source account for the operation.
+ *     Defaults to the transaction's source account.
+ *
+ * @returns {xdr.Operation}   The resulting operation (xdr.LiquidityPoolDepositOp).
+ */
+export function liquidityPoolDeposit(opts) {
+  if (!opts) {
+    throw new TypeError('opts cannot be empty');
+  }
+
+  const attributes = {};
+  if (!opts.liquidityPoolId) {
+    throw new TypeError('liquidityPoolId argument is required');
+  }
+  attributes.liquidityPoolId = xdr.PoolId.fromXDR(opts.liquidityPoolId, 'hex');
+
+  if (isUndefined(opts.maxAmounta)) {
+    throw new TypeError('maxAmounta argument is required');
+  }
+  attributes.maxAmounta = this._toXDRAmount(opts.maxAmounta);
+
+  if (isUndefined(opts.maxAmountB)) {
+    throw new TypeError('maxAmountB argument is required');
+  }
+  attributes.maxAmountB = this._toXDRAmount(opts.maxAmountB);
+
+  if (isUndefined(opts.minPrice)) {
+    throw new TypeError('minPrice argument is required');
+  }
+  attributes.minPrice = this._toXDRPrice(opts.minPrice);
+
+  if (isUndefined(opts.maxPrice)) {
+    throw new TypeError('maxPrice argument is required');
+  }
+  attributes.maxPrice = this._toXDRPrice(opts.maxPrice);
+
+  const liquidityPoolDepositOp = new xdr.LiquidityPoolDepositOp(attributes);
+  const opAttributes = {
+    body: xdr.OperationBody.liquidityPoolDeposit(liquidityPoolDepositOp)
+  };
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/liquidity_pool_withdraw.js
+++ b/src/operations/liquidity_pool_withdraw.js
@@ -1,0 +1,54 @@
+import isUndefined from 'lodash/isUndefined';
+import xdr from '../generated/stellar-xdr_generated';
+
+/**
+ * Create a liquidity pool withdraw operation.
+ *
+ * @function
+ * @alias Operation.liquidityPoolWithdraw
+ * @see https://developers.stellar.org/docs/start/list-of-operations/#liquidity-pool-withdraw
+ *
+ * @param {object} opts - Options object
+ * @param {string} opts.liquidityPoolId - The liquidity pool ID.
+ * @param {string} opts.amount          - Amount of pool shares to withdraw.
+ * @param {string} opts.minAmounta      - Minimum amount of first asset to withdraw.
+ * @param {string} opts.minAmountB      - Minimum amount of second asset to withdraw.
+ * @param {string} [opts.source]        - The source account for the operation.
+ *     Defaults to the transaction's source account.
+ *
+ * @returns {xdr.Operation}   The resulting operation (xdr.LiquidityPoolWithdrawOp).
+ */
+export function liquidityPoolWithdraw(opts) {
+  if (!opts) {
+    throw new TypeError('opts cannot be empty');
+  }
+
+  const attributes = {};
+  if (!opts.liquidityPoolId) {
+    throw new TypeError('liquidityPoolId argument is required');
+  }
+  attributes.liquidityPoolId = xdr.PoolId.fromXDR(opts.liquidityPoolId, 'hex');
+
+  if (isUndefined(opts.amount)) {
+    throw new TypeError('amount argument is required');
+  }
+  attributes.amount = this._toXDRAmount(opts.amount);
+
+  if (isUndefined(opts.minAmounta)) {
+    throw new TypeError('minAmounta argument is required');
+  }
+  attributes.minAmounta = this._toXDRAmount(opts.minAmounta);
+
+  if (isUndefined(opts.minAmountB)) {
+    throw new TypeError('minAmountB argument is required');
+  }
+  attributes.minAmountB = this._toXDRAmount(opts.minAmountB);
+
+  const liquidityPoolWithdrawOp = new xdr.LiquidityPoolWithdrawOp(attributes);
+  const opAttributes = {
+    body: xdr.OperationBody.liquidityPoolWithdraw(liquidityPoolWithdrawOp)
+  };
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}

--- a/src/operations/liquidity_pool_withdraw.js
+++ b/src/operations/liquidity_pool_withdraw.js
@@ -2,7 +2,7 @@ import isUndefined from 'lodash/isUndefined';
 import xdr from '../generated/stellar-xdr_generated';
 
 /**
- * Create a liquidity pool withdraw operation.
+ * Creates a liquidity pool withdraw operation.
  *
  * @function
  * @alias Operation.liquidityPoolWithdraw
@@ -10,19 +10,14 @@ import xdr from '../generated/stellar-xdr_generated';
  *
  * @param {object} opts - Options object
  * @param {string} opts.liquidityPoolId - The liquidity pool ID.
- * @param {string} opts.amount          - Amount of pool shares to withdraw.
- * @param {string} opts.minAmounta      - Minimum amount of first asset to withdraw.
- * @param {string} opts.minAmountB      - Minimum amount of second asset to withdraw.
- * @param {string} [opts.source]        - The source account for the operation.
- *     Defaults to the transaction's source account.
+ * @param {string} opts.amount - Amount of pool shares to withdraw.
+ * @param {string} opts.minAmounta - Minimum amount of first asset to withdraw.
+ * @param {string} opts.minAmountB - Minimum amount of second asset to withdraw.
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
  *
  * @returns {xdr.Operation}   The resulting operation (xdr.LiquidityPoolWithdrawOp).
  */
-export function liquidityPoolWithdraw(opts) {
-  if (!opts) {
-    throw new TypeError('opts cannot be empty');
-  }
-
+export function liquidityPoolWithdraw(opts = {}) {
   const attributes = {};
   if (!opts.liquidityPoolId) {
     throw new TypeError('liquidityPoolId argument is required');

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -45,14 +45,14 @@ export function revokeAccountSponsorship(opts = {}) {
  * @alias Operation.revokeTrustlineSponsorship
  * @param {object} opts Options object
  * @param {string} opts.account - The account ID which owns the trustline.
- * @param {TrustLineAsset} opts.asset - The asset in the trustline.
+ * @param {TrustLineAsset} opts.asset - The trustline asset.
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
  * @returns {xdr.Operation} xdr operation
  *
  * @example
  * const op = Operation.revokeTrustlineSponsorship({
  *   account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7
- *   asset: new StellarBase.Asset(
+ *   asset: new StellarBase.TrustLineAsset(
  *     'USDUSD',
  *     'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
  *   )
@@ -196,14 +196,14 @@ export function revokeClaimableBalanceSponsorship(opts = {}) {
 }
 
 /**
- * Create a "revoke sponsorship" operation for a claimable balance.
+ * Creates a "revoke sponsorship" operation for a liquidity pool.
  *
  * @function
  * @alias Operation.revokeLiquidityPoolSponsorship
- * @param {object} opts Options object
+ * @param {object} opts – Options object.
  * @param {string} opts.liquidityPoolId - The sponsored liquidity pool ID in 'hex' string.
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
- * @returns {xdr.Operation} xdr operation
+ * @returns {xdr.Operation} xdr Operation.
  *
  * @example
  * const op = Operation.revokeLiquidityPoolSponsorship({
@@ -223,8 +223,9 @@ export function revokeLiquidityPoolSponsorship(opts = {}) {
   );
 
   const op = xdr.RevokeSponsorshipOp.revokeSponsorshipLedgerEntry(ledgerKey);
-  const opAttributes = {};
-  opAttributes.body = xdr.OperationBody.revokeSponsorship(op);
+  const opAttributes = {
+    body: xdr.OperationBody.revokeSponsorship(op)
+  };
   this.setSourceAccount(opAttributes, opts);
 
   return new xdr.Operation(opAttributes);

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -196,6 +196,41 @@ export function revokeClaimableBalanceSponsorship(opts = {}) {
 }
 
 /**
+ * Create a "revoke sponsorship" operation for a claimable balance.
+ *
+ * @function
+ * @alias Operation.revokeLiquidityPoolSponsorship
+ * @param {object} opts Options object
+ * @param {string} opts.liquidityPoolId - The sponsored liquidity pool ID in 'hex' string.
+ * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
+ * @returns {xdr.Operation} xdr operation
+ *
+ * @example
+ * const op = Operation.revokeLiquidityPoolSponsorship({
+ *   liquidityPoolId: 'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7',
+ * });
+ *
+ */
+export function revokeLiquidityPoolSponsorship(opts = {}) {
+  if (!isString(opts.liquidityPoolId)) {
+    throw new Error('liquidityPoolId is invalid');
+  }
+
+  const ledgerKey = xdr.LedgerKey.liquidityPool(
+    new xdr.LedgerKeyLiquidityPool({
+      liquidityPoolId: xdr.PoolId.fromXDR(opts.liquidityPoolId, 'hex')
+    })
+  );
+
+  const op = xdr.RevokeSponsorshipOp.revokeSponsorshipLedgerEntry(ledgerKey);
+  const opAttributes = {};
+  opAttributes.body = xdr.OperationBody.revokeSponsorship(op);
+  this.setSourceAccount(opAttributes, opts);
+
+  return new xdr.Operation(opAttributes);
+}
+
+/**
  * Create a "revoke sponsorship" operation for a signer.
  *
  * @function

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -2,7 +2,7 @@ import isString from 'lodash/isString';
 import xdr from '../generated/stellar-xdr_generated';
 import { StrKey } from '../strkey';
 import { Keypair } from '../keypair';
-import { Asset } from '../asset';
+import { TrustLineAsset } from '../trustline_asset';
 
 /**
  * Create a "revoke sponsorship" operation for an account.
@@ -45,7 +45,7 @@ export function revokeAccountSponsorship(opts = {}) {
  * @alias Operation.revokeTrustlineSponsorship
  * @param {object} opts Options object
  * @param {string} opts.account - The account ID which owns the trustline.
- * @param {Asset} opts.asset - The asset in the trustline.
+ * @param {TrustLineAsset} opts.asset - The asset in the trustline.
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
  * @returns {xdr.Operation} xdr operation
  *
@@ -63,7 +63,7 @@ export function revokeTrustlineSponsorship(opts = {}) {
   if (!StrKey.isValidEd25519PublicKey(opts.account)) {
     throw new Error('account is invalid');
   }
-  if (!(opts.asset instanceof Asset)) {
+  if (!(opts.asset instanceof TrustLineAsset)) {
     throw new Error('asset is invalid');
   }
 

--- a/src/trustline_asset.js
+++ b/src/trustline_asset.js
@@ -6,16 +6,14 @@ import { Keypair } from './keypair';
 import { StrKey } from './strkey';
 
 /**
- * TrustLineAsset class represents a trustline to either a liquidity pool, a
+ * TrustLineAsset class represents a trustline to either a liquidity pool, the
  * native asset (`XLM`) or an issued asset with an asset code / issuer account
  * ID pair.
  *
- * The trustline asset can either represent a trustline to the native asset, an
- * issued asset or to a liquidity pool. In case of the native asset, the code
- * will represent `XLM` while the issuer and liquidityPoolId will be empty. For
- * an issued asset, the code and issuer will be valid and liquidityPoolId will
- * be empty. For liquidity pools, the liquidityPoolId will be valid and the
- * remaining two fields will be empty.
+ * In case of the native asset, the code will represent `XLM` while the issuer
+ * and liquidityPoolId will be empty. For an issued asset, the code and issuer
+ * will be valid and liquidityPoolId will be empty. For liquidity pools, the
+ * liquidityPoolId will be valid and the remaining two fields will be empty.
  *
  * @constructor
  * @param {string} code - The asset code.
@@ -59,7 +57,7 @@ export class TrustLineAsset {
 
   /**
    * Returns a trustline asset object from its XDR object representation.
-   * @param {xdr.TrustLineAsset} tlAssetXdr - The asset xdr object.
+   * @param {xdr.TrustLineAsset} tlAssetXdr - The asset XDR object.
    * @returns {TrustLineAsset}
    */
   static fromOperation(tlAssetXdr) {
@@ -88,7 +86,7 @@ export class TrustLineAsset {
   }
 
   /**
-   * Returns the xdr object for this asset.
+   * Returns the XDR object for this trustline asset.
    * @returns {xdr.TrustLineAsset} XDR TrustLineAsset object
    */
   toXDRObject() {
@@ -122,21 +120,21 @@ export class TrustLineAsset {
   }
 
   /**
-   * @returns {string} Asset code
+   * @returns {string} Asset code.
    */
   getCode() {
     return clone(this.code);
   }
 
   /**
-   * @returns {string} Asset issuer
+   * @returns {string} Asset issuer.
    */
   getIssuer() {
     return clone(this.issuer);
   }
 
   /**
-   * @returns {string} Liquidity pool ID
+   * @returns {string} Liquidity pool ID.
    */
   getLiquidityPoolId() {
     return clone(this.liquidityPoolId);
@@ -144,7 +142,7 @@ export class TrustLineAsset {
 
   /**
    * @see [Assets concept](https://www.stellar.org/developers/guides/concepts/assets.html)
-   * @returns {string} Asset type. Can be one of following types:
+   * @returns {string} Asset type. Can be one of the following:
    *
    * * `native`
    * * `credit_alphanum4`
@@ -169,22 +167,22 @@ export class TrustLineAsset {
   }
 
   /**
-   * @returns {boolean}  true if this trustline asset object is the native asset.
+   * @returns {boolean} `true` if this trustline asset object is the native asset.
    */
   isNative() {
     return this.code && !this.issuer;
   }
 
   /**
-   * @returns {boolean}  true if this trustline asset object is a liquidity pool.
+   * @returns {boolean} `true` if this trustline asset object is a liquidity pool.
    */
   isLiquidityPool() {
     return !!this.liquidityPoolId;
   }
 
   /**
-   * @param {TrustLineAsset} asset Asset to compare
-   * @returns {boolean} true if this asset equals the given asset.
+   * @param {TrustLineAsset} asset TrustLineAsset to compare.
+   * @returns {boolean} `true` if this asset equals the given asset.
    */
   equals(asset) {
     return (
@@ -200,7 +198,6 @@ export class TrustLineAsset {
     }
 
     if (this.isLiquidityPool()) {
-      // TODO: review if this is correct
       return `liquidity_pool:${this.liquidityPoolId}`;
     }
 

--- a/src/trustline_asset.js
+++ b/src/trustline_asset.js
@@ -5,15 +5,6 @@ import xdr from './generated/stellar-xdr_generated';
 import { Keypair } from './keypair';
 import { StrKey } from './strkey';
 
-// TODO: TrustLineAsset
-// - [ ] TrustLineEntry.asset changes from Asset to TrustLineAsset
-// - [ ] TrustLineEntry.ext can now be `TrustLineEntryExtensionV2`
-// - [ ] LedgerKeyTrustLine.asset changes from Asset to TrustLineAsset
-
-// TODO: ledger Key:
-// - [ ] LedgerKey type can also be liquidityPool -> LedgerKeyLiquidityPool
-// - [ ] (Create) new LedgerKeyLiquidityPool. All it contains is a liquidityPoolId: PoolId
-
 /**
  * TrustLineAsset class represents a trustline to either a liquidity pool, a
  * native asset (`XLM`) or an issued asset with an asset code / issuer account

--- a/src/trustline_asset.js
+++ b/src/trustline_asset.js
@@ -5,13 +5,22 @@ import xdr from './generated/stellar-xdr_generated';
 import { Keypair } from './keypair';
 import { StrKey } from './strkey';
 
+// TODO: TrustLineAsset
+// - [ ] TrustLineEntry.asset changes from Asset to TrustLineAsset
+// - [ ] TrustLineEntry.ext can now be `TrustLineEntryExtensionV2`
+// - [ ] LedgerKeyTrustLine.asset changes from Asset to TrustLineAsset
+
+// TODO: ledger Key:
+// - [ ] LedgerKey type can also be liquidityPool -> LedgerKeyLiquidityPool
+// - [ ] (Create) new LedgerKeyLiquidityPool. All it contains is a liquidityPoolId: PoolId
+
 /**
  * TrustLineAsset class represents a trustline to either a liquidity pool, a
- * native asset (`XLM`) of an issued asset with an asset code / issuer account
+ * native asset (`XLM`) or an issued asset with an asset code / issuer account
  * ID pair.
  *
- * The trustline asset can wither represent a trustline to the native asset, an
- * issued asset of to a liquidity pool. In case of the native asset, the code
+ * The trustline asset can either represent a trustline to the native asset, an
+ * issued asset or to a liquidity pool. In case of the native asset, the code
  * will represent `XLM` while the issuer and liquidityPoolId will be empty. For
  * an issued asset, the code and issuer will be valid and liquidityPoolId will
  * be empty. For liquidity pools, the liquidityPoolId will be valid and the
@@ -20,7 +29,7 @@ import { StrKey } from './strkey';
  * @constructor
  * @param {string} code - The asset code.
  * @param {string} issuer - The account ID of the asset issuer.
- * @param {string} liquidityPoolId - The ID of the liquidity pool.
+ * @param {string} liquidityPoolId - The ID of the liquidity poolin string 'hex'.
  */
 export class TrustLineAsset {
   constructor(code, issuer, liquidityPoolId) {
@@ -77,7 +86,7 @@ export class TrustLineAsset {
         return new this(code, issuer);
       case xdr.AssetType.assetTypePoolShare():
         // TODO: review if this is correct
-        liquidityPoolId = tlAssetXdr.liquidityPoolId();
+        liquidityPoolId = tlAssetXdr.liquidityPoolId().toString('hex');
         return new this(null, null, liquidityPoolId);
       default:
         throw new Error(`Invalid asset type: ${tlAssetXdr.switch().name}`);

--- a/src/trustline_asset.js
+++ b/src/trustline_asset.js
@@ -2,6 +2,7 @@ import clone from 'lodash/clone';
 import padEnd from 'lodash/padEnd';
 import trimEnd from 'lodash/trimEnd';
 import xdr from './generated/stellar-xdr_generated';
+import { hash } from './hashing';
 import { Keypair } from './keypair';
 import { StrKey } from './strkey';
 
@@ -90,7 +91,7 @@ export class TrustLineAsset {
    */
   toXDRObject() {
     if (this.isNative()) {
-      return xdr.Asset.assetTypeNative();
+      return xdr.TrustLineAsset.assetTypeNative();
     }
 
     if (this.isLiquidityPool()) {
@@ -123,7 +124,7 @@ export class TrustLineAsset {
       issuer: Keypair.fromPublicKey(this.issuer).xdrAccountId()
     });
 
-    return new xdr.Asset(xdrTypeString, assetType);
+    return new xdr.TrustLineAsset(xdrTypeString, assetType);
   }
 
   /**

--- a/src/trustline_asset.js
+++ b/src/trustline_asset.js
@@ -2,7 +2,6 @@ import clone from 'lodash/clone';
 import padEnd from 'lodash/padEnd';
 import trimEnd from 'lodash/trimEnd';
 import xdr from './generated/stellar-xdr_generated';
-import { hash } from './hashing';
 import { Keypair } from './keypair';
 import { StrKey } from './strkey';
 

--- a/src/trustline_asset.js
+++ b/src/trustline_asset.js
@@ -27,12 +27,12 @@ export class TrustLineAsset {
     if (!code && !issuer && !liquidityPoolId) {
       throw new Error('Must provide either code, issuer or liquidityPoolId');
     }
-    if (code && !/^[a-zA-Z0-9]{1,12}$/.test(code)) {
+    if ((code || issuer) && !/^[a-zA-Z0-9]{1,12}$/.test(code)) {
       throw new Error(
         'Asset code is invalid (maximum alphanumeric, 12 characters at max)'
       );
     }
-    if (String(code).toLowerCase() !== 'xlm' && !issuer) {
+    if (code && String(code).toLowerCase() !== 'xlm' && !issuer) {
       throw new Error('Issuer cannot be null');
     }
     if (issuer && !StrKey.isValidEd25519PublicKey(issuer)) {

--- a/src/trustline_asset.js
+++ b/src/trustline_asset.js
@@ -1,0 +1,214 @@
+import clone from 'lodash/clone';
+import padEnd from 'lodash/padEnd';
+import trimEnd from 'lodash/trimEnd';
+import xdr from './generated/stellar-xdr_generated';
+import { Keypair } from './keypair';
+import { StrKey } from './strkey';
+
+/**
+ * TrustLineAsset class represents a trustline to either a liquidity pool, a
+ * native asset (`XLM`) of an issued asset with an asset code / issuer account
+ * ID pair.
+ *
+ * The trustline asset can wither represent a trustline to the native asset, an
+ * issued asset of to a liquidity pool. In case of the native asset, the code
+ * will represent `XLM` while the issuer and liquidityPoolId will be empty. For
+ * an issued asset, the code and issuer will be valid and liquidityPoolId will
+ * be empty. For liquidity pools, the liquidityPoolId will be valid and the
+ * remaining two fields will be empty.
+ *
+ * @constructor
+ * @param {string} code - The asset code.
+ * @param {string} issuer - The account ID of the asset issuer.
+ * @param {string} liquidityPoolId - The ID of the liquidity pool.
+ */
+export class TrustLineAsset {
+  constructor(code, issuer, liquidityPoolId) {
+    if (!code && !issuer && !liquidityPoolId) {
+      throw new Error('Must provide either code, issuer or liquidityPoolId');
+    }
+    if (code && !/^[a-zA-Z0-9]{1,12}$/.test(code)) {
+      throw new Error(
+        'Asset code is invalid (maximum alphanumeric, 12 characters at max)'
+      );
+    }
+    if (String(code).toLowerCase() !== 'xlm' && !issuer) {
+      throw new Error('Issuer cannot be null');
+    }
+    if (issuer && !StrKey.isValidEd25519PublicKey(issuer)) {
+      throw new Error('Issuer is invalid');
+    }
+
+    // TODO: test if the liquidityPoolId is valid
+
+    this.code = code;
+    this.issuer = issuer;
+    this.liquidityPoolId = liquidityPoolId;
+  }
+
+  /**
+   * Returns a trustline asset object for the native asset.
+   * @returns {TrustLineAsset}
+   */
+  static native() {
+    return new TrustLineAsset('XLM');
+  }
+
+  /**
+   * Returns a trustline asset object from its XDR object representation.
+   * @param {xdr.TrustLineAsset} tlAssetXdr - The asset xdr object.
+   * @returns {TrustLineAsset}
+   */
+  static fromOperation(tlAssetXdr) {
+    let anum;
+    let code;
+    let issuer;
+    let liquidityPoolId;
+    switch (tlAssetXdr.switch()) {
+      case xdr.AssetType.assetTypeNative():
+        return this.native();
+      case xdr.AssetType.assetTypeCreditAlphanum4():
+        anum = tlAssetXdr.alphaNum4();
+      /* falls through */
+      case xdr.AssetType.assetTypeCreditAlphanum12():
+        anum = anum || tlAssetXdr.alphaNum12();
+        issuer = StrKey.encodeEd25519PublicKey(anum.issuer().ed25519());
+        code = trimEnd(anum.assetCode(), '\0');
+        return new this(code, issuer);
+      case xdr.AssetType.assetTypePoolShare():
+        // TODO: review if this is correct
+        liquidityPoolId = tlAssetXdr.liquidityPoolId();
+        return new this(null, null, liquidityPoolId);
+      default:
+        throw new Error(`Invalid asset type: ${tlAssetXdr.switch().name}`);
+    }
+  }
+
+  /**
+   * Returns the xdr object for this asset.
+   * @returns {xdr.TrustLineAsset} XDR TrustLineAsset object
+   */
+  toXDRObject() {
+    if (this.isNative()) {
+      return xdr.Asset.assetTypeNative();
+    }
+
+    if (this.isLiquidityPool()) {
+      // TODO: review if this is correct
+      const xdrTypeString = 'assetTypePoolShare';
+      const xdrType = new xdr.LiquidityPoolEntry({
+        liquidityPoolId: this.liquidityPoolId,
+        body: xdr.LiquidityPoolType.liquidityPoolConstantProduct()
+      });
+      return xdr.PoolId(xdrTypeString, xdrType);
+    }
+
+    let xdrType;
+    let xdrTypeString;
+    if (this.code.length <= 4) {
+      xdrType = xdr.AlphaNum4;
+      xdrTypeString = 'assetTypeCreditAlphanum4';
+    } else {
+      xdrType = xdr.AlphaNum12;
+      xdrTypeString = 'assetTypeCreditAlphanum12';
+    }
+
+    // pad code with null bytes if necessary
+    const padLength = this.code.length <= 4 ? 4 : 12;
+    const paddedCode = padEnd(this.code, padLength, '\0');
+
+    // eslint-disable-next-line new-cap
+    const assetType = new xdrType({
+      assetCode: paddedCode,
+      issuer: Keypair.fromPublicKey(this.issuer).xdrAccountId()
+    });
+
+    return new xdr.Asset(xdrTypeString, assetType);
+  }
+
+  /**
+   * @returns {string} Asset code
+   */
+  getCode() {
+    return clone(this.code);
+  }
+
+  /**
+   * @returns {string} Asset issuer
+   */
+  getIssuer() {
+    return clone(this.issuer);
+  }
+
+  /**
+   * @returns {string} Liquidity pool ID
+   */
+  getLiquidityPoolId() {
+    return clone(this.liquidityPoolId);
+  }
+
+  /**
+   * @see [Assets concept](https://www.stellar.org/developers/guides/concepts/assets.html)
+   * @returns {string} Asset type. Can be one of following types:
+   *
+   * * `native`
+   * * `credit_alphanum4`
+   * * `credit_alphanum12`
+   * * `liquidity_pool_shares`
+   */
+  getAssetType() {
+    if (this.isNative()) {
+      return 'native';
+    }
+    if (this.isLiquidityPool()) {
+      return 'liquidity_pool_shares';
+    }
+    if (this.code.length >= 1 && this.code.length <= 4) {
+      return 'credit_alphanum4';
+    }
+    if (this.code.length >= 5 && this.code.length <= 12) {
+      return 'credit_alphanum12';
+    }
+
+    return null;
+  }
+
+  /**
+   * @returns {boolean}  true if this trustline asset object is the native asset.
+   */
+  isNative() {
+    return this.code && !this.issuer;
+  }
+
+  /**
+   * @returns {boolean}  true if this trustline asset object is a liquidity pool.
+   */
+  isLiquidityPool() {
+    return !!this.liquidityPoolId;
+  }
+
+  /**
+   * @param {TrustLineAsset} asset Asset to compare
+   * @returns {boolean} true if this asset equals the given asset.
+   */
+  equals(asset) {
+    return (
+      this.code === asset.getCode() &&
+      this.issuer === asset.getIssuer() &&
+      this.liquidityPoolId === asset.getLiquidityPoolId()
+    );
+  }
+
+  toString() {
+    if (this.isNative()) {
+      return 'native';
+    }
+
+    if (this.isLiquidityPool()) {
+      // TODO: review if this is correct
+      return `liquidity_pool:${this.liquidityPoolId}`;
+    }
+
+    return `${this.getCode()}:${this.getIssuer()}`;
+  }
+}

--- a/src/trustline_asset.js
+++ b/src/trustline_asset.js
@@ -96,12 +96,8 @@ export class TrustLineAsset {
 
     if (this.isLiquidityPool()) {
       // TODO: review if this is correct
-      const xdrTypeString = 'assetTypePoolShare';
-      const xdrType = new xdr.LiquidityPoolEntry({
-        liquidityPoolId: this.liquidityPoolId,
-        body: xdr.LiquidityPoolType.liquidityPoolConstantProduct()
-      });
-      return xdr.PoolId(xdrTypeString, xdrType);
+      const xdrPoolId = xdr.PoolId.fromXDR(this.liquidityPoolId, 'hex');
+      return new xdr.TrustLineAsset('assetTypePoolShare', xdrPoolId);
     }
 
     let xdrType;

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -189,7 +189,7 @@ describe('Asset', function() {
     it('parses a 12-alphanum asset XDR', function() {
       var issuer = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
       var assetCode = 'KHLTOKEN';
-      var assetType = new StellarBase.xdr.AlphaNum4({
+      var assetType = new StellarBase.xdr.AlphaNum12({
         assetCode: assetCode + '\0\0\0\0',
         issuer: StellarBase.Keypair.fromPublicKey(issuer).xdrAccountId()
       });

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -170,7 +170,7 @@ describe('Asset', function() {
     it('parses a 4-alphanum asset XDR', function() {
       var issuer = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
       var assetCode = 'KHL';
-      var assetType = new StellarBase.xdr.AssetAlphaNum4({
+      var assetType = new StellarBase.xdr.AlphaNum4({
         assetCode: assetCode + '\0',
         issuer: StellarBase.Keypair.fromPublicKey(issuer).xdrAccountId()
       });
@@ -189,7 +189,7 @@ describe('Asset', function() {
     it('parses a 12-alphanum asset XDR', function() {
       var issuer = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
       var assetCode = 'KHLTOKEN';
-      var assetType = new StellarBase.xdr.AssetAlphaNum4({
+      var assetType = new StellarBase.xdr.AlphaNum4({
         assetCode: assetCode + '\0\0\0\0',
         issuer: StellarBase.Keypair.fromPublicKey(issuer).xdrAccountId()
       });

--- a/test/unit/change_trust_asset_test.js
+++ b/test/unit/change_trust_asset_test.js
@@ -295,8 +295,8 @@ describe('ChangeTrustAsset', function() {
     it('parses a liquidityPool asset XDR', function() {
       const lpConstantProductParamsXdr = new StellarBase.xdr.LiquidityPoolConstantProductParameters(
         {
-          asseta: assetA,
-          assetB,
+          asseta: assetA.toXDRObject(),
+          assetB: assetB.toXDRObject(),
           fee
         }
       );
@@ -316,8 +316,8 @@ describe('ChangeTrustAsset', function() {
       expect(asset).to.be.instanceof(StellarBase.ChangeTrustAsset);
 
       const gotPoolParams = asset.getLiquidityPoolParams();
-      expect(gotPoolParams.asseta).to.be.equal(assetA);
-      expect(gotPoolParams.assetB).to.be.equal(assetB);
+      expect(gotPoolParams.asseta).to.be.deep.equal(assetA);
+      expect(gotPoolParams.assetB).to.be.deep.equal(assetB);
       expect(gotPoolParams.fee).to.be.equal(fee);
     });
   });

--- a/test/unit/change_trust_asset_test.js
+++ b/test/unit/change_trust_asset_test.js
@@ -12,13 +12,7 @@ describe('ChangeTrustAsset', function() {
   describe('constructor', function() {
     it('throws an error when no parameter is provided', function() {
       expect(() => new StellarBase.ChangeTrustAsset()).to.throw(
-        /Must provide either code, issuer or liquidityPoolParams/
-      );
-    });
-
-    it("throws an error when there's no issuer for a trustline asset with code `XLM`", function() {
-      expect(() => new StellarBase.ChangeTrustAsset('USD')).to.throw(
-        /Issuer cannot be null/
+        /Must provide either code, issuer or liquidityPoolParameters/
       );
     });
 
@@ -46,16 +40,26 @@ describe('ChangeTrustAsset', function() {
       ).to.throw(/Asset code is invalid/);
     });
 
+    it('throws an error when issuer is null and asset is not XLM', function() {
+      expect(() => new StellarBase.ChangeTrustAsset('USD')).to.throw(
+        /Issuer cannot be null/
+      );
+    });
+
     it('throws an error when issuer is invalid', function() {
       expect(
         () => new StellarBase.ChangeTrustAsset('USD', 'GCEZWKCA5')
       ).to.throw(/Issuer is invalid/);
     });
+
+    it('native asset does not throw', function() {
+      expect(() => new StellarBase.ChangeTrustAsset.native()).to.not.throw;
+    });
   });
 
   describe('getCode()', function() {
-    it('returns a code for a native asset object', function() {
-      var asset = new StellarBase.ChangeTrustAsset.native();
+    it('returns a code for a native asset', function() {
+      const asset = new StellarBase.ChangeTrustAsset.native();
       expect(asset.getCode()).to.be.equal('XLM');
     });
 
@@ -78,12 +82,12 @@ describe('ChangeTrustAsset', function() {
   });
 
   describe('getIssuer()', function() {
-    it('returns a code for a native asset object', function() {
+    it('returns undefined issuer for a native asset', function() {
       const asset = new StellarBase.ChangeTrustAsset.native();
       expect(asset.getIssuer()).to.be.undefined;
     });
 
-    it('returns a code for a non-native asset', function() {
+    it('returns an issuer for a non-native asset', function() {
       const asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
@@ -103,18 +107,18 @@ describe('ChangeTrustAsset', function() {
     });
   });
 
-  describe('getLiquidityPoolParams()', function() {
-    it('returns empty liquidity pool params for a native asset object', function() {
-      var asset = new StellarBase.ChangeTrustAsset.native();
-      expect(asset.getLiquidityPoolParams()).to.be.undefined;
+  describe('getLiquidityPoolParameters()', function() {
+    it('returns undefined liquidity pool params for a native asset', function() {
+      const asset = new StellarBase.ChangeTrustAsset.native();
+      expect(asset.getLiquidityPoolParameters()).to.be.undefined;
     });
 
-    it('returns empty liquidity pool params for a non-native asset', function() {
-      var asset = new StellarBase.ChangeTrustAsset(
+    it('returns undefined liquidity pool params for a non-native asset', function() {
+      const asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
-      expect(asset.getLiquidityPoolParams()).to.be.undefined;
+      expect(asset.getLiquidityPoolParameters()).to.be.undefined;
     });
 
     it('returns liquidity pool parameters for a liquidity pool asset', function() {
@@ -123,7 +127,7 @@ describe('ChangeTrustAsset', function() {
         assetB,
         fee
       });
-      const gotPoolParams = asset.getLiquidityPoolParams();
+      const gotPoolParams = asset.getLiquidityPoolParameters();
       expect(gotPoolParams.asseta).to.be.equal(assetA);
       expect(gotPoolParams.assetB).to.be.equal(assetB);
       expect(gotPoolParams.fee).to.be.equal(fee);
@@ -131,28 +135,28 @@ describe('ChangeTrustAsset', function() {
   });
 
   describe('getAssetType()', function() {
-    it('returns native for native assets', function() {
-      var asset = StellarBase.ChangeTrustAsset.native();
+    it('returns "native" for native assets', function() {
+      const asset = StellarBase.ChangeTrustAsset.native();
       expect(asset.getAssetType()).to.eq('native');
     });
 
-    it('returns credit_alphanum4 if the trustline asset code length is between 1 and 4', function() {
-      var asset = new StellarBase.ChangeTrustAsset(
+    it('returns "credit_alphanum4" if the trustline asset code length is between 1 and 4', function() {
+      const asset = new StellarBase.ChangeTrustAsset(
         'ABCD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
       expect(asset.getAssetType()).to.eq('credit_alphanum4');
     });
 
-    it('returns credit_alphanum12 if the trustline asset code length is between 5 and 12', function() {
-      var asset = new StellarBase.ChangeTrustAsset(
+    it('returns "credit_alphanum12" if the trustline asset code length is between 5 and 12', function() {
+      const asset = new StellarBase.ChangeTrustAsset(
         'ABCDEF',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
       expect(asset.getAssetType()).to.eq('credit_alphanum12');
     });
 
-    it('returns liquidity_pool_shares if the trustline asset is a liquidity pool ID', function() {
+    it('returns "liquidity_pool_shares" if the trustline asset is a liquidity pool ID', function() {
       const asset = new StellarBase.ChangeTrustAsset(undefined, undefined, {
         asseta: assetA,
         assetB,
@@ -164,19 +168,19 @@ describe('ChangeTrustAsset', function() {
 
   describe('toXDRObject()', function() {
     it('parses a native asset object', function() {
-      var asset = new StellarBase.ChangeTrustAsset.native();
-      var xdr = asset.toXDRObject();
+      const asset = new StellarBase.ChangeTrustAsset.native();
+      const xdr = asset.toXDRObject();
       expect(xdr.toXDR().toString()).to.be.equal(
         Buffer.from([0, 0, 0, 0]).toString()
       );
     });
 
     it('parses a 3-alphanum asset object', function() {
-      var asset = new StellarBase.ChangeTrustAsset(
+      const asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
-      var xdr = asset.toXDRObject();
+      const xdr = asset.toXDRObject();
 
       expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
       expect(() => xdr.toXDR('hex')).to.not.throw();
@@ -186,11 +190,11 @@ describe('ChangeTrustAsset', function() {
     });
 
     it('parses a 4-alphanum asset object', function() {
-      var asset = new StellarBase.ChangeTrustAsset(
+      const asset = new StellarBase.ChangeTrustAsset(
         'BART',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
-      var xdr = asset.toXDRObject();
+      const xdr = asset.toXDRObject();
 
       expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
       expect(() => xdr.toXDR('hex')).to.not.throw();
@@ -200,11 +204,11 @@ describe('ChangeTrustAsset', function() {
     });
 
     it('parses a 5-alphanum asset object', function() {
-      var asset = new StellarBase.ChangeTrustAsset(
+      const asset = new StellarBase.ChangeTrustAsset(
         '12345',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
-      var xdr = asset.toXDRObject();
+      const xdr = asset.toXDRObject();
 
       expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
       expect(() => xdr.toXDR('hex')).to.not.throw();
@@ -214,11 +218,11 @@ describe('ChangeTrustAsset', function() {
     });
 
     it('parses a 12-alphanum asset object', function() {
-      var asset = new StellarBase.ChangeTrustAsset(
+      const asset = new StellarBase.ChangeTrustAsset(
         '123456789012',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
-      var xdr = asset.toXDRObject();
+      const xdr = asset.toXDRObject();
 
       expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
       expect(() => xdr.toXDR('hex')).to.not.throw();
@@ -238,7 +242,7 @@ describe('ChangeTrustAsset', function() {
       expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
       expect(xdr.arm()).to.equal('liquidityPool');
 
-      const gotPoolParams = asset.getLiquidityPoolParams();
+      const gotPoolParams = asset.getLiquidityPoolParameters();
       expect(gotPoolParams.asseta).to.be.equal(assetA);
       expect(gotPoolParams.assetB).to.be.equal(assetB);
       expect(gotPoolParams.fee).to.be.equal(fee);
@@ -247,49 +251,51 @@ describe('ChangeTrustAsset', function() {
 
   describe('fromOperation()', function() {
     it('parses a native asset XDR', function() {
-      var xdr = new StellarBase.xdr.ChangeTrustAsset.assetTypeNative();
-      var asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
+      const xdr = new StellarBase.xdr.ChangeTrustAsset.assetTypeNative();
+      const asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
 
       expect(asset).to.be.instanceof(StellarBase.ChangeTrustAsset);
       expect(asset.isNative()).to.equal(true);
+      expect(asset.getAssetType()).to.equal('native');
     });
 
     it('parses a 4-alphanum asset XDR', function() {
-      var issuer = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
-      var assetCode = 'KHL';
-      var assetType = new StellarBase.xdr.AlphaNum4({
+      const issuer = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      const assetCode = 'KHL';
+      const assetXdr = new StellarBase.xdr.AlphaNum4({
         assetCode: assetCode + '\0',
         issuer: StellarBase.Keypair.fromPublicKey(issuer).xdrAccountId()
       });
-      var xdr = new StellarBase.xdr.ChangeTrustAsset(
+      const xdr = new StellarBase.xdr.ChangeTrustAsset(
         'assetTypeCreditAlphanum4',
-        assetType
+        assetXdr
       );
 
-      var asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
-
+      const asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
       expect(asset).to.be.instanceof(StellarBase.ChangeTrustAsset);
       expect(asset.getCode()).to.equal(assetCode);
       expect(asset.getIssuer()).to.equal(issuer);
+      expect(asset.getAssetType()).to.equal('credit_alphanum4');
     });
 
     it('parses a 12-alphanum asset XDR', function() {
-      var issuer = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
-      var assetCode = 'KHLTOKEN';
-      var assetType = new StellarBase.xdr.AlphaNum4({
+      const issuer = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      const assetCode = 'KHLTOKEN';
+      const assetXdr = new StellarBase.xdr.AlphaNum12({
         assetCode: assetCode + '\0\0\0\0',
         issuer: StellarBase.Keypair.fromPublicKey(issuer).xdrAccountId()
       });
-      var xdr = new StellarBase.xdr.ChangeTrustAsset(
+      const xdr = new StellarBase.xdr.ChangeTrustAsset(
         'assetTypeCreditAlphanum12',
-        assetType
+        assetXdr
       );
 
-      var asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
+      const asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
 
       expect(asset).to.be.instanceof(StellarBase.ChangeTrustAsset);
       expect(asset.getCode()).to.equal(assetCode);
       expect(asset.getIssuer()).to.equal(issuer);
+      expect(asset.getAssetType()).to.equal('credit_alphanum12');
     });
 
     it('parses a liquidityPool asset XDR', function() {
@@ -314,22 +320,22 @@ describe('ChangeTrustAsset', function() {
 
       const asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
       expect(asset).to.be.instanceof(StellarBase.ChangeTrustAsset);
-
-      const gotPoolParams = asset.getLiquidityPoolParams();
+      const gotPoolParams = asset.getLiquidityPoolParameters();
       expect(gotPoolParams.asseta).to.be.deep.equal(assetA);
       expect(gotPoolParams.assetB).to.be.deep.equal(assetB);
       expect(gotPoolParams.fee).to.be.equal(fee);
+      expect(asset.getAssetType()).to.equal('liquidity_pool_shares');
     });
   });
 
   describe('toString()', function() {
     it("returns 'native' for native asset", function() {
-      var asset = StellarBase.ChangeTrustAsset.native();
+      const asset = StellarBase.ChangeTrustAsset.native();
       expect(asset.toString()).to.be.equal('native');
     });
 
     it("returns 'code:issuer' for non-native asset", function() {
-      var asset = new StellarBase.ChangeTrustAsset(
+      const asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -338,8 +344,8 @@ describe('ChangeTrustAsset', function() {
       );
     });
 
-    it("returns 'liquidity_pool:<id>' for liquidity pool assets", function() {
-      var asset = new StellarBase.ChangeTrustAsset(undefined, undefined, {
+    it("returns 'liquidity_pool:<pool_id>' for liquidity pool assets", function() {
+      const asset = new StellarBase.ChangeTrustAsset(undefined, undefined, {
         asseta: assetA,
         assetB,
         fee

--- a/test/unit/change_trust_asset_test.js
+++ b/test/unit/change_trust_asset_test.js
@@ -1,13 +1,23 @@
-describe('TrustLineAsset', function() {
+const assetA = new StellarBase.Asset(
+  'ARST',
+  'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+);
+const assetB = new StellarBase.Asset(
+  'USD',
+  'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+);
+const fee = StellarBase.LiquidityPoolFeeV18;
+
+describe('ChangeTrustAsset', function() {
   describe('constructor', function() {
     it('throws an error when no parameter is provided', function() {
-      expect(() => new StellarBase.TrustLineAsset()).to.throw(
-        /Must provide either code, issuer or liquidityPoolId/
+      expect(() => new StellarBase.ChangeTrustAsset()).to.throw(
+        /Must provide either code, issuer or liquidityPoolParams/
       );
     });
 
     it("throws an error when there's no issuer for a trustline asset with code `XLM`", function() {
-      expect(() => new StellarBase.TrustLineAsset('USD')).to.throw(
+      expect(() => new StellarBase.ChangeTrustAsset('USD')).to.throw(
         /Issuer cannot be null/
       );
     });
@@ -15,21 +25,21 @@ describe('TrustLineAsset', function() {
     it('throws an error when there is an asset issuer but the code is invalid', function() {
       expect(
         () =>
-          new StellarBase.TrustLineAsset(
+          new StellarBase.ChangeTrustAsset(
             '',
             'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
           )
       ).to.throw(/Asset code is invalid/);
       expect(
         () =>
-          new StellarBase.TrustLineAsset(
+          new StellarBase.ChangeTrustAsset(
             '1234567890123',
             'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
           )
       ).to.throw(/Asset code is invalid/);
       expect(
         () =>
-          new StellarBase.TrustLineAsset(
+          new StellarBase.ChangeTrustAsset(
             'ab_',
             'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
           )
@@ -37,26 +47,20 @@ describe('TrustLineAsset', function() {
     });
 
     it('throws an error when issuer is invalid', function() {
-      expect(() => new StellarBase.TrustLineAsset('USD', 'GCEZWKCA5')).to.throw(
-        /Issuer is invalid/
-      );
-    });
-
-    it('throws an error when issuer is null and asset is not XLM', function() {
-      expect(() => new StellarBase.TrustLineAsset('USD')).to.throw(
-        /Issuer cannot be null/
-      );
+      expect(
+        () => new StellarBase.ChangeTrustAsset('USD', 'GCEZWKCA5')
+      ).to.throw(/Issuer is invalid/);
     });
   });
 
   describe('getCode()', function() {
     it('returns a code for a native asset object', function() {
-      var asset = new StellarBase.TrustLineAsset.native();
+      var asset = new StellarBase.ChangeTrustAsset.native();
       expect(asset.getCode()).to.be.equal('XLM');
     });
 
     it('returns a code for a non-native asset', function() {
-      var asset = new StellarBase.TrustLineAsset(
+      const asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -64,23 +68,23 @@ describe('TrustLineAsset', function() {
     });
 
     it('returns undefined code for a liquidity pool asset', function() {
-      var asset = new StellarBase.TrustLineAsset(
-        undefined,
-        undefined,
-        'liquidity_pool_id_here'
-      );
+      const asset = new StellarBase.ChangeTrustAsset(undefined, undefined, {
+        asseta: assetA,
+        assetB,
+        fee
+      });
       expect(asset.getCode()).to.be.undefined;
     });
   });
 
   describe('getIssuer()', function() {
     it('returns a code for a native asset object', function() {
-      var asset = new StellarBase.TrustLineAsset.native();
+      const asset = new StellarBase.ChangeTrustAsset.native();
       expect(asset.getIssuer()).to.be.undefined;
     });
 
     it('returns a code for a non-native asset', function() {
-      var asset = new StellarBase.TrustLineAsset(
+      const asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -90,47 +94,50 @@ describe('TrustLineAsset', function() {
     });
 
     it('returns undefined issuer for a liquidity pool asset', function() {
-      var asset = new StellarBase.TrustLineAsset(
-        undefined,
-        undefined,
-        'liquidity_pool_id_here'
-      );
+      const asset = new StellarBase.ChangeTrustAsset(undefined, undefined, {
+        asseta: assetA,
+        assetB,
+        fee
+      });
       expect(asset.getIssuer()).to.be.undefined;
     });
   });
 
-  describe('getLiquidityPoolId()', function() {
-    it('returns empty liquidity pool ID for a native asset object', function() {
-      var asset = new StellarBase.TrustLineAsset.native();
-      expect(asset.getLiquidityPoolId()).to.be.undefined;
+  describe('getLiquidityPoolParams()', function() {
+    it('returns empty liquidity pool params for a native asset object', function() {
+      var asset = new StellarBase.ChangeTrustAsset.native();
+      expect(asset.getLiquidityPoolParams()).to.be.undefined;
     });
 
-    it('returns empty liquidity pool ID for a non-native asset', function() {
-      var asset = new StellarBase.TrustLineAsset(
+    it('returns empty liquidity pool params for a non-native asset', function() {
+      var asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
-      expect(asset.getLiquidityPoolId()).to.be.undefined;
+      expect(asset.getLiquidityPoolParams()).to.be.undefined;
     });
 
-    it('returns liquidity pool ID of liquidity pool asset', function() {
-      var asset = new StellarBase.TrustLineAsset(
-        undefined,
-        undefined,
-        'liquidity_pool_id_here'
-      );
-      expect(asset.getLiquidityPoolId()).to.be.equal('liquidity_pool_id_here');
+    it('returns liquidity pool parameters for a liquidity pool asset', function() {
+      const asset = new StellarBase.ChangeTrustAsset(undefined, undefined, {
+        asseta: assetA,
+        assetB,
+        fee
+      });
+      const gotPoolParams = asset.getLiquidityPoolParams();
+      expect(gotPoolParams.asseta).to.be.equal(assetA);
+      expect(gotPoolParams.assetB).to.be.equal(assetB);
+      expect(gotPoolParams.fee).to.be.equal(fee);
     });
   });
 
   describe('getAssetType()', function() {
     it('returns native for native assets', function() {
-      var asset = StellarBase.TrustLineAsset.native();
+      var asset = StellarBase.ChangeTrustAsset.native();
       expect(asset.getAssetType()).to.eq('native');
     });
 
     it('returns credit_alphanum4 if the trustline asset code length is between 1 and 4', function() {
-      var asset = new StellarBase.TrustLineAsset(
+      var asset = new StellarBase.ChangeTrustAsset(
         'ABCD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -138,7 +145,7 @@ describe('TrustLineAsset', function() {
     });
 
     it('returns credit_alphanum12 if the trustline asset code length is between 5 and 12', function() {
-      var asset = new StellarBase.TrustLineAsset(
+      var asset = new StellarBase.ChangeTrustAsset(
         'ABCDEF',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -146,18 +153,18 @@ describe('TrustLineAsset', function() {
     });
 
     it('returns liquidity_pool_shares if the trustline asset is a liquidity pool ID', function() {
-      var asset = new StellarBase.TrustLineAsset(
-        undefined,
-        undefined,
-        'liquidity_pool_id_here'
-      );
+      const asset = new StellarBase.ChangeTrustAsset(undefined, undefined, {
+        asseta: assetA,
+        assetB,
+        fee
+      });
       expect(asset.getAssetType()).to.eq('liquidity_pool_shares');
     });
   });
 
   describe('toXDRObject()', function() {
     it('parses a native asset object', function() {
-      var asset = new StellarBase.TrustLineAsset.native();
+      var asset = new StellarBase.ChangeTrustAsset.native();
       var xdr = asset.toXDRObject();
       expect(xdr.toXDR().toString()).to.be.equal(
         Buffer.from([0, 0, 0, 0]).toString()
@@ -165,13 +172,13 @@ describe('TrustLineAsset', function() {
     });
 
     it('parses a 3-alphanum asset object', function() {
-      var asset = new StellarBase.TrustLineAsset(
+      var asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
       var xdr = asset.toXDRObject();
 
-      expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+      expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
       expect(() => xdr.toXDR('hex')).to.not.throw();
 
       expect(xdr.arm()).to.equal('alphaNum4');
@@ -179,13 +186,13 @@ describe('TrustLineAsset', function() {
     });
 
     it('parses a 4-alphanum asset object', function() {
-      var asset = new StellarBase.TrustLineAsset(
+      var asset = new StellarBase.ChangeTrustAsset(
         'BART',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
       var xdr = asset.toXDRObject();
 
-      expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+      expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
       expect(() => xdr.toXDR('hex')).to.not.throw();
 
       expect(xdr.arm()).to.equal('alphaNum4');
@@ -193,13 +200,13 @@ describe('TrustLineAsset', function() {
     });
 
     it('parses a 5-alphanum asset object', function() {
-      var asset = new StellarBase.TrustLineAsset(
+      var asset = new StellarBase.ChangeTrustAsset(
         '12345',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
       var xdr = asset.toXDRObject();
 
-      expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+      expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
       expect(() => xdr.toXDR('hex')).to.not.throw();
 
       expect(xdr.arm()).to.equal('alphaNum12');
@@ -207,13 +214,13 @@ describe('TrustLineAsset', function() {
     });
 
     it('parses a 12-alphanum asset object', function() {
-      var asset = new StellarBase.TrustLineAsset(
+      var asset = new StellarBase.ChangeTrustAsset(
         '123456789012',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
       var xdr = asset.toXDRObject();
 
-      expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+      expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
       expect(() => xdr.toXDR('hex')).to.not.throw();
 
       expect(xdr.arm()).to.equal('alphaNum12');
@@ -221,30 +228,29 @@ describe('TrustLineAsset', function() {
     });
 
     it('parses a liquidity pool trustline asset object', function() {
-      const asset = new StellarBase.TrustLineAsset(
-        undefined,
-        undefined,
-        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
-      );
+      const asset = new StellarBase.ChangeTrustAsset(undefined, undefined, {
+        asseta: assetA,
+        assetB,
+        fee
+      });
       const xdr = asset.toXDRObject();
 
-      expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
-      expect(xdr.arm()).to.equal('liquidityPoolId');
-      expect(xdr.liquidityPoolId().toString('hex')).to.equal(
-        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
-      );
-      expect(xdr.liquidityPoolId().toString('hex')).to.equal(
-        asset.getLiquidityPoolId()
-      );
+      expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
+      expect(xdr.arm()).to.equal('liquidityPool');
+
+      const gotPoolParams = asset.getLiquidityPoolParams();
+      expect(gotPoolParams.asseta).to.be.equal(assetA);
+      expect(gotPoolParams.assetB).to.be.equal(assetB);
+      expect(gotPoolParams.fee).to.be.equal(fee);
     });
   });
 
   describe('fromOperation()', function() {
     it('parses a native asset XDR', function() {
-      var xdr = new StellarBase.xdr.TrustLineAsset.assetTypeNative();
-      var asset = StellarBase.TrustLineAsset.fromOperation(xdr);
+      var xdr = new StellarBase.xdr.ChangeTrustAsset.assetTypeNative();
+      var asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
 
-      expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
+      expect(asset).to.be.instanceof(StellarBase.ChangeTrustAsset);
       expect(asset.isNative()).to.equal(true);
     });
 
@@ -255,14 +261,14 @@ describe('TrustLineAsset', function() {
         assetCode: assetCode + '\0',
         issuer: StellarBase.Keypair.fromPublicKey(issuer).xdrAccountId()
       });
-      var xdr = new StellarBase.xdr.TrustLineAsset(
+      var xdr = new StellarBase.xdr.ChangeTrustAsset(
         'assetTypeCreditAlphanum4',
         assetType
       );
 
-      var asset = StellarBase.TrustLineAsset.fromOperation(xdr);
+      var asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
 
-      expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
+      expect(asset).to.be.instanceof(StellarBase.ChangeTrustAsset);
       expect(asset.getCode()).to.equal(assetCode);
       expect(asset.getIssuer()).to.equal(issuer);
     });
@@ -274,41 +280,56 @@ describe('TrustLineAsset', function() {
         assetCode: assetCode + '\0\0\0\0',
         issuer: StellarBase.Keypair.fromPublicKey(issuer).xdrAccountId()
       });
-      var xdr = new StellarBase.xdr.TrustLineAsset(
+      var xdr = new StellarBase.xdr.ChangeTrustAsset(
         'assetTypeCreditAlphanum12',
         assetType
       );
 
-      var asset = StellarBase.TrustLineAsset.fromOperation(xdr);
+      var asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
 
-      expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
+      expect(asset).to.be.instanceof(StellarBase.ChangeTrustAsset);
       expect(asset.getCode()).to.equal(assetCode);
       expect(asset.getIssuer()).to.equal(issuer);
     });
 
-    it('parses a liquidityPoolId asset XDR', function() {
-      const poolId =
-        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7';
-      const xdrPoolId = StellarBase.xdr.PoolId.fromXDR(poolId, 'hex');
-      const xdr = new StellarBase.xdr.TrustLineAsset(
+    it('parses a liquidityPool asset XDR', function() {
+      const lpConstantProductParamsXdr = new StellarBase.xdr.LiquidityPoolConstantProductParameters(
+        {
+          asseta: assetA,
+          assetB,
+          fee
+        }
+      );
+      const lpParamsXdr = new StellarBase.xdr.LiquidityPoolParameters(
+        'liquidityPoolConstantProduct',
+        lpConstantProductParamsXdr
+      );
+      const xdr = new StellarBase.xdr.ChangeTrustAsset(
         'assetTypePoolShare',
-        xdrPoolId
+        lpParamsXdr
       );
 
-      const asset = StellarBase.TrustLineAsset.fromOperation(xdr);
-      expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
-      expect(asset.getLiquidityPoolId()).to.equal(poolId);
+      expect(xdr).to.be.instanceof(StellarBase.xdr.ChangeTrustAsset);
+      expect(xdr.arm()).to.equal('liquidityPool');
+
+      const asset = StellarBase.ChangeTrustAsset.fromOperation(xdr);
+      expect(asset).to.be.instanceof(StellarBase.ChangeTrustAsset);
+
+      const gotPoolParams = asset.getLiquidityPoolParams();
+      expect(gotPoolParams.asseta).to.be.equal(assetA);
+      expect(gotPoolParams.assetB).to.be.equal(assetB);
+      expect(gotPoolParams.fee).to.be.equal(fee);
     });
   });
 
   describe('toString()', function() {
     it("returns 'native' for native asset", function() {
-      var asset = StellarBase.TrustLineAsset.native();
+      var asset = StellarBase.ChangeTrustAsset.native();
       expect(asset.toString()).to.be.equal('native');
     });
 
     it("returns 'code:issuer' for non-native asset", function() {
-      var asset = new StellarBase.TrustLineAsset(
+      var asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -318,13 +339,13 @@ describe('TrustLineAsset', function() {
     });
 
     it("returns 'liquidity_pool:<id>' for liquidity pool assets", function() {
-      var asset = new StellarBase.TrustLineAsset(
-        undefined,
-        undefined,
-        'liquidity_pool_id_here'
-      );
+      var asset = new StellarBase.ChangeTrustAsset(undefined, undefined, {
+        asseta: assetA,
+        assetB,
+        fee
+      });
       expect(asset.toString()).to.be.equal(
-        'liquidity_pool:liquidity_pool_id_here'
+        'liquidity_pool:dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
       );
     });
   });

--- a/test/unit/liquidity_pool_id_test.js
+++ b/test/unit/liquidity_pool_id_test.js
@@ -1,30 +1,30 @@
-import {
-  liquidityPoolId,
-  validateLexicographicalAssetsOrder,
-  xdr
-} from '../../src';
-import { LiquidityPoolFeeV18 } from '../../src/liquidity_pool_id';
-const liquidityPoolTypeConstantProduct = xdr.LiquidityPoolType.liquidityPoolConstantProduct();
+const liquidityPoolTypeConstantProduct = 'constant_product';
 
 describe('StellarBase#liquidityPoolId', function() {
   it('throws an error if the liquidity pool type is not `0` for constant product', function() {
-    expect(() => liquidityPoolId()).to.throw(/liquidityPoolType is invalid/);
+    expect(() => StellarBase.getLiquidityPoolId()).to.throw(
+      /liquidityPoolType is invalid/
+    );
 
-    expect(() => liquidityPoolId(1)).to.throw(/liquidityPoolType is invalid/);
+    expect(() => StellarBase.getLiquidityPoolId(1)).to.throw(
+      /liquidityPoolType is invalid/
+    );
   });
 
   it('throws an error if liquidity pool parameters is missing', function() {
-    expect(() => liquidityPoolId(liquidityPoolTypeConstantProduct)).to.throw(
-      /liquidityPoolParams cannot be empty/
-    );
+    expect(() =>
+      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct)
+    ).to.throw(/liquidityPoolParams cannot be empty/);
   });
 
   it('throws an error if assetA is invalid', function() {
     expect(() =>
-      liquidityPoolId(liquidityPoolTypeConstantProduct, {})
+      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {})
     ).to.throw(/asseta is invalid/);
     expect(() =>
-      liquidityPoolId(liquidityPoolTypeConstantProduct, { asseta: 'random' })
+      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {
+        asseta: 'random'
+      })
     ).to.throw(/asseta is invalid/);
   });
 
@@ -34,10 +34,12 @@ describe('StellarBase#liquidityPoolId', function() {
       'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
     );
     expect(() =>
-      liquidityPoolId(liquidityPoolTypeConstantProduct, { asseta: assetA })
+      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {
+        asseta: assetA
+      })
     ).to.throw(/assetB is invalid/);
     expect(() =>
-      liquidityPoolId(liquidityPoolTypeConstantProduct, {
+      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {
         asseta: assetA,
         assetB: 'random'
       })
@@ -54,7 +56,7 @@ describe('StellarBase#liquidityPoolId', function() {
       'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
     );
     expect(() =>
-      liquidityPoolId(liquidityPoolTypeConstantProduct, {
+      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {
         asseta: assetA,
         assetB
       })
@@ -70,15 +72,17 @@ describe('StellarBase#liquidityPoolId', function() {
       'USD',
       'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
     );
-    const fee = LiquidityPoolFeeV18;
+    const fee = StellarBase.LiquidityPoolFeeV18;
 
-    const poolId = liquidityPoolId(liquidityPoolTypeConstantProduct, {
-      asseta: assetA,
-      assetB,
-      fee
-    });
+    const poolId = StellarBase.getLiquidityPoolId(
+      liquidityPoolTypeConstantProduct,
+      {
+        asseta: assetA,
+        assetB,
+        fee
+      }
+    );
 
-    expect(poolId).to.be.instanceof(Buffer);
     expect(poolId.toString('hex')).to.equal(
       'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
     );
@@ -93,10 +97,10 @@ describe('StellarBase#liquidityPoolId', function() {
       'ARST',
       'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
     );
-    const fee = LiquidityPoolFeeV18;
+    const fee = StellarBase.LiquidityPoolFeeV18;
 
     expect(() =>
-      liquidityPoolId(liquidityPoolTypeConstantProduct, {
+      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {
         asseta: assetA,
         assetB,
         fee
@@ -107,7 +111,7 @@ describe('StellarBase#liquidityPoolId', function() {
 
 describe('StellarBase#validateLexicographicalAssetsOrder', function() {
   it('throws an error if the input assets are invalid', function() {
-    expect(() => validateLexicographicalAssetsOrder()).to.throw(
+    expect(() => StellarBase.validateLexicographicalAssetsOrder()).to.throw(
       /assetA is invalid/
     );
 
@@ -115,14 +119,14 @@ describe('StellarBase#validateLexicographicalAssetsOrder', function() {
       'ARST',
       'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
     );
-    expect(() => validateLexicographicalAssetsOrder(assetA)).to.throw(
-      /assetB is invalid/
-    );
+    expect(() =>
+      StellarBase.validateLexicographicalAssetsOrder(assetA)
+    ).to.throw(/assetB is invalid/);
   });
 
   it('returns false if assets are equal', function() {
     const XLM = new StellarBase.Asset.native();
-    expect(validateLexicographicalAssetsOrder(XLM, XLM)).to.false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(XLM, XLM)).to.false;
   });
 
   it('test if asset types are being validated as native < anum4 < anum12', function() {
@@ -135,17 +139,22 @@ describe('StellarBase#validateLexicographicalAssetsOrder', function() {
       'ARSTANUM12',
       'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
     );
-    expect(validateLexicographicalAssetsOrder(XLM, XLM)).to.false;
-    expect(validateLexicographicalAssetsOrder(XLM, anum4)).to.true;
-    expect(validateLexicographicalAssetsOrder(XLM, anum12)).to.true;
+    expect(StellarBase.validateLexicographicalAssetsOrder(XLM, XLM)).to.false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(XLM, anum4)).to.true;
+    expect(StellarBase.validateLexicographicalAssetsOrder(XLM, anum12)).to.true;
 
-    expect(validateLexicographicalAssetsOrder(anum4, XLM)).to.false;
-    expect(validateLexicographicalAssetsOrder(anum4, anum4)).to.false;
-    expect(validateLexicographicalAssetsOrder(anum4, anum12)).to.true;
+    expect(StellarBase.validateLexicographicalAssetsOrder(anum4, XLM)).to.false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(anum4, anum4)).to
+      .false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(anum4, anum12)).to
+      .true;
 
-    expect(validateLexicographicalAssetsOrder(anum12, XLM)).to.false;
-    expect(validateLexicographicalAssetsOrder(anum12, anum4)).to.false;
-    expect(validateLexicographicalAssetsOrder(anum12, anum12)).to.false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(anum12, XLM)).to
+      .false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(anum12, anum4)).to
+      .false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(anum12, anum12)).to
+      .false;
   });
 
   it('test if asset codes are being validated as assetACode < assetBCode', function() {
@@ -157,11 +166,15 @@ describe('StellarBase#validateLexicographicalAssetsOrder', function() {
       'USDX',
       'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
     );
-    expect(validateLexicographicalAssetsOrder(assetARST, assetUSDX)).to.true;
-    expect(validateLexicographicalAssetsOrder(assetARST, assetARST)).to.false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(assetARST, assetUSDX))
+      .to.true;
+    expect(StellarBase.validateLexicographicalAssetsOrder(assetARST, assetARST))
+      .to.false;
 
-    expect(validateLexicographicalAssetsOrder(assetUSDX, assetARST)).to.false;
-    expect(validateLexicographicalAssetsOrder(assetUSDX, assetUSDX)).to.false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(assetUSDX, assetARST))
+      .to.false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(assetUSDX, assetUSDX))
+      .to.false;
   });
 
   it('test if asset issuers are being validated as assetAIssuer < assetBIssuer', function() {
@@ -174,17 +187,29 @@ describe('StellarBase#validateLexicographicalAssetsOrder', function() {
       'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
     );
     expect(
-      validateLexicographicalAssetsOrder(assetARSTIssuerA, assetARSTIssuerB)
+      StellarBase.validateLexicographicalAssetsOrder(
+        assetARSTIssuerA,
+        assetARSTIssuerB
+      )
     ).to.true;
     expect(
-      validateLexicographicalAssetsOrder(assetARSTIssuerA, assetARSTIssuerA)
+      StellarBase.validateLexicographicalAssetsOrder(
+        assetARSTIssuerA,
+        assetARSTIssuerA
+      )
     ).to.false;
 
     expect(
-      validateLexicographicalAssetsOrder(assetARSTIssuerB, assetARSTIssuerA)
+      StellarBase.validateLexicographicalAssetsOrder(
+        assetARSTIssuerB,
+        assetARSTIssuerA
+      )
     ).to.false;
     expect(
-      validateLexicographicalAssetsOrder(assetARSTIssuerB, assetARSTIssuerB)
+      StellarBase.validateLexicographicalAssetsOrder(
+        assetARSTIssuerB,
+        assetARSTIssuerB
+      )
     ).to.false;
   });
 });

--- a/test/unit/liquidity_pool_id_test.js
+++ b/test/unit/liquidity_pool_id_test.js
@@ -1,7 +1,15 @@
-const liquidityPoolTypeConstantProduct = 'constant_product';
+const assetA = new StellarBase.Asset(
+  'ARST',
+  'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+);
+const assetB = new StellarBase.Asset(
+  'USD',
+  'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+);
+const fee = StellarBase.LiquidityPoolFeeV18;
 
-describe('StellarBase#liquidityPoolId', function() {
-  it('throws an error if the liquidity pool type is not `0` for constant product', function() {
+describe('StellarBase#getLiquidityPoolId()', function() {
+  it('throws an error if the liquidity pool type is not `constant_product`', function() {
     expect(() => StellarBase.getLiquidityPoolId()).to.throw(
       /liquidityPoolType is invalid/
     );
@@ -9,37 +17,31 @@ describe('StellarBase#liquidityPoolId', function() {
     expect(() => StellarBase.getLiquidityPoolId(1)).to.throw(
       /liquidityPoolType is invalid/
     );
-  });
 
-  it('throws an error if liquidity pool parameters is missing', function() {
-    expect(() =>
-      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct)
-    ).to.throw(/liquidityPoolParams cannot be empty/);
+    expect(() => StellarBase.getLiquidityPoolId('random_type')).to.throw(
+      /liquidityPoolType is invalid/
+    );
   });
 
   it('throws an error if assetA is invalid', function() {
     expect(() =>
-      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {})
+      StellarBase.getLiquidityPoolId('constant_product', {})
     ).to.throw(/asseta is invalid/);
+
     expect(() =>
-      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {
-        asseta: 'random'
-      })
+      StellarBase.getLiquidityPoolId('constant_product', { asseta: 'random' })
     ).to.throw(/asseta is invalid/);
   });
 
   it('throws an error if assetB is invalid', function() {
-    const assetA = new StellarBase.Asset(
-      'ARST',
-      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
-    );
     expect(() =>
-      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {
+      StellarBase.getLiquidityPoolId('constant_product', {
         asseta: assetA
       })
     ).to.throw(/assetB is invalid/);
+
     expect(() =>
-      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {
+      StellarBase.getLiquidityPoolId('constant_product', {
         asseta: assetA,
         assetB: 'random'
       })
@@ -47,16 +49,8 @@ describe('StellarBase#liquidityPoolId', function() {
   });
 
   it('throws an error if fee is invalid', function() {
-    const assetA = new StellarBase.Asset(
-      'ARST',
-      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
-    );
-    const assetB = new StellarBase.Asset(
-      'USD',
-      'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
-    );
     expect(() =>
-      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {
+      StellarBase.getLiquidityPoolId('constant_product', {
         asseta: assetA,
         assetB
       })
@@ -64,69 +58,49 @@ describe('StellarBase#liquidityPoolId', function() {
   });
 
   it('returns poolId correctly', function() {
-    const assetA = new StellarBase.Asset(
-      'ARST',
-      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
-    );
-    const assetB = new StellarBase.Asset(
-      'USD',
-      'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
-    );
-    const fee = StellarBase.LiquidityPoolFeeV18;
-
-    const poolId = StellarBase.getLiquidityPoolId(
-      liquidityPoolTypeConstantProduct,
-      {
-        asseta: assetA,
-        assetB,
-        fee
-      }
-    );
+    const poolId = StellarBase.getLiquidityPoolId('constant_product', {
+      asseta: assetA,
+      assetB,
+      fee
+    });
 
     expect(poolId.toString('hex')).to.equal(
       'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
     );
   });
 
-  it('throws an error if assets are not in lexicografichal order', function() {
-    const assetA = new StellarBase.Asset(
-      'USD',
-      'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
-    );
-    const assetB = new StellarBase.Asset(
-      'ARST',
-      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
-    );
-    const fee = StellarBase.LiquidityPoolFeeV18;
-
+  it('throws an error if assets are not in lexicographical order', function() {
     expect(() =>
-      StellarBase.getLiquidityPoolId(liquidityPoolTypeConstantProduct, {
-        asseta: assetA,
-        assetB,
+      StellarBase.getLiquidityPoolId('constant_product', {
+        asseta: assetB,
+        assetB: assetA,
         fee
       })
-    ).to.throw(/assets are not in lexicografichal order/);
+    ).to.throw(/Assets are not in lexicographical order/);
   });
 });
 
-describe('StellarBase#validateLexicographicalAssetsOrder', function() {
+describe('StellarBase#validateLexicographicalAssetsOrder()', function() {
   it('throws an error if the input assets are invalid', function() {
     expect(() => StellarBase.validateLexicographicalAssetsOrder()).to.throw(
       /assetA is invalid/
     );
 
-    const assetA = new StellarBase.Asset(
-      'ARST',
-      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
-    );
     expect(() =>
       StellarBase.validateLexicographicalAssetsOrder(assetA)
     ).to.throw(/assetB is invalid/);
+
+    expect(() => StellarBase.validateLexicographicalAssetsOrder(assetA, assetB))
+      .to.not.throw;
   });
 
   it('returns false if assets are equal', function() {
     const XLM = new StellarBase.Asset.native();
     expect(StellarBase.validateLexicographicalAssetsOrder(XLM, XLM)).to.false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(assetA, assetA)).to
+      .false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(assetB, assetB)).to
+      .false;
   });
 
   it('test if asset types are being validated as native < anum4 < anum12', function() {
@@ -139,6 +113,7 @@ describe('StellarBase#validateLexicographicalAssetsOrder', function() {
       'ARSTANUM12',
       'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
     );
+
     expect(StellarBase.validateLexicographicalAssetsOrder(XLM, XLM)).to.false;
     expect(StellarBase.validateLexicographicalAssetsOrder(XLM, anum4)).to.true;
     expect(StellarBase.validateLexicographicalAssetsOrder(XLM, anum12)).to.true;
@@ -157,7 +132,7 @@ describe('StellarBase#validateLexicographicalAssetsOrder', function() {
       .false;
   });
 
-  it('test if asset codes are being validated as assetACode < assetBCode', function() {
+  it('test if asset codes are being validated as assetCodeA < assetCodeB', function() {
     const assetARST = new StellarBase.Asset(
       'ARST',
       'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
@@ -166,10 +141,11 @@ describe('StellarBase#validateLexicographicalAssetsOrder', function() {
       'USDX',
       'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
     );
-    expect(StellarBase.validateLexicographicalAssetsOrder(assetARST, assetUSDX))
-      .to.true;
+
     expect(StellarBase.validateLexicographicalAssetsOrder(assetARST, assetARST))
       .to.false;
+    expect(StellarBase.validateLexicographicalAssetsOrder(assetARST, assetUSDX))
+      .to.true;
 
     expect(StellarBase.validateLexicographicalAssetsOrder(assetUSDX, assetARST))
       .to.false;
@@ -177,39 +153,34 @@ describe('StellarBase#validateLexicographicalAssetsOrder', function() {
       .to.false;
   });
 
-  it('test if asset issuers are being validated as assetAIssuer < assetBIssuer', function() {
-    const assetARSTIssuerA = new StellarBase.Asset(
+  it('test if asset issuers are being validated as assetIssuerA < assetIssuerB', function() {
+    const assetIssuerA = new StellarBase.Asset(
       'ARST',
       'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
     );
-    const assetARSTIssuerB = new StellarBase.Asset(
+    const assetIssuerB = new StellarBase.Asset(
       'ARST',
       'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
     );
+
     expect(
-      StellarBase.validateLexicographicalAssetsOrder(
-        assetARSTIssuerA,
-        assetARSTIssuerB
-      )
+      StellarBase.validateLexicographicalAssetsOrder(assetIssuerA, assetIssuerB)
     ).to.true;
     expect(
-      StellarBase.validateLexicographicalAssetsOrder(
-        assetARSTIssuerA,
-        assetARSTIssuerA
-      )
+      StellarBase.validateLexicographicalAssetsOrder(assetIssuerA, assetIssuerA)
     ).to.false;
 
     expect(
-      StellarBase.validateLexicographicalAssetsOrder(
-        assetARSTIssuerB,
-        assetARSTIssuerA
-      )
+      StellarBase.validateLexicographicalAssetsOrder(assetIssuerB, assetIssuerA)
     ).to.false;
     expect(
-      StellarBase.validateLexicographicalAssetsOrder(
-        assetARSTIssuerB,
-        assetARSTIssuerB
-      )
+      StellarBase.validateLexicographicalAssetsOrder(assetIssuerB, assetIssuerB)
     ).to.false;
+  });
+});
+
+describe('StellarBase#LiquidityPoolFeeV18', function() {
+  it('throws an error if the input assets are invalid', function() {
+    expect(StellarBase.LiquidityPoolFeeV18).to.equal(30);
   });
 });

--- a/test/unit/liquidity_pool_id_test.js
+++ b/test/unit/liquidity_pool_id_test.js
@@ -1,0 +1,190 @@
+import {
+  liquidityPoolId,
+  validateLexicographicalAssetsOrder,
+  xdr
+} from '../../src';
+import { LiquidityPoolFeeV18 } from '../../src/liquidity_pool_id';
+const liquidityPoolTypeConstantProduct = xdr.LiquidityPoolType.liquidityPoolConstantProduct();
+
+describe('StellarBase#liquidityPoolId', function() {
+  it('throws an error if the liquidity pool type is not `0` for constant product', function() {
+    expect(() => liquidityPoolId()).to.throw(/liquidityPoolType is invalid/);
+
+    expect(() => liquidityPoolId(1)).to.throw(/liquidityPoolType is invalid/);
+  });
+
+  it('throws an error if liquidity pool parameters is missing', function() {
+    expect(() => liquidityPoolId(liquidityPoolTypeConstantProduct)).to.throw(
+      /liquidityPoolParams cannot be empty/
+    );
+  });
+
+  it('throws an error if assetA is invalid', function() {
+    expect(() =>
+      liquidityPoolId(liquidityPoolTypeConstantProduct, {})
+    ).to.throw(/asseta is invalid/);
+    expect(() =>
+      liquidityPoolId(liquidityPoolTypeConstantProduct, { asseta: 'random' })
+    ).to.throw(/asseta is invalid/);
+  });
+
+  it('throws an error if assetB is invalid', function() {
+    const assetA = new StellarBase.Asset(
+      'ARST',
+      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+    );
+    expect(() =>
+      liquidityPoolId(liquidityPoolTypeConstantProduct, { asseta: assetA })
+    ).to.throw(/assetB is invalid/);
+    expect(() =>
+      liquidityPoolId(liquidityPoolTypeConstantProduct, {
+        asseta: assetA,
+        assetB: 'random'
+      })
+    ).to.throw(/assetB is invalid/);
+  });
+
+  it('throws an error if fee is invalid', function() {
+    const assetA = new StellarBase.Asset(
+      'ARST',
+      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+    );
+    const assetB = new StellarBase.Asset(
+      'USD',
+      'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+    );
+    expect(() =>
+      liquidityPoolId(liquidityPoolTypeConstantProduct, {
+        asseta: assetA,
+        assetB
+      })
+    ).to.throw(/fee is invalid/);
+  });
+
+  it('returns poolId correctly', function() {
+    const assetA = new StellarBase.Asset(
+      'ARST',
+      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+    );
+    const assetB = new StellarBase.Asset(
+      'USD',
+      'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+    );
+    const fee = LiquidityPoolFeeV18;
+
+    const poolId = liquidityPoolId(liquidityPoolTypeConstantProduct, {
+      asseta: assetA,
+      assetB,
+      fee
+    });
+
+    expect(poolId).to.be.instanceof(Buffer);
+    expect(poolId.toString('hex')).to.equal(
+      'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
+    );
+  });
+
+  it('throws an error if assets are not in lexicografichal order', function() {
+    const assetA = new StellarBase.Asset(
+      'USD',
+      'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+    );
+    const assetB = new StellarBase.Asset(
+      'ARST',
+      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+    );
+    const fee = LiquidityPoolFeeV18;
+
+    expect(() =>
+      liquidityPoolId(liquidityPoolTypeConstantProduct, {
+        asseta: assetA,
+        assetB,
+        fee
+      })
+    ).to.throw(/assets are not in lexicografichal order/);
+  });
+});
+
+describe('StellarBase#validateLexicographicalAssetsOrder', function() {
+  it('throws an error if the input assets are invalid', function() {
+    expect(() => validateLexicographicalAssetsOrder()).to.throw(
+      /assetA is invalid/
+    );
+
+    const assetA = new StellarBase.Asset(
+      'ARST',
+      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+    );
+    expect(() => validateLexicographicalAssetsOrder(assetA)).to.throw(
+      /assetB is invalid/
+    );
+  });
+
+  it('returns false if assets are equal', function() {
+    const XLM = new StellarBase.Asset.native();
+    expect(validateLexicographicalAssetsOrder(XLM, XLM)).to.false;
+  });
+
+  it('test if asset types are being validated as native < anum4 < anum12', function() {
+    const XLM = new StellarBase.Asset.native();
+    const anum4 = new StellarBase.Asset(
+      'ARST',
+      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+    );
+    const anum12 = new StellarBase.Asset(
+      'ARSTANUM12',
+      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+    );
+    expect(validateLexicographicalAssetsOrder(XLM, XLM)).to.false;
+    expect(validateLexicographicalAssetsOrder(XLM, anum4)).to.true;
+    expect(validateLexicographicalAssetsOrder(XLM, anum12)).to.true;
+
+    expect(validateLexicographicalAssetsOrder(anum4, XLM)).to.false;
+    expect(validateLexicographicalAssetsOrder(anum4, anum4)).to.false;
+    expect(validateLexicographicalAssetsOrder(anum4, anum12)).to.true;
+
+    expect(validateLexicographicalAssetsOrder(anum12, XLM)).to.false;
+    expect(validateLexicographicalAssetsOrder(anum12, anum4)).to.false;
+    expect(validateLexicographicalAssetsOrder(anum12, anum12)).to.false;
+  });
+
+  it('test if asset codes are being validated as assetACode < assetBCode', function() {
+    const assetARST = new StellarBase.Asset(
+      'ARST',
+      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+    );
+    const assetUSDX = new StellarBase.Asset(
+      'USDX',
+      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+    );
+    expect(validateLexicographicalAssetsOrder(assetARST, assetUSDX)).to.true;
+    expect(validateLexicographicalAssetsOrder(assetARST, assetARST)).to.false;
+
+    expect(validateLexicographicalAssetsOrder(assetUSDX, assetARST)).to.false;
+    expect(validateLexicographicalAssetsOrder(assetUSDX, assetUSDX)).to.false;
+  });
+
+  it('test if asset issuers are being validated as assetAIssuer < assetBIssuer', function() {
+    const assetARSTIssuerA = new StellarBase.Asset(
+      'ARST',
+      'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+    );
+    const assetARSTIssuerB = new StellarBase.Asset(
+      'ARST',
+      'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+    );
+    expect(
+      validateLexicographicalAssetsOrder(assetARSTIssuerA, assetARSTIssuerB)
+    ).to.true;
+    expect(
+      validateLexicographicalAssetsOrder(assetARSTIssuerA, assetARSTIssuerA)
+    ).to.false;
+
+    expect(
+      validateLexicographicalAssetsOrder(assetARSTIssuerB, assetARSTIssuerA)
+    ).to.false;
+    expect(
+      validateLexicographicalAssetsOrder(assetARSTIssuerB, assetARSTIssuerB)
+    ).to.false;
+  });
+});

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -589,7 +589,7 @@ describe('Operation', function() {
         assetB,
         fee
       });
-      const op = StellarBase.Operation.changeTrust({ asset: asset });
+      const op = StellarBase.Operation.changeTrust({ asset });
       expect(op).to.be.instanceof(StellarBase.xdr.Operation);
 
       const opXdr = op.toXDR('hex');
@@ -2253,11 +2253,13 @@ describe('Operation', function() {
 
       const operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
       expect(operation.body().switch().name).to.equal('revokeSponsorship');
+
       const obj = StellarBase.Operation.fromXDRObject(operation);
       expect(obj.type).to.be.equal('revokeLiquidityPoolSponsorship');
       expect(obj.liquidityPoolId).to.be.equal(liquidityPoolId);
     });
-    it('throws an error when balanceId is invalid', function() {
+
+    it('throws an error when liquidityPoolId is invalid', function() {
       expect(() =>
         StellarBase.Operation.revokeLiquidityPoolSponsorship({})
       ).to.throw(/liquidityPoolId is invalid/);
@@ -2462,7 +2464,7 @@ describe('Operation', function() {
   describe('liquidityPoolDeposit()', function() {
     it('throws an error if a required parameter is missing', function() {
       expect(() => StellarBase.Operation.liquidityPoolDeposit()).to.throw(
-        /opts cannot be empty/
+        /liquidityPoolId argument is required/
       );
 
       let opts = {};
@@ -2676,7 +2678,7 @@ describe('Operation', function() {
   describe('liquidityPoolWithdraw()', function() {
     it('throws an error if a required parameter is missing', function() {
       expect(() => StellarBase.Operation.liquidityPoolWithdraw()).to.throw(
-        /opts cannot be empty/
+        /liquidityPoolId argument is required/
       );
 
       let opts = {};

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2242,6 +2242,28 @@ describe('Operation', function() {
     });
   });
 
+  describe('revokeLiquidityPoolSponsorship()', function() {
+    it('creates a revokeLiquidityPoolSponsorship', function() {
+      const liquidityPoolId =
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7';
+      const op = StellarBase.Operation.revokeLiquidityPoolSponsorship({
+        liquidityPoolId
+      });
+      const xdr = op.toXDR('hex');
+
+      const operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      expect(operation.body().switch().name).to.equal('revokeSponsorship');
+      const obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeLiquidityPoolSponsorship');
+      expect(obj.liquidityPoolId).to.be.equal(liquidityPoolId);
+    });
+    it('throws an error when balanceId is invalid', function() {
+      expect(() =>
+        StellarBase.Operation.revokeLiquidityPoolSponsorship({})
+      ).to.throw(/liquidityPoolId is invalid/);
+    });
+  });
+
   describe('revokeSignerSponsorship()', function() {
     it('creates a revokeSignerSponsorship', function() {
       const account =

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2459,6 +2459,222 @@ describe('Operation', function() {
     });
   });
 
+  describe('liquidityPoolDeposit()', function() {
+    it('throws an error if a required parameter is missing', function() {
+      expect(() => StellarBase.Operation.liquidityPoolDeposit()).to.throw(
+        /opts cannot be empty/
+      );
+
+      let opts = {};
+      expect(() => StellarBase.Operation.liquidityPoolDeposit(opts)).to.throw(
+        /liquidityPoolId argument is required/
+      );
+
+      opts.liquidityPoolId =
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7';
+      expect(() => StellarBase.Operation.liquidityPoolDeposit(opts)).to.throw(
+        /maxAmounta argument is required/
+      );
+
+      opts.maxAmounta = '10';
+      expect(() => StellarBase.Operation.liquidityPoolDeposit(opts)).to.throw(
+        /maxAmountB argument is required/
+      );
+
+      opts.maxAmountB = '20';
+      expect(() => StellarBase.Operation.liquidityPoolDeposit(opts)).to.throw(
+        /minPrice argument is required/
+      );
+
+      opts.minPrice = '0.45';
+      expect(() => StellarBase.Operation.liquidityPoolDeposit(opts)).to.throw(
+        /maxPrice argument is required/
+      );
+
+      opts.maxPrice = '0.55';
+      expect(() => StellarBase.Operation.liquidityPoolDeposit(opts)).to.not
+        .throw;
+    });
+
+    it('throws an error if prices are negative', function() {
+      const opts = {
+        liquidityPoolId:
+          'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7',
+        maxAmounta: '10.0000000',
+        maxAmountB: '20.0000000',
+        minPrice: '-0.45',
+        maxPrice: '0.55'
+      };
+      expect(() => StellarBase.Operation.liquidityPoolDeposit(opts)).to.throw(
+        /price must be positive/
+      );
+    });
+
+    it('creates a liquidityPoolDeposit (string prices)', function() {
+      const opts = {
+        liquidityPoolId:
+          'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7',
+        maxAmounta: '10.0000000',
+        maxAmountB: '20.0000000',
+        minPrice: '0.45',
+        maxPrice: '0.55'
+      };
+      const op = StellarBase.Operation.liquidityPoolDeposit(opts);
+      const xdr = op.toXDR('hex');
+
+      const xdrObj = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, 'hex'));
+      expect(xdrObj.body().switch().name).to.equal('liquidityPoolDeposit');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .maxAmounta()
+          .toString()
+      ).to.equal('100000000');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .maxAmountB()
+          .toString()
+      ).to.equal('200000000');
+
+      const operation = StellarBase.Operation.fromXDRObject(xdrObj);
+      expect(operation.type).to.be.equal('liquidityPoolDeposit');
+      expect(operation.liquidityPoolId).to.be.equals(opts.liquidityPoolId);
+      expect(operation.maxAmounta).to.be.equals(opts.maxAmounta);
+      expect(operation.maxAmountB).to.be.equals(opts.maxAmountB);
+      expect(operation.minPrice).to.be.equals(opts.minPrice);
+      expect(operation.maxPrice).to.be.equals(opts.maxPrice);
+    });
+
+    it('creates a liquidityPoolDeposit (fraction prices)', function() {
+      const opts = {
+        liquidityPoolId:
+          'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7',
+        maxAmounta: '10.0000000',
+        maxAmountB: '20.0000000',
+        minPrice: {
+          n: 9,
+          d: 20
+        },
+        maxPrice: {
+          n: 11,
+          d: 20
+        }
+      };
+      const op = StellarBase.Operation.liquidityPoolDeposit(opts);
+      const xdr = op.toXDR('hex');
+
+      const xdrObj = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, 'hex'));
+      expect(xdrObj.body().switch().name).to.equal('liquidityPoolDeposit');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .maxAmounta()
+          .toString()
+      ).to.equal('100000000');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .maxAmountB()
+          .toString()
+      ).to.equal('200000000');
+
+      const operation = StellarBase.Operation.fromXDRObject(xdrObj);
+      expect(operation.type).to.be.equal('liquidityPoolDeposit');
+      expect(operation.liquidityPoolId).to.be.equals(opts.liquidityPoolId);
+      expect(operation.maxAmounta).to.be.equals(opts.maxAmounta);
+      expect(operation.maxAmountB).to.be.equals(opts.maxAmountB);
+      expect(operation.minPrice).to.be.equals(
+        new BigNumber(opts.minPrice.n).div(opts.minPrice.d).toString()
+      );
+      expect(operation.maxPrice).to.be.equals(
+        new BigNumber(opts.maxPrice.n).div(opts.maxPrice.d).toString()
+      );
+    });
+
+    it('creates a liquidityPoolDeposit (number prices)', function() {
+      const opts = {
+        liquidityPoolId:
+          'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7',
+        maxAmounta: '10.0000000',
+        maxAmountB: '20.0000000',
+        minPrice: 0.45,
+        maxPrice: 0.55
+      };
+      const op = StellarBase.Operation.liquidityPoolDeposit(opts);
+      const xdr = op.toXDR('hex');
+
+      const xdrObj = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, 'hex'));
+      expect(xdrObj.body().switch().name).to.equal('liquidityPoolDeposit');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .maxAmounta()
+          .toString()
+      ).to.equal('100000000');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .maxAmountB()
+          .toString()
+      ).to.equal('200000000');
+
+      const operation = StellarBase.Operation.fromXDRObject(xdrObj);
+      expect(operation.type).to.be.equal('liquidityPoolDeposit');
+      expect(operation.liquidityPoolId).to.be.equals(opts.liquidityPoolId);
+      expect(operation.maxAmounta).to.be.equals(opts.maxAmounta);
+      expect(operation.maxAmountB).to.be.equals(opts.maxAmountB);
+      expect(operation.minPrice).to.be.equals(opts.minPrice.toString());
+      expect(operation.maxPrice).to.be.equals(opts.maxPrice.toString());
+    });
+
+    it('creates a liquidityPoolDeposit (BigNumber prices)', function() {
+      const opts = {
+        liquidityPoolId:
+          'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7',
+        maxAmounta: '10.0000000',
+        maxAmountB: '20.0000000',
+        minPrice: new BigNumber(9).dividedBy(20),
+        maxPrice: new BigNumber(11).dividedBy(20)
+      };
+      const op = StellarBase.Operation.liquidityPoolDeposit(opts);
+      const xdr = op.toXDR('hex');
+
+      const xdrObj = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, 'hex'));
+      expect(xdrObj.body().switch().name).to.equal('liquidityPoolDeposit');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .maxAmounta()
+          .toString()
+      ).to.equal('100000000');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .maxAmountB()
+          .toString()
+      ).to.equal('200000000');
+
+      const operation = StellarBase.Operation.fromXDRObject(xdrObj);
+      expect(operation.type).to.be.equal('liquidityPoolDeposit');
+      expect(operation.liquidityPoolId).to.be.equals(opts.liquidityPoolId);
+      expect(operation.maxAmounta).to.be.equals(opts.maxAmounta);
+      expect(operation.maxAmountB).to.be.equals(opts.maxAmountB);
+      expect(operation.minPrice).to.be.equals(opts.minPrice.toString());
+      expect(operation.maxPrice).to.be.equals(opts.maxPrice.toString());
+    });
+  });
+
+  // TODO: liquidityPoolWithdrawOp tests
+
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {
       let amounts = [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -574,6 +574,40 @@ describe('Operation', function() {
       expect(obj.limit).to.be.equal('50.0000000');
     });
 
+    it('creates a changeTrustOp to a liquidity pool', function() {
+      const assetA = new StellarBase.Asset(
+        'ARST',
+        'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
+      );
+      const assetB = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      const fee = StellarBase.LiquidityPoolFeeV18;
+      const asset = new StellarBase.ChangeTrustAsset(null, null, {
+        asseta: assetA,
+        assetB,
+        fee
+      });
+      const op = StellarBase.Operation.changeTrust({ asset: asset });
+      expect(op).to.be.instanceof(StellarBase.xdr.Operation);
+
+      const opXdr = op.toXDR('hex');
+      const opXdrObj = StellarBase.xdr.Operation.fromXDR(opXdr, 'hex');
+      const operation = StellarBase.Operation.fromXDRObject(opXdrObj);
+
+      expect(operation.type).to.be.equal('changeTrust');
+      expect(operation.line).to.be.deep.equal(asset);
+      expect(
+        opXdrObj
+          .body()
+          .value()
+          .limit()
+          .toString()
+      ).to.be.equal('9223372036854775807'); // MAX_INT64
+      expect(operation.limit).to.be.equal('922337203685.4775807');
+    });
+
     it('deletes a trustline', function() {
       let asset = new StellarBase.ChangeTrustAsset(
         'USD',

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2673,7 +2673,81 @@ describe('Operation', function() {
     });
   });
 
-  // TODO: liquidityPoolWithdrawOp tests
+  describe('liquidityPoolWithdraw()', function() {
+    it('throws an error if a required parameter is missing', function() {
+      expect(() => StellarBase.Operation.liquidityPoolWithdraw()).to.throw(
+        /opts cannot be empty/
+      );
+
+      let opts = {};
+      expect(() => StellarBase.Operation.liquidityPoolWithdraw(opts)).to.throw(
+        /liquidityPoolId argument is required/
+      );
+
+      opts.liquidityPoolId =
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7';
+      expect(() => StellarBase.Operation.liquidityPoolWithdraw(opts)).to.throw(
+        /amount argument is required/
+      );
+
+      opts.amount = '10';
+      expect(() => StellarBase.Operation.liquidityPoolWithdraw(opts)).to.throw(
+        /minAmounta argument is required/
+      );
+
+      opts.minAmounta = '10000';
+      expect(() => StellarBase.Operation.liquidityPoolWithdraw(opts)).to.throw(
+        /minAmountB argument is required/
+      );
+
+      opts.minAmountB = '20000';
+      expect(() => StellarBase.Operation.liquidityPoolWithdraw(opts)).to.not
+        .throw;
+    });
+
+    it('creates a liquidityPoolWithdraw', function() {
+      const opts = {
+        liquidityPoolId:
+          'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7',
+        amount: '5.0000000',
+        minAmounta: '10.0000000',
+        minAmountB: '20.0000000'
+      };
+      const op = StellarBase.Operation.liquidityPoolWithdraw(opts);
+      const xdr = op.toXDR('hex');
+
+      const xdrObj = StellarBase.xdr.Operation.fromXDR(Buffer.from(xdr, 'hex'));
+      expect(xdrObj.body().switch().name).to.equal('liquidityPoolWithdraw');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .amount()
+          .toString()
+      ).to.equal('50000000');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .minAmounta()
+          .toString()
+      ).to.equal('100000000');
+      expect(
+        xdrObj
+          .body()
+          .value()
+          .minAmountB()
+          .toString()
+      ).to.equal('200000000');
+
+      const operation = StellarBase.Operation.fromXDRObject(xdrObj);
+      expect(operation.type).to.be.equal('liquidityPoolWithdraw');
+      expect(operation.liquidityPoolId).to.be.equals(opts.liquidityPoolId);
+      expect(operation.amount).to.be.equals(opts.amount);
+      expect(operation.minAmounta).to.be.equals(opts.minAmounta);
+      expect(operation.minAmountB).to.be.equals(opts.minAmountB);
+    });
+  });
 
   describe('.isValidAmount()', function() {
     it('returns true for valid amounts', function() {

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2060,7 +2060,7 @@ describe('Operation', function() {
     it('creates a revokeTrustlineSponsorship', function() {
       const account =
         'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
-      var asset = new StellarBase.Asset(
+      var asset = new StellarBase.TrustLineAsset(
         'USDUSD',
         'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
       );
@@ -2073,6 +2073,25 @@ describe('Operation', function() {
       var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
       expect(operation.body().switch().name).to.equal('revokeSponsorship');
       var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeTrustlineSponsorship');
+    });
+    it('creates a revokeTrustlineSponsorship for a liquidity pool', function() {
+      const account =
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7';
+      const asset = new StellarBase.TrustLineAsset(
+        undefined,
+        undefined,
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
+      );
+      const op = StellarBase.Operation.revokeTrustlineSponsorship({
+        account,
+        asset
+      });
+      const xdr = op.toXDR('hex');
+
+      const operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      expect(operation.body().switch().name).to.equal('revokeSponsorship');
+      const obj = StellarBase.Operation.fromXDRObject(operation);
       expect(obj.type).to.be.equal('revokeTrustlineSponsorship');
     });
     it('throws an error when account is invalid', function() {

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -526,7 +526,7 @@ describe('Operation', function() {
 
   describe('.changeTrust()', function() {
     it('creates a changeTrustOp', function() {
-      let asset = new StellarBase.Asset(
+      let asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
       );
@@ -549,7 +549,7 @@ describe('Operation', function() {
     });
 
     it('creates a changeTrustOp with limit', function() {
-      let asset = new StellarBase.Asset(
+      let asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
       );
@@ -575,7 +575,7 @@ describe('Operation', function() {
     });
 
     it('deletes a trustline', function() {
-      let asset = new StellarBase.Asset(
+      let asset = new StellarBase.ChangeTrustAsset(
         'USD',
         'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
       );

--- a/test/unit/trustline_asset_test.js
+++ b/test/unit/trustline_asset_test.js
@@ -164,61 +164,61 @@ describe('TrustLineAsset', function() {
       );
     });
 
-    // it('parses a 3-alphanum asset object', function() {
-    //   var asset = new StellarBase.TrustLineAsset(
-    //     'USD',
-    //     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
-    //   );
-    //   var xdr = asset.toXDRObject();
+    it('parses a 3-alphanum asset object', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        'USD',
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      var xdr = asset.toXDRObject();
 
-    //   expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
-    //   expect(() => xdr.toXDR('hex')).to.not.throw();
+      expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+      expect(() => xdr.toXDR('hex')).to.not.throw();
 
-    //   expect(xdr.arm()).to.equal('alphaNum4');
-    //   expect(xdr.value().assetCode()).to.equal('USD\0');
-    // });
+      expect(xdr.arm()).to.equal('alphaNum4');
+      expect(xdr.value().assetCode()).to.equal('USD\0');
+    });
 
-    // it('parses a 4-alphanum asset object', function() {
-    //   var asset = new StellarBase.TrustLineAsset(
-    //     'BART',
-    //     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
-    //   );
-    //   var xdr = asset.toXDRObject();
+    it('parses a 4-alphanum asset object', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        'BART',
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      var xdr = asset.toXDRObject();
 
-    //   expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
-    //   expect(() => xdr.toXDR('hex')).to.not.throw();
+      expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+      expect(() => xdr.toXDR('hex')).to.not.throw();
 
-    //   expect(xdr.arm()).to.equal('alphaNum4');
-    //   expect(xdr.value().assetCode()).to.equal('BART');
-    // });
+      expect(xdr.arm()).to.equal('alphaNum4');
+      expect(xdr.value().assetCode()).to.equal('BART');
+    });
 
-    // it('parses a 5-alphanum asset object', function() {
-    //   var asset = new StellarBase.TrustLineAsset(
-    //     '12345',
-    //     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
-    //   );
-    //   var xdr = asset.toXDRObject();
+    it('parses a 5-alphanum asset object', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        '12345',
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      var xdr = asset.toXDRObject();
 
-    //   expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
-    //   expect(() => xdr.toXDR('hex')).to.not.throw();
+      expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+      expect(() => xdr.toXDR('hex')).to.not.throw();
 
-    //   expect(xdr.arm()).to.equal('alphaNum12');
-    //   expect(xdr.value().assetCode()).to.equal('12345\0\0\0\0\0\0\0');
-    // });
+      expect(xdr.arm()).to.equal('alphaNum12');
+      expect(xdr.value().assetCode()).to.equal('12345\0\0\0\0\0\0\0');
+    });
 
-    // it('parses a 12-alphanum asset object', function() {
-    //   var asset = new StellarBase.TrustLineAsset(
-    //     '123456789012',
-    //     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
-    //   );
-    //   var xdr = asset.toXDRObject();
+    it('parses a 12-alphanum asset object', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        '123456789012',
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      var xdr = asset.toXDRObject();
 
-    //   expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
-    //   expect(() => xdr.toXDR('hex')).to.not.throw();
+      expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+      expect(() => xdr.toXDR('hex')).to.not.throw();
 
-    //   expect(xdr.arm()).to.equal('alphaNum12');
-    //   expect(xdr.value().assetCode()).to.equal('123456789012');
-    // });
+      expect(xdr.arm()).to.equal('alphaNum12');
+      expect(xdr.value().assetCode()).to.equal('123456789012');
+    });
   });
 
   describe('fromOperation()', function() {

--- a/test/unit/trustline_asset_test.js
+++ b/test/unit/trustline_asset_test.js
@@ -6,12 +6,6 @@ describe('TrustLineAsset', function() {
       );
     });
 
-    it("throws an error when there's no issuer for a trustline asset with code `XLM`", function() {
-      expect(() => new StellarBase.TrustLineAsset('USD')).to.throw(
-        /Issuer cannot be null/
-      );
-    });
-
     it('throws an error when there is an asset issuer but the code is invalid', function() {
       expect(
         () =>
@@ -36,15 +30,15 @@ describe('TrustLineAsset', function() {
       ).to.throw(/Asset code is invalid/);
     });
 
-    it('throws an error when issuer is invalid', function() {
-      expect(() => new StellarBase.TrustLineAsset('USD', 'GCEZWKCA5')).to.throw(
-        /Issuer is invalid/
-      );
-    });
-
     it('throws an error when issuer is null and asset is not XLM', function() {
       expect(() => new StellarBase.TrustLineAsset('USD')).to.throw(
         /Issuer cannot be null/
+      );
+    });
+
+    it('throws an error when issuer is invalid', function() {
+      expect(() => new StellarBase.TrustLineAsset('USD', 'GCEZWKCA5')).to.throw(
+        /Issuer is invalid/
       );
     });
 
@@ -67,7 +61,7 @@ describe('TrustLineAsset', function() {
   });
 
   describe('getCode()', function() {
-    it('returns a code for a native asset object', function() {
+    it('returns an issuer for a native asset', function() {
       var asset = new StellarBase.TrustLineAsset.native();
       expect(asset.getCode()).to.be.equal('XLM');
     });
@@ -91,12 +85,12 @@ describe('TrustLineAsset', function() {
   });
 
   describe('getIssuer()', function() {
-    it('returns a code for a native asset object', function() {
+    it('returns undefined issuer for a native asset', function() {
       var asset = new StellarBase.TrustLineAsset.native();
       expect(asset.getIssuer()).to.be.undefined;
     });
 
-    it('returns a code for a non-native asset', function() {
+    it('returns an issuer for a non-native asset', function() {
       var asset = new StellarBase.TrustLineAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
@@ -117,12 +111,12 @@ describe('TrustLineAsset', function() {
   });
 
   describe('getLiquidityPoolId()', function() {
-    it('returns empty liquidity pool ID for a native asset object', function() {
+    it('returns undefined liquidity pool ID for a native asset', function() {
       var asset = new StellarBase.TrustLineAsset.native();
       expect(asset.getLiquidityPoolId()).to.be.undefined;
     });
 
-    it('returns empty liquidity pool ID for a non-native asset', function() {
+    it('returns undefined liquidity pool ID for a non-native asset', function() {
       var asset = new StellarBase.TrustLineAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
@@ -143,12 +137,12 @@ describe('TrustLineAsset', function() {
   });
 
   describe('getAssetType()', function() {
-    it('returns native for native assets', function() {
+    it('returns "native" for native assets', function() {
       var asset = StellarBase.TrustLineAsset.native();
       expect(asset.getAssetType()).to.eq('native');
     });
 
-    it('returns credit_alphanum4 if the trustline asset code length is between 1 and 4', function() {
+    it('returns "credit_alphanum4" if the trustline asset code length is between 1 and 4', function() {
       var asset = new StellarBase.TrustLineAsset(
         'ABCD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
@@ -156,7 +150,7 @@ describe('TrustLineAsset', function() {
       expect(asset.getAssetType()).to.eq('credit_alphanum4');
     });
 
-    it('returns credit_alphanum12 if the trustline asset code length is between 5 and 12', function() {
+    it('returns "credit_alphanum12" if the trustline asset code length is between 5 and 12', function() {
       var asset = new StellarBase.TrustLineAsset(
         'ABCDEF',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
@@ -164,7 +158,7 @@ describe('TrustLineAsset', function() {
       expect(asset.getAssetType()).to.eq('credit_alphanum12');
     });
 
-    it('returns liquidity_pool_shares if the trustline asset is a liquidity pool ID', function() {
+    it('returns "liquidity_pool_shares" if the trustline asset is a liquidity pool ID', function() {
       var asset = new StellarBase.TrustLineAsset(
         undefined,
         undefined,
@@ -265,6 +259,7 @@ describe('TrustLineAsset', function() {
 
       expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
       expect(asset.isNative()).to.equal(true);
+      expect(asset.getAssetType()).to.equal('native');
     });
 
     it('parses a 4-alphanum asset XDR', function() {
@@ -284,12 +279,13 @@ describe('TrustLineAsset', function() {
       expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
       expect(asset.getCode()).to.equal(assetCode);
       expect(asset.getIssuer()).to.equal(issuer);
+      expect(asset.getAssetType()).to.equal('credit_alphanum4');
     });
 
     it('parses a 12-alphanum asset XDR', function() {
       var issuer = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
       var assetCode = 'KHLTOKEN';
-      var assetType = new StellarBase.xdr.AlphaNum4({
+      var assetType = new StellarBase.xdr.AlphaNum12({
         assetCode: assetCode + '\0\0\0\0',
         issuer: StellarBase.Keypair.fromPublicKey(issuer).xdrAccountId()
       });
@@ -303,6 +299,7 @@ describe('TrustLineAsset', function() {
       expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
       expect(asset.getCode()).to.equal(assetCode);
       expect(asset.getIssuer()).to.equal(issuer);
+      expect(asset.getAssetType()).to.equal('credit_alphanum12');
     });
 
     it('parses a liquidityPoolId asset XDR', function() {
@@ -317,6 +314,7 @@ describe('TrustLineAsset', function() {
       const asset = StellarBase.TrustLineAsset.fromOperation(xdr);
       expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
       expect(asset.getLiquidityPoolId()).to.equal(poolId);
+      expect(asset.getAssetType()).to.equal('liquidity_pool_shares');
     });
   });
 
@@ -326,7 +324,7 @@ describe('TrustLineAsset', function() {
       expect(asset.toString()).to.be.equal('native');
     });
 
-    it("returns 'code:issuer' for non-native asset", function() {
+    it("returns '<code>:<issuer>' for non-native asset", function() {
       var asset = new StellarBase.TrustLineAsset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'

--- a/test/unit/trustline_asset_test.js
+++ b/test/unit/trustline_asset_test.js
@@ -219,6 +219,21 @@ describe('TrustLineAsset', function() {
       expect(xdr.arm()).to.equal('alphaNum12');
       expect(xdr.value().assetCode()).to.equal('123456789012');
     });
+
+    it('parses a liquidity pool trustline asset object', function() {
+      const asset = new StellarBase.TrustLineAsset(
+        undefined,
+        undefined,
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
+      );
+      const xdr = asset.toXDRObject();
+
+      expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+      expect(xdr.arm()).to.equal('liquidityPoolId');
+      expect(xdr.liquidityPoolId().toString('hex')).to.equal(
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
+      );
+    });
   });
 
   describe('fromOperation()', function() {
@@ -266,6 +281,21 @@ describe('TrustLineAsset', function() {
       expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
       expect(asset.getCode()).to.equal(assetCode);
       expect(asset.getIssuer()).to.equal(issuer);
+    });
+
+    it('parses a liquidityPoolId asset XDR', function() {
+      const poolId =
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7';
+      const xdrPoolId = StellarBase.xdr.PoolId.fromXDR(poolId, 'hex');
+      const xdr = new StellarBase.xdr.TrustLineAsset(
+        'assetTypePoolShare',
+        xdrPoolId
+      );
+
+      const asset = StellarBase.TrustLineAsset.fromOperation(xdr);
+
+      expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
+      expect(asset.getLiquidityPoolId().toString('hex')).to.equal(poolId);
     });
   });
 

--- a/test/unit/trustline_asset_test.js
+++ b/test/unit/trustline_asset_test.js
@@ -47,6 +47,23 @@ describe('TrustLineAsset', function() {
         /Issuer cannot be null/
       );
     });
+
+    it('throws an error when pool ID is not a valid hash', function() {
+      expect(
+        () => new StellarBase.TrustLineAsset(undefined, undefined, 'abc')
+      ).to.throw(/Liquidity pool ID is not a valid hash/);
+    });
+
+    it('does not throw an error when pool ID is a valid hash', function() {
+      expect(
+        () =>
+          new StellarBase.TrustLineAsset(
+            undefined,
+            undefined,
+            'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
+          )
+      ).to.not.throw;
+    });
   });
 
   describe('getCode()', function() {
@@ -67,7 +84,7 @@ describe('TrustLineAsset', function() {
       var asset = new StellarBase.TrustLineAsset(
         undefined,
         undefined,
-        'liquidity_pool_id_here'
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
       );
       expect(asset.getCode()).to.be.undefined;
     });
@@ -93,7 +110,7 @@ describe('TrustLineAsset', function() {
       var asset = new StellarBase.TrustLineAsset(
         undefined,
         undefined,
-        'liquidity_pool_id_here'
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
       );
       expect(asset.getIssuer()).to.be.undefined;
     });
@@ -117,9 +134,11 @@ describe('TrustLineAsset', function() {
       var asset = new StellarBase.TrustLineAsset(
         undefined,
         undefined,
-        'liquidity_pool_id_here'
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
       );
-      expect(asset.getLiquidityPoolId()).to.be.equal('liquidity_pool_id_here');
+      expect(asset.getLiquidityPoolId()).to.be.equal(
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
+      );
     });
   });
 
@@ -149,7 +168,7 @@ describe('TrustLineAsset', function() {
       var asset = new StellarBase.TrustLineAsset(
         undefined,
         undefined,
-        'liquidity_pool_id_here'
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
       );
       expect(asset.getAssetType()).to.eq('liquidity_pool_shares');
     });
@@ -321,10 +340,10 @@ describe('TrustLineAsset', function() {
       var asset = new StellarBase.TrustLineAsset(
         undefined,
         undefined,
-        'liquidity_pool_id_here'
+        'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
       );
       expect(asset.toString()).to.be.equal(
-        'liquidity_pool:liquidity_pool_id_here'
+        'liquidity_pool:dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
       );
     });
   });

--- a/test/unit/trustline_asset_test.js
+++ b/test/unit/trustline_asset_test.js
@@ -1,0 +1,299 @@
+describe('TrustLineAsset', function() {
+  describe('constructor', function() {
+    it('throws an error when no parameter is provided', function() {
+      expect(() => new StellarBase.TrustLineAsset()).to.throw(
+        /Must provide either code, issuer or liquidityPoolId/
+      );
+    });
+
+    it("throws an error when there's no issuer for a trustline asset with code `XLM`", function() {
+      expect(() => new StellarBase.TrustLineAsset('USD')).to.throw(
+        /Issuer cannot be null/
+      );
+    });
+
+    it('throws an error when there is an asset issuer but the code is invalid', function() {
+      expect(
+        () =>
+          new StellarBase.TrustLineAsset(
+            '',
+            'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+          )
+      ).to.throw(/Asset code is invalid/);
+      expect(
+        () =>
+          new StellarBase.TrustLineAsset(
+            '1234567890123',
+            'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+          )
+      ).to.throw(/Asset code is invalid/);
+      expect(
+        () =>
+          new StellarBase.TrustLineAsset(
+            'ab_',
+            'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+          )
+      ).to.throw(/Asset code is invalid/);
+    });
+
+    it('throws an error when issuer is invalid', function() {
+      expect(() => new StellarBase.TrustLineAsset('USD', 'GCEZWKCA5')).to.throw(
+        /Issuer is invalid/
+      );
+    });
+
+    it('throws an error when issuer is null and asset is not XLM', function() {
+      expect(() => new StellarBase.TrustLineAsset('USD')).to.throw(
+        /Issuer cannot be null/
+      );
+    });
+  });
+
+  describe('getCode()', function() {
+    it('returns a code for a native asset object', function() {
+      var asset = new StellarBase.TrustLineAsset.native();
+      expect(asset.getCode()).to.be.equal('XLM');
+    });
+
+    it('returns a code for a non-native asset', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        'USD',
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      expect(asset.getCode()).to.be.equal('USD');
+    });
+
+    it('returns undefined code for a liquidity pool asset', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        undefined,
+        undefined,
+        'liquidity_pool_id_here'
+      );
+      expect(asset.getCode()).to.be.undefined;
+    });
+  });
+
+  describe('getIssuer()', function() {
+    it('returns a code for a native asset object', function() {
+      var asset = new StellarBase.TrustLineAsset.native();
+      expect(asset.getIssuer()).to.be.undefined;
+    });
+
+    it('returns a code for a non-native asset', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        'USD',
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      expect(asset.getIssuer()).to.be.equal(
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+    });
+
+    it('returns undefined issuer for a liquidity pool asset', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        undefined,
+        undefined,
+        'liquidity_pool_id_here'
+      );
+      expect(asset.getIssuer()).to.be.undefined;
+    });
+  });
+
+  describe('getLiquidityPoolId()', function() {
+    it('returns empty liquidity pool ID for a native asset object', function() {
+      var asset = new StellarBase.TrustLineAsset.native();
+      expect(asset.getLiquidityPoolId()).to.be.undefined;
+    });
+
+    it('returns empty liquidity pool ID for a non-native asset', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        'USD',
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      expect(asset.getLiquidityPoolId()).to.be.undefined;
+    });
+
+    it('returns empty issuer for a liquidity pool asset', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        undefined,
+        undefined,
+        'liquidity_pool_id_here'
+      );
+      expect(asset.getLiquidityPoolId()).to.be.equal('liquidity_pool_id_here');
+    });
+  });
+
+  describe('getAssetType()', function() {
+    it('returns native for native assets', function() {
+      var asset = StellarBase.TrustLineAsset.native();
+      expect(asset.getAssetType()).to.eq('native');
+    });
+
+    it('returns credit_alphanum4 if the trustline asset code length is between 1 and 4', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        'ABCD',
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      expect(asset.getAssetType()).to.eq('credit_alphanum4');
+    });
+
+    it('returns credit_alphanum12 if the trustline asset code length is between 5 and 12', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        'ABCDEF',
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      expect(asset.getAssetType()).to.eq('credit_alphanum12');
+    });
+
+    it('returns liquidity_pool_shares if the trustline asset is a liquidity pool ID', function() {
+      var asset = new StellarBase.TrustLineAsset(
+        undefined,
+        undefined,
+        'liquidity_pool_id_here'
+      );
+      expect(asset.getAssetType()).to.eq('liquidity_pool_shares');
+    });
+  });
+
+  describe('toXDRObject()', function() {
+    it('parses a native asset object', function() {
+      var asset = new StellarBase.TrustLineAsset.native();
+      var xdr = asset.toXDRObject();
+      expect(xdr.toXDR().toString()).to.be.equal(
+        Buffer.from([0, 0, 0, 0]).toString()
+      );
+    });
+
+    // it('parses a 3-alphanum asset object', function() {
+    //   var asset = new StellarBase.TrustLineAsset(
+    //     'USD',
+    //     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+    //   );
+    //   var xdr = asset.toXDRObject();
+
+    //   expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+    //   expect(() => xdr.toXDR('hex')).to.not.throw();
+
+    //   expect(xdr.arm()).to.equal('alphaNum4');
+    //   expect(xdr.value().assetCode()).to.equal('USD\0');
+    // });
+
+    // it('parses a 4-alphanum asset object', function() {
+    //   var asset = new StellarBase.TrustLineAsset(
+    //     'BART',
+    //     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+    //   );
+    //   var xdr = asset.toXDRObject();
+
+    //   expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+    //   expect(() => xdr.toXDR('hex')).to.not.throw();
+
+    //   expect(xdr.arm()).to.equal('alphaNum4');
+    //   expect(xdr.value().assetCode()).to.equal('BART');
+    // });
+
+    // it('parses a 5-alphanum asset object', function() {
+    //   var asset = new StellarBase.TrustLineAsset(
+    //     '12345',
+    //     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+    //   );
+    //   var xdr = asset.toXDRObject();
+
+    //   expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+    //   expect(() => xdr.toXDR('hex')).to.not.throw();
+
+    //   expect(xdr.arm()).to.equal('alphaNum12');
+    //   expect(xdr.value().assetCode()).to.equal('12345\0\0\0\0\0\0\0');
+    // });
+
+    // it('parses a 12-alphanum asset object', function() {
+    //   var asset = new StellarBase.TrustLineAsset(
+    //     '123456789012',
+    //     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+    //   );
+    //   var xdr = asset.toXDRObject();
+
+    //   expect(xdr).to.be.instanceof(StellarBase.xdr.TrustLineAsset);
+    //   expect(() => xdr.toXDR('hex')).to.not.throw();
+
+    //   expect(xdr.arm()).to.equal('alphaNum12');
+    //   expect(xdr.value().assetCode()).to.equal('123456789012');
+    // });
+  });
+
+  describe('fromOperation()', function() {
+    it('parses a native asset XDR', function() {
+      var xdr = new StellarBase.xdr.TrustLineAsset.assetTypeNative();
+      var asset = StellarBase.TrustLineAsset.fromOperation(xdr);
+
+      expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
+      expect(asset.isNative()).to.equal(true);
+    });
+
+    it('parses a 4-alphanum asset XDR', function() {
+      var issuer = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      var assetCode = 'KHL';
+      var assetType = new StellarBase.xdr.AlphaNum4({
+        assetCode: assetCode + '\0',
+        issuer: StellarBase.Keypair.fromPublicKey(issuer).xdrAccountId()
+      });
+      var xdr = new StellarBase.xdr.TrustLineAsset(
+        'assetTypeCreditAlphanum4',
+        assetType
+      );
+
+      var asset = StellarBase.TrustLineAsset.fromOperation(xdr);
+
+      expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
+      expect(asset.getCode()).to.equal(assetCode);
+      expect(asset.getIssuer()).to.equal(issuer);
+    });
+
+    it('parses a 12-alphanum asset XDR', function() {
+      var issuer = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ';
+      var assetCode = 'KHLTOKEN';
+      var assetType = new StellarBase.xdr.AlphaNum4({
+        assetCode: assetCode + '\0\0\0\0',
+        issuer: StellarBase.Keypair.fromPublicKey(issuer).xdrAccountId()
+      });
+      var xdr = new StellarBase.xdr.TrustLineAsset(
+        'assetTypeCreditAlphanum12',
+        assetType
+      );
+
+      var asset = StellarBase.TrustLineAsset.fromOperation(xdr);
+
+      expect(asset).to.be.instanceof(StellarBase.TrustLineAsset);
+      expect(asset.getCode()).to.equal(assetCode);
+      expect(asset.getIssuer()).to.equal(issuer);
+    });
+  });
+
+  describe('toString()', function() {
+    it("returns 'native' for native asset", function() {
+      var asset = StellarBase.TrustLineAsset.native();
+      expect(asset.toString()).to.be.equal('native');
+    });
+
+    it("returns 'code:issuer' for non-native asset", function() {
+      var asset = new StellarBase.TrustLineAsset(
+        'USD',
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+      expect(asset.toString()).to.be.equal(
+        'USD:GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+      );
+    });
+
+    it("returns 'liquidity_pool:<id>' for liquidity pool assets", function() {
+      var asset = new StellarBase.TrustLineAsset(
+        undefined,
+        undefined,
+        'liquidity_pool_id_here'
+      );
+      expect(asset.toString()).to.be.equal(
+        'liquidity_pool:liquidity_pool_id_here'
+      );
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,6 +60,26 @@ export class Asset {
   issuer: string;
 }
 
+export class ChangeTrustAsset {
+  static native(): ChangeTrustAsset;
+  static fromOperation(xdr: xdr.ChangeTrustAsset): ChangeTrustAsset;
+
+  constructor(code?: string, issuer?: string, liquidityPoolParams?: LiquidityPoolParams.ConstantProduct);
+
+  getCode(): string;
+  getIssuer(): string;
+  getLiquidityPoolParams(): LiquidityPoolParams.ConstantProduct;
+  getAssetType(): AssetType;
+  isNative(): boolean;
+  isLiquidityPool(): boolean;
+  equals(other: ChangeTrustAsset): boolean;
+  toXDRObject(): xdr.ChangeTrustAsset;
+
+  code: string;
+  issuer: string;
+  liquidityPoolParams: LiquidityPoolParams.ConstantProduct;
+}
+
 export class Claimant {
   readonly destination: string;
   readonly predicate: xdr.ClaimPredicate;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,11 +35,13 @@ export namespace AssetType {
   type native = 'native';
   type credit4 = 'credit_alphanum4';
   type credit12 = 'credit_alphanum12';
+  type liquidityPoolShares = 'liquidity_pool_shares';
 }
 export type AssetType =
   | AssetType.native
   | AssetType.credit4
-  | AssetType.credit12;
+  | AssetType.credit12
+  | AssetType.liquidityPoolShares;
 
 export class Asset {
   static native(): Asset;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -311,6 +311,7 @@ export namespace OperationType {
   type ClawbackClaimableBalance = 'clawbackClaimableBalance';
   type SetTrustLineFlags = 'setTrustLineFlags';
   type LiquidityPoolDeposit = 'liquidityPoolDeposit';
+  type LiquidityPoolWithdraw = 'liquidityPoolWithdraw';
 }
 export type OperationType =
   | OperationType.CreateAccount
@@ -335,7 +336,8 @@ export type OperationType =
   | OperationType.Clawback
   | OperationType.ClawbackClaimableBalance
   | OperationType.SetTrustLineFlags
-  | OperationType.LiquidityPoolDeposit;
+  | OperationType.LiquidityPoolDeposit
+  | OperationType.LiquidityPoolWithdraw;
 
 export namespace OperationOptions {
   interface BaseOptions {
@@ -476,6 +478,12 @@ export namespace OperationOptions {
     minPrice: number | string | object /* bignumber.js */;
     maxPrice: number | string | object /* bignumber.js */;
   }
+  interface LiquidityPoolWithdraw extends BaseOptions {
+    liquidityPoolId: string;
+    amount: string;
+    minAmounta: string;
+    minAmountB: string;
+  }
 }
 export type OperationOptions =
   | OperationOptions.CreateAccount
@@ -505,7 +513,8 @@ export type OperationOptions =
   | OperationOptions.Clawback
   | OperationOptions.ClawbackClaimableBalance
   | OperationOptions.SetTrustLineFlags
-  | OperationOptions.LiquidityPoolDeposit;
+  | OperationOptions.LiquidityPoolDeposit
+  | OperationOptions.LiquidityPoolWithdraw;
 
 export namespace Operation {
   interface BaseOperation<T extends OperationType = OperationType> {
@@ -775,6 +784,15 @@ export namespace Operation {
   function liquidityPoolDeposit(
     options: OperationOptions.LiquidityPoolDeposit
   ): xdr.Operation<LiquidityPoolDeposit>;
+  interface LiquidityPoolWithdraw extends BaseOperation<OperationType.LiquidityPoolWithdraw> {
+    liquidityPoolId: string;
+    amount: string;
+    minAmounta: string;
+    minAmountB: string;
+  }
+  function liquidityPoolWithdraw(
+    options: OperationOptions.LiquidityPoolWithdraw
+  ): xdr.Operation<LiquidityPoolWithdraw>;
 
   function fromXDRObject<T extends Operation = Operation>(
     xdrOperation: xdr.Operation<T>
@@ -809,7 +827,8 @@ export type Operation =
   | Operation.Clawback
   | Operation.ClawbackClaimableBalance
   | Operation.SetTrustLineFlags
-  | Operation.LiquidityPoolDeposit;
+  | Operation.LiquidityPoolDeposit
+  | Operation.LiquidityPoolWithdraw;
 
 export namespace StrKey {
   function encodeEd25519PublicKey(data: Buffer): string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -845,3 +845,23 @@ export function verify(
   signature: Buffer,
   rawPublicKey: Buffer
 ): boolean;
+
+export class TrustLineAsset {
+  static native(): TrustLineAsset;
+  static fromOperation(xdr: xdr.TrustLineAsset): TrustLineAsset;
+
+  constructor(code?: string, issuer?: string, liquidityPoolId?: string);
+
+  getCode(): string;
+  getIssuer(): string;
+  getLiquidityPoolId(): string;
+  getAssetType(): AssetType;
+  isNative(): boolean;
+  isLiquidityPool(): boolean;
+  equals(other: TrustLineAsset): boolean;
+  toXDRObject(): xdr.TrustLineAsset;
+
+  code: string;
+  issuer: string;
+  liquidityPoolId: string;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -64,11 +64,11 @@ export class ChangeTrustAsset {
   static native(): ChangeTrustAsset;
   static fromOperation(xdr: xdr.ChangeTrustAsset): ChangeTrustAsset;
 
-  constructor(code?: string, issuer?: string, liquidityPoolParams?: LiquidityPoolParams.ConstantProduct);
+  constructor(code?: string, issuer?: string, liquidityPoolParameters?: LiquidityPoolParameters);
 
   getCode(): string;
   getIssuer(): string;
-  getLiquidityPoolParams(): LiquidityPoolParams.ConstantProduct;
+  getLiquidityPoolParameters(): LiquidityPoolParameters;
   getAssetType(): AssetType;
   isNative(): boolean;
   isLiquidityPool(): boolean;
@@ -77,7 +77,7 @@ export class ChangeTrustAsset {
 
   code: string;
   issuer: string;
-  liquidityPoolParams: LiquidityPoolParams.ConstantProduct;
+  liquidityPoolParameters: LiquidityPoolParameters;
 }
 
 export class Claimant {
@@ -129,20 +129,21 @@ export class Keypair {
   xdrMuxedAccount(id: string): xdr.MuxedAccount;
 }
 
-export const LiquidityPoolFeeV18: number;
+export const LiquidityPoolFeeV18 = 30;
 
-export function getLiquidityPoolId(liquidityPoolType: LiquidityPoolType, liquidityPoolParams: LiquidityPoolParams.ConstantProduct): Buffer;
+export function getLiquidityPoolId(liquidityPoolType: LiquidityPoolType, liquidityPoolParameters: LiquidityPoolParameters): Buffer;
 
 export function validateLexicographicalAssetsOrder(assetA: Asset, assetB: Asset): boolean;
 
-// TODO: review how we're exporting this interface and namespace
-export namespace LiquidityPoolParams {
+export namespace LiquidityPoolParameters {
   interface ConstantProduct {
     asseta: Asset;
     assetB: Asset;
     fee: number;
   }
 }
+export type LiquidityPoolParameters =
+  | LiquidityPoolParameters.ConstantProduct;
 
 export namespace LiquidityPoolType {
   type constantProduct = 'constant_product';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -443,6 +443,9 @@ export namespace OperationOptions {
   interface RevokeClaimableBalanceSponsorship extends BaseOptions {
     balanceId: string;
   }
+  interface RevokeLiquidityPoolSponsorship extends BaseOptions {
+    liquidityPoolId: string;
+  }
   interface RevokeSignerSponsorship extends BaseOptions {
     account: string;
     signer: SignerKeyOptions;
@@ -488,6 +491,7 @@ export type OperationOptions =
   | OperationOptions.RevokeOfferSponsorship
   | OperationOptions.RevokeDataSponsorship
   | OperationOptions.RevokeClaimableBalanceSponsorship
+  | OperationOptions.RevokeLiquidityPoolSponsorship
   | OperationOptions.RevokeSignerSponsorship
   | OperationOptions.Clawback
   | OperationOptions.ClawbackClaimableBalance
@@ -707,6 +711,13 @@ export namespace Operation {
   function revokeClaimableBalanceSponsorship(
     options: OperationOptions.RevokeClaimableBalanceSponsorship
   ): xdr.Operation<RevokeClaimableBalanceSponsorship>;
+  
+  interface RevokeLiquidityPoolSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+    balanceId: string;
+  }
+  function revokeLiquidityPoolSponsorship(
+    options: OperationOptions.RevokeLiquidityPoolSponsorship
+  ): xdr.Operation<RevokeLiquidityPoolSponsorship>;
 
   interface RevokeSignerSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
     account: string;
@@ -773,6 +784,7 @@ export type Operation =
   | Operation.RevokeOfferSponsorship
   | Operation.RevokeDataSponsorship
   | Operation.RevokeClaimableBalanceSponsorship
+  | Operation.RevokeLiquidityPoolSponsorship
   | Operation.RevokeSignerSponsorship
   | Operation.Clawback
   | Operation.ClawbackClaimableBalance

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -137,7 +137,7 @@ export function validateLexicographicalAssetsOrder(assetA: Asset, assetB: Asset)
 
 // TODO: review how we're exporting this interface and namespace
 export namespace LiquidityPoolParams {
-  export interface ConstantProduct{
+  interface ConstantProduct {
     asseta: Asset;
     assetB: Asset;
     fee: number;
@@ -711,7 +711,7 @@ export namespace Operation {
   function revokeClaimableBalanceSponsorship(
     options: OperationOptions.RevokeClaimableBalanceSponsorship
   ): xdr.Operation<RevokeClaimableBalanceSponsorship>;
-  
+
   interface RevokeLiquidityPoolSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
     balanceId: string;
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -129,9 +129,11 @@ export class Keypair {
   xdrMuxedAccount(id: string): xdr.MuxedAccount;
 }
 
-export const LiquidityPoolFeeV18 = 30;
+export const LiquidityPoolFeeV18: number;
 
-export function liquidityPoolId(liquidityPoolType: LiquidityPoolType, liquidityPoolParams: LiquidityPoolParams.ConstantProduct): Buffer;
+export function getLiquidityPoolId(liquidityPoolType: LiquidityPoolType, liquidityPoolParams: LiquidityPoolParams.ConstantProduct): Buffer;
+
+export function validateLexicographicalAssetsOrder(assetA: Asset, assetB: Asset): boolean;
 
 // TODO: review how we're exporting this interface and namespace
 export namespace LiquidityPoolParams {
@@ -143,10 +145,10 @@ export namespace LiquidityPoolParams {
 }
 
 export namespace LiquidityPoolType {
-  type ConstantProduct = 0;
+  type constantProduct = 'constant_product';
 }
-export type LiquidityPoolType = LiquidityPoolType.ConstantProduct;
-
+export type LiquidityPoolType =
+  | LiquidityPoolType.constantProduct;
 
 export const MemoNone = 'none';
 export const MemoID = 'id';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -109,6 +109,25 @@ export class Keypair {
   xdrMuxedAccount(id: string): xdr.MuxedAccount;
 }
 
+export const LiquidityPoolFeeV18 = 30;
+
+export function liquidityPoolId(liquidityPoolType: LiquidityPoolType, liquidityPoolParams: LiquidityPoolParams.ConstantProduct): Buffer;
+
+// TODO: review how we're exporting this interface and namespace
+export namespace LiquidityPoolParams {
+  export interface ConstantProduct{
+    asseta: Asset;
+    assetB: Asset;
+    fee: number;
+  }
+}
+
+export namespace LiquidityPoolType {
+  type ConstantProduct = 0;
+}
+export type LiquidityPoolType = LiquidityPoolType.ConstantProduct;
+
+
 export const MemoNone = 'none';
 export const MemoID = 'id';
 export const MemoText = 'text';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -310,6 +310,7 @@ export namespace OperationType {
   type Clawback = 'clawback';
   type ClawbackClaimableBalance = 'clawbackClaimableBalance';
   type SetTrustLineFlags = 'setTrustLineFlags';
+  type LiquidityPoolDeposit = 'liquidityPoolDeposit';
 }
 export type OperationType =
   | OperationType.CreateAccount
@@ -333,7 +334,8 @@ export type OperationType =
   | OperationType.RevokeSponsorship
   | OperationType.Clawback
   | OperationType.ClawbackClaimableBalance
-  | OperationType.SetTrustLineFlags;
+  | OperationType.SetTrustLineFlags
+  | OperationType.LiquidityPoolDeposit;
 
 export namespace OperationOptions {
   interface BaseOptions {
@@ -467,6 +469,13 @@ export namespace OperationOptions {
       clawbackEnabled?: boolean;
     };
   }
+  interface LiquidityPoolDeposit extends BaseOptions {
+    liquidityPoolId: string;
+    maxAmounta: string;
+    maxAmountB: string;
+    minPrice: number | string | object /* bignumber.js */;
+    maxPrice: number | string | object /* bignumber.js */;
+  }
 }
 export type OperationOptions =
   | OperationOptions.CreateAccount
@@ -495,7 +504,8 @@ export type OperationOptions =
   | OperationOptions.RevokeSignerSponsorship
   | OperationOptions.Clawback
   | OperationOptions.ClawbackClaimableBalance
-  | OperationOptions.SetTrustLineFlags;
+  | OperationOptions.SetTrustLineFlags
+  | OperationOptions.LiquidityPoolDeposit;
 
 export namespace Operation {
   interface BaseOperation<T extends OperationType = OperationType> {
@@ -755,6 +765,16 @@ export namespace Operation {
   function setTrustLineFlags(
     options: OperationOptions.SetTrustLineFlags
   ): xdr.Operation<SetTrustLineFlags>;
+  interface LiquidityPoolDeposit extends BaseOperation<OperationType.LiquidityPoolDeposit> {
+    liquidityPoolId: string;
+    maxAmounta: string;
+    maxAmountB: string;
+    minPrice: string;
+    maxPrice: string;
+  }
+  function liquidityPoolDeposit(
+    options: OperationOptions.LiquidityPoolDeposit
+  ): xdr.Operation<LiquidityPoolDeposit>;
 
   function fromXDRObject<T extends Operation = Operation>(
     xdrOperation: xdr.Operation<T>
@@ -788,7 +808,8 @@ export type Operation =
   | Operation.RevokeSignerSponsorship
   | Operation.Clawback
   | Operation.ClawbackClaimableBalance
-  | Operation.SetTrustLineFlags;
+  | Operation.SetTrustLineFlags
+  | Operation.LiquidityPoolDeposit;
 
 export namespace StrKey {
   function encodeEd25519PublicKey(data: Buffer): string;

--- a/types/test.ts
+++ b/types/test.ts
@@ -297,6 +297,7 @@ const lpDeposit = StellarSdk.xdr.LiquidityPoolDepositOp.fromXDR(
 );
 lpDeposit; // $ExpectType LiquidityPoolDepositOp
 
+// TODO: check if this is correct
 const lpWithdraw = StellarSdk.xdr.LiquidityPoolWithdrawOp.fromXDR(
   // tslint:disable:max-line-length
   '3XsauDHCczEN2+xvl4cKqDwvvXjOIq3tN+y/TzOA+scAAAAAAvrwgAAAAAAF9eEAAAAAAAvrwgA=',

--- a/types/test.ts
+++ b/types/test.ts
@@ -113,6 +113,14 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
       },
     })
   ).addOperation(
+    StellarSdk.Operation.liquidityPoolDeposit({
+      liquidityPoolId: "dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7",
+      maxAmounta: "10000",
+      maxAmountB: "20000",
+      minPrice: "0.45",
+      maxPrice: "0.55",
+    })
+  ).addOperation(
     StellarSdk.Operation.setOptions({
       setFlags:   (StellarSdk.AuthImmutableFlag | StellarSdk.AuthRequiredFlag) as StellarSdk.AuthFlag,
       clearFlags: (StellarSdk.AuthRevocableFlag | StellarSdk.AuthClawbackEnabledFlag) as StellarSdk.AuthFlag,
@@ -273,3 +281,11 @@ const trust = StellarSdk.xdr.SetTrustLineFlagsOp.fromXDR(
   'base64'
 );
 trust; // $ExpectType SetTrustLineFlagsOp
+
+// TODO: check if this is correct
+const lpDeposit = StellarSdk.xdr.LiquidityPoolDepositOp.fromXDR(
+  // tslint:disable:max-line-length
+  '3XsauDHCczEN2+xvl4cKqDwvvXjOIq3tN+y/TzOA+scAAAAABfXhAAAAAAAL68IAAAAACQAAABQAAAALAAAAFA==',
+  'base64'
+);
+lpDeposit; // $ExpectType LiquidityPoolDepositOp

--- a/types/test.ts
+++ b/types/test.ts
@@ -60,6 +60,10 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
       balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
     })
   ).addOperation(
+    StellarSdk.Operation.revokeLiquidityPoolSponsorship({
+      liquidityPoolId: "dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7",
+    })
+  ).addOperation(
     StellarSdk.Operation.revokeSignerSponsorship({
       account: account.accountId(),
       signer: {

--- a/types/test.ts
+++ b/types/test.ts
@@ -121,6 +121,13 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
       maxPrice: "0.55",
     })
   ).addOperation(
+    StellarSdk.Operation.liquidityPoolWithdraw({
+      liquidityPoolId: "dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7",
+      amount: "100",
+      minAmounta: "10000",
+      minAmountB: "20000",
+    })
+  ).addOperation(
     StellarSdk.Operation.setOptions({
       setFlags:   (StellarSdk.AuthImmutableFlag | StellarSdk.AuthRequiredFlag) as StellarSdk.AuthFlag,
       clearFlags: (StellarSdk.AuthRevocableFlag | StellarSdk.AuthClawbackEnabledFlag) as StellarSdk.AuthFlag,
@@ -289,3 +296,10 @@ const lpDeposit = StellarSdk.xdr.LiquidityPoolDepositOp.fromXDR(
   'base64'
 );
 lpDeposit; // $ExpectType LiquidityPoolDepositOp
+
+const lpWithdraw = StellarSdk.xdr.LiquidityPoolWithdrawOp.fromXDR(
+  // tslint:disable:max-line-length
+  '3XsauDHCczEN2+xvl4cKqDwvvXjOIq3tN+y/TzOA+scAAAAAAvrwgAAAAAAF9eEAAAAAAAvrwgA=',
+  'base64'
+);
+lpWithdraw; // $ExpectType LiquidityPoolWithdrawOp

--- a/types/xdr.d.ts
+++ b/types/xdr.d.ts
@@ -1612,7 +1612,7 @@ export namespace xdr {
 
   const DataValue: VarOpaque;
 
-  type PoolId = Hash;
+  type PoolId = typeof Hash;
 
   const AssetCode4: Opaque;
 

--- a/types/xdr.d.ts
+++ b/types/xdr.d.ts
@@ -236,15 +236,18 @@ export namespace xdr {
     readonly name:
       | 'assetTypeNative'
       | 'assetTypeCreditAlphanum4'
-      | 'assetTypeCreditAlphanum12';
+      | 'assetTypeCreditAlphanum12'
+      | 'assetTypePoolShare';
 
-    readonly value: 0 | 1 | 2;
+    readonly value: 0 | 1 | 2 | 3;
 
     static assetTypeNative(): AssetType;
 
     static assetTypeCreditAlphanum4(): AssetType;
 
     static assetTypeCreditAlphanum12(): AssetType;
+
+    static assetTypePoolShare(): AssetType;
   }
 
   class ThresholdIndices {
@@ -271,9 +274,10 @@ export namespace xdr {
       | 'trustline'
       | 'offer'
       | 'data'
-      | 'claimableBalance';
+      | 'claimableBalance'
+      | 'liquidityPool';
 
-    readonly value: 0 | 1 | 2 | 3 | 4;
+    readonly value: 0 | 1 | 2 | 3 | 4 | 5;
 
     static account(): LedgerEntryType;
 
@@ -284,6 +288,8 @@ export namespace xdr {
     static data(): LedgerEntryType;
 
     static claimableBalance(): LedgerEntryType;
+
+    static liquidityPool(): LedgerEntryType;
   }
 
   class AccountFlags {
@@ -317,6 +323,14 @@ export namespace xdr {
     static authorizedToMaintainLiabilitiesFlag(): TrustLineFlags;
 
     static trustlineClawbackEnabledFlag(): TrustLineFlags;
+  }
+
+  class LiquidityPoolType {
+    readonly name: 'liquidityPoolConstantProduct';
+
+    readonly value: 0;
+
+    static liquidityPoolConstantProduct(): LiquidityPoolType;
   }
 
   class OfferEntryFlags {
@@ -603,7 +617,9 @@ export namespace xdr {
       | 'revokeSponsorship'
       | 'clawback'
       | 'clawbackClaimableBalance'
-      | 'setTrustLineFlags';
+      | 'setTrustLineFlags'
+      | 'liquidityPoolDeposit'
+      | 'liquidityPoolWithdraw';
 
     readonly value:
       | 0
@@ -627,7 +643,9 @@ export namespace xdr {
       | 18
       | 19
       | 20
-      | 21;
+      | 21
+      | 22
+      | 23;
 
     static createAccount(): OperationType;
 
@@ -672,6 +690,10 @@ export namespace xdr {
     static clawbackClaimableBalance(): OperationType;
 
     static setTrustLineFlags(): OperationType;
+
+    static liquidityPoolDeposit(): OperationType;
+
+    static liquidityPoolWithdraw(): OperationType;
   }
 
   class RevokeSponsorshipType {
@@ -703,6 +725,16 @@ export namespace xdr {
     static memoHash(): MemoType;
 
     static memoReturn(): MemoType;
+  }
+
+  class ClaimAtomType {
+    readonly name: 'claimAtomTypeV0' | 'claimAtomTypeOrderBook';
+
+    readonly value: 0 | 1;
+
+    static claimAtomTypeV0(): ClaimAtomType;
+
+    static claimAtomTypeOrderBook(): ClaimAtomType;
   }
 
   class CreateAccountResultCode {
@@ -1055,9 +1087,12 @@ export namespace xdr {
       | 'changeTrustNoIssuer'
       | 'changeTrustInvalidLimit'
       | 'changeTrustLowReserve'
-      | 'changeTrustSelfNotAllowed';
+      | 'changeTrustSelfNotAllowed'
+      | 'changeTrustTrustLineMissing'
+      | 'changeTrustCannotDelete'
+      | 'changeTrustNotAuthMaintainLiabilities';
 
-    readonly value: 0 | -1 | -2 | -3 | -4 | -5;
+    readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8;
 
     static changeTrustSuccess(): ChangeTrustResultCode;
 
@@ -1070,6 +1105,12 @@ export namespace xdr {
     static changeTrustLowReserve(): ChangeTrustResultCode;
 
     static changeTrustSelfNotAllowed(): ChangeTrustResultCode;
+
+    static changeTrustTrustLineMissing(): ChangeTrustResultCode;
+
+    static changeTrustCannotDelete(): ChangeTrustResultCode;
+
+    static changeTrustNotAuthMaintainLiabilities(): ChangeTrustResultCode;
   }
 
   class AllowTrustResultCode {
@@ -1251,9 +1292,10 @@ export namespace xdr {
       | 'revokeSponsorshipDoesNotExist'
       | 'revokeSponsorshipNotSponsor'
       | 'revokeSponsorshipLowReserve'
-      | 'revokeSponsorshipOnlyTransferable';
+      | 'revokeSponsorshipOnlyTransferable'
+      | 'revokeSponsorshipMalformed';
 
-    readonly value: 0 | -1 | -2 | -3 | -4;
+    readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
     static revokeSponsorshipSuccess(): RevokeSponsorshipResultCode;
 
@@ -1264,6 +1306,8 @@ export namespace xdr {
     static revokeSponsorshipLowReserve(): RevokeSponsorshipResultCode;
 
     static revokeSponsorshipOnlyTransferable(): RevokeSponsorshipResultCode;
+
+    static revokeSponsorshipMalformed(): RevokeSponsorshipResultCode;
   }
 
   class ClawbackResultCode {
@@ -1324,6 +1368,60 @@ export namespace xdr {
     static setTrustLineFlagsCantRevoke(): SetTrustLineFlagsResultCode;
 
     static setTrustLineFlagsInvalidState(): SetTrustLineFlagsResultCode;
+  }
+
+  class LiquidityPoolDepositResultCode {
+    readonly name:
+      | 'liquidityPoolDepositSuccess'
+      | 'liquidityPoolDepositMalformed'
+      | 'liquidityPoolDepositNoTrust'
+      | 'liquidityPoolDepositNotAuthorized'
+      | 'liquidityPoolDepositUnderfunded'
+      | 'liquidityPoolDepositLineFull'
+      | 'liquidityPoolDepositBadPrice'
+      | 'liquidityPoolDepositPoolFull';
+
+    readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7;
+
+    static liquidityPoolDepositSuccess(): LiquidityPoolDepositResultCode;
+
+    static liquidityPoolDepositMalformed(): LiquidityPoolDepositResultCode;
+
+    static liquidityPoolDepositNoTrust(): LiquidityPoolDepositResultCode;
+
+    static liquidityPoolDepositNotAuthorized(): LiquidityPoolDepositResultCode;
+
+    static liquidityPoolDepositUnderfunded(): LiquidityPoolDepositResultCode;
+
+    static liquidityPoolDepositLineFull(): LiquidityPoolDepositResultCode;
+
+    static liquidityPoolDepositBadPrice(): LiquidityPoolDepositResultCode;
+
+    static liquidityPoolDepositPoolFull(): LiquidityPoolDepositResultCode;
+  }
+
+  class LiquidityPoolWithdrawResultCode {
+    readonly name:
+      | 'liquidityPoolWithdrawSuccess'
+      | 'liquidityPoolWithdrawMalformed'
+      | 'liquidityPoolWithdrawNoTrust'
+      | 'liquidityPoolWithdrawUnderfunded'
+      | 'liquidityPoolWithdrawLineFull'
+      | 'liquidityPoolWithdrawUnderMinimum';
+
+    readonly value: 0 | -1 | -2 | -3 | -4 | -5;
+
+    static liquidityPoolWithdrawSuccess(): LiquidityPoolWithdrawResultCode;
+
+    static liquidityPoolWithdrawMalformed(): LiquidityPoolWithdrawResultCode;
+
+    static liquidityPoolWithdrawNoTrust(): LiquidityPoolWithdrawResultCode;
+
+    static liquidityPoolWithdrawUnderfunded(): LiquidityPoolWithdrawResultCode;
+
+    static liquidityPoolWithdrawLineFull(): LiquidityPoolWithdrawResultCode;
+
+    static liquidityPoolWithdrawUnderMinimum(): LiquidityPoolWithdrawResultCode;
   }
 
   class OperationResultCode {
@@ -1478,6 +1576,8 @@ export namespace xdr {
 
   const DataValue: VarOpaque;
 
+  type PoolId = Hash;
+
   const AssetCode4: Opaque;
 
   const AssetCode12: Opaque;
@@ -1512,7 +1612,7 @@ export namespace xdr {
 
   type NodeId = PublicKey;
 
-  class AssetAlphaNum4 {
+  class AlphaNum4 {
     constructor(attributes: { assetCode: Buffer; issuer: AccountId });
 
     assetCode(value?: Buffer): Buffer;
@@ -1523,24 +1623,24 @@ export namespace xdr {
 
     toXDR(format: 'hex' | 'base64'): string;
 
-    static read(io: Buffer): AssetAlphaNum4;
+    static read(io: Buffer): AlphaNum4;
 
-    static write(value: AssetAlphaNum4, io: Buffer): void;
+    static write(value: AlphaNum4, io: Buffer): void;
 
-    static isValid(value: AssetAlphaNum4): boolean;
+    static isValid(value: AlphaNum4): boolean;
 
-    static toXDR(value: AssetAlphaNum4): Buffer;
+    static toXDR(value: AlphaNum4): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AssetAlphaNum4;
+    static fromXDR(input: Buffer, format?: 'raw'): AlphaNum4;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AssetAlphaNum4;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AlphaNum4;
 
     static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
-  class AssetAlphaNum12 {
+  class AlphaNum12 {
     constructor(attributes: { assetCode: Buffer; issuer: AccountId });
 
     assetCode(value?: Buffer): Buffer;
@@ -1551,17 +1651,17 @@ export namespace xdr {
 
     toXDR(format: 'hex' | 'base64'): string;
 
-    static read(io: Buffer): AssetAlphaNum12;
+    static read(io: Buffer): AlphaNum12;
 
-    static write(value: AssetAlphaNum12, io: Buffer): void;
+    static write(value: AlphaNum12, io: Buffer): void;
 
-    static isValid(value: AssetAlphaNum12): boolean;
+    static isValid(value: AlphaNum12): boolean;
 
-    static toXDR(value: AssetAlphaNum12): Buffer;
+    static toXDR(value: AlphaNum12): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AssetAlphaNum12;
+    static fromXDR(input: Buffer, format?: 'raw'): AlphaNum12;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AssetAlphaNum12;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AlphaNum12;
 
     static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
@@ -1783,6 +1883,40 @@ export namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class TrustLineEntryExtensionV2 {
+    constructor(attributes: {
+      liquidityPoolUseCount: number;
+      ext: TrustLineEntryExtensionV2Ext;
+    });
+
+    liquidityPoolUseCount(value?: number): number;
+
+    ext(value?: TrustLineEntryExtensionV2Ext): TrustLineEntryExtensionV2Ext;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): TrustLineEntryExtensionV2;
+
+    static write(value: TrustLineEntryExtensionV2, io: Buffer): void;
+
+    static isValid(value: TrustLineEntryExtensionV2): boolean;
+
+    static toXDR(value: TrustLineEntryExtensionV2): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExtensionV2;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): TrustLineEntryExtensionV2;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class TrustLineEntryV1 {
     constructor(attributes: {
       liabilities: Liabilities;
@@ -1817,7 +1951,7 @@ export namespace xdr {
   class TrustLineEntry {
     constructor(attributes: {
       accountId: AccountId;
-      asset: Asset;
+      asset: TrustLineAsset;
       balance: Int64;
       limit: Int64;
       flags: number;
@@ -1826,7 +1960,7 @@ export namespace xdr {
 
     accountId(value?: AccountId): AccountId;
 
-    asset(value?: Asset): Asset;
+    asset(value?: TrustLineAsset): TrustLineAsset;
 
     balance(value?: Int64): Int64;
 
@@ -2056,6 +2190,124 @@ export namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class LiquidityPoolConstantProductParameters {
+    constructor(attributes: { asseta: Asset; assetB: Asset; fee: number });
+
+    asseta(value?: Asset): Asset;
+
+    assetB(value?: Asset): Asset;
+
+    fee(value?: number): number;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LiquidityPoolConstantProductParameters;
+
+    static write(
+      value: LiquidityPoolConstantProductParameters,
+      io: Buffer
+    ): void;
+
+    static isValid(value: LiquidityPoolConstantProductParameters): boolean;
+
+    static toXDR(value: LiquidityPoolConstantProductParameters): Buffer;
+
+    static fromXDR(
+      input: Buffer,
+      format?: 'raw'
+    ): LiquidityPoolConstantProductParameters;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LiquidityPoolConstantProductParameters;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
+  class LiquidityPoolEntryConstantProduct {
+    constructor(attributes: {
+      params: LiquidityPoolConstantProductParameters;
+      reserveA: Int64;
+      reserveB: Int64;
+      totalPoolShares: Int64;
+      poolSharesTrustLineCount: Int64;
+    });
+
+    params(
+      value?: LiquidityPoolConstantProductParameters
+    ): LiquidityPoolConstantProductParameters;
+
+    reserveA(value?: Int64): Int64;
+
+    reserveB(value?: Int64): Int64;
+
+    totalPoolShares(value?: Int64): Int64;
+
+    poolSharesTrustLineCount(value?: Int64): Int64;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LiquidityPoolEntryConstantProduct;
+
+    static write(value: LiquidityPoolEntryConstantProduct, io: Buffer): void;
+
+    static isValid(value: LiquidityPoolEntryConstantProduct): boolean;
+
+    static toXDR(value: LiquidityPoolEntryConstantProduct): Buffer;
+
+    static fromXDR(
+      input: Buffer,
+      format?: 'raw'
+    ): LiquidityPoolEntryConstantProduct;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LiquidityPoolEntryConstantProduct;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
+  class LiquidityPoolEntry {
+    constructor(attributes: {
+      liquidityPoolId: PoolId;
+      body: LiquidityPoolEntryBody;
+    });
+
+    liquidityPoolId(value?: PoolId): PoolId;
+
+    body(value?: LiquidityPoolEntryBody): LiquidityPoolEntryBody;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LiquidityPoolEntry;
+
+    static write(value: LiquidityPoolEntry, io: Buffer): void;
+
+    static isValid(value: LiquidityPoolEntry): boolean;
+
+    static toXDR(value: LiquidityPoolEntry): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolEntry;
+
+    static fromXDR(input: string, format: 'hex' | 'base64'): LiquidityPoolEntry;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class LedgerEntryExtensionV1 {
     constructor(attributes: {
       sponsoringId: SponsorshipDescriptor;
@@ -2151,11 +2403,11 @@ export namespace xdr {
   }
 
   class LedgerKeyTrustLine {
-    constructor(attributes: { accountId: AccountId; asset: Asset });
+    constructor(attributes: { accountId: AccountId; asset: TrustLineAsset });
 
     accountId(value?: AccountId): AccountId;
 
-    asset(value?: Asset): Asset;
+    asset(value?: TrustLineAsset): TrustLineAsset;
 
     toXDR(format?: 'raw'): Buffer;
 
@@ -2260,6 +2512,35 @@ export namespace xdr {
       input: string,
       format: 'hex' | 'base64'
     ): LedgerKeyClaimableBalance;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
+  class LedgerKeyLiquidityPool {
+    constructor(attributes: { liquidityPoolId: PoolId });
+
+    liquidityPoolId(value?: PoolId): PoolId;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LedgerKeyLiquidityPool;
+
+    static write(value: LedgerKeyLiquidityPool, io: Buffer): void;
+
+    static isValid(value: LedgerKeyLiquidityPool): boolean;
+
+    static toXDR(value: LedgerKeyLiquidityPool): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyLiquidityPool;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LedgerKeyLiquidityPool;
 
     static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
@@ -3656,13 +3937,13 @@ export namespace xdr {
   class ScpQuorumSet {
     constructor(attributes: {
       threshold: number;
-      validators: PublicKey[];
+      validators: NodeId[];
       innerSets: ScpQuorumSet[];
     });
 
     threshold(value?: number): number;
 
-    validators(value?: PublicKey[]): PublicKey[];
+    validators(value?: NodeId[]): NodeId[];
 
     innerSets(value?: ScpQuorumSet[]): ScpQuorumSet[];
 
@@ -4073,9 +4354,9 @@ export namespace xdr {
   }
 
   class ChangeTrustOp {
-    constructor(attributes: { line: Asset; limit: Int64 });
+    constructor(attributes: { line: ChangeTrustAsset; limit: Int64 });
 
-    line(value?: Asset): Asset;
+    line(value?: ChangeTrustAsset): ChangeTrustAsset;
 
     limit(value?: Int64): Int64;
 
@@ -4423,14 +4704,97 @@ export namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class LiquidityPoolDepositOp {
+    constructor(attributes: {
+      liquidityPoolId: PoolId;
+      maxAmounta: Int64;
+      maxAmountB: Int64;
+      minPrice: Price;
+      maxPrice: Price;
+    });
+
+    liquidityPoolId(value?: PoolId): PoolId;
+
+    maxAmounta(value?: Int64): Int64;
+
+    maxAmountB(value?: Int64): Int64;
+
+    minPrice(value?: Price): Price;
+
+    maxPrice(value?: Price): Price;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LiquidityPoolDepositOp;
+
+    static write(value: LiquidityPoolDepositOp, io: Buffer): void;
+
+    static isValid(value: LiquidityPoolDepositOp): boolean;
+
+    static toXDR(value: LiquidityPoolDepositOp): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolDepositOp;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LiquidityPoolDepositOp;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
+  class LiquidityPoolWithdrawOp {
+    constructor(attributes: {
+      liquidityPoolId: PoolId;
+      amount: Int64;
+      minAmounta: Int64;
+      minAmountB: Int64;
+    });
+
+    liquidityPoolId(value?: PoolId): PoolId;
+
+    amount(value?: Int64): Int64;
+
+    minAmounta(value?: Int64): Int64;
+
+    minAmountB(value?: Int64): Int64;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LiquidityPoolWithdrawOp;
+
+    static write(value: LiquidityPoolWithdrawOp, io: Buffer): void;
+
+    static isValid(value: LiquidityPoolWithdrawOp): boolean;
+
+    static toXDR(value: LiquidityPoolWithdrawOp): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolWithdrawOp;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LiquidityPoolWithdrawOp;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class OperationIdId {
     constructor(attributes: {
-      sourceAccount: MuxedAccount;
+      sourceAccount: AccountId;
       seqNum: SequenceNumber;
       opNum: number;
     });
 
-    sourceAccount(value?: MuxedAccount): MuxedAccount;
+    sourceAccount(value?: AccountId): AccountId;
 
     seqNum(value?: SequenceNumber): SequenceNumber;
 
@@ -4752,6 +5116,49 @@ export namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class ClaimOfferAtomV0 {
+    constructor(attributes: {
+      sellerEd25519: Buffer;
+      offerId: Int64;
+      assetSold: Asset;
+      amountSold: Int64;
+      assetBought: Asset;
+      amountBought: Int64;
+    });
+
+    sellerEd25519(value?: Buffer): Buffer;
+
+    offerId(value?: Int64): Int64;
+
+    assetSold(value?: Asset): Asset;
+
+    amountSold(value?: Int64): Int64;
+
+    assetBought(value?: Asset): Asset;
+
+    amountBought(value?: Int64): Int64;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): ClaimOfferAtomV0;
+
+    static write(value: ClaimOfferAtomV0, io: Buffer): void;
+
+    static isValid(value: ClaimOfferAtomV0): boolean;
+
+    static toXDR(value: ClaimOfferAtomV0): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimOfferAtomV0;
+
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimOfferAtomV0;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class ClaimOfferAtom {
     constructor(attributes: {
       sellerId: AccountId;
@@ -4833,12 +5240,9 @@ export namespace xdr {
   }
 
   class PathPaymentStrictReceiveResultSuccess {
-    constructor(attributes: {
-      offers: ClaimOfferAtom[];
-      last: SimplePaymentResult;
-    });
+    constructor(attributes: { offers: ClaimAtom[]; last: SimplePaymentResult });
 
-    offers(value?: ClaimOfferAtom[]): ClaimOfferAtom[];
+    offers(value?: ClaimAtom[]): ClaimAtom[];
 
     last(value?: SimplePaymentResult): SimplePaymentResult;
 
@@ -4873,12 +5277,9 @@ export namespace xdr {
   }
 
   class PathPaymentStrictSendResultSuccess {
-    constructor(attributes: {
-      offers: ClaimOfferAtom[];
-      last: SimplePaymentResult;
-    });
+    constructor(attributes: { offers: ClaimAtom[]; last: SimplePaymentResult });
 
-    offers(value?: ClaimOfferAtom[]): ClaimOfferAtom[];
+    offers(value?: ClaimAtom[]): ClaimAtom[];
 
     last(value?: SimplePaymentResult): SimplePaymentResult;
 
@@ -4911,11 +5312,11 @@ export namespace xdr {
 
   class ManageOfferSuccessResult {
     constructor(attributes: {
-      offersClaimed: ClaimOfferAtom[];
+      offersClaimed: ClaimAtom[];
       offer: ManageOfferSuccessResultOffer;
     });
 
-    offersClaimed(value?: ClaimOfferAtom[]): ClaimOfferAtom[];
+    offersClaimed(value?: ClaimAtom[]): ClaimAtom[];
 
     offer(value?: ManageOfferSuccessResultOffer): ManageOfferSuccessResultOffer;
 
@@ -5217,17 +5618,17 @@ export namespace xdr {
   class Asset {
     switch(): AssetType;
 
-    alphaNum4(value?: AssetAlphaNum4): AssetAlphaNum4;
+    alphaNum4(value?: AlphaNum4): AlphaNum4;
 
-    alphaNum12(value?: AssetAlphaNum12): AssetAlphaNum12;
+    alphaNum12(value?: AlphaNum12): AlphaNum12;
 
     static assetTypeNative(): Asset;
 
-    static assetTypeCreditAlphanum4(value: AssetAlphaNum4): Asset;
+    static assetTypeCreditAlphanum4(value: AlphaNum4): Asset;
 
-    static assetTypeCreditAlphanum12(value: AssetAlphaNum12): Asset;
+    static assetTypeCreditAlphanum12(value: AlphaNum12): Asset;
 
-    value(): AssetAlphaNum4 | AssetAlphaNum12 | void;
+    value(): AlphaNum4 | AlphaNum12 | void;
 
     toXDR(format?: 'raw'): Buffer;
 
@@ -5348,12 +5749,87 @@ export namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class TrustLineAsset {
+    switch(): AssetType;
+
+    alphaNum4(value?: AlphaNum4): AlphaNum4;
+
+    alphaNum12(value?: AlphaNum12): AlphaNum12;
+
+    liquidityPoolId(value?: PoolId): PoolId;
+
+    static assetTypeNative(): TrustLineAsset;
+
+    static assetTypeCreditAlphanum4(value: AlphaNum4): TrustLineAsset;
+
+    static assetTypeCreditAlphanum12(value: AlphaNum12): TrustLineAsset;
+
+    static assetTypePoolShare(value: PoolId): TrustLineAsset;
+
+    value(): AlphaNum4 | AlphaNum12 | PoolId | void;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): TrustLineAsset;
+
+    static write(value: TrustLineAsset, io: Buffer): void;
+
+    static isValid(value: TrustLineAsset): boolean;
+
+    static toXDR(value: TrustLineAsset): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineAsset;
+
+    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineAsset;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
+  class TrustLineEntryExtensionV2Ext {
+    switch(): number;
+
+    static 0(): TrustLineEntryExtensionV2Ext;
+
+    value(): void;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): TrustLineEntryExtensionV2Ext;
+
+    static write(value: TrustLineEntryExtensionV2Ext, io: Buffer): void;
+
+    static isValid(value: TrustLineEntryExtensionV2Ext): boolean;
+
+    static toXDR(value: TrustLineEntryExtensionV2Ext): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExtensionV2Ext;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): TrustLineEntryExtensionV2Ext;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class TrustLineEntryV1Ext {
     switch(): number;
 
+    v2(value?: TrustLineEntryExtensionV2): TrustLineEntryExtensionV2;
+
     static 0(): TrustLineEntryV1Ext;
 
-    value(): void;
+    static 2(value: TrustLineEntryExtensionV2): TrustLineEntryV1Ext;
+
+    value(): TrustLineEntryExtensionV2 | void;
 
     toXDR(format?: 'raw'): Buffer;
 
@@ -5653,6 +6129,43 @@ export namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class LiquidityPoolEntryBody {
+    switch(): LiquidityPoolType;
+
+    constantProduct(
+      value?: LiquidityPoolEntryConstantProduct
+    ): LiquidityPoolEntryConstantProduct;
+
+    static liquidityPoolConstantProduct(
+      value: LiquidityPoolEntryConstantProduct
+    ): LiquidityPoolEntryBody;
+
+    value(): LiquidityPoolEntryConstantProduct;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LiquidityPoolEntryBody;
+
+    static write(value: LiquidityPoolEntryBody, io: Buffer): void;
+
+    static isValid(value: LiquidityPoolEntryBody): boolean;
+
+    static toXDR(value: LiquidityPoolEntryBody): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolEntryBody;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LiquidityPoolEntryBody;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class LedgerEntryExtensionV1Ext {
     switch(): number;
 
@@ -5697,6 +6210,8 @@ export namespace xdr {
 
     claimableBalance(value?: ClaimableBalanceEntry): ClaimableBalanceEntry;
 
+    liquidityPool(value?: LiquidityPoolEntry): LiquidityPoolEntry;
+
     static account(value: AccountEntry): LedgerEntryData;
 
     static trustline(value: TrustLineEntry): LedgerEntryData;
@@ -5707,12 +6222,15 @@ export namespace xdr {
 
     static claimableBalance(value: ClaimableBalanceEntry): LedgerEntryData;
 
+    static liquidityPool(value: LiquidityPoolEntry): LedgerEntryData;
+
     value():
       | AccountEntry
       | TrustLineEntry
       | OfferEntry
       | DataEntry
-      | ClaimableBalanceEntry;
+      | ClaimableBalanceEntry
+      | LiquidityPoolEntry;
 
     toXDR(format?: 'raw'): Buffer;
 
@@ -5782,6 +6300,8 @@ export namespace xdr {
       value?: LedgerKeyClaimableBalance
     ): LedgerKeyClaimableBalance;
 
+    liquidityPool(value?: LedgerKeyLiquidityPool): LedgerKeyLiquidityPool;
+
     static account(value: LedgerKeyAccount): LedgerKey;
 
     static trustline(value: LedgerKeyTrustLine): LedgerKey;
@@ -5792,12 +6312,15 @@ export namespace xdr {
 
     static claimableBalance(value: LedgerKeyClaimableBalance): LedgerKey;
 
+    static liquidityPool(value: LedgerKeyLiquidityPool): LedgerKey;
+
     value():
       | LedgerKeyAccount
       | LedgerKeyTrustLine
       | LedgerKeyOffer
       | LedgerKeyData
-      | LedgerKeyClaimableBalance;
+      | LedgerKeyClaimableBalance
+      | LedgerKeyLiquidityPool;
 
     toXDR(format?: 'raw'): Buffer;
 
@@ -6481,6 +7004,43 @@ export namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class LiquidityPoolParameters {
+    switch(): LiquidityPoolType;
+
+    constantProduct(
+      value?: LiquidityPoolConstantProductParameters
+    ): LiquidityPoolConstantProductParameters;
+
+    static liquidityPoolConstantProduct(
+      value: LiquidityPoolConstantProductParameters
+    ): LiquidityPoolParameters;
+
+    value(): LiquidityPoolConstantProductParameters;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LiquidityPoolParameters;
+
+    static write(value: LiquidityPoolParameters, io: Buffer): void;
+
+    static isValid(value: LiquidityPoolParameters): boolean;
+
+    static toXDR(value: LiquidityPoolParameters): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolParameters;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LiquidityPoolParameters;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class MuxedAccount {
     switch(): CryptoKeyType;
 
@@ -6509,6 +7069,46 @@ export namespace xdr {
     static fromXDR(input: Buffer, format?: 'raw'): MuxedAccount;
 
     static fromXDR(input: string, format: 'hex' | 'base64'): MuxedAccount;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
+  class ChangeTrustAsset {
+    switch(): AssetType;
+
+    alphaNum4(value?: AlphaNum4): AlphaNum4;
+
+    alphaNum12(value?: AlphaNum12): AlphaNum12;
+
+    liquidityPool(value?: LiquidityPoolParameters): LiquidityPoolParameters;
+
+    static assetTypeNative(): ChangeTrustAsset;
+
+    static assetTypeCreditAlphanum4(value: AlphaNum4): ChangeTrustAsset;
+
+    static assetTypeCreditAlphanum12(value: AlphaNum12): ChangeTrustAsset;
+
+    static assetTypePoolShare(value: LiquidityPoolParameters): ChangeTrustAsset;
+
+    value(): AlphaNum4 | AlphaNum12 | LiquidityPoolParameters | void;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): ChangeTrustAsset;
+
+    static write(value: ChangeTrustAsset, io: Buffer): void;
+
+    static isValid(value: ChangeTrustAsset): boolean;
+
+    static toXDR(value: ChangeTrustAsset): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustAsset;
+
+    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustAsset;
 
     static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
@@ -6611,6 +7211,14 @@ export namespace xdr {
 
     setTrustLineFlagsOp(value?: SetTrustLineFlagsOp): SetTrustLineFlagsOp;
 
+    liquidityPoolDepositOp(
+      value?: LiquidityPoolDepositOp
+    ): LiquidityPoolDepositOp;
+
+    liquidityPoolWithdrawOp(
+      value?: LiquidityPoolWithdrawOp
+    ): LiquidityPoolWithdrawOp;
+
     static createAccount(value: CreateAccountOp): OperationBody;
 
     static payment(value: PaymentOp): OperationBody;
@@ -6665,6 +7273,10 @@ export namespace xdr {
 
     static setTrustLineFlags(value: SetTrustLineFlagsOp): OperationBody;
 
+    static liquidityPoolDeposit(value: LiquidityPoolDepositOp): OperationBody;
+
+    static liquidityPoolWithdraw(value: LiquidityPoolWithdrawOp): OperationBody;
+
     value():
       | CreateAccountOp
       | PaymentOp
@@ -6686,6 +7298,8 @@ export namespace xdr {
       | ClawbackOp
       | ClawbackClaimableBalanceOp
       | SetTrustLineFlagsOp
+      | LiquidityPoolDepositOp
+      | LiquidityPoolWithdrawOp
       | void;
 
     toXDR(format?: 'raw'): Buffer;
@@ -6994,6 +7608,40 @@ export namespace xdr {
       input: string,
       format: 'hex' | 'base64'
     ): TransactionSignaturePayloadTaggedTransaction;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
+  class ClaimAtom {
+    switch(): ClaimAtomType;
+
+    v0(value?: ClaimOfferAtomV0): ClaimOfferAtomV0;
+
+    orderBook(value?: ClaimOfferAtom): ClaimOfferAtom;
+
+    static claimAtomTypeV0(value: ClaimOfferAtomV0): ClaimAtom;
+
+    static claimAtomTypeOrderBook(value: ClaimOfferAtom): ClaimAtom;
+
+    value(): ClaimOfferAtomV0 | ClaimOfferAtom;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): ClaimAtom;
+
+    static write(value: ClaimAtom, io: Buffer): void;
+
+    static isValid(value: ClaimAtom): boolean;
+
+    static toXDR(value: ClaimAtom): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimAtom;
+
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimAtom;
 
     static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
@@ -7714,6 +8362,68 @@ export namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class LiquidityPoolDepositResult {
+    switch(): LiquidityPoolDepositResultCode;
+
+    static liquidityPoolDepositSuccess(): LiquidityPoolDepositResult;
+
+    value(): void;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LiquidityPoolDepositResult;
+
+    static write(value: LiquidityPoolDepositResult, io: Buffer): void;
+
+    static isValid(value: LiquidityPoolDepositResult): boolean;
+
+    static toXDR(value: LiquidityPoolDepositResult): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolDepositResult;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LiquidityPoolDepositResult;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
+  class LiquidityPoolWithdrawResult {
+    switch(): LiquidityPoolWithdrawResultCode;
+
+    static liquidityPoolWithdrawSuccess(): LiquidityPoolWithdrawResult;
+
+    value(): void;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LiquidityPoolWithdrawResult;
+
+    static write(value: LiquidityPoolWithdrawResult, io: Buffer): void;
+
+    static isValid(value: LiquidityPoolWithdrawResult): boolean;
+
+    static toXDR(value: LiquidityPoolWithdrawResult): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolWithdrawResult;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LiquidityPoolWithdrawResult;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class OperationResultTr {
     switch(): OperationType;
 
@@ -7781,6 +8491,14 @@ export namespace xdr {
       value?: SetTrustLineFlagsResult
     ): SetTrustLineFlagsResult;
 
+    liquidityPoolDepositResult(
+      value?: LiquidityPoolDepositResult
+    ): LiquidityPoolDepositResult;
+
+    liquidityPoolWithdrawResult(
+      value?: LiquidityPoolWithdrawResult
+    ): LiquidityPoolWithdrawResult;
+
     static createAccount(value: CreateAccountResult): OperationResultTr;
 
     static payment(value: PaymentResult): OperationResultTr;
@@ -7841,6 +8559,14 @@ export namespace xdr {
 
     static setTrustLineFlags(value: SetTrustLineFlagsResult): OperationResultTr;
 
+    static liquidityPoolDeposit(
+      value: LiquidityPoolDepositResult
+    ): OperationResultTr;
+
+    static liquidityPoolWithdraw(
+      value: LiquidityPoolWithdrawResult
+    ): OperationResultTr;
+
     value():
       | CreateAccountResult
       | PaymentResult
@@ -7863,7 +8589,9 @@ export namespace xdr {
       | RevokeSponsorshipResult
       | ClawbackResult
       | ClawbackClaimableBalanceResult
-      | SetTrustLineFlagsResult;
+      | SetTrustLineFlagsResult
+      | LiquidityPoolDepositResult
+      | LiquidityPoolWithdrawResult;
 
     toXDR(format?: 'raw'): Buffer;
 

--- a/types/xdr.d.ts
+++ b/types/xdr.d.ts
@@ -374,11 +374,15 @@ export namespace xdr {
   }
 
   class ClaimableBalanceIdType {
-    readonly name: 'claimableBalanceIdTypeV0';
+    readonly name:
+      | 'claimableBalanceIdTypeV0'
+      | 'claimableBalanceIdTypeFromPoolRevoke';
 
-    readonly value: 0;
+    readonly value: 0 | 1;
 
     static claimableBalanceIdTypeV0(): ClaimableBalanceIdType;
+
+    static claimableBalanceIdTypeFromPoolRevoke(): ClaimableBalanceIdType;
   }
 
   class ClaimableBalanceFlags {
@@ -397,9 +401,10 @@ export namespace xdr {
       | 'envelopeTypeAuth'
       | 'envelopeTypeScpvalue'
       | 'envelopeTypeTxFeeBump'
-      | 'envelopeTypeOpId';
+      | 'envelopeTypeOpId'
+      | 'envelopeTypePoolRevokeOpId';
 
-    readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+    readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
     static envelopeTypeTxV0(): EnvelopeType;
 
@@ -414,6 +419,8 @@ export namespace xdr {
     static envelopeTypeTxFeeBump(): EnvelopeType;
 
     static envelopeTypeOpId(): EnvelopeType;
+
+    static envelopeTypePoolRevokeOpId(): EnvelopeType;
   }
 
   class StellarValueType {
@@ -426,14 +433,30 @@ export namespace xdr {
     static stellarValueSigned(): StellarValueType;
   }
 
+  class LedgerHeaderFlags {
+    readonly name:
+      | 'disableLiquidityPoolTradingFlag'
+      | 'disableLiquidityPoolDepositFlag'
+      | 'disableLiquidityPoolWithdrawalFlag';
+
+    readonly value: 1 | 2 | 4;
+
+    static disableLiquidityPoolTradingFlag(): LedgerHeaderFlags;
+
+    static disableLiquidityPoolDepositFlag(): LedgerHeaderFlags;
+
+    static disableLiquidityPoolWithdrawalFlag(): LedgerHeaderFlags;
+  }
+
   class LedgerUpgradeType {
     readonly name:
       | 'ledgerUpgradeVersion'
       | 'ledgerUpgradeBaseFee'
       | 'ledgerUpgradeMaxTxSetSize'
-      | 'ledgerUpgradeBaseReserve';
+      | 'ledgerUpgradeBaseReserve'
+      | 'ledgerUpgradeFlags';
 
-    readonly value: 1 | 2 | 3 | 4;
+    readonly value: 1 | 2 | 3 | 4 | 5;
 
     static ledgerUpgradeVersion(): LedgerUpgradeType;
 
@@ -442,6 +465,8 @@ export namespace xdr {
     static ledgerUpgradeMaxTxSetSize(): LedgerUpgradeType;
 
     static ledgerUpgradeBaseReserve(): LedgerUpgradeType;
+
+    static ledgerUpgradeFlags(): LedgerUpgradeType;
   }
 
   class BucketEntryType {
@@ -728,13 +753,18 @@ export namespace xdr {
   }
 
   class ClaimAtomType {
-    readonly name: 'claimAtomTypeV0' | 'claimAtomTypeOrderBook';
+    readonly name:
+      | 'claimAtomTypeV0'
+      | 'claimAtomTypeOrderBook'
+      | 'claimAtomTypeLiquidityPool';
 
-    readonly value: 0 | 1;
+    readonly value: 0 | 1 | 2;
 
     static claimAtomTypeV0(): ClaimAtomType;
 
     static claimAtomTypeOrderBook(): ClaimAtomType;
+
+    static claimAtomTypeLiquidityPool(): ClaimAtomType;
   }
 
   class CreateAccountResultCode {
@@ -1120,9 +1150,10 @@ export namespace xdr {
       | 'allowTrustNoTrustLine'
       | 'allowTrustTrustNotRequired'
       | 'allowTrustCantRevoke'
-      | 'allowTrustSelfNotAllowed';
+      | 'allowTrustSelfNotAllowed'
+      | 'allowTrustLowReserve';
 
-    readonly value: 0 | -1 | -2 | -3 | -4 | -5;
+    readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6;
 
     static allowTrustSuccess(): AllowTrustResultCode;
 
@@ -1135,6 +1166,8 @@ export namespace xdr {
     static allowTrustCantRevoke(): AllowTrustResultCode;
 
     static allowTrustSelfNotAllowed(): AllowTrustResultCode;
+
+    static allowTrustLowReserve(): AllowTrustResultCode;
   }
 
   class AccountMergeResultCode {
@@ -1355,9 +1388,10 @@ export namespace xdr {
       | 'setTrustLineFlagsMalformed'
       | 'setTrustLineFlagsNoTrustLine'
       | 'setTrustLineFlagsCantRevoke'
-      | 'setTrustLineFlagsInvalidState';
+      | 'setTrustLineFlagsInvalidState'
+      | 'setTrustLineFlagsLowReserve';
 
-    readonly value: 0 | -1 | -2 | -3 | -4;
+    readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
     static setTrustLineFlagsSuccess(): SetTrustLineFlagsResultCode;
 
@@ -1368,6 +1402,8 @@ export namespace xdr {
     static setTrustLineFlagsCantRevoke(): SetTrustLineFlagsResultCode;
 
     static setTrustLineFlagsInvalidState(): SetTrustLineFlagsResultCode;
+
+    static setTrustLineFlagsLowReserve(): SetTrustLineFlagsResultCode;
   }
 
   class LiquidityPoolDepositResultCode {
@@ -2609,6 +2645,37 @@ export namespace xdr {
     static fromXDR(input: Buffer, format?: 'raw'): StellarValue;
 
     static fromXDR(input: string, format: 'hex' | 'base64'): StellarValue;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
+  class LedgerHeaderExtensionV1 {
+    constructor(attributes: { flags: number; ext: LedgerHeaderExtensionV1Ext });
+
+    flags(value?: number): number;
+
+    ext(value?: LedgerHeaderExtensionV1Ext): LedgerHeaderExtensionV1Ext;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LedgerHeaderExtensionV1;
+
+    static write(value: LedgerHeaderExtensionV1, io: Buffer): void;
+
+    static isValid(value: LedgerHeaderExtensionV1): boolean;
+
+    static toXDR(value: LedgerHeaderExtensionV1): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExtensionV1;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LedgerHeaderExtensionV1;
 
     static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
@@ -4821,6 +4888,49 @@ export namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class OperationIdRevokeId {
+    constructor(attributes: {
+      sourceAccount: AccountId;
+      seqNum: SequenceNumber;
+      opNum: number;
+      liquidityPoolId: PoolId;
+      asset: Asset;
+    });
+
+    sourceAccount(value?: AccountId): AccountId;
+
+    seqNum(value?: SequenceNumber): SequenceNumber;
+
+    opNum(value?: number): number;
+
+    liquidityPoolId(value?: PoolId): PoolId;
+
+    asset(value?: Asset): Asset;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): OperationIdRevokeId;
+
+    static write(value: OperationIdRevokeId, io: Buffer): void;
+
+    static isValid(value: OperationIdRevokeId): boolean;
+
+    static toXDR(value: OperationIdRevokeId): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): OperationIdRevokeId;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): OperationIdRevokeId;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class TimeBounds {
     constructor(attributes: { minTime: TimePoint; maxTime: TimePoint });
 
@@ -5196,6 +5306,46 @@ export namespace xdr {
     static fromXDR(input: Buffer, format?: 'raw'): ClaimOfferAtom;
 
     static fromXDR(input: string, format: 'hex' | 'base64'): ClaimOfferAtom;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
+  class ClaimLiquidityAtom {
+    constructor(attributes: {
+      liquidityPoolId: PoolId;
+      assetSold: Asset;
+      amountSold: Int64;
+      assetBought: Asset;
+      amountBought: Int64;
+    });
+
+    liquidityPoolId(value?: PoolId): PoolId;
+
+    assetSold(value?: Asset): Asset;
+
+    amountSold(value?: Int64): Int64;
+
+    assetBought(value?: Asset): Asset;
+
+    amountBought(value?: Int64): Int64;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): ClaimLiquidityAtom;
+
+    static write(value: ClaimLiquidityAtom, io: Buffer): void;
+
+    static isValid(value: ClaimLiquidityAtom): boolean;
+
+    static toXDR(value: ClaimLiquidityAtom): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimLiquidityAtom;
+
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimLiquidityAtom;
 
     static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
@@ -6033,9 +6183,15 @@ export namespace xdr {
 
     v0(value?: Buffer): Buffer;
 
+    fromPoolRevoke(value?: Buffer): Buffer;
+
     static claimableBalanceIdTypeV0(value: Buffer): ClaimableBalanceId;
 
-    value(): Buffer;
+    static claimableBalanceIdTypeFromPoolRevoke(
+      value: Buffer
+    ): ClaimableBalanceId;
+
+    value(): Buffer | Buffer;
 
     toXDR(format?: 'raw'): Buffer;
 
@@ -6379,12 +6535,47 @@ export namespace xdr {
     static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
+  class LedgerHeaderExtensionV1Ext {
+    switch(): number;
+
+    static 0(): LedgerHeaderExtensionV1Ext;
+
+    value(): void;
+
+    toXDR(format?: 'raw'): Buffer;
+
+    toXDR(format: 'hex' | 'base64'): string;
+
+    static read(io: Buffer): LedgerHeaderExtensionV1Ext;
+
+    static write(value: LedgerHeaderExtensionV1Ext, io: Buffer): void;
+
+    static isValid(value: LedgerHeaderExtensionV1Ext): boolean;
+
+    static toXDR(value: LedgerHeaderExtensionV1Ext): Buffer;
+
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExtensionV1Ext;
+
+    static fromXDR(
+      input: string,
+      format: 'hex' | 'base64'
+    ): LedgerHeaderExtensionV1Ext;
+
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+  }
+
   class LedgerHeaderExt {
     switch(): number;
 
+    v1(value?: LedgerHeaderExtensionV1): LedgerHeaderExtensionV1;
+
     static 0(): LedgerHeaderExt;
 
-    value(): void;
+    static 1(value: LedgerHeaderExtensionV1): LedgerHeaderExt;
+
+    value(): LedgerHeaderExtensionV1 | void;
 
     toXDR(format?: 'raw'): Buffer;
 
@@ -6418,6 +6609,8 @@ export namespace xdr {
 
     newBaseReserve(value?: number): number;
 
+    newFlags(value?: number): number;
+
     static ledgerUpgradeVersion(value: number): LedgerUpgrade;
 
     static ledgerUpgradeBaseFee(value: number): LedgerUpgrade;
@@ -6426,7 +6619,9 @@ export namespace xdr {
 
     static ledgerUpgradeBaseReserve(value: number): LedgerUpgrade;
 
-    value(): number | number | number | number;
+    static ledgerUpgradeFlags(value: number): LedgerUpgrade;
+
+    value(): number | number | number | number | number;
 
     toXDR(format?: 'raw'): Buffer;
 
@@ -7328,9 +7523,13 @@ export namespace xdr {
 
     id(value?: OperationIdId): OperationIdId;
 
+    revokeId(value?: OperationIdRevokeId): OperationIdRevokeId;
+
     static envelopeTypeOpId(value: OperationIdId): OperationId;
 
-    value(): OperationIdId;
+    static envelopeTypePoolRevokeOpId(value: OperationIdRevokeId): OperationId;
+
+    value(): OperationIdId | OperationIdRevokeId;
 
     toXDR(format?: 'raw'): Buffer;
 
@@ -7621,11 +7820,15 @@ export namespace xdr {
 
     orderBook(value?: ClaimOfferAtom): ClaimOfferAtom;
 
+    liquidityPool(value?: ClaimLiquidityAtom): ClaimLiquidityAtom;
+
     static claimAtomTypeV0(value: ClaimOfferAtomV0): ClaimAtom;
 
     static claimAtomTypeOrderBook(value: ClaimOfferAtom): ClaimAtom;
 
-    value(): ClaimOfferAtomV0 | ClaimOfferAtom;
+    static claimAtomTypeLiquidityPool(value: ClaimLiquidityAtom): ClaimAtom;
+
+    value(): ClaimOfferAtomV0 | ClaimOfferAtom | ClaimLiquidityAtom;
 
     toXDR(format?: 'raw'): Buffer;
 

--- a/types/xdr.d.ts
+++ b/types/xdr.d.ts
@@ -1612,6 +1612,7 @@ export namespace xdr {
 
   const DataValue: VarOpaque;
 
+  // The generated code was `type PoolId = Hash;` but that's not a valid type.
   type PoolId = typeof Hash;
 
   const AssetCode4: Opaque;

--- a/xdr/Stellar-SCP.x
+++ b/xdr/Stellar-SCP.x
@@ -80,7 +80,7 @@ struct SCPEnvelope
 struct SCPQuorumSet
 {
     uint32 threshold;
-    PublicKey validators<>;
+    NodeID validators<>;
     SCPQuorumSet innerSets<>;
 };
 }

--- a/xdr/Stellar-ledger-entries.x
+++ b/xdr/Stellar-ledger-entries.x
@@ -391,13 +391,16 @@ case CLAIMANT_TYPE_V0:
 
 enum ClaimableBalanceIDType
 {
-    CLAIMABLE_BALANCE_ID_TYPE_V0 = 0
+    CLAIMABLE_BALANCE_ID_TYPE_V0 = 0,
+    CLAIMABLE_BALANCE_ID_TYPE_FROM_POOL_REVOKE = 1
 };
 
 union ClaimableBalanceID switch (ClaimableBalanceIDType type)
 {
 case CLAIMABLE_BALANCE_ID_TYPE_V0:
     Hash v0;
+case CLAIMABLE_BALANCE_ID_TYPE_FROM_POOL_REVOKE:
+    Hash fromPoolRevoke;
 };
 
 enum ClaimableBalanceFlags
@@ -570,6 +573,7 @@ enum EnvelopeType
     ENVELOPE_TYPE_AUTH = 3,
     ENVELOPE_TYPE_SCPVALUE = 4,
     ENVELOPE_TYPE_TX_FEE_BUMP = 5,
-    ENVELOPE_TYPE_OP_ID = 6
+    ENVELOPE_TYPE_OP_ID = 6,
+    ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7
 };
 }

--- a/xdr/Stellar-ledger-entries.x
+++ b/xdr/Stellar-ledger-entries.x
@@ -14,6 +14,7 @@ typedef string string64<64>;
 typedef int64 SequenceNumber;
 typedef uint64 TimePoint;
 typedef opaque DataValue<64>;
+typedef Hash PoolID; // SHA256(LiquidityPoolParameters)
 
 // 1-4 alphanumeric characters right-padded with 0 bytes
 typedef opaque AssetCode4[4];
@@ -25,7 +26,8 @@ enum AssetType
 {
     ASSET_TYPE_NATIVE = 0,
     ASSET_TYPE_CREDIT_ALPHANUM4 = 1,
-    ASSET_TYPE_CREDIT_ALPHANUM12 = 2
+    ASSET_TYPE_CREDIT_ALPHANUM12 = 2,
+    ASSET_TYPE_POOL_SHARE = 3
 };
 
 union AssetCode switch (AssetType type)
@@ -39,24 +41,28 @@ case ASSET_TYPE_CREDIT_ALPHANUM12:
     // add other asset types here in the future
 };
 
+struct AlphaNum4
+{
+    AssetCode4 assetCode;
+    AccountID issuer;
+};
+
+struct AlphaNum12
+{
+    AssetCode12 assetCode;
+    AccountID issuer;
+};
+
 union Asset switch (AssetType type)
 {
 case ASSET_TYPE_NATIVE: // Not credit
     void;
 
 case ASSET_TYPE_CREDIT_ALPHANUM4:
-    struct
-    {
-        AssetCode4 assetCode;
-        AccountID issuer;
-    } alphaNum4;
+    AlphaNum4 alphaNum4;
 
 case ASSET_TYPE_CREDIT_ALPHANUM12:
-    struct
-    {
-        AssetCode12 assetCode;
-        AccountID issuer;
-    } alphaNum12;
+    AlphaNum12 alphaNum12;
 
     // add other asset types here in the future
 };
@@ -90,7 +96,8 @@ enum LedgerEntryType
     TRUSTLINE = 1,
     OFFER = 2,
     DATA = 3,
-    CLAIMABLE_BALANCE = 4
+    CLAIMABLE_BALANCE = 4,
+    LIQUIDITY_POOL = 5
 };
 
 struct Signer
@@ -119,7 +126,7 @@ enum AccountFlags
 
 // mask for all valid flags
 const MASK_ACCOUNT_FLAGS = 0x7;
-const MASK_ACCOUNT_FLAGS_V16 = 0xF;
+const MASK_ACCOUNT_FLAGS_V17 = 0xF;
 
 // maximum number of signers
 const MAX_SIGNERS = 20;
@@ -212,12 +219,46 @@ enum TrustLineFlags
 // mask for all trustline flags
 const MASK_TRUSTLINE_FLAGS = 1;
 const MASK_TRUSTLINE_FLAGS_V13 = 3;
-const MASK_TRUSTLINE_FLAGS_V16 = 7;
+const MASK_TRUSTLINE_FLAGS_V17 = 7;
+
+enum LiquidityPoolType
+{
+    LIQUIDITY_POOL_CONSTANT_PRODUCT = 0
+};
+
+union TrustLineAsset switch (AssetType type)
+{
+case ASSET_TYPE_NATIVE: // Not credit
+    void;
+
+case ASSET_TYPE_CREDIT_ALPHANUM4:
+    AlphaNum4 alphaNum4;
+
+case ASSET_TYPE_CREDIT_ALPHANUM12:
+    AlphaNum12 alphaNum12;
+
+case ASSET_TYPE_POOL_SHARE:
+    PoolID liquidityPoolID;
+
+    // add other asset types here in the future
+};
+
+struct TrustLineEntryExtensionV2
+{
+    int32 liquidityPoolUseCount;
+
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
+};
 
 struct TrustLineEntry
 {
     AccountID accountID; // account this trustline belongs to
-    Asset asset;         // type of asset (with issuer)
+    TrustLineAsset asset;         // type of asset (with issuer)
     int64 balance;       // how much of this asset the user has.
                          // Asset defines the unit for this;
 
@@ -238,6 +279,8 @@ struct TrustLineEntry
             {
             case 0:
                 void;
+            case 2:
+                TrustLineEntryExtensionV2 v2;
             }
             ext;
         } v1;
@@ -403,6 +446,33 @@ struct ClaimableBalanceEntry
     ext;
 };
 
+struct LiquidityPoolConstantProductParameters
+{
+    Asset assetA; // assetA < assetB
+    Asset assetB;
+    int32 fee;    // Fee is in basis points, so the actual rate is (fee/100)%
+};
+
+struct LiquidityPoolEntry
+{
+    PoolID liquidityPoolID;
+
+    union switch (LiquidityPoolType type)
+    {
+    case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+        struct
+        {
+            LiquidityPoolConstantProductParameters params;
+
+            int64 reserveA;        // amount of A in the pool
+            int64 reserveB;        // amount of B in the pool
+            int64 totalPoolShares; // total number of pool shares issued
+            int64 poolSharesTrustLineCount; // number of trust lines for the associated pool shares
+        } constantProduct;
+    }
+    body;
+};
+
 struct LedgerEntryExtensionV1
 {
     SponsorshipDescriptor sponsoringID;
@@ -431,6 +501,8 @@ struct LedgerEntry
         DataEntry data;
     case CLAIMABLE_BALANCE:
         ClaimableBalanceEntry claimableBalance;
+    case LIQUIDITY_POOL:
+        LiquidityPoolEntry liquidityPool;
     }
     data;
 
@@ -457,7 +529,7 @@ case TRUSTLINE:
     struct
     {
         AccountID accountID;
-        Asset asset;
+        TrustLineAsset asset;
     } trustLine;
 
 case OFFER:
@@ -479,6 +551,12 @@ case CLAIMABLE_BALANCE:
     {
         ClaimableBalanceID balanceID;
     } claimableBalance;
+
+case LIQUIDITY_POOL:
+    struct
+    {
+        PoolID liquidityPoolID;
+    } liquidityPool;
 };
 
 // list of all envelope types used in the application

--- a/xdr/Stellar-ledger.x
+++ b/xdr/Stellar-ledger.x
@@ -33,7 +33,7 @@ struct StellarValue
     // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
     // unknown steps during consensus if needed.
     // see notes below on 'LedgerUpgrade' for more detail
-    // max size is dictated by number of upgrade types (+ room for future)
+    // max size is dictated by number of upgrade types ( room for future)
     UpgradeType upgrades<6>;
 
     // reserved for future use
@@ -46,6 +46,29 @@ struct StellarValue
     }
     ext;
 };
+
+const MASK_LEDGERHEADER_FLAGS = 0x7;
+
+enum LedgerHeaderFlags
+{ // masks for each flag
+
+    DISABLE_LIQUIDITY_POOL_TRADING_FLAG = 0x1,
+    DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG = 0x2,
+    DISABLE_LIQUIDITY_POOL_WITHDRAWAL_FLAG = 0x4
+};
+
+struct LedgerHeaderExtensionV1
+{
+    uint32 flags; // UpgradeFlags
+
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
+};
+
 
 /* The LedgerHeader is the highest level structure representing the
  * state of a ledger, cryptographically linked to previous ledgers.
@@ -84,6 +107,8 @@ struct LedgerHeader
     {
     case 0:
         void;
+    case 1:
+        LedgerHeaderExtensionV1 v1;
     }
     ext;
 };
@@ -98,7 +123,8 @@ enum LedgerUpgradeType
     LEDGER_UPGRADE_VERSION = 1,
     LEDGER_UPGRADE_BASE_FEE = 2,
     LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3,
-    LEDGER_UPGRADE_BASE_RESERVE = 4
+    LEDGER_UPGRADE_BASE_RESERVE = 4,
+    LEDGER_UPGRADE_FLAGS = 5
 };
 
 union LedgerUpgrade switch (LedgerUpgradeType type)
@@ -111,6 +137,8 @@ case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
     uint32 newMaxTxSetSize; // update maxTxSetSize
 case LEDGER_UPGRADE_BASE_RESERVE:
     uint32 newBaseReserve; // update baseReserve
+case LEDGER_UPGRADE_FLAGS:
+    uint32 newFlags; // update flags
 };
 
 /* Entries used to define the bucket list */

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -7,6 +7,12 @@
 namespace stellar
 {
 
+union LiquidityPoolParameters switch (LiquidityPoolType type)
+{
+case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+    LiquidityPoolConstantProductParameters constantProduct;
+};
+
 // Source or destination of a payment operation
 union MuxedAccount switch (CryptoKeyType type)
 {
@@ -49,7 +55,9 @@ enum OperationType
     REVOKE_SPONSORSHIP = 18,
     CLAWBACK = 19,
     CLAWBACK_CLAIMABLE_BALANCE = 20,
-    SET_TRUST_LINE_FLAGS = 21
+    SET_TRUST_LINE_FLAGS = 21,
+    LIQUIDITY_POOL_DEPOSIT = 22,
+    LIQUIDITY_POOL_WITHDRAW = 23
 };
 
 /* CreateAccount
@@ -212,6 +220,23 @@ struct SetOptionsOp
     Signer* signer;
 };
 
+union ChangeTrustAsset switch (AssetType type)
+{
+case ASSET_TYPE_NATIVE: // Not credit
+    void;
+
+case ASSET_TYPE_CREDIT_ALPHANUM4:
+    AlphaNum4 alphaNum4;
+
+case ASSET_TYPE_CREDIT_ALPHANUM12:
+    AlphaNum12 alphaNum12;
+
+case ASSET_TYPE_POOL_SHARE:
+    LiquidityPoolParameters liquidityPool;
+
+    // add other asset types here in the future
+};
+
 /* Creates, updates or deletes a trust line
 
     Threshold: med
@@ -221,7 +246,7 @@ struct SetOptionsOp
 */
 struct ChangeTrustOp
 {
-    Asset line;
+    ChangeTrustAsset line;
 
     // if limit is set to 0, deletes the trust line
     int64 limit;
@@ -409,6 +434,37 @@ struct SetTrustLineFlagsOp
     uint32 setFlags;   // which flags to set
 };
 
+const LIQUIDITY_POOL_FEE_V18 = 30;
+
+/* Deposit assets into a liquidity pool
+
+    Threshold: med
+
+    Result: LiquidityPoolDepositResult
+*/
+struct LiquidityPoolDepositOp
+{
+    PoolID liquidityPoolID;
+    int64 maxAmountA;     // maximum amount of first asset to deposit
+    int64 maxAmountB;     // maximum amount of second asset to deposit
+    Price minPrice;       // minimum depositA/depositB
+    Price maxPrice;       // maximum depositA/depositB
+};
+
+/* Withdraw assets from a liquidity pool
+
+    Threshold: med
+
+    Result: LiquidityPoolWithdrawResult
+*/
+struct LiquidityPoolWithdrawOp
+{
+    PoolID liquidityPoolID;
+    int64 amount;         // amount of pool shares to withdraw
+    int64 minAmountA;     // minimum amount of first asset to withdraw
+    int64 minAmountB;     // minimum amount of second asset to withdraw
+};
+
 /* An operation is the lowest unit of work that a transaction does */
 struct Operation
 {
@@ -463,6 +519,10 @@ struct Operation
         ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
     case SET_TRUST_LINE_FLAGS:
         SetTrustLineFlagsOp setTrustLineFlagsOp;
+    case LIQUIDITY_POOL_DEPOSIT:
+        LiquidityPoolDepositOp liquidityPoolDepositOp;
+    case LIQUIDITY_POOL_WITHDRAW:
+        LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
     }
     body;
 };
@@ -472,7 +532,7 @@ union OperationID switch (EnvelopeType type)
 case ENVELOPE_TYPE_OP_ID:
     struct
     {
-        MuxedAccount sourceAccount;
+        AccountID sourceAccount;
         SequenceNumber seqNum;
         uint32 opNum;
     } id;
@@ -635,7 +695,32 @@ struct TransactionSignaturePayload
 
 /* Operation Results section */
 
-/* This result is used when offers are taken during an operation */
+enum ClaimAtomType
+{
+    CLAIM_ATOM_TYPE_V0 = 0,
+    CLAIM_ATOM_TYPE_ORDER_BOOK = 1
+};
+
+// ClaimOfferAtomV0 is a ClaimOfferAtom with the AccountID discriminant stripped
+// off, leaving a raw ed25519 public key to identify the source account. This is
+// used for backwards compatibility starting from the protocol 17/18 boundary.
+// If an "old-style" ClaimOfferAtom is parsed with this XDR definition, it will
+// be parsed as a "new-style" ClaimAtom containing a ClaimOfferAtomV0.
+struct ClaimOfferAtomV0
+{
+    // emitted to identify the offer
+    uint256 sellerEd25519; // Account that owns the offer
+    int64 offerID;
+
+    // amount and asset taken from the owner
+    Asset assetSold;
+    int64 amountSold;
+
+    // amount and asset sent to the owner
+    Asset assetBought;
+    int64 amountBought;
+};
+
 struct ClaimOfferAtom
 {
     // emitted to identify the offer
@@ -649,6 +734,17 @@ struct ClaimOfferAtom
     // amount and asset sent to the owner
     Asset assetBought;
     int64 amountBought;
+};
+
+/* This result is used when offers are taken or liquidity is exchanged with a
+   liquidity pool during an operation
+*/
+union ClaimAtom switch (ClaimAtomType type)
+{
+case CLAIM_ATOM_TYPE_V0:
+    ClaimOfferAtomV0 v0;
+case CLAIM_ATOM_TYPE_ORDER_BOOK:
+    ClaimOfferAtom orderBook;
 };
 
 /******* CreateAccount Result ********/
@@ -679,7 +775,7 @@ default:
 enum PaymentResultCode
 {
     // codes considered as "success" for the operation
-    PAYMENT_SUCCESS = 0, // payment successfuly completed
+    PAYMENT_SUCCESS = 0, // payment successfully completed
 
     // codes considered as "failure" for the operation
     PAYMENT_MALFORMED = -1,          // bad input
@@ -745,7 +841,7 @@ union PathPaymentStrictReceiveResult switch (
 case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
     struct
     {
-        ClaimOfferAtom offers<>;
+        ClaimAtom offers<>;
         SimplePaymentResult last;
     } success;
 case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
@@ -789,7 +885,7 @@ union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
 case PATH_PAYMENT_STRICT_SEND_SUCCESS:
     struct
     {
-        ClaimOfferAtom offers<>;
+        ClaimAtom offers<>;
         SimplePaymentResult last;
     } success;
 case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
@@ -837,7 +933,7 @@ enum ManageOfferEffect
 struct ManageOfferSuccessResult
 {
     // offers that got claimed while creating this offer
-    ClaimOfferAtom offersClaimed<>;
+    ClaimAtom offersClaimed<>;
 
     union switch (ManageOfferEffect effect)
     {
@@ -933,7 +1029,10 @@ enum ChangeTrustResultCode
                                      // cannot create with a limit of 0
     CHANGE_TRUST_LOW_RESERVE =
         -4, // not enough funds to create a new trust line,
-    CHANGE_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
+    CHANGE_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
+    CHANGE_TRUST_TRUST_LINE_MISSING = -6, // Asset trustline is missing for pool
+    CHANGE_TRUST_CANNOT_DELETE = -7, // Asset trustline is still referenced in a pool
+    CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES = -8 // Asset trustline is deauthorized
 };
 
 union ChangeTrustResult switch (ChangeTrustResultCode code)
@@ -987,7 +1086,7 @@ enum AccountMergeResultCode
 union AccountMergeResult switch (AccountMergeResultCode code)
 {
 case ACCOUNT_MERGE_SUCCESS:
-    int64 sourceAccountBalance; // how much got transfered from source account
+    int64 sourceAccountBalance; // how much got transferred from source account
 default:
     void;
 };
@@ -1152,7 +1251,8 @@ enum RevokeSponsorshipResultCode
     REVOKE_SPONSORSHIP_DOES_NOT_EXIST = -1,
     REVOKE_SPONSORSHIP_NOT_SPONSOR = -2,
     REVOKE_SPONSORSHIP_LOW_RESERVE = -3,
-    REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE = -4
+    REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE = -4,
+    REVOKE_SPONSORSHIP_MALFORMED = -5
 };
 
 union RevokeSponsorshipResult switch (RevokeSponsorshipResultCode code)
@@ -1229,6 +1329,63 @@ default:
     void;
 };
 
+/******* LiquidityPoolDeposit Result ********/
+
+enum LiquidityPoolDepositResultCode
+{
+    // codes considered as "success" for the operation
+    LIQUIDITY_POOL_DEPOSIT_SUCCESS = 0,
+
+    // codes considered as "failure" for the operation
+    LIQUIDITY_POOL_DEPOSIT_MALFORMED = -1,      // bad input
+    LIQUIDITY_POOL_DEPOSIT_NO_TRUST = -2,       // no trust line for one of the
+                                                // assets
+    LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED = -3, // not authorized for one of the
+                                                // assets
+    LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED = -4,    // not enough balance for one of
+                                                // the assets
+    LIQUIDITY_POOL_DEPOSIT_LINE_FULL = -5,      // pool share trust line doesn't
+                                                // have sufficient limit
+    LIQUIDITY_POOL_DEPOSIT_BAD_PRICE = -6,      // deposit price outside bounds
+    LIQUIDITY_POOL_DEPOSIT_POOL_FULL = -7       // pool reserves are full
+};
+
+union LiquidityPoolDepositResult switch (
+    LiquidityPoolDepositResultCode code)
+{
+case LIQUIDITY_POOL_DEPOSIT_SUCCESS:
+    void;
+default:
+    void;
+};
+
+/******* LiquidityPoolWithdraw Result ********/
+
+enum LiquidityPoolWithdrawResultCode
+{
+    // codes considered as "success" for the operation
+    LIQUIDITY_POOL_WITHDRAW_SUCCESS = 0,
+
+    // codes considered as "failure" for the operation
+    LIQUIDITY_POOL_WITHDRAW_MALFORMED = -1,      // bad input
+    LIQUIDITY_POOL_WITHDRAW_NO_TRUST = -2,       // no trust line for one of the
+                                                 // assets
+    LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED = -3,    // not enough balance of the
+                                                 // pool share
+    LIQUIDITY_POOL_WITHDRAW_LINE_FULL = -4,      // would go above limit for one
+                                                 // of the assets
+    LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM = -5   // didn't withdraw enough
+};
+
+union LiquidityPoolWithdrawResult switch (
+    LiquidityPoolWithdrawResultCode code)
+{
+case LIQUIDITY_POOL_WITHDRAW_SUCCESS:
+    void;
+default:
+    void;
+};
+
 /* High level Operation Result */
 enum OperationResultCode
 {
@@ -1291,6 +1448,10 @@ case opINNER:
         ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
     case SET_TRUST_LINE_FLAGS:
         SetTrustLineFlagsResult setTrustLineFlagsResult;
+    case LIQUIDITY_POOL_DEPOSIT:
+        LiquidityPoolDepositResult liquidityPoolDepositResult;
+    case LIQUIDITY_POOL_WITHDRAW:
+        LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
     }
     tr;
 default:
@@ -1314,7 +1475,7 @@ enum TransactionResultCode
     txNO_ACCOUNT = -8,           // source account not found
     txINSUFFICIENT_FEE = -9,     // fee is too small
     txBAD_AUTH_EXTRA = -10,      // unused signatures attached to transaction
-    txINTERNAL_ERROR = -11,      // an unknown error occured
+    txINTERNAL_ERROR = -11,      // an unknown error occurred
 
     txNOT_SUPPORTED = -12,         // transaction type not supported
     txFEE_BUMP_INNER_FAILED = -13, // fee bump inner transaction failed


### PR DESCRIPTION
## [v6.0.0](https://github.com/stellar/js-stellar-base/compare/v5.3.2..v6.0.0)

### Add

- Introduced new CAP-38 operations `LiquidityPoolDepositOp` and `LiquidityPoolWithdrawOp`.
- Introduced two new types of assets, `TrustLineAsset` and `ChangeTrustAsset`.

### Update

- The XDR definitions have been updated to support CAP-38.
- Extended `Operation` class with the `Operation.revokeLiquidityPoolSponsorship` helper that allows revoking a liquidity pool sponsorship.
- Asset types now include `AssetType.liquidityPoolShares`.

### Breaking

- Must use `TrustLineAsset` instead of `Asset` in the function `Operation.revokeTrustlineSponsorship` and the XDR objects `TrustLineEntry` and `LedgerKeyTrustLine`.
- Must use `ChangeTrustAsset` instead of `Asset` in the function `Operation.changeTrust` and the XDR object `ChangeTrustOp`.
- The `AssetAlphaNum4` and `AssetAlphaNum12` objects were renamed to `AlphaNum4` and `AlphaNum12` respectively.