### PR TITLE
Bugfix: Signature hints should append zeroes rather than prepend them

### DIFF
--- a/src/keypair.js
+++ b/src/keypair.js
@@ -255,8 +255,8 @@ export class Keypair {
 
     let hint = Buffer.from(data.slice(-4));
     if (hint.length < 4) {
-      // front-pad with zeroes if necessary
-      hint = Buffer.concat([Buffer.alloc(4 - data.length, 0), hint]);
+      // append zeroes as needed
+      hint = Buffer.concat([hint, Buffer.alloc(4 - data.length, 0)]);
     }
 
     return new xdr.DecoratedSignature({

--- a/test/unit/keypair_test.js
+++ b/test/unit/keypair_test.js
@@ -147,7 +147,7 @@ describe('Keypair.xdrMuxedAccount', function() {
 });
 
 describe('Keypair.sign*Decorated', function() {
-  it('returns the correct hints', function() {
+  describe('returning the correct hints', function() {
     const secret = 'SDVSYBKP7ESCODJSNGVDNXAJB63NPS5GQXSBZXLNT2Y4YVUJCFZWODGJ';
     const kp = StellarBase.Keypair.fromSecret(secret);
 
@@ -174,13 +174,13 @@ describe('Keypair.sign*Decorated', function() {
       const data = testCase.data;
       const sig = kp.sign(data);
 
-      it(`#signedPayloads#${data.length}`, function() {
+      it(`signedPayloads#${data.length}`, function() {
         const decoSig = kp.signPayloadDecorated(data);
         expect(decoSig.hint()).to.eql(Buffer.from(testCase.payload));
         expect(decoSig.signature()).to.eql(sig);
       });
 
-      it(`#regular#${data.length}`, function() {
+      it(`regular#${data.length}`, function() {
         const decoSig = kp.signDecorated(data);
         expect(decoSig.hint()).to.eql(Buffer.from(testCase.regular));
         expect(decoSig.signature()).to.eql(sig);

--- a/test/unit/keypair_test.js
+++ b/test/unit/keypair_test.js
@@ -175,15 +175,23 @@ describe('Keypair.sign*Decorated', function() {
       const sig = kp.sign(data);
 
       it(`signedPayloads#${data.length}`, function() {
+        const expectedXdr = new StellarBase.xdr.DecoratedSignature({
+          hint: testCase.payload,
+          signature: sig
+        });
+
         const decoSig = kp.signPayloadDecorated(data);
-        expect(decoSig.hint()).to.eql(Buffer.from(testCase.payload));
-        expect(decoSig.signature()).to.eql(sig);
+        expect(decoSig.toXDR('hex')).to.eql(expectedXdr.toXDR('hex'));
       });
 
       it(`regular#${data.length}`, function() {
+        const expectedXdr = new StellarBase.xdr.DecoratedSignature({
+          hint: testCase.regular,
+          signature: sig
+        });
+
         const decoSig = kp.signDecorated(data);
-        expect(decoSig.hint()).to.eql(Buffer.from(testCase.regular));
-        expect(decoSig.signature()).to.eql(sig);
+        expect(decoSig.toXDR('hex')).to.eql(expectedXdr.toXDR('hex'));
       });
     });
   });


### PR DESCRIPTION
This wasn't caught by tests because

```js
describe('', function() {
  it('', function() {
    it('', function() { 
    });
  });
});
```

will not run the inner set of `it`s... :facepalm:   