### PR TITLE
Properly do lexographic comparison of ascii strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,13 @@
 
 ### Fix
 
+- Resolves a bug that incorrectly sorted `Asset`s with mixed-case asset codes (it preferred lowercase codes incorrectly) ([#516](https://github.com/stellar/js-stellar-base/pull/516)).
+
 - Update developer dependencies:
   * `isparta`, `jsdoc`, and `underscore` ([#500](https://github.com/stellar/js-stellar-base/pull/500))
   * `ajv` ([#503](https://github.com/stellar/js-stellar-base/pull/503))
   * `karma` ([#505](https://github.com/stellar/js-stellar-base/pull/505))
   * `minimist` ([#514](https://github.com/stellar/js-stellar-base/pull/514))
-
-
-### Fix
-
- - Resolves a bug that incorrectly sorted `Asset`s with mixed-case asset codes (it preferred lowercase codes incorrectly) ([#516](https://github.com/stellar/js-stellar-base/pull/516)).
 
 
 ## [v7.0.0](https://github.com/stellar/js-stellar-base/compare/v6.0.6..v7.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 **Note:** As of this release, the minimum supported version of NodeJS is 14.x.
 
 
+### Fix
+
+ - Resolves a bug that incorrectly sorted `Asset`s with mixed-case asset codes (it preferred lowercase codes incorrectly) ([#516](https://github.com/stellar/js-stellar-base/pull/516)).
+
+
 ## [v7.0.0](https://github.com/stellar/js-stellar-base/compare/v6.0.6..v7.0.0)
 
 This release introduces **unconditional support for muxed accounts** ([#485](https://github.com/stellar/js-stellar-base/pull/485)).

--- a/src/asset.js
+++ b/src/asset.js
@@ -147,14 +147,15 @@ export class Asset {
    * * `credit_alphanum12`
    */
   getAssetType() {
-    if (this.isNative()) {
-      return 'native';
-    }
-    if (this.code.length >= 1 && this.code.length <= 4) {
-      return 'credit_alphanum4';
-    }
-    if (this.code.length >= 5 && this.code.length <= 12) {
-      return 'credit_alphanum12';
+    switch (this.getRawAssetType()) {
+      case xdr.AssetType.assetTypeNative():
+        return 'native';
+      case xdr.AssetType.assetTypeCreditAlphanum4():
+        return 'credit_alphanum4';
+      case xdr.AssetType.assetTypeCreditAlphanum12():
+        return 'credit_alphanum12';
+      default:
+        break;
     }
 
     return null;

--- a/src/asset.js
+++ b/src/asset.js
@@ -161,9 +161,7 @@ export class Asset {
   }
 
   /**
-   * Returns the XDR representation of the asset type.
-   *
-   * @return {xdr.AssetType} the raw asset type structure
+   * @returns {xdr.AssetType}  the raw XDR representation of the asset type
    */
   getRawAssetType() {
     if (this.isNative()) {

--- a/src/asset.js
+++ b/src/asset.js
@@ -142,9 +142,10 @@ export class Asset {
    * @see [Assets concept](https://developers.stellar.org/docs/glossary/assets/)
    * @returns {string} Asset type. Can be one of following types:
    *
-   * * `native`
-   * * `credit_alphanum4`
-   * * `credit_alphanum12`
+   *  - `native`,
+   *  - `credit_alphanum4`,
+   *  - `credit_alphanum12`, or
+   *  - `unknown` as the error case (which should never occur)
    */
   getAssetType() {
     switch (this.getRawAssetType()) {
@@ -155,10 +156,8 @@ export class Asset {
       case xdr.AssetType.assetTypeCreditAlphanum12():
         return 'credit_alphanum12';
       default:
-        break;
+        return 'unknown';
     }
-
-    return null;
   }
 
   /**

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -334,16 +334,18 @@ describe('Asset', function() {
         'ARST',
         'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
       );
-      const assetUSDX = new StellarBase.Asset(
-        'USDX',
-        'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
-      );
+      const assetUSDX = new StellarBase.Asset('USDA', assetARST.getIssuer());
 
       expect(StellarBase.Asset.compare(assetARST, assetARST)).to.eq(0);
       expect(StellarBase.Asset.compare(assetARST, assetUSDX)).to.eq(-1);
 
       expect(StellarBase.Asset.compare(assetUSDX, assetARST)).to.eq(1);
       expect(StellarBase.Asset.compare(assetUSDX, assetUSDX)).to.eq(0);
+
+      // uppercase should be smaller
+      const assetLower = new StellarBase.Asset('aRST', assetARST.getIssuer());
+      expect(StellarBase.Asset.compare(assetARST, assetLower)).to.eq(-1);
+      expect(StellarBase.Asset.compare(assetLower, assetA)).to.eq(1);
     });
 
     it('test if asset issuers are being validated as assetIssuerA < assetIssuerB', function() {


### PR DESCRIPTION
There are two changes here to the way that assets are compared:

1. In order to align better with how Stellar Core sorts assets (that is to say, in no special way besides [the default](https://github.com/xdrpp/xdrpp/blob/8756126cc734c11b75e05f174ca35a192860d0a6/xdrpp/types.h#L1019)), we rely on the actual, raw, XDR asset type (`xdr.AssetType`) value to distinguish based on type. The logic is still the same, but is much easier to understand since there are no convoluted branching string comparisons. 

2. JavaScript's [`String.prototype.localeCompare`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) function will sort strings with lowercase letters as having lower preference to those with uppercase ones (proof: [RunKit](https://runkit.com/61833274873f8c000b42e673/624b753823ad3c00081f0f39)). This is not how the ASCII table sorts them, nor is it how Stellar Core will sort them as it essentially looks at the raw byte values for ordering.

For (2), we introduce `asciiCompare`, which hard-codes the `en` locale rather than leaving it system specific and also forces uppercase letters to take precedence.

Closes #515.