### PR TITLE
Add strkey parsing for contracts, and Address helper for building ScAddresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "8.2.2-soroban.7",
+  "version": "8.2.2-soroban.9",
   "description": "Low level stellar support library",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/src/address.js
+++ b/src/address.js
@@ -1,0 +1,82 @@
+import { StrKey } from './strkey';
+import xdr from './xdr';
+
+/**
+ * Create a new Address object.
+ *
+ * `Address` represents a single address in the Stellar network. An address can
+ * represent an account or a contract.
+ *
+ * @constructor
+ *
+ * @param {string} address - ID of the account (ex.
+ *     `GB3KJPLFUYN5VL6R3GU3EGCGVCKFDSD7BEDX42HWG5BWFKB3KQGJJRMA`). If you
+ *     provide a muxed account address, this will throw; use {@link
+ *     MuxedAccount} instead.
+ */
+export class Address {
+  constructor(address) {
+    if (StrKey.isValidEd25519PublicKey(address)) {
+      this._type = 'account';
+      this._key = StrKey.decodeEd25519PublicKey(address);
+    } else if (StrKey.isValidContract(address)) {
+      this._type = 'contract';
+      this._key = StrKey.decodeContract(address);
+    } else {
+      throw new Error('Unsupported address type');
+    }
+  }
+
+  /**
+   * Parses a string and returns an Address object.
+   *
+   * @param {string} address - The address to parse. ex. `GB3KJPLFUYN5VL6R3GU3EGCGVCKFDSD7BEDX42HWG5BWFKB3KQGJJRMA`
+   * @returns {Address}
+   */
+  static fromString(address) {
+    return new Address(address);
+  }
+
+  /**
+   * Serialize an address to string.
+   *
+   * @returns {string}
+   */
+  toString() {
+    switch (this._type) {
+      case 'account':
+        return StrKey.encodeEd25519PublicKey(this._key);
+      case 'contract':
+        return StrKey.encodeContract(this._key);
+      default:
+        throw new Error('Unsupported address type');
+    }
+  }
+
+  /**
+   * Convert this Address to an xdr.ScVal type.
+   *
+   * @returns {xdr.ScVal}
+   */
+  toScVal() {
+    return xdr.ScVal.scvObject(xdr.ScObject.scoAddress(this.toScAddress()));
+  }
+
+  /**
+   * Convert this Address to an xdr.ScAddress type.
+   *
+   * @returns {xdr.ScAddress}
+   */
+  toScAddress() {
+    switch (this._type) {
+      case 'account':
+        return xdr.ScAddress.scAddressTypeAccount(
+          xdr.PublicKey.publicKeyTypeEd25519(this._key)
+        );
+      case 'contract':
+        return xdr.ScAddress.scAddressTypeContract(this._key);
+      default:
+        throw new Error('Unsupported address type');
+    }
+  }
+}

