### PR TITLE
Coalesce all xLM, Xlm, etc. => 'XLM' native asset code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Fix
+
+* Turn all XLM-like (i.e. casing agnostic) asset codes into the native asset with code `XLM` ([#546](https://github.com/stellar/js-stellar-base/pull/546)).
+
 
 ## [v8.2.0](https://github.com/stellar/js-stellar-base/compare/v8.1.0..v8.2.0)
 

--- a/src/asset.js
+++ b/src/asset.js
@@ -30,7 +30,13 @@ export class Asset {
       throw new Error('Issuer is invalid');
     }
 
-    this.code = code;
+    if (String(code).toLowerCase() === 'xlm') {
+      // transform all xLM, Xlm, etc. variants -> XLM
+      this.code = 'XLM';
+    } else {
+      this.code = code;
+    }
+
     this.issuer = issuer;
   }
 


### PR DESCRIPTION
Closes #544.