### PR TITLE
Add support for signed payloads to the `setOptions` operation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 
 ## Unreleased
 
+### Fix
+
+- This allows signed payload signers to be modified with `Operation.setOptions`:
+
+```
+const thisWorks = Operation.setOptions({
+  signer: {
+    signedPayload: {
+      signer: Keypair.random().publicKey(),
+      payload: "deadbeef"
+    },
+    weight: 1
+  }
+});
+```
+
 
 ## [v8.0.0](https://github.com/stellar/js-stellar-base/compare/v7.0.0..v8.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 
 ### Add
 
-- This adds a helper function for managing signed payloads (introduced in [CAP-40](https://stellar.org/protocol/cap-40) and [v8.0.0](#v8.0.0) of this library):
+- This adds helper functions for managing signed payloads (introduced in [CAP-40](https://stellar.org/protocol/cap-40) and [v8.0.0](#v8.0.0) of this library):
 
-  * `SignerKey.encodeSignedPayloadFromAddress` is a convenient way to create a signed payload signer (`P...` address) from a Stellar account acting as the signer (`G...`) and a raw payload.
+  * Convenient ways to create a signed payload signer (`P...` address) from a Stellar account acting as the signer (`G...`) and a raw payload and vice-versa: `SignerKey.composeSignedPayload()` and `SignerKey.decomposeSignedPayload()`. ([#534](https://github.com/stellar/js-stellar-base/pull/534)).
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## Unreleased
 
+### Add
+
+- This adds a helper function for managing signed payloads (introduced in [CAP-40](https://stellar.org/protocol/cap-40) and [v8.0.0](#v8.0.0) of this library):
+
+  * `SignerKey.encodeSignedPayloadFromAddress` is a convenient way to create a signed payload signer (`P...` address) from a Stellar account acting as the signer (`G...`) and a raw payload.
+
 ### Fix
 
 - This allows signed payload signers to be modified with `Operation.setOptions`:

--- a/src/operation.js
+++ b/src/operation.js
@@ -218,18 +218,45 @@ export class Operation {
             .signer()
             .key()
             .arm();
-          if (arm === 'ed25519') {
-            signer.ed25519PublicKey = accountIdtoAddress(attrs.signer().key());
-          } else if (arm === 'preAuthTx') {
-            signer.preAuthTx = attrs
-              .signer()
-              .key()
-              .preAuthTx();
-          } else if (arm === 'hashX') {
-            signer.sha256Hash = attrs
-              .signer()
-              .key()
-              .hashX();
+
+          switch (arm) {
+            case 'ed25519': {
+              signer.ed25519PublicKey = accountIdtoAddress(
+                attrs.signer().key()
+              );
+              break;
+            }
+
+            case 'preAuthTx': {
+              signer.preAuthTx = attrs
+                .signer()
+                .key()
+                .preAuthTx();
+              break;
+            }
+
+            case 'hashX': {
+              signer.sha256Hash = attrs
+                .signer()
+                .key()
+                .hashX();
+              break;
+            }
+
+            case 'ed25519SignedPayload': {
+              const sp = attrs
+                .signer()
+                .key()
+                .ed25519SignedPayload();
+              signer.signedPayload = {
+                signer: accountIdtoAddress(sp),
+                payload: sp.payload()
+              };
+              break;
+            }
+
+            default:
+              throw new Error(`unknown setOptionsOp signer: ${arm}`);
           }
 
           signer.weight = attrs.signer().weight();

--- a/src/operations/set_options.js
+++ b/src/operations/set_options.js
@@ -125,12 +125,8 @@ export function setOptions(opts) {
       if (!StrKey.isValidEd25519PublicKey(opts.signer.ed25519PublicKey)) {
         throw new Error('signer.ed25519PublicKey is invalid.');
       }
-      const rawKey = StrKey.decodeEd25519PublicKey(
-        opts.signer.ed25519PublicKey
-      );
 
-      // eslint-disable-next-line new-cap
-      key = new xdr.SignerKey.signerKeyTypeEd25519(rawKey);
+      key = SignerKey.decodeAddress(opts.signer.ed25519PublicKey);
       setValues += 1;
     }
 
@@ -181,7 +177,7 @@ export function setOptions(opts) {
       }
 
       key = SignerKey.decodeAddress(
-        SignerKey.encodeSignedPayloadFromAddress(
+        SignerKey.composeSignedPayload(
           opts.signer.signedPayload.signer,
           opts.signer.signedPayload.payload
         )

--- a/src/signerkey.js
+++ b/src/signerkey.js
@@ -98,7 +98,7 @@ export class SignerKey {
    *
    * @returns {string}   the StrKey-encoded signed payload address (P...)
    */
-  static encodeSignedPayloadFromAddress(address, payload) {
+  static composeSignedPayload(address, payload) {
     return SignerKey.encodeSignerKey(
       xdr.SignerKey.signerKeyTypeEd25519SignedPayload(
         new xdr.SignerKeyEd25519SignedPayload({
@@ -107,5 +107,26 @@ export class SignerKey {
         })
       )
     );
+  }
+
+  /**
+   * Decomposes a signed payload (P...) into its signer (G...) and payload.
+   *
+   * @param {string} pAddress  the StrKey-encoded signed payload address (P...)
+   *
+   * @returns {object} an object with two keys:
+   *     `signer` indicating the signer of the signed payload as a StrKey (G...)
+   *     `payload` specifying the raw payload that was signed
+   */
+  static decomposeSignedPayload(pAddress) {
+    const sp = xdr.SignerKeyEd25519SignedPayload.fromXDR(
+      StrKey.decodeSignedPayload(pAddress),
+      'raw'
+    );
+
+    return {
+      signer: StrKey.encodeEd25519PublicKey(sp.ed25519()),
+      payload: sp.payload()
+    };
   }
 }

--- a/src/signerkey.js
+++ b/src/signerkey.js
@@ -89,4 +89,23 @@ export class SignerKey {
 
     return encodeCheck(strkeyType, raw);
   }
+
+  /**
+   * Creates a signed payload address (P...) from a signer (G...) and a payload.
+   *
+   * @param  {string} address  the signer of the signed payload, as a StrKey (G...)
+   * @param  {Buffer} payload  the raw payload that was signed
+   *
+   * @returns {string}   the StrKey-encoded signed payload address (P...)
+   */
+  static encodeSignedPayloadFromAddress(address, payload) {
+    return SignerKey.encodeSignerKey(
+      xdr.SignerKey.signerKeyTypeEd25519SignedPayload(
+        new xdr.SignerKeyEd25519SignedPayload({
+          ed25519: StrKey.decodeEd25519PublicKey(address),
+          payload
+        })
+      )
+    );
+  }
 }

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -768,6 +768,26 @@ describe('Operation', function() {
       expect(obj.signer.weight).to.be.equal(opts.signer.weight);
     });
 
+    it('creates a setOptionsOp with signed payload', function() {
+      const signer = StellarBase.Keypair.random().publicKey();
+      const payload = Buffer.from('deadbeef', 'hex');
+      const opts = {
+        signedPayload: { signer, payload },
+        weight: 1
+      };
+
+      let op = StellarBase.Operation.setOptions({ signer: opts });
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+
+      expect(obj.signer.signedPayload.signer).to.eql(signer);
+      expectBuffersToBeEqual(obj.signer.signedPayload.payload, payload);
+      expect(obj.signer.weight).to.be.equal(opts.weight);
+    });
+
     it('empty homeDomain is decoded correctly', function() {
       const keypair = StellarBase.Keypair.random();
       const account = new StellarBase.Account(keypair.publicKey(), '0');

--- a/test/unit/signerkey_test.js
+++ b/test/unit/signerkey_test.js
@@ -35,6 +35,47 @@ describe('SignerKey', function() {
     });
   });
 
+  describe('signed payloads', function() {
+    const SIGNER = 'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ';
+    const TEST_CASES = [
+      // generated via the Go SDK
+      {
+        payload: Buffer.from('hello world', 'ascii'),
+        strkey:
+          'PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAFWQZLMNRXSA53POJWGIADD24'
+      },
+      {
+        payload: Buffer.from('', 'ascii'),
+        strkey:
+          'PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAKH4Y'
+      },
+      {
+        payload: Buffer.from('1', 'ascii'),
+        strkey:
+          'PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAATCAAAABIRA'
+      },
+      {
+        payload: Buffer.from(
+          'Here is a payload; its length is the maximum length of 64 bytes!',
+          'ascii'
+        ),
+        strkey:
+          'PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAEQZLSMUQGS4ZAMEQHAYLZNRXWCZB3EBUXI4ZANRSW4Z3UNAQGS4ZAORUGKIDNMF4GS3LVNUQGYZLOM52GQIDPMYQDMNBAMJ4XIZLTEGSE4'
+      }
+    ];
+
+    TEST_CASES.forEach((testCase) => {
+      it(`works for ${testCase.strkey.substring(0, 5)}...`, function() {
+        const sp = StellarBase.SignerKey.encodeSignedPayloadFromAddress(
+          SIGNER,
+          testCase.payload
+        );
+        expect(sp).to.eql(testCase.strkey);
+        expect(sp.length).to.be.lessThan(226);
+      });
+    });
+  });
+
   describe('error cases', function() {
     [
       // these are valid strkeys, just not valid signers

--- a/test/unit/signerkey_test.js
+++ b/test/unit/signerkey_test.js
@@ -66,12 +66,17 @@ describe('SignerKey', function() {
 
     TEST_CASES.forEach((testCase) => {
       it(`works for ${testCase.strkey.substring(0, 5)}...`, function() {
-        const sp = StellarBase.SignerKey.encodeSignedPayloadFromAddress(
+        const sp = StellarBase.SignerKey.composeSignedPayload(
           SIGNER,
           testCase.payload
         );
         expect(sp).to.eql(testCase.strkey);
-        expect(sp.length).to.be.lessThan(226);
+
+        const obj = StellarBase.SignerKey.decomposeSignedPayload(sp);
+        expect(obj.signer).to.eql(SIGNER);
+        expect(obj.payload.toString('hex')).to.eql(
+          testCase.payload.toString('hex')
+        );
       });
     });
   });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -897,7 +897,10 @@ export namespace SignerKey {
   function decodeAddress(address: string): xdr.SignerKey;
   function encodeSignerKey(signerKey: xdr.SignerKey): string;
 
-  function encodeSignedPayloadFromAddress(address: string, payload: Buffer): string;
+  function composeSignedPayload(address: string, payload: Buffer): string;
+  function decomposeSignedPayload(address: string): {
+    signer: string, payload: Buffer
+  };
 }
 
 export class TransactionI {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -896,6 +896,8 @@ export namespace StrKey {
 export namespace SignerKey {
   function decodeAddress(address: string): xdr.SignerKey;
   function encodeSignerKey(signerKey: xdr.SignerKey): string;
+
+  function encodeSignedPayloadFromAddress(address: string, payload: Buffer): string;
 }
 
 export class TransactionI {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -254,12 +254,18 @@ export namespace Signer {
     weight: number | undefined;
   }
   interface Sha256Hash {
-    sha256Hash: Buffer;
+    sha256Hash: Buffer | string;
     weight: number | undefined;
   }
   interface PreAuthTx {
-    preAuthTx: Buffer;
+    preAuthTx: Buffer | string;
     weight: number | undefined;
+  }
+  interface SignedPayload {
+    signedPayload: {
+      signer: string;
+      payload: Buffer | string;
+    };
   }
 }
 export namespace SignerKeyOptions {
@@ -272,16 +278,24 @@ export namespace SignerKeyOptions {
   interface PreAuthTx {
     preAuthTx: Buffer | string;
   }
+  interface SignedPayload {
+    signedPayload: {
+      signer: string;
+      payload: Buffer | string;
+    };
+  }
 }
 export type Signer =
   | Signer.Ed25519PublicKey
   | Signer.Sha256Hash
-  | Signer.PreAuthTx;
+  | Signer.PreAuthTx
+  | Signer.SignedPayload;
 
 export type SignerKeyOptions =
   | SignerKeyOptions.Ed25519PublicKey
   | SignerKeyOptions.Sha256Hash
-  | SignerKeyOptions.PreAuthTx;
+  | SignerKeyOptions.PreAuthTx
+  | SignerKeyOptions.SignedPayload;
 
 export namespace SignerOptions {
   interface Ed25519PublicKey {
@@ -296,11 +310,19 @@ export namespace SignerOptions {
     preAuthTx: Buffer | string;
     weight?: number | string;
   }
+  interface SignedPayload {
+    signedPayload: {
+      payload: Buffer | string;
+      signer: string;
+    };
+    weight?: number | string;
+  }
 }
 export type SignerOptions =
   | SignerOptions.Ed25519PublicKey
   | SignerOptions.Sha256Hash
-  | SignerOptions.PreAuthTx;
+  | SignerOptions.PreAuthTx
+  | SignerOptions.SignedPayload;
 
 export namespace OperationType {
   type CreateAccount = 'createAccount';
@@ -666,6 +688,8 @@ export namespace Operation {
       ? Signer.Sha256Hash
       : T extends { preAuthTx: any }
       ? Signer.PreAuthTx
+      : T extends { signedPayload: any }
+      ? Signer.SignedPayload
       : never;
   }
   function setOptions<T extends SignerOptions = never>(

--- a/types/test.ts
+++ b/types/test.ts
@@ -156,7 +156,13 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
   .setMinAccountSequence("5")
   .setMinAccountSequenceAge(5)
   .setMinAccountSequenceLedgerGap(5)
-  .setExtraSigners([sourceKey.publicKey()])
+  .setExtraSigners([
+    sourceKey.publicKey(),
+    StellarSdk.SignerKey.encodeSignedPayloadFromAddress(
+      sourceKey.publicKey(),
+      Buffer.from("hello, world!", "ascii")
+    )
+  ])
   .build(); // $ExpectType () => Transaction<Memo<MemoType>, Operation[]>
 
 const transactionFromXDR = new StellarSdk.Transaction(transaction.toEnvelope(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]>

--- a/types/test.ts
+++ b/types/test.ts
@@ -92,6 +92,16 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
       }
     })
   ).addOperation(
+    StellarSdk.Operation.revokeSignerSponsorship({
+      account: account.accountId(),
+      signer: {
+        signedPayload: {
+          signer: account.accountId(),
+          payload: "da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be"
+        }
+      }
+    })
+  ).addOperation(
     StellarSdk.Operation.clawback({
       from: account.accountId(),
       amount: "1000",
@@ -212,6 +222,11 @@ const newSignerXDR3 = StellarSdk.Operation.setOptions({
   signer: { preAuthTx: '', weight: 1 }
 });
 StellarSdk.Operation.fromXDRObject(newSignerXDR3).signer; // $ExpectType PreAuthTx
+
+const newSignerXDR4 = StellarSdk.Operation.setOptions({
+  signer: { signedPayload: {signer: '', payload: ''}, weight: 1 }
+});
+StellarSdk.Operation.fromXDRObject(newSignerXDR4).signer; // $ExpectType SignedPayload
 
 StellarSdk.TimeoutInfinite; // $ExpectType 0
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -158,7 +158,7 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
   .setMinAccountSequenceLedgerGap(5)
   .setExtraSigners([
     sourceKey.publicKey(),
-    StellarSdk.SignerKey.encodeSignedPayloadFromAddress(
+    StellarSdk.SignerKey.composeSignedPayload(
       sourceKey.publicKey(),
       Buffer.from("hello, world!", "ascii")
     )


### PR DESCRIPTION
While many parts of the SDK have been updated to enable the new signer type from [CAP-40](https://stellar.org/protocol/cap-40), the `SetOptions` operation has not.

As part of this, new helpers exist:
```typescript
  function composeSignedPayload(address: string, payload: Buffer): string;
  function decomposeSignedPayload(address: string): { signer: string; payload: Buffer };
```

which should make it easy to create a P-address from a G-address and a payload and vice-versa.