### PR TITLE
Encodes the correct field name in the `RevokeLiquidityPoolSponsorship` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Fix
 
+- Correct a TypeScript definition on the `RevokeLiquidityPoolSponsorship` operation ([#522](https://github.com/stellar/js-stellar-base/pull/522)).
+
 - Resolves a bug that incorrectly sorted `Asset`s with mixed-case asset codes (it preferred lowercase codes incorrectly) ([#516](https://github.com/stellar/js-stellar-base/pull/516)).
 
 - Update developer dependencies:

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -746,7 +746,7 @@ export namespace Operation {
   ): xdr.Operation<RevokeClaimableBalanceSponsorship>;
 
   interface RevokeLiquidityPoolSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
-    balanceId: string;
+    liquidityPoolId: string;
   }
   function revokeLiquidityPoolSponsorship(
     options: OperationOptions.RevokeLiquidityPoolSponsorship


### PR DESCRIPTION
Closes #502.