### PR TITLE
Add a `withMuxing` parameter to all operation options in Typescript.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+
+## [v6.0.2](https://github.com/stellar/js-stellar-base/compare/v6.0.1..v6.0.2)
+
+### Fix
+ - Fix Typescript signatures for operations to universally allow setting the `withMuxing` flag.
+
+
 ## [v6.0.1](https://github.com/stellar/js-stellar-base/compare/v5.3.2..v6.0.1)
 
 ### Add

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Once all of the PRs for a particular release are in, it's time to actually publi
 
  - [ ] Update the top-level `"version"` field in the [package.json](./package.json) file to reflect the new version.
 
- - [ ] Run the final sanity check to ensure the builds pass: `yarn dtslint && yarn test && yarn preversion`.
+ - [ ] Run the final sanity check to ensure the builds pass: `yarn dtslint && yarn test && yarn preversion`. The first command checks that you have Typescript compatibility (one of the most common sources of bugs, since this library is written purely in JS but must be usable from TS).
 
  - [ ] Commit & push your branch, then [create a PR](https://github.com/stellar/js-stellar-base/compare).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Low level stellar support library",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -351,6 +351,7 @@ export type OperationType =
 export namespace OperationOptions {
   interface BaseOptions {
     source?: string;
+    withMuxing?: boolean; // all operations support a muxed source
   }
   interface AccountMerge extends BaseOptions {
     destination: string;

--- a/types/test.ts
+++ b/types/test.ts
@@ -15,10 +15,19 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
   .addOperation(
     StellarSdk.Operation.beginSponsoringFutureReserves({
       sponsoredId: account.accountId(),
-      source: masterKey.publicKey()
+      source: masterKey.publicKey(),
+      withMuxing: false, // ensures source can always be muxed
     })
   ).addOperation(
     StellarSdk.Operation.accountMerge({ destination: destKey.publicKey() }),
+  ).addOperation(
+    StellarSdk.Operation.payment({
+      source: account.accountId(),
+      destination: muxedAccount.accountId(),
+      amount: "100",
+      asset: usd,
+      withMuxing: false, // ensure muxed ops also allow the flag
+    })
   ).addOperation(
     StellarSdk.Operation.createClaimableBalance({
       amount: "10",


### PR DESCRIPTION
### What
This allows all operations to set a muxed source account, as required by [CAP-27](https://stellar.org/protocol/cap-27).

### Why
While JavaScript consumers of this library are unaffected, as passing extra parameters to functions is always allowed, Typescript libraries will not compile when passing `withMuxing: true` to any operation.