### PR TITLE
Throw error if you try to sign transactions that need contract signatures.

### DIFF
--- a/src/fee_bump_transaction.js
+++ b/src/fee_bump_transaction.js
@@ -62,6 +62,14 @@ export class FeeBumpTransaction extends TransactionBase {
   }
 
   /**
+   * @type {Operation[]}
+   * @readonly
+   */
+  get operations() {
+    return this._innerTransaction.operations;
+  }
+
+  /**
    * @type {string}
    * @readonly
    */

--- a/src/transaction_base.js
+++ b/src/transaction_base.js
@@ -70,7 +70,7 @@ export class TransactionBase {
    */
   sign(...keypairs) {
     // Temporary warning for contract auth-next signatures not being supported.
-    const requiresContractSignatures = (this._tx.operations || []).some(
+    const requiresContractSignatures = (this.operations || []).some(
       (op) =>
         op.type === 'invokeHostFunction' &&
         op.auth.some((a) => a.addressWithNonce())

--- a/src/transaction_base.js
+++ b/src/transaction_base.js
@@ -69,6 +69,17 @@ export class TransactionBase {
    * @returns {void}
    */
   sign(...keypairs) {
+    // Temporary warning for contract auth-next signatures not being supported.
+    const requiresContractSignatures = (this._tx.operations || []).some(
+      (op) =>
+        op.type === 'invokeHostFunction' &&
+        op.auth.some((a) => a.addressWithNonce())
+    );
+    if (requiresContractSignatures) {
+      throw new Error(
+        'Soroban contract signatures are not supported in this version of the SDK.'
+      );
+    }
     const txHash = this.hash();
     keypairs.forEach((kp) => {
       const sig = kp.signDecorated(txHash);

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -283,7 +283,7 @@ describe('Transaction', function() {
                 nonce: StellarBase.xdr.Uint64.fromString('0')
               }),
               // Rest of params are irrelevant
-              rootInvocation: StellarBase.xdr.AuthorizedInvocation({
+              rootInvocation: new StellarBase.xdr.AuthorizedInvocation({
                 contractId: new Buffer(32),
                 functionName: 'test',
                 args: [],

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -253,6 +253,55 @@ describe('Transaction', function() {
     );
   });
 
+  it('returns error when transaction includes soroban contract auth', function() {
+    let source = new StellarBase.Account(
+      'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
+      '0'
+    );
+    let signer = StellarBase.Keypair.master(StellarBase.Networks.TESTNET);
+
+    let tx = new StellarBase.TransactionBuilder(source, {
+      fee: 100,
+      networkPassphrase: StellarBase.Networks.TESTNET
+    })
+      .addOperation(
+        StellarBase.Operation.invokeHostFunction({
+          function: StellarBase.xdr.HostFunction.hostFunctionTypeInvokeContract(
+            []
+          ),
+          footprint: new StellarBase.xdr.LedgerFootprint({
+            readOnly: [],
+            readWrite: []
+          }),
+          auth: [
+            new StellarBase.xdr.ContractAuth({
+              // Include an AddressWithNonce to trigger this
+              addressWithNonce: new StellarBase.xdr.AddressWithNonce({
+                address: new StellarBase.Address(
+                  source.accountId()
+                ).toScAddress(),
+                nonce: StellarBase.xdr.Uint64.fromString('0')
+              }),
+              // Rest of params are irrelevant
+              rootInvocation: StellarBase.xdr.AuthorizedInvocation({
+                contractId: new Buffer(32),
+                functionName: 'test',
+                args: [],
+                subInvocations: []
+              }),
+              signatureArgs: []
+            })
+          ]
+        })
+      )
+      .setTimeout(StellarBase.TimeoutInfinite)
+      .build();
+
+    expect(() => tx.sign(signer)).to.throw(
+      /Soroban contract signatures are not supported in this version of the SDK./
+    );
+  });
+
   it('adds signature correctly', function() {
     const sourceKey =
       'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -856,6 +856,7 @@ export namespace Operation {
     function: xdr.HostFunction;
     parameters: xdr.ScVal[];
     footprint: xdr.LedgerFootprint;
+    auth: xdr.ContractAuth[];
   }
   function invokeHostFunction(
     options: OperationOptions.InvokeHostFunction


### PR DESCRIPTION
I spent a while debugging this, and an error here would have helped me.

For some reason this test says that `[].some()` doesn't exist, though.. cc @Shaptic ?