### PR TITLE
Adds helper to predict claimable balance IDs given a transaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ function encodeMuxedAccountToAddress(account: xdr.MuxedAccount, supportMuxing: b
 function encodeMuxedAccount(gAddress: string, id: string): xdr.MuxedAccount;
 ```
 
+- Adds a helper function `Transaction.getClaimableBalanceId(int)` which lets you pre-determine the hex claimable balance ID of a `createClaimableBalance` operation prior to submission to the network ([#482](https://github.com/stellar/js-stellar-base/pull/482)).
 
 ### Breaking Changes
 

--- a/src/operations/set_trustline_flags.js
+++ b/src/operations/set_trustline_flags.js
@@ -42,7 +42,7 @@ export function setTrustLineFlags(opts = {}) {
   const attributes = {};
 
   if (typeof opts.flags !== 'object' || Object.keys(opts.flags).length === 0) {
-    throw new Error('opts.flags must be an map of boolean flags to modify');
+    throw new Error('opts.flags must be a map of boolean flags to modify');
   }
 
   const mapping = {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -221,16 +221,15 @@ export class Transaction extends TransactionBase {
   /**
    * Calculate the claimable balance ID for an operation within the transaction.
    *
-   * This helper throws under the following circumstances:
-   *    - invalid `opIndex` value
-   *    - the operation at the `opIndex` is not a CreateClaimableBalance op
-   *    - the source account doesn't have a sequence number
-   *    - general XDR un/marshalling failures
-   *
    * @param   {integer}  opIndex   the index of the CreateClaimableBalance op
    * @returns {string}   a hex string representing the claimable balance ID
    *
-   * @see https://github.com/stellar/go/blob/master/txnbuild/transaction.go#L392
+   * @throws {RangeError}   for invalid `opIndex` value
+   * @throws {TypeError}    if op at `opIndex` is not `CreateClaimableBalance`
+   * @throws for general XDR un/marshalling failures
+   *
+   * @see https://github.com/stellar/go/blob/d712346e61e288d450b0c08038c158f8848cc3e4/txnbuild/transaction.go#L392-L435
+   *
    */
   getClaimableBalanceId(opIndex) {
     // Validate and then extract the operation from the transaction.
@@ -251,9 +250,8 @@ export class Transaction extends TransactionBase {
       );
     }
 
-    // Use the operation's source account or the transaction's source if not. In
-    // either case, use the unmuxed version.
-    let account = decodeAddressToMuxedAccount(this.source, true);
+    // Always use the transaction's *unmuxed* source.
+    let account = decodeAddressToMuxedAccount(this.source);
     if (account.switch() === xdr.CryptoKeyType.keyTypeMuxedEd25519()) {
       account = account.med25519();
     }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -8,7 +8,7 @@ import { Operation } from './operation';
 import { Memo } from './memo';
 import { TransactionBase } from './transaction_base';
 import {
-  decodeAddressToMuxedAccount,
+  extractBaseAddress,
   encodeMuxedAccountToAddress
 } from './util/decode_encode_muxed_account';
 
@@ -251,14 +251,12 @@ export class Transaction extends TransactionBase {
     }
 
     // Always use the transaction's *unmuxed* source.
-    let account = decodeAddressToMuxedAccount(this.source);
-    if (account.switch() === xdr.CryptoKeyType.keyTypeMuxedEd25519()) {
-      account = account.med25519();
-    }
-
+    const account = StrKey.decodeEd25519PublicKey(
+      extractBaseAddress(this.source)
+    );
     const operationId = xdr.OperationId.envelopeTypeOpId(
       new xdr.OperationIdId({
-        sourceAccount: xdr.AccountId.publicKeyTypeEd25519(account.ed25519()),
+        sourceAccount: xdr.AccountId.publicKeyTypeEd25519(account),
         seqNum: new xdr.SequenceNumber(this.sequence),
         opNum: opIndex
       })

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -1,5 +1,4 @@
 import map from 'lodash/map';
-import { isInteger } from 'lodash';
 
 import xdr from './generated/stellar-xdr_generated';
 import { hash } from './hashing';
@@ -228,7 +227,7 @@ export class Transaction extends TransactionBase {
    *    - the source account doesn't have a sequence number
    *    - general XDR un/marshalling failures
    *
-   * @param   {integer}  opIndex   the index of the operation to calculate
+   * @param   {integer}  opIndex   the index of the CreateClaimableBalance op
    * @returns {string}   a hex string representing the claimable balance ID
    *
    * @see https://github.com/stellar/go/blob/master/txnbuild/transaction.go#L392
@@ -236,7 +235,7 @@ export class Transaction extends TransactionBase {
   getClaimableBalanceId(opIndex) {
     // Validate and then extract the operation from the transaction.
     if (
-      !isInteger(opIndex) ||
+      !Number.isInteger(opIndex) ||
       opIndex < 0 ||
       opIndex >= this.operations.length
     ) {

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2425,6 +2425,20 @@ describe('Operation', function() {
         StellarBase.Operation.setTrustLineFlags({});
       }).to.throw();
     });
+    it('fails with a muxed account trustor', function() {
+      expect(() => {
+        const mAddress =
+          'MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAAGZFQ';
+        console.log(mAddress);
+        StellarBase.Operation.setTrustLineFlags({
+          trustor: mAddress,
+          asset: StellarBase.Asset.native(),
+          flags: {
+            clawbackEnabled: false
+          }
+        });
+      }).to.throw();
+    });
   });
 
   describe('liquidityPoolDeposit()', function() {

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2425,19 +2425,6 @@ describe('Operation', function() {
         StellarBase.Operation.setTrustLineFlags({});
       }).to.throw();
     });
-    it('fails with a muxed account trustor', function() {
-      expect(() => {
-        const mAddress =
-          'MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAAGZFQ';
-        StellarBase.Operation.setTrustLineFlags({
-          trustor: mAddress,
-          asset: StellarBase.Asset.native(),
-          flags: {
-            clawbackEnabled: false
-          }
-        });
-      }).to.throw();
-    });
   });
 
   describe('liquidityPoolDeposit()', function() {

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2429,7 +2429,6 @@ describe('Operation', function() {
       expect(() => {
         const mAddress =
           'MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAAGZFQ';
-        console.log(mAddress);
         StellarBase.Operation.setTrustLineFlags({
           trustor: mAddress,
           asset: StellarBase.Asset.native(),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -903,6 +903,8 @@ export class Transaction<
     minTime: string;
     maxTime: string;
   };
+
+  getClaimableBalanceId(opIndex: number): string;
 }
 
 export const BASE_FEE = '100';


### PR DESCRIPTION
This change introduces a helper method 

```typescript
Transaction.getClaimableBalanceId(opIndex: number): string;
```

which lets you predetermine the hex claimable balance ID of a `createClaimableBalance` operation prior to submission to the network.

Closes part (1) of stellar/js-stellar-sdk#584.