--- a/src/address.js
+++ b/src/address.js
@@ -38,6 +38,26 @@ export class Address {
   }
 
   /**
+   * Creates a new account Address object from a buffer of raw bytes.
+   *
+   * @param {Buffer} buffer - The bytes of an address to parse.
+   * @returns {Address}
+   */
+  static account(buffer) {
+    return new Address(StrKey.encodeEd25519PublicKey(buffer));
+  }
+
+  /**
+   * Creates a new contract Address object from a buffer of raw bytes.
+   *
+   * @param {Buffer} buffer - The bytes of an address to parse.
+   * @returns {Address}
+   */
+  static contract(buffer) {
+    return new Address(StrKey.encodeContract(buffer));
+  }
+
+  /**
    * Serialize an address to string.
    *
    * @returns {string}

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ export {
 } from './operation';
 export * from './memo';
 export { Account } from './account';
+export { Address } from './address';
 export { Contract } from './contract';
 export { MuxedAccount } from './muxed_account';
 export { Claimant } from './claimant';

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export {
 } from './operation';
 export * from './memo';
 export { Account } from './account';
-export { Address } from './address';
+export * from './address';
 export { Contract } from './contract';
 export { MuxedAccount } from './muxed_account';
 export { Claimant } from './claimant';

--- a/src/strkey.js
+++ b/src/strkey.js
@@ -13,7 +13,8 @@ const versionBytes = {
   med25519PublicKey: 12 << 3, // M
   preAuthTx: 19 << 3, // T
   sha256Hash: 23 << 3, // X
-  signedPayload: 15 << 3 // P
+  signedPayload: 15 << 3, // P
+  contract: 2 << 3 // C
 };
 
 const strkeyTypes = {
@@ -22,7 +23,8 @@ const strkeyTypes = {
   M: 'med25519PublicKey',
   T: 'preAuthTx',
   X: 'sha256Hash',
-  P: 'signedPayload'
+  P: 'signedPayload',
+  C: 'contract'
 };
 
 /**
@@ -180,6 +182,33 @@ export class StrKey {
     return isValid('signedPayload', address);
   }
 
+  /**
+   * Encodes raw data to strkey contract (C...).
+   * @param   {Buffer} data  data to encode
+   * @returns {string}
+   */
+  static encodeContract(data) {
+    return encodeCheck('contract', data);
+  }
+
+  /**
+   * Decodes strkey contract (C...) to raw data.
+   * @param   {string} address  address to decode
+   * @returns {Buffer}
+   */
+  static decodeContract(address) {
+    return decodeCheck('contract', address);
+  }
+
+  /**
+   * Checks validity of alleged contract (C...) strkey address.
+   * @param   {string} address  signer key to check
+   * @returns {boolean}
+   */
+  static isValidContract(address) {
+    return isValid('contract', address);
+  }
+
   static getVersionByteForPrefix(address) {
     return strkeyTypes[address[0]];
   }
@@ -208,7 +237,8 @@ function isValid(versionByteName, encoded) {
     case 'ed25519PublicKey': // falls through
     case 'ed25519SecretSeed': // falls through
     case 'preAuthTx': // falls through
-    case 'sha256Hash':
+    case 'sha256Hash': // falls through
+    case 'contract':
       if (encoded.length !== 56) {
         return false;
       }
@@ -242,7 +272,8 @@ function isValid(versionByteName, encoded) {
     case 'ed25519PublicKey': // falls through
     case 'ed25519SecretSeed': // falls through
     case 'preAuthTx': // falls through
-    case 'sha256Hash':
+    case 'sha256Hash': // falls through
+    case 'contract':
       return decoded.length === 32;
 
     case 'med25519PublicKey':

--- a/test/unit/address_test.js
+++ b/test/unit/address_test.js
@@ -28,6 +28,27 @@ describe('Address', function() {
     });
   });
 
+  describe('static constructors', function() {
+    it('.fromString', function() {
+      let account = StellarBase.Address.fromString(ACCOUNT);
+      expect(account.toString()).to.equal(ACCOUNT);
+    });
+
+    it('.account', function() {
+      let account = StellarBase.Address.account(Buffer.alloc(32));
+      expect(account.toString()).to.equal(
+        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+      );
+    });
+
+    it('.contract', function() {
+      let account = StellarBase.Address.contract(Buffer.alloc(32));
+      expect(account.toString()).to.equal(
+        'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4'
+      );
+    });
+  });
+
   describe('.toScAddress', function() {
     it('converts accounts to an ScAddress', function() {
       const a = new StellarBase.Address(ACCOUNT);

--- a/test/unit/address_test.js
+++ b/test/unit/address_test.js
@@ -1,0 +1,59 @@
+describe('Address', function() {
+  const ACCOUNT = 'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB';
+  const CONTRACT = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+  const MUXED_ADDRESS =
+    'MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK';
+
+  describe('.constructor', function() {
+    it('fails to create Address object from an invalid address', function() {
+      expect(() => new StellarBase.Address('GBBB')).to.throw(
+        /Unsupported address type/
+      );
+    });
+
+    it('creates an Address object for accounts', function() {
+      let account = new StellarBase.Address(ACCOUNT);
+      expect(account.toString()).to.equal(ACCOUNT);
+    });
+
+    it('creates an Address object for contracts', function() {
+      let account = new StellarBase.Address(CONTRACT);
+      expect(account.toString()).to.equal(CONTRACT);
+    });
+
+    it('wont create Address objects from muxed account strings', function() {
+      expect(() => {
+        new StellarBase.Account(MUXED_ADDRESS, '123');
+      }).to.throw(/MuxedAccount/);
+    });
+  });
+
+  describe('.toScAddress', function() {
+    it('converts accounts to an ScAddress', function() {
+      const a = new StellarBase.Address(ACCOUNT);
+      const s = a.toScAddress();
+      expect(s).to.be.instanceof(StellarBase.xdr.ScAddress);
+      expect(s.switch()).to.equal(
+        StellarBase.xdr.ScAddressType.scAddressTypeAccount()
+      );
+    });
+
+    it('converts contracts to an ScAddress', function() {
+      const a = new StellarBase.Address(CONTRACT);
+      const s = a.toScAddress();
+      expect(s).to.be.instanceof(StellarBase.xdr.ScAddress);
+      expect(s.switch()).to.equal(
+        StellarBase.xdr.ScAddressType.scAddressTypeContract()
+      );
+    });
+  });
+
+  describe('.toScVal', function() {
+    it('converts to an ScAddress', function() {
+      const a = new StellarBase.Address(ACCOUNT);
+      const s = a.toScVal();
+      expect(s).to.be.instanceof(StellarBase.xdr.ScVal);
+      expect(s.obj().address()).to.deep.equal(a.toScAddress());
+    });
+  });
+});

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -394,6 +394,27 @@ describe('StrKey', function() {
     });
   });
 
+  describe('#contracts', function() {
+    it('valid w/ 32-byte payload', function() {
+      const strkey = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+      const buf = StellarBase.StrKey.decodeContract(strkey);
+
+      expect(buf.toString('hex')).to.equal(
+        '363eaa3867841fbad0f4ed88c779e4fe66e56a2470dc98c0ec9c073d05c7b103'
+      );
+
+      expect(StellarBase.StrKey.encodeContract(buf)).to.equal(strkey);
+    });
+
+    it('isValid', function() {
+      const valid = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+      expect(StellarBase.StrKey.isValidContract(valid)).to.be.true;
+      const invalid =
+        'GA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+      expect(StellarBase.StrKey.isValidContract(invalid)).to.be.false;
+    });
+  });
+
   describe('#invalidStrKeys', function() {
     // From https://stellar.org/protocol/sep-23#invalid-test-cases
     const BAD_STRKEYS = [

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,6 +12,14 @@ export class Account {
   incrementSequenceNumber(): void;
 }
 
+export class Address {
+  constructor(address: string);
+  static fromString(address: string): Address;
+  toString(): string;
+  toScVal(): xdr.ScVal;
+  toScAddress(): xdr.ScAddress;
+}
+
 export class Contract {
   constructor(contractId: string);
   contractId(): string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,6 +15,8 @@ export class Account {
 export class Address {
   constructor(address: string);
   static fromString(address: string): Address;
+  static account(buffer: Buffer): Address;
+  static contract(buffer: Buffer): Address;
   toString(): string;
   toScVal(): xdr.ScVal;
   toScAddress(): xdr.ScAddress;


### PR DESCRIPTION
Two things here:
- There's a new strkey type, for `C...` keys for contracts. This adds strkey parsing/serialization for those.
- When updating soroban-example-dapp, I found building ScAddresses to be a faff. Added an `Address` class to make that easier.
  - I considered having two classes (`AccountAddress`, and `ContractAddress`), but didn't see the point for now.
  - You would use this via: `new Address("C..34").toScVal().toXDR("base64")`, or `.toScAddress()` if that is what you wanted.