### PR TITLE
Fix logical errors in the GitHub Action for docgen.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -22,7 +22,6 @@ jobs:
         run: gulp
 
       - name: Checkout GH pages
-        uses: actions/checkout@v2
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -32,7 +31,6 @@ jobs:
         run: yarn docs
 
       - name: Publish JS docs
-        uses: actions/checkout@v2
         run: |
           DESCRIPTION=`git describe --tags`
           cd jsdoc


### PR DESCRIPTION
Whelp, that broke fast ... (see [build](https://github.com/stellar/js-stellar-base/actions/runs/1230815646)) :laughing: 

A misinterpretation of [the docs](https://github.com/actions/checkout#push-a-commit-using-the-built-in-token) on my part: The `uses` and `run` steps should be separate, and the former is already part of the first build step.