### PR TITLE
Expose muxed account validators to Typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,22 @@
 ## Unreleased
 
 ### Add
-A new helper method is introduced to help convert from muxed account addresses to their underlying Stellar addresses:
+A new helper method is introduced to help convert from muxed account addresses to their underlying Stellar addresses ([#485](https://github.com/stellar/js-stellar-base/pull/485)):
 
 ```ts
 function extractBaseAddess(address: string): string;
 ```
 
+The following muxed account validation functions are now available from Typescript ([#483](https://github.com/stellar/js-stellar-base/pull/483/files)):
+
+  - `encodeMed25519PublicKey(data: Buffer): string`
+  - `decodeMed25519PublicKey(data: string): Buffer`
+  - `isValidMed25519PublicKey(publicKey: string): boolean`
+
+
 ### Breaking Changes
 
-This release introduces **unconditional support for muxed accounts** [#485](https://github.com/stellar/js-stellar-base/pull/485).
+This release introduces **unconditional support for muxed accounts** ([#485](https://github.com/stellar/js-stellar-base/pull/485)).
 
 In [v5.2.0](https://github.com/stellar/js-stellar-base/releases/tag/v5.2.0), we introduced _opt-in_ support for muxed accounts, where you would need to explicitly pass a `true` flag if you wanted to interpret muxed account objects as muxed addresses (in the form `M...`, see [SEP-23](https://stellar.org/protocol/sep-23)). We stated that this would become the default in the future. That is now the case.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,17 @@ function extractBaseAddess(address: string): string;
 
 The following muxed account validation functions are now available from Typescript ([#483](https://github.com/stellar/js-stellar-base/pull/483/files)):
 
-  - `encodeMed25519PublicKey(data: Buffer): string`
-  - `decodeMed25519PublicKey(data: string): Buffer`
-  - `isValidMed25519PublicKey(publicKey: string): boolean`
+```typescript
+namespace StrKey {
+  function encodeMed25519PublicKey(data: Buffer): string;
+  function decodeMed25519PublicKey(data: string): Buffer;
+  function isValidMed25519PublicKey(publicKey: string): boolean;
+}
+
+function decodeAddressToMuxedAccount(address: string, supportMuxing: boolean): xdr.MuxedAccount;
+function encodeMuxedAccountToAddress(account: xdr.MuxedAccount, supportMuxing: boolean): string;
+function encodeMuxedAccount(gAddress: string, id: string): xdr.MuxedAccount;
+```
 
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 ## Unreleased
 
 ### Add
-A new helper method is introduced to help convert from muxed account addresses to their underlying Stellar addresses ([#485](https://github.com/stellar/js-stellar-base/pull/485)):
+
+ - A new helper method is introduced to help convert from muxed account addresses to their underlying Stellar addresses ([#485](https://github.com/stellar/js-stellar-base/pull/485)):
 
 ```ts
 function extractBaseAddess(address: string): string;
 ```
 
-The following muxed account validation functions are now available from Typescript ([#483](https://github.com/stellar/js-stellar-base/pull/483/files)):
+ - The following muxed account validation functions are now available from Typescript ([#483](https://github.com/stellar/js-stellar-base/pull/483/files)):
 
 ```typescript
 namespace StrKey {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -846,6 +846,10 @@ export namespace StrKey {
   function decodeEd25519SecretSeed(data: string): Buffer;
   function isValidEd25519SecretSeed(seed: string): boolean;
 
+  function encodeMed25519PublicKey(data: Buffer): string;
+  function decodeMed25519PublicKey(data: string): Buffer;
+  function isValidMed25519PublicKey(publicKey: string): boolean;
+
   function encodePreAuthTx(data: Buffer): string;
   function decodePreAuthTx(data: string): Buffer;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -944,4 +944,7 @@ export function verify(
   rawPublicKey: Buffer
 ): boolean;
 
+export function decodeAddressToMuxedAccount(address: string, supportMuxing: boolean): xdr.MuxedAccount;
+export function encodeMuxedAccountToAddress(account: xdr.MuxedAccount, supportMuxing: boolean): string;
+export function encodeMuxedAccount(gAddress: string, id: string): xdr.MuxedAccount;
 export function extractBaseAddress(address: string): string;

--- a/types/test.ts
+++ b/types/test.ts
@@ -309,3 +309,23 @@ const lpWithdraw = StellarSdk.xdr.LiquidityPoolWithdrawOp.fromXDR(
   'base64'
 );
 lpWithdraw; // $ExpectType LiquidityPoolWithdrawOp
+
+const pubkey = masterKey.rawPublicKey(); // $ExpectType Buffer
+const seckey = masterKey.rawSecretKey(); // $ExpectType Buffer
+const muxed = StellarSdk.encodeMuxedAccount(masterKey.publicKey(), '1'); // $ExpectType MuxedAccount
+const muxkey = muxed.toXDR("raw"); // $ExpectType Buffer
+
+let result = StellarSdk.StrKey.encodeEd25519PublicKey(pubkey);  // $ExpectType string
+StellarSdk.StrKey.decodeEd25519PublicKey(result);               // $ExpectType Buffer
+StellarSdk.StrKey.isValidEd25519PublicKey(result);              // $ExpectType boolean
+
+result = StellarSdk.StrKey.encodeEd25519SecretSeed(seckey); // $ExpectType string
+StellarSdk.StrKey.decodeEd25519SecretSeed(result);          // $ExpectType Buffer
+StellarSdk.StrKey.isValidEd25519SecretSeed(result);         // $ExpectType boolean
+
+result = StellarSdk.StrKey.encodeMed25519PublicKey(muxkey);   // $ExpectType string
+StellarSdk.StrKey.decodeMed25519PublicKey(result);            // $ExpectType Buffer
+StellarSdk.StrKey.isValidMed25519PublicKey(result);           // $ExpectType boolean
+
+const muxedAddr = StellarSdk.encodeMuxedAccountToAddress(muxed, true);  // $ExpectType string
+StellarSdk.decodeAddressToMuxedAccount(muxedAddr, true);                // $ExpectType MuxedAccount


### PR DESCRIPTION
The following muxed account validation functions are now available from Typescript:

```typescript
namespace StrKey {
  function encodeMed25519PublicKey(data: Buffer): string;
  function decodeMed25519PublicKey(data: string): Buffer;
  function isValidMed25519PublicKey(publicKey: string): boolean;
}

function decodeAddressToMuxedAccount(address: string, supportMuxing: boolean): xdr.MuxedAccount;
function encodeMuxedAccountToAddress(account: xdr.MuxedAccount, supportMuxing: boolean): string;
function encodeMuxedAccount(gAddress: string, id: string): xdr.MuxedAccount;
```