### PR TITLE
New soroban xdr updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "8.0.1-soroban.5",
+  "version": "8.0.1-soroban.6",
   "description": "Low level stellar support library",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/src/contract.js
+++ b/src/contract.js
@@ -36,21 +36,22 @@ export class Contract {
    * @returns {xdr.Operation} Build a InvokeHostFunctionOp operation to call the contract.
    */
   call(method, ...params) {
+    let contractId = Buffer.from(this._id, 'hex');
     return Operation.invokeHostFunction({
       function: xdr.HostFunction.hostFunctionTypeInvokeContract([
-        xdr.ScVal.scvObject(
-          xdr.ScObject.scoBytes(Buffer.from(this._id, 'hex'))
-        ),
+        xdr.ScVal.scvObject(xdr.ScObject.scoBytes(contractId)),
         xdr.ScVal.scvSymbol(method),
         ...params
       ]),
       // TODO: Figure out how to calculate this or get it from the user?
       footprint: new xdr.LedgerFootprint({
         readOnly: [
-          new xdr.LedgerKeyContractData({
-            contractId: this._id,
-            key: xdr.ScVal.scvStatic(xdr.ScStatic.scsLedgerKeyContractCode())
-          })
+          xdr.LedgerKey.contractData(
+            new xdr.LedgerKeyContractData({
+              contractId,
+              key: xdr.ScVal.scvStatic(xdr.ScStatic.scsLedgerKeyContractCode())
+            })
+          )
         ],
         readWrite: []
       })

--- a/src/contract.js
+++ b/src/contract.js
@@ -18,7 +18,7 @@ export class Contract {
   // TODO: Figure out contract owner/id stuff here. How should we represent that?
   constructor(contractId) {
     // TODO: Add methods based on the contractSpec (or do that elsewhere?)
-    this._id = contractId;
+    this._id = Buffer.from(contractId, 'hex');
   }
 
   /**
@@ -27,7 +27,7 @@ export class Contract {
    * @returns {string}
    */
   contractId() {
-    return this._id;
+    return this._id.toString('hex');
   }
 
   /**
@@ -36,7 +36,7 @@ export class Contract {
    * @returns {xdr.Operation} Build a InvokeHostFunctionOp operation to call the contract.
    */
   call(method, ...params) {
-    let contractId = Buffer.from(this._id, 'hex');
+    const contractId = Buffer.from(this._id, 'hex');
     return Operation.invokeHostFunction({
       function: xdr.HostFunction.hostFunctionTypeInvokeContract([
         xdr.ScVal.scvObject(xdr.ScObject.scoBytes(contractId)),

--- a/src/operation.js
+++ b/src/operation.js
@@ -383,7 +383,6 @@ export class Operation {
       case 'invokeHostFunction': {
         result.type = 'invokeHostFunction';
         result.function = attrs.function();
-        result.parameters = attrs.parameters();
         result.footprint = attrs.footprint();
         break;
       }

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -1,17 +1,21 @@
 describe('Contract.call', function() {
   it('includes the contract code footprint', function() {
-    let contractId = '00000000000000000000000000000001';
+    let contractId =
+      '0000000000000000000000000000000000000000000000000000000000000001';
     let contract = new StellarBase.Contract(contractId);
+    expect(contract.contractId()).to.equal(contractId);
     let call = contract.call('foo');
     let op = call.body().invokeHostFunctionOp();
     let readOnly = op.footprint().readOnly();
     expect(readOnly.length).to.equal(1);
-    let expected = new StellarBase.xdr.LedgerKeyContractData({
-      contractId,
-      key: StellarBase.xdr.ScVal.scvStatic(
-        StellarBase.xdr.ScStatic.scsLedgerKeyContractCode()
-      )
-    })
+    let expected = new StellarBase.xdr.LedgerKey.contractData(
+      new StellarBase.xdr.LedgerKeyContractData({
+        contractId: Buffer.from(contractId, 'hex'),
+        key: StellarBase.xdr.ScVal.scvStatic(
+          StellarBase.xdr.ScStatic.scsLedgerKeyContractCode()
+        )
+      })
+    )
       .toXDR()
       .toString('base64');
     expect(readOnly[0].toXDR().toString('base64')).to.equal(expected);


### PR DESCRIPTION
- Missed an instance of the old `.parameters()` field
- Also, fixing a bug introduced in https://github.com/stellar/js-stellar-base/pull/557