### PR TITLE
Try checking out the repo via the built-in action.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v2
 
       - name: Install Node (14.x)
         uses: actions/setup-node@v2
@@ -22,10 +22,11 @@ jobs:
         run: gulp
 
       - name: Checkout GH pages
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git clone -b gh-pages "git@github.com:stellar/js-stellar-base.git" jsdoc
+        uses: actions/checkout@v2
+        with:
+          repository: stellar/js-stellar-base
+          ref: gh-pages
+          path: jsdoc
 
       - name: Generate JS docs
         run: yarn docs


### PR DESCRIPTION
The [run](https://github.com/stellar/js-stellar-base/runs/3592335593) had a different error (but at least it runs!):

>  Cloning into 'jsdoc'...
> Warning: Permanently added the RSA host key for IP address '140.82.114.3' to the list of known hosts.
> git@github.com: Permission denied (publickey).
> fatal: Could not read from remote repository.

Perhaps using the native method ([docs](https://github.com/actions/checkout#checkout-multiple-repos-nested)) from `actions/checkout` will work better.