### PR TITLE
Publish to `stellar-base@soroban` on merges to `soroban` branch.

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -2,6 +2,10 @@ name: npm publish
 on:
   release:
     types: [published]
+  push:
+    branches: [soroban]
+    inputs:
+      publish_args: --tag soroban
 
 jobs:
   build:
@@ -23,6 +27,6 @@ jobs:
         run: gulp
 
       - name: Publish npm package
-        run: yarn publish
+        run: yarn publish {{ inputs.publish_args }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This should specify the `--tag soroban` tag when publishing to [npm](https://www.npmjs.com/package/stellar-base), meaning you will be able to install `stellar-base@soroban`. The latest / untagged version will still only be published on [releases](https://github.com/stellar/js-stellar-base/releases).

(Note that I haven't done this in GHA before, but based on [this](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#defining-inputs-for-manually-triggered-workflows) and [this](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#example-using-event-type), it should work.)