### PR TITLE
Add round-trip XDR tests for transaction preconditions

### DIFF
--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -654,12 +654,22 @@ describe('Transaction', function() {
         let tx = makeBuilder()
           .setTimebounds(now, now)
           .build();
-        expect(tx.timeBounds.minTime).to.eql(
-          `${Math.floor(now.valueOf() / 1000)}`
+        const expMin = `${Math.floor(now.valueOf() / 1000)}`;
+        const expMax = `${Math.floor(now.valueOf() / 1000)}`;
+        expect(tx.timeBounds.minTime).to.equal(expMin);
+        expect(tx.timeBounds.maxTime).to.equal(expMax);
+
+        const txe = tx
+          .toEnvelope()
+          .v1()
+          .tx();
+        expect(txe.cond().switch()).to.equal(
+          StellarBase.xdr.PreconditionType.precondTime()
         );
-        expect(tx.timeBounds.maxTime).to.eql(
-          `${Math.floor(now.valueOf() / 1000)}`
-        );
+
+        const tb = txe.cond().timeBounds();
+        expect(tb.minTime().toString()).to.equal(expMin);
+        expect(tb.maxTime().toString()).to.equal(expMax);
       });
 
       it('number', function() {
@@ -668,6 +678,18 @@ describe('Transaction', function() {
           .build();
         expect(tx.timeBounds.minTime).to.eql('5');
         expect(tx.timeBounds.maxTime).to.eql('10');
+
+        const txe = tx
+          .toEnvelope()
+          .v1()
+          .tx();
+        expect(txe.cond().switch()).to.equal(
+          StellarBase.xdr.PreconditionType.precondTime()
+        );
+
+        const tb = txe.cond().timeBounds();
+        expect(tb.minTime().toString()).to.equal('5');
+        expect(tb.maxTime().toString()).to.equal('10');
       });
     });
 
@@ -679,6 +701,21 @@ describe('Transaction', function() {
 
       expect(tx.ledgerBounds.minLedger).to.equal(5);
       expect(tx.ledgerBounds.maxLedger).to.equal(10);
+
+      const txe = tx
+        .toEnvelope()
+        .v1()
+        .tx();
+      expect(txe.cond().switch()).to.equal(
+        StellarBase.xdr.PreconditionType.precondV2()
+      );
+
+      const lb = txe
+        .cond()
+        .v2()
+        .ledgerBounds();
+      expect(lb.minLedger()).to.equal(5);
+      expect(lb.maxLedger()).to.equal(10);
     });
 
     it('minAccountSequence', function() {
@@ -687,6 +724,20 @@ describe('Transaction', function() {
         .setMinAccountSequence('5')
         .build();
       expect(tx.minAccountSequence).to.eql('5');
+
+      const txe = tx
+        .toEnvelope()
+        .v1()
+        .tx();
+      expect(txe.cond().switch()).to.equal(
+        StellarBase.xdr.PreconditionType.precondV2()
+      );
+
+      const val = txe
+        .cond()
+        .v2()
+        .minSeqNum();
+      expect(val.toString()).to.equal('5');
     });
 
     it('minAccountSequenceAge', function() {
@@ -694,8 +745,21 @@ describe('Transaction', function() {
         .setTimeout(5)
         .setMinAccountSequenceAge(5)
         .build();
-
       expect(tx.minAccountSequenceAge.toString()).to.equal('5');
+
+      const txe = tx
+        .toEnvelope()
+        .v1()
+        .tx();
+      expect(txe.cond().switch()).to.equal(
+        StellarBase.xdr.PreconditionType.precondV2()
+      );
+
+      const val = txe
+        .cond()
+        .v2()
+        .minSeqAge();
+      expect(val.toString()).to.equal('5');
     });
 
     it('minAccountSequenceLedgerGap', function() {
@@ -704,6 +768,20 @@ describe('Transaction', function() {
         .setMinAccountSequenceLedgerGap(5)
         .build();
       expect(tx.minAccountSequenceLedgerGap).to.equal(5);
+
+      const txe = tx
+        .toEnvelope()
+        .v1()
+        .tx();
+      expect(txe.cond().switch()).to.equal(
+        StellarBase.xdr.PreconditionType.precondV2()
+      );
+
+      const val = txe
+        .cond()
+        .v2()
+        .minSeqLedgerGap();
+      expect(val.toString()).to.equal('5');
     });
 
     it('extraSigners', function() {
@@ -715,6 +793,21 @@ describe('Transaction', function() {
       expect(
         tx.extraSigners.map(StellarBase.SignerKey.encodeSignerKey)
       ).to.eql([address]);
+
+      const txe = tx
+        .toEnvelope()
+        .v1()
+        .tx();
+      expect(txe.cond().switch()).to.equal(
+        StellarBase.xdr.PreconditionType.precondV2()
+      );
+
+      const signers = txe
+        .cond()
+        .v2()
+        .extraSigners();
+      expect(signers).to.have.lengthOf(1);
+      expect(signers[0]).to.eql(StellarBase.SignerKey.decodeAddress(address));
     });
   });
 });

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -659,15 +659,13 @@ describe('Transaction', function() {
         expect(tx.timeBounds.minTime).to.equal(expMin);
         expect(tx.timeBounds.maxTime).to.equal(expMax);
 
-        const txe = tx
+        const tb = tx
           .toEnvelope()
           .v1()
-          .tx();
-        expect(txe.cond().switch()).to.equal(
-          StellarBase.xdr.PreconditionType.precondTime()
-        );
+          .tx()
+          .cond()
+          .timeBounds();
 
-        const tb = txe.cond().timeBounds();
         expect(tb.minTime().toString()).to.equal(expMin);
         expect(tb.maxTime().toString()).to.equal(expMax);
       });
@@ -679,15 +677,12 @@ describe('Transaction', function() {
         expect(tx.timeBounds.minTime).to.eql('5');
         expect(tx.timeBounds.maxTime).to.eql('10');
 
-        const txe = tx
+        const tb = tx
           .toEnvelope()
           .v1()
-          .tx();
-        expect(txe.cond().switch()).to.equal(
-          StellarBase.xdr.PreconditionType.precondTime()
-        );
-
-        const tb = txe.cond().timeBounds();
+          .tx()
+          .cond()
+          .timeBounds();
         expect(tb.minTime().toString()).to.equal('5');
         expect(tb.maxTime().toString()).to.equal('10');
       });
@@ -702,15 +697,10 @@ describe('Transaction', function() {
       expect(tx.ledgerBounds.minLedger).to.equal(5);
       expect(tx.ledgerBounds.maxLedger).to.equal(10);
 
-      const txe = tx
+      const lb = tx
         .toEnvelope()
         .v1()
-        .tx();
-      expect(txe.cond().switch()).to.equal(
-        StellarBase.xdr.PreconditionType.precondV2()
-      );
-
-      const lb = txe
+        .tx()
         .cond()
         .v2()
         .ledgerBounds();
@@ -725,15 +715,10 @@ describe('Transaction', function() {
         .build();
       expect(tx.minAccountSequence).to.eql('5');
 
-      const txe = tx
+      const val = tx
         .toEnvelope()
         .v1()
-        .tx();
-      expect(txe.cond().switch()).to.equal(
-        StellarBase.xdr.PreconditionType.precondV2()
-      );
-
-      const val = txe
+        .tx()
         .cond()
         .v2()
         .minSeqNum();
@@ -747,15 +732,10 @@ describe('Transaction', function() {
         .build();
       expect(tx.minAccountSequenceAge.toString()).to.equal('5');
 
-      const txe = tx
+      const val = tx
         .toEnvelope()
         .v1()
-        .tx();
-      expect(txe.cond().switch()).to.equal(
-        StellarBase.xdr.PreconditionType.precondV2()
-      );
-
-      const val = txe
+        .tx()
         .cond()
         .v2()
         .minSeqAge();
@@ -769,15 +749,10 @@ describe('Transaction', function() {
         .build();
       expect(tx.minAccountSequenceLedgerGap).to.equal(5);
 
-      const txe = tx
+      const val = tx
         .toEnvelope()
         .v1()
-        .tx();
-      expect(txe.cond().switch()).to.equal(
-        StellarBase.xdr.PreconditionType.precondV2()
-      );
-
-      const val = txe
+        .tx()
         .cond()
         .v2()
         .minSeqLedgerGap();
@@ -794,15 +769,10 @@ describe('Transaction', function() {
         tx.extraSigners.map(StellarBase.SignerKey.encodeSignerKey)
       ).to.eql([address]);
 
-      const txe = tx
+      const signers = tx
         .toEnvelope()
         .v1()
-        .tx();
-      expect(txe.cond().switch()).to.equal(
-        StellarBase.xdr.PreconditionType.precondV2()
-      );
-
-      const signers = txe
+        .tx()
         .cond()
         .v2()
         .extraSigners();


### PR DESCRIPTION
Instead of just checking the returned `Transaction` abstraction, the tests now additionally check that the final, built XDR (i.e. the `xdr.TransactionEnvelope`) also contains the right preconditions within it.