### PR TITLE
Release v6.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fix
 
-- Upgrades the `path-parse` dependency from 1.0.6 to 1.0.7 ([#450](https://github.com/stellar/js-stellar-base/pull/450)).
+- Upgrades dependencies: `path-parse` (1.0.6 --> 1.0.7) and `jszip` (3.4.0 to 3.7.1) ([#450](https://github.com/stellar/js-stellar-base/pull/450), [#458](https://github.com/stellar/js-stellar-base/pull/458)).
 
 
 ## [v6.0.5](https://github.com/stellar/js-stellar-base/compare/v6.0.4..v6.0.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ## Unreleased
 
 
+## [v6.0.6](https://github.com/stellar/js-stellar-base/compare/v6.0.5..v6.0.6)
+
+### Fix
+
+- Upgrades the `path-parse` dependency from 1.0.6 to 1.0.7 ([#450](https://github.com/stellar/js-stellar-base/pull/450)).
+
+
 ## [v6.0.5](https://github.com/stellar/js-stellar-base/compare/v6.0.4..v6.0.5)
 
 This version bump fixes a security vulnerability in a _developer_ dependency; **please upgrade as soon as possible!** You may be affected if you are working on this package in a developer capacity (i.e. you've cloned this repository) and have run `yarn` or `yarn install` any time on Oct 22nd, 2021.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Low level stellar support library",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
This is a patch version bump intended to update some vulnerable developer dependencies. These vulnerabilities have no meaningful impact on this repository.