### PR TITLE
Add TypeScript definitions for Protocol 19

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -973,7 +973,6 @@ export namespace TransactionBuilder {
     extraSigners?: string[];
     memo?: Memo;
     networkPassphrase?: string;
-    v1?: boolean;
   }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -869,6 +869,11 @@ export namespace StrKey {
   function decodeSha256Hash(address: string): Buffer;
 }
 
+export namespace SignerKey {
+  function decodeAddress(address: string): xdr.SignerKey;
+  function encodeSignerKey(signerKey: xdr.SignerKey): string;
+}
+
 export class TransactionI {
   addSignature(publicKey: string, signature: string): void;
   fee: string;
@@ -908,6 +913,14 @@ export class Transaction<
     minTime: string;
     maxTime: string;
   };
+  ledgerBounds?: {
+    minLedger: number;
+    maxLedger: number;
+  };
+  minAccountSequence?: string;
+  minAccountSequenceAge?: number;
+  minAccountSequenceLedgerGap?: number;
+  extraSigners?: string[];
 
   getClaimableBalanceId(opIndex: number): string;
 }
@@ -928,7 +941,7 @@ export class TransactionBuilder {
   setMinAccountSequence(minAccountSequence: string): this;
   setMinAccountSequenceAge(durationInSeconds: number): this;
   setMinAccountSequenceLedgerGap(gap: number): this;
-  setExtraSigners(extraSigners: xdr.SignerKey[]): this;
+  setExtraSigners(extraSigners: string[]): this;
   build(): Transaction;
   setNetworkPassphrase(networkPassphrase: string): this;
   static buildFeeBumpTransaction(
@@ -947,8 +960,8 @@ export namespace TransactionBuilder {
   interface TransactionBuilderOptions {
     fee: string;
     timebounds?: {
-      minTime?: number | string;
-      maxTime?: number | string;
+      minTime?: Date | number | string;
+      maxTime?: Date | number | string;
     };
     ledgerbounds?: {
       minLedger?: number;
@@ -957,7 +970,7 @@ export namespace TransactionBuilder {
     minAccountSequence?: string;
     minAccountSequenceAge?: number;
     minAccountSequenceLedgerGap?: number;
-    extraSigners?: xdr.SignerKey[];
+    extraSigners?: string[];
     memo?: Memo;
     networkPassphrase?: string;
     v1?: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -959,6 +959,9 @@ export class TransactionBuilder {
 export namespace TransactionBuilder {
   interface TransactionBuilderOptions {
     fee: string;
+    memo?: Memo;
+    networkPassphrase?: string;
+    // preconditions:
     timebounds?: {
       minTime?: Date | number | string;
       maxTime?: Date | number | string;
@@ -971,8 +974,6 @@ export namespace TransactionBuilder {
     minAccountSequenceAge?: number;
     minAccountSequenceLedgerGap?: number;
     extraSigners?: string[];
-    memo?: Memo;
-    networkPassphrase?: string;
   }
 }
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -146,7 +146,7 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
   .setMinAccountSequence("5")
   .setMinAccountSequenceAge(5)
   .setMinAccountSequenceLedgerGap(5)
-  .setExtraSigners([new StellarSdk.xdr.SignerKey()])
+  .setExtraSigners([sourceKey.publicKey()])
   .build(); // $ExpectType () => Transaction<Memo<MemoType>, Operation[]>
 
 const transactionFromXDR = new StellarSdk.Transaction(transaction.toEnvelope(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]>
@@ -339,3 +339,12 @@ StellarSdk.StrKey.isValidSignedPayload(result);           // $ExpectType boolean
 
 const muxedAddr = StellarSdk.encodeMuxedAccountToAddress(muxed, true);  // $ExpectType string
 StellarSdk.decodeAddressToMuxedAccount(muxedAddr, true);                // $ExpectType MuxedAccount
+
+const sk = StellarSdk.xdr.SignerKey.signerKeyTypeEd25519SignedPayload(
+  new StellarSdk.xdr.SignerKeyEd25519SignedPayload({
+    ed25519: sourceKey.rawPublicKey(),
+    payload: Buffer.alloc(1)
+  })
+);
+StellarSdk.SignerKey.encodeSignerKey(sk);                   // $ExpectType string
+StellarSdk.SignerKey.decodeAddress(sourceKey.publicKey());  // $ExpectType SignerKey


### PR DESCRIPTION
We need to expose everything (new `SignerKey` helpers and new tx preconditions) in TypeScript, otherwise it won't be usable.