### PR TITLE
Remove sodium-native optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ implementation in JavaScript that can be used on either Node.js or web browsers.
 
 - **[API Reference](https://stellar.github.io/js-stellar-base/)**
 
-> **Warning!** Node version of this package is using [`sodium-native`](https://www.npmjs.com/package/sodium-native) package, a native implementation of [Ed25519](https://ed25519.cr.yp.to/) in Node.js, as an [optional dependency](https://docs.npmjs.com/files/package.json#optionaldependencies).
-> This means that if for any reason installation of this package fails, `stellar-base` will fallback to the much slower implementation contained in [`tweetnacl`](https://www.npmjs.com/package/tweetnacl).
->
-> If you are using `stellar-base` in a browser you can ignore this. However, for production backend deployments you should definitely be using `sodium-native`.
-> If `sodium-native` is successfully installed and working
-> `StellarBase.FastSigning` variable will be equal `true`. Otherwise it will be
-> `false`.
-
 ## Quick start
 
 Using yarn to include js-stellar-base in your own project:

--- a/package.json
+++ b/package.json
@@ -111,9 +111,6 @@
     "sha.js": "^2.3.6",
     "tweetnacl": "^1.0.0"
   },
-  "optionalDependencies": {
-    "sodium-native": "^2.3.0"
-  },
   "resolutions": {
     "**/ua-parser-js": "0.7.28"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import xdr from './generated/stellar-xdr_generated';
 
 export { xdr };
 export { hash } from './hashing';
-export { sign, verify, FastSigning } from './signing';
+export { sign, verify } from './signing';
 export {
   getLiquidityPoolId,
   LiquidityPoolFeeV18

--- a/src/signing.js
+++ b/src/signing.js
@@ -1,103 +1,28 @@
-//  This module provides the signing functionality used by the stellar network
-//  The code below may look a little strange... this is because we try to provide
-//  the most efficient signing method possible.  First, we try to load the
-//  native `sodium-native` package for node.js environments, and if that fails we
-//  fallback to `tweetnacl`
+//  This module provides the signing functionality used by the Stellar network
 
-const actualMethods = {};
+import * as nacl from 'tweetnacl';
 
-/**
- * Use this flag to check if fast signing (provided by `sodium-native` package) is available.
- * If your app is signing a large number of transaction or verifying a large number
- * of signatures make sure `sodium-native` package is installed.
- */
-export const FastSigning = checkFastSigning();
+export function generate(secretKey) {
+  const secretKeyUint8 = new Uint8Array(secretKey);
+  const naclKeys = nacl.sign.keyPair.fromSeed(secretKeyUint8);
+  return Buffer.from(naclKeys.publicKey);
+}
 
 export function sign(data, secretKey) {
-  return actualMethods.sign(data, secretKey);
+  data = Buffer.from(data);
+  data = new Uint8Array(data.toJSON().data);
+  secretKey = new Uint8Array(secretKey.toJSON().data);
+
+  const signature = nacl.sign.detached(data, secretKey);
+
+  return Buffer.from(signature);
 }
 
 export function verify(data, signature, publicKey) {
-  return actualMethods.verify(data, signature, publicKey);
-}
+  data = Buffer.from(data);
+  data = new Uint8Array(data.toJSON().data);
+  signature = new Uint8Array(signature.toJSON().data);
+  publicKey = new Uint8Array(publicKey.toJSON().data);
 
-export function generate(secretKey) {
-  return actualMethods.generate(secretKey);
-}
-
-function checkFastSigning() {
-  return typeof window === 'undefined'
-    ? checkFastSigningNode()
-    : checkFastSigningBrowser();
-}
-
-function checkFastSigningNode() {
-  // NOTE: we use commonjs style require here because es6 imports
-  // can only occur at the top level.  thanks, obama.
-  let sodium;
-  try {
-    // eslint-disable-next-line
-    sodium = require('sodium-native');
-  } catch (err) {
-    return checkFastSigningBrowser();
-  }
-
-  actualMethods.generate = (secretKey) => {
-    const pk = Buffer.alloc(sodium.crypto_sign_PUBLICKEYBYTES);
-    const sk = Buffer.alloc(sodium.crypto_sign_SECRETKEYBYTES);
-    sodium.crypto_sign_seed_keypair(pk, sk, secretKey);
-    return pk;
-  };
-
-  actualMethods.sign = (data, secretKey) => {
-    data = Buffer.from(data);
-    const signature = Buffer.alloc(sodium.crypto_sign_BYTES);
-    sodium.crypto_sign_detached(signature, data, secretKey);
-    return signature;
-  };
-
-  actualMethods.verify = (data, signature, publicKey) => {
-    data = Buffer.from(data);
-    try {
-      return sodium.crypto_sign_verify_detached(signature, data, publicKey);
-    } catch (e) {
-      return false;
-    }
-  };
-
-  return true;
-}
-
-function checkFastSigningBrowser() {
-  // fallback to `tweetnacl` if we're in the browser or
-  // if there was a failure installing `sodium-native`
-  // eslint-disable-next-line
-  const nacl = require('tweetnacl');
-
-  actualMethods.generate = (secretKey) => {
-    const secretKeyUint8 = new Uint8Array(secretKey);
-    const naclKeys = nacl.sign.keyPair.fromSeed(secretKeyUint8);
-    return Buffer.from(naclKeys.publicKey);
-  };
-
-  actualMethods.sign = (data, secretKey) => {
-    data = Buffer.from(data);
-    data = new Uint8Array(data.toJSON().data);
-    secretKey = new Uint8Array(secretKey.toJSON().data);
-
-    const signature = nacl.sign.detached(data, secretKey);
-
-    return Buffer.from(signature);
-  };
-
-  actualMethods.verify = (data, signature, publicKey) => {
-    data = Buffer.from(data);
-    data = new Uint8Array(data.toJSON().data);
-    signature = new Uint8Array(signature.toJSON().data);
-    publicKey = new Uint8Array(publicKey.toJSON().data);
-
-    return nacl.sign.detached.verify(data, signature, publicKey);
-  };
-
-  return false;
+  return nacl.sign.detached.verify(data, signature, publicKey);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -104,8 +104,6 @@ export class Claimant {
   static predicateBeforeRelativeTime(seconds: string): xdr.ClaimPredicate;
 }
 
-export const FastSigning: boolean;
-
 export type KeypairType = 'ed25519';
 
 export class Keypair {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4502,7 +4502,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@^1.3.5:
+ini@^1.3.4:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
   integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
@@ -5973,11 +5973,6 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
-nan@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -6035,11 +6030,6 @@ node-environment-flags@1.0.6:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
-
-node-gyp-build@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.1.tgz#f28f0d3d3ab268d48ab76c6f446f19bc3d0db9dc"
-  integrity sha512-XyCKXsqZfLqHep1hhsMncoXuUNt/cXCjg1+8CLbu69V1TKuPiOeSGbL9n+k/ByKH8UT0p4rdIX8XkTRZV0i7Sw==
 
 node-libs-browser@^2.2.1:
   version "2.2.1"
@@ -7665,15 +7655,6 @@ socket.io@^3.1.0:
     engine.io "~4.1.0"
     socket.io-adapter "~2.1.0"
     socket.io-parser "~4.0.3"
-
-sodium-native@^2.3.0:
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-2.4.9.tgz#7a7beb997efdbd2c773a385fb959f0cead5f5162"
-  integrity sha512-mbkiyA2clyfwAyOFIzMvsV6ny2KrKEIhFVASJxWfsmgfUEymgLIS2MLHHcGIQMkrcKhPErRaMR5Dzv0EEn+BWg==
-  dependencies:
-    ini "^1.3.5"
-    nan "^2.14.0"
-    node-gyp-build "^4.1.0"
 
 source-list-map@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This commit addresses the following issues:

https://github.com/stellar/js-stellar-base/issues/339
https://github.com/stellar/js-stellar-base/issues/404

Changes:

- removal of optional sodium-native native compiled module
- promotion of existing version of
tweetnacl-js to handle all sign/verify duties

Removal of the optional dependency greatly simplifies the
code in `src/signing.js` and removes all native compilation
issues that have negatively impacted developers for at least
two years when using modern versions of NodeJS.

This commit does not choose to prefer a new method of signing,
it simply delegates that task to the existing primary signature
library (tweetnacl-js) in all cases. This also has the pleasant
side-effect of greatly simplifying the signature code removing
what had been described in the code comments as
being "a little strange".

The actual signature generate/sign/verify functions remain
completely unchanged from prior code and have been refactored
only to simplify the code.  This also has the pleasant side
effect of allowing any security audits of this code, or the
associated tweetnacl-js library, to have far less surface
area to examine.

Cryptographic 'agility', as previously existed here to address
theoretical performance issues, is considered a security anti-pattern.

All existing gulp test suites pass when tested with Node version 14.18.2