### PR TITLE
Add support for signed payload signer keys to `StrKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Add
+
+- Adds support for converting signed payloads ([CAP-40](https://stellar.org/protocol/cap-40)) to and from their StrKey (`P...`) representation ([#511](https://github.com/stellar/js-stellar-base/pull/511)).
+
 
 ## [v7.0.0](https://github.com/stellar/js-stellar-base/compare/v6.0.6..v7.0.0)
 

--- a/src/keypair.js
+++ b/src/keypair.js
@@ -1,3 +1,5 @@
+/* eslint no-bitwise: ["error", {"allow": ["^"]}] */
+
 import nacl from 'tweetnacl';
 import isUndefined from 'lodash/isUndefined';
 import isString from 'lodash/isString';
@@ -235,5 +237,31 @@ export class Keypair {
     const hint = this.signatureHint();
 
     return new xdr.DecoratedSignature({ hint, signature });
+  }
+
+  /**
+   * Returns the signature hint for a signed payload signer.
+   *  This is defined as the last 4 bytes of the signer key XORed with last 4
+   *  bytes of the payload (zero-left-padded if necessary).
+   *
+   * @param  {Buffer} data    data to both sign and treat as the payload
+   * @return {xdr.DecoratedSignature}
+   *
+   * @see https://github.com/stellar/stellar-protocol/blob/master/core/cap-0040.md#signature-hint
+   */
+  signPayloadDecorated(data) {
+    const signature = this.sign(data);
+    const keyHint = this.signatureHint();
+
+    let hint = Buffer.from(data.slice(-4));
+    if (hint.length < 4) {
+      // front-pad with zeroes if necessary
+      hint = Buffer.concat([Buffer.alloc(4 - data.length, 0), hint]);
+    }
+
+    return new xdr.DecoratedSignature({
+      hint: hint.map((byte, i) => byte ^ keyHint[i]),
+      signature
+    });
   }
 }

--- a/src/strkey.js
+++ b/src/strkey.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-bitwise */
+/* eslint no-bitwise: ["error", {"allow": ["<<"]}] */
 
 import base32 from 'base32.js';
 import crc from 'crc';

--- a/src/strkey.js
+++ b/src/strkey.js
@@ -233,10 +233,12 @@ function isValid(versionByteName, encoded) {
       return decoded.length === 32;
 
     case 'med25519PublicKey':
-      return decoded.length === 40;
+      return decoded.length === 40; // +8 bytes for the ID
 
     case 'signedPayload':
-      return decoded.length >= 32 + 4 && decoded.length <= 32 + 4 + 64;
+      return (
+        decoded.length >= 32 + 4 && decoded.length <= 32 + 4 + 64 // +4 for the payload size
+      ); // +64 for the max payload
 
     default:
       return false;

--- a/src/strkey.js
+++ b/src/strkey.js
@@ -12,7 +12,8 @@ const versionBytes = {
   ed25519SecretSeed: 18 << 3, // S
   med25519PublicKey: 12 << 3, // M
   preAuthTx: 19 << 3, // T
-  sha256Hash: 23 << 3 // X
+  sha256Hash: 23 << 3, // X
+  signedPayload: 15 << 3 // P
 };
 
 /**
@@ -64,11 +65,11 @@ export class StrKey {
 
   /**
    * Decodes strkey ed25519 seed to raw data.
-   * @param {string} data data to decode
+   * @param {string} address data to decode
    * @returns {Buffer}
    */
-  static decodeEd25519SecretSeed(data) {
-    return decodeCheck('ed25519SecretSeed', data);
+  static decodeEd25519SecretSeed(address) {
+    return decodeCheck('ed25519SecretSeed', address);
   }
 
   /**
@@ -91,11 +92,11 @@ export class StrKey {
 
   /**
    * Decodes strkey med25519 public key to raw data.
-   * @param {string} data data to decode
+   * @param {string} address data to decode
    * @returns {Buffer}
    */
-  static decodeMed25519PublicKey(data) {
-    return decodeCheck('med25519PublicKey', data);
+  static decodeMed25519PublicKey(address) {
+    return decodeCheck('med25519PublicKey', address);
   }
 
   /**
@@ -118,11 +119,11 @@ export class StrKey {
 
   /**
    * Decodes strkey PreAuthTx to raw data.
-   * @param {string} data data to decode
+   * @param {string} address data to decode
    * @returns {Buffer}
    */
-  static decodePreAuthTx(data) {
-    return decodeCheck('preAuthTx', data);
+  static decodePreAuthTx(address) {
+    return decodeCheck('preAuthTx', address);
   }
 
   /**
@@ -136,31 +137,110 @@ export class StrKey {
 
   /**
    * Decodes strkey sha256 hash to raw data.
-   * @param {string} data data to decode
+   * @param {string} address data to decode
    * @returns {Buffer}
    */
-  static decodeSha256Hash(data) {
-    return decodeCheck('sha256Hash', data);
+  static decodeSha256Hash(address) {
+    return decodeCheck('sha256Hash', address);
+  }
+
+  /**
+   * Encodes raw data to strkey signed payload (P...).
+   * @param   {Buffer} data  data to encode
+   * @returns {string}
+   */
+  static encodeSignedPayload(data) {
+    return encodeCheck('signedPayload', data);
+  }
+
+  /**
+   * Decodes strkey signed payload (P...) to raw data.
+   * @param   {string} address  address to decode
+   * @returns {Buffer}
+   */
+  static decodeSignedPayload(address) {
+    return decodeCheck('signedPayload', address);
+  }
+
+  /**
+   * Checks validity of alleged signed payload (P...) strkey address.
+   * @param   {string} address  signer key to check
+   * @returns {boolean}
+   */
+  static isValidSignedPayload(address) {
+    return isValid('signedPayload', address);
   }
 }
 
-// Warning: This isn't a *definitive* check of validity, but rather just a
-// basic-effort check.
+/**
+ * Sanity-checks whether or not a strkey *appears* valid.
+ *
+ * @param  {string}  versionByteName the type of strkey to expect in `encoded`
+ * @param  {string}  encoded         the strkey to validate
+ *
+ * @return {Boolean} whether or not the `encoded` strkey appears valid for the
+ *     `versionByteName` strkey type (see `versionBytes`, above).
+ *
+ * @note This isn't a *definitive* check of validity, but rather a best-effort
+ *     check based on (a) input length, (b) whether or not it can be decoded,
+ *     and (c) output length.
+ */
 function isValid(versionByteName, encoded) {
-  // it's either non-muxed && len=56, or muxed && len=69
-  if (encoded && encoded.length !== 56 && encoded.length !== 69) {
+  if (!isString(encoded)) {
     return false;
   }
 
-  try {
-    const decoded = decodeCheck(versionByteName, encoded);
-    if (decoded.length !== 32 && decoded.length !== 40) {
+  // basic length checks on the strkey lengths
+  switch (versionByteName) {
+    case 'ed25519PublicKey': // falls through
+    case 'ed25519SecretSeed': // falls through
+    case 'preAuthTx': // falls through
+    case 'sha256Hash':
+      if (encoded.length !== 56) {
+        return false;
+      }
+      break;
+
+    case 'med25519PublicKey':
+      if (encoded.length !== 69) {
+        return false;
+      }
+      break;
+
+    case 'signedPayload':
+      if (encoded.length < 56 || encoded.length > 165) {
+        return false;
+      }
+      break;
+
+    default:
       return false;
-    }
+  }
+
+  let decoded = '';
+  try {
+    decoded = decodeCheck(versionByteName, encoded);
   } catch (err) {
     return false;
   }
-  return true;
+
+  // basic length checks on the resulting buffer sizes
+  switch (versionByteName) {
+    case 'ed25519PublicKey': // falls through
+    case 'ed25519SecretSeed': // falls through
+    case 'preAuthTx': // falls through
+    case 'sha256Hash':
+      return decoded.length === 32;
+
+    case 'med25519PublicKey':
+      return decoded.length === 40;
+
+    case 'signedPayload':
+      return decoded.length >= 32 + 4 && decoded.length <= 32 + 4 + 64;
+
+    default:
+      return false;
+  }
 }
 
 export function decodeCheck(versionByteName, encoded) {

--- a/test/unit/keypair_test.js
+++ b/test/unit/keypair_test.js
@@ -145,3 +145,46 @@ describe('Keypair.xdrMuxedAccount', function() {
     );
   });
 });
+
+describe('Keypair.sign*Decorated', function() {
+  it('returns the correct hints', function() {
+    const secret = 'SDVSYBKP7ESCODJSNGVDNXAJB63NPS5GQXSBZXLNT2Y4YVUJCFZWODGJ';
+    const kp = StellarBase.Keypair.fromSecret(secret);
+
+    // Note: these were generated using the Go SDK as a source of truth
+    const CASES = [
+      {
+        data: [1, 2, 3, 4, 5, 6],
+        regular: [8, 170, 203, 16],
+        payload: [11, 174, 206, 22]
+      },
+      {
+        data: [1, 2],
+        regular: [8, 170, 203, 16],
+        payload: [9, 168, 203, 16]
+      },
+      {
+        data: [],
+        regular: [8, 170, 203, 16],
+        payload: [8, 170, 203, 16]
+      }
+    ];
+
+    CASES.forEach((testCase) => {
+      const data = testCase.data;
+      const sig = kp.sign(data);
+
+      it(`#signedPayloads#${data.length}`, function() {
+        const decoSig = kp.signPayloadDecorated(data);
+        expect(decoSig.hint()).to.eql(Buffer.from(testCase.payload));
+        expect(decoSig.signature()).to.eql(sig);
+      });
+
+      it(`#regular#${data.length}`, function() {
+        const decoSig = kp.signDecorated(data);
+        expect(decoSig.hint()).to.eql(Buffer.from(testCase.regular));
+        expect(decoSig.signature()).to.eql(sig);
+      });
+    });
+  });
+});

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -381,7 +381,6 @@ describe('StrKey', function() {
     HAPPY_PATHS.forEach((testCase) => {
       it(testCase.desc, function() {
         const spBuf = StellarBase.StrKey.decodeSignedPayload(testCase.strkey);
-        expect(spBuf).to.be.instanceof(Buffer);
         const sp = StellarBase.xdr.SignerKeyEd25519SignedPayload.fromXDR(
           spBuf,
           'raw'

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -349,7 +349,9 @@ describe('StrKey', function() {
         expect(mpubkey).to.equal(CASE_MPUBKEY);
       });
     }
+  });
 
+  describe('#invalidStrKeys', function() {
     // From https://stellar.org/protocol/sep-23#invalid-test-cases
     const BAD_STRKEYS = [
       // The unused trailing bit must be zero in the encoding of the last three

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -846,22 +846,26 @@ export type Operation =
 
 export namespace StrKey {
   function encodeEd25519PublicKey(data: Buffer): string;
-  function decodeEd25519PublicKey(data: string): Buffer;
+  function decodeEd25519PublicKey(address: string): Buffer;
   function isValidEd25519PublicKey(Key: string): boolean;
 
   function encodeEd25519SecretSeed(data: Buffer): string;
-  function decodeEd25519SecretSeed(data: string): Buffer;
+  function decodeEd25519SecretSeed(address: string): Buffer;
   function isValidEd25519SecretSeed(seed: string): boolean;
 
   function encodeMed25519PublicKey(data: Buffer): string;
-  function decodeMed25519PublicKey(data: string): Buffer;
+  function decodeMed25519PublicKey(address: string): Buffer;
   function isValidMed25519PublicKey(publicKey: string): boolean;
 
+  function encodeSignedPayload(data: Buffer): string;
+  function decodeSignedPayload(address: string): Buffer;
+  function isValidSignedPayload(address: string): boolean;
+
   function encodePreAuthTx(data: Buffer): string;
-  function decodePreAuthTx(data: string): Buffer;
+  function decodePreAuthTx(address: string): Buffer;
 
   function encodeSha256Hash(data: Buffer): string;
-  function decodeSha256Hash(data: string): Buffer;
+  function decodeSha256Hash(address: string): Buffer;
 }
 
 export class TransactionI {

--- a/types/test.ts
+++ b/types/test.ts
@@ -327,5 +327,9 @@ result = StellarSdk.StrKey.encodeMed25519PublicKey(muxkey);   // $ExpectType str
 StellarSdk.StrKey.decodeMed25519PublicKey(result);            // $ExpectType Buffer
 StellarSdk.StrKey.isValidMed25519PublicKey(result);           // $ExpectType boolean
 
+result = StellarSdk.StrKey.encodeSignedPayload(pubkey);   // $ExpectType string
+StellarSdk.StrKey.decodeSignedPayload(result);            // $ExpectType Buffer
+StellarSdk.StrKey.isValidSignedPayload(result);           // $ExpectType boolean
+
 const muxedAddr = StellarSdk.encodeMuxedAccountToAddress(muxed, true);  // $ExpectType string
 StellarSdk.decodeAddressToMuxedAccount(muxedAddr, true);                // $ExpectType MuxedAccount


### PR DESCRIPTION
This adds support for encode signed payload signers ([CAP-40](https://stellar.org/protocol/cap-40)) to their StrKey representation ([SEP-23](https://github.com/stellar/stellar-protocol/pull/1014)):

```
+--------------------+
|   signer address   |
|                    | <------------> "PA7QYNF7SOWQ3GL..."
|      payload       |
+--------------------+
```

Closes #507.