### PR TITLE
Default to include the contract code footprint, as that is always needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "8.0.1-soroban.3",
+  "version": "8.0.1-soroban.4",
   "description": "Low level stellar support library",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/src/contract.js
+++ b/src/contract.js
@@ -46,7 +46,15 @@ export class Contract {
         ...params
       ],
       // TODO: Figure out how to calculate this or get it from the user?
-      footprint: new xdr.LedgerFootprint({ readOnly: [], readWrite: [] })
+      footprint: new xdr.LedgerFootprint({
+        readOnly: [
+          new xdr.LedgerKeyContractData({
+            contractId: this._id,
+            key: xdr.ScVal.scvStatic(xdr.ScStatic.scsLedgerKeyContractCode())
+          })
+        ],
+        readWrite: []
+      })
     });
   }
 }

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -1,0 +1,19 @@
+describe('Contract.call', function() {
+  it('includes the contract code footprint', function() {
+    let contractId = '00000000000000000000000000000001';
+    let contract = new StellarBase.Contract(contractId);
+    let call = contract.call('foo');
+    let op = call.body().invokeHostFunctionOp();
+    let readOnly = op.footprint().readOnly();
+    expect(readOnly.length).to.equal(1);
+    let expected = new StellarBase.xdr.LedgerKeyContractData({
+      contractId,
+      key: StellarBase.xdr.ScVal.scvStatic(
+        StellarBase.xdr.ScStatic.scsLedgerKeyContractCode()
+      )
+    })
+      .toXDR()
+      .toString('base64');
+    expect(readOnly[0].toXDR().toString('base64')).to.equal(expected);
+  });
+});


### PR DESCRIPTION
The minimal footprint any call can have is the contract code being invoked. So there's no reason not to always include it.