### PR TITLE
Clarify types in the docstring for the `getLiquidityPoolId` helper.

### DIFF
--- a/src/get_liquidity_pool_id.js
+++ b/src/get_liquidity_pool_id.js
@@ -7,15 +7,17 @@ export const LiquidityPoolFeeV18 = 30;
 
 /**
  * getLiquidityPoolId computes the Pool ID for the given assets, fee and pool type.
+ *
  * @see [stellar-core getPoolID](https://github.com/stellar/stellar-core/blob/9f3a48c6a8f1aa77b6043a055d0638661f718080/src/ledger/test/LedgerTxnTests.cpp#L3746-L3751)
  *
  * @export
- * @param {LiquidityPoolType} liquidityPoolType – A number representing the liquidity pool type.
- * @param {LiquidityPoolParameters} liquidityPoolParameters – The liquidity pool parameters.
- * @param {Asset} liquidityPoolParameters.assetA – The first asset in the Pool, it must respect the rule assetA < assetB.
- * @param {Asset} liquidityPoolParameters.assetB – The second asset in the Pool, it must respect the rule assetA < assetB.
- * @param {number} liquidityPoolParameters.fee – The liquidity pool fee. For now the only fee supported is `30`.
- * @return {Buffer} the Pool ID buffer, it can be stringfied with `toString('hex')`.
+ * @param {string} liquidityPoolType – A string representing the liquidity pool type.
+ * @param {object} liquidityPoolParameters        – The liquidity pool parameters.
+ * @param {Asset}  liquidityPoolParameters.assetA – The first asset in the Pool, it must respect the rule assetA < assetB.
+ * @param {Asset}  liquidityPoolParameters.assetB – The second asset in the Pool, it must respect the rule assetA < assetB.
+ * @param {number} liquidityPoolParameters.fee    – The liquidity pool fee. For now the only fee supported is `30`.
+ *
+ * @return {Buffer} the raw Pool ID buffer, which can be stringfied with `toString('hex')`
  */
 export function getLiquidityPoolId(
   liquidityPoolType,


### PR DESCRIPTION
The type is a string, not the XDR type, and the parameters are an object.