### PR TITLE
[CD] Add Action to publish a new version to npm registry every time a GH release is published

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -12,8 +12,6 @@ jobs:
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
-          # Defaults to the user or organization that owns the workflow file
-          scope: '@octocat'
       - run: yarn
       - run: yarn publish
         env:


### PR DESCRIPTION
Add Action to publish a new version to npm registry every time a GH release is published.

References:
* https://docs.github.com/en/actions/guides/publishing-nodejs-packages#publishing-packages-using-yarn
* https://javascript.plainenglish.io/how-to-publish-npm-packages-6f70178fe789