### PR TITLE
Removes unnecessary base fee check

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -108,7 +108,7 @@ export class TransactionBuilder {
     this.source = sourceAccount;
     this.operations = [];
 
-    this.baseFee = isUndefined(opts.fee) ? BASE_FEE : opts.fee;
+    this.baseFee = opts.fee;
     this.timebounds = clone(opts.timebounds) || null;
     this.memo = opts.memo || Memo.none();
     this.networkPassphrase = opts.networkPassphrase || null;


### PR DESCRIPTION
The `opts.fee` field will never be undefined because of the earlier conditional:

https://github.com/stellar/js-stellar-base/blob/cf7e64c8d2e7e2701c2a98c69e8df7297335dba0/src/transaction_builder.js#L108-L110

Thus, this ternary is not necessary.