### PR TITLE
Merge upstream into `soroban` branch and tag a new version.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Install Node (14.x)
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14.x'
 
@@ -24,7 +24,7 @@ jobs:
         run: yarn preversion
 
       - name: Checkout GH pages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: stellar/js-stellar-base
           ref: gh-pages

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
         node-version: [14, 16, 18]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 
 ## Unreleased
 
-## [v9.0.0-beta.0](https://github.com/stellar/js-stellar-base/compare/v8.2.2..v9.0.0)
+
+## [v9.0.0-beta.1](https://github.com/stellar/js-stellar-base/compare/v9.0.0-beta.0..v9.0.0-beta.1)
+
+### Fix
+
+- Correct XDR type definition for raw `xdr.Operation`s ([#591](https://github.com/stellar/js-stellar-base/pull/591)).
+
+
+## [v9.0.0-beta.0](https://github.com/stellar/js-stellar-base/compare/v8.2.2..v9.0.0-beta.0)
 
 This version is marked by a major version bump because of the significant upgrades to underlying dependencies. While there should be no noticeable API changes from a downstream perspective, there may be breaking changes in the way that this library is bundled.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 
 ## Unreleased
 
+## [v9.0.0-beta.0](https://github.com/stellar/js-stellar-base/compare/v8.2.2..v9.0.0)
+
+This version is marked by a major version bump because of the significant upgrades to underlying dependencies. While there should be no noticeable API changes from a downstream perspective, there may be breaking changes in the way that this library is bundled.
+
+### Fix
+
+- Build system has been overhauled to support Webpack 5 ([#585](https://github.com/stellar/js-stellar-base/pull/585)).
+
+- Current and vNext XDR updated to latest versions ([#587](https://github.com/stellar/js-stellar-base/pull/587)).
+
+
 ## [v8.2.2](https://github.com/stellar/js-stellar-base/compare/v8.2.1..v8.2.2)
 
 ### Fix
@@ -25,7 +36,7 @@
 
 ## [v8.1.0](https://github.com/stellar/js-stellar-base/compare/v8.0.1..v8.1.0)
 
-### Add 
+### Add
 
 * `TransactionBase.addDecoratedSignature` is a clearer way to add signatures directly to a built transaction without fiddling with the underlying `signatures` array ([#535](https://github.com/stellar/js-stellar-base/pull/535)).
 
@@ -231,7 +242,7 @@ Please refer to the [security advisory](https://github.com/advisories/GHSA-pjwm-
 ## [v5.3.1](https://github.com/stellar/js-stellar-base/compare/v5.3.0..v5.3.1)
 
 ### Fix
-- Creating operations with both muxed and unmuxed properties resulted in unintuitive XDR. Specifically, the unmuxed property would be transformed into the equivalent property with an ID of 0 ([#441](https://github.com/stellar/js-stellar-base/pull/441)). 
+- Creating operations with both muxed and unmuxed properties resulted in unintuitive XDR. Specifically, the unmuxed property would be transformed into the equivalent property with an ID of 0 ([#441](https://github.com/stellar/js-stellar-base/pull/441)).
 
 
 ## [v5.3.0](https://github.com/stellar/js-stellar-base/compare/v5.2.1..v5.3.0)
@@ -268,13 +279,13 @@ Please refer to the [security advisory](https://github.com/advisories/GHSA-pjwm-
   // MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAD5DTGC 1000
 
   const mux2 = ACC.createSubaccount('2000');
-  console.log("Parent relationship preserved:", 
+  console.log("Parent relationship preserved:",
               mux2.baseAccount().accountId() === mux1.baseAccount().accountId());
   console.log(mux2.accountId(), mux2.id());
   // MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAH2B4RU 2000
 
   mux1.setID('3000');
-  console.log("Underlying account unchanged:", 
+  console.log("Underlying account unchanged:",
               ACC.accountId() === mux1.baseAccount().accountId());
   console.log(mux1.accountId(), mux1.id());
   // MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAALXC5LE 3000
@@ -293,7 +304,7 @@ Please refer to the [security advisory](https://github.com/advisories/GHSA-pjwm-
 
 ### Update
 
-- The Typescript definitions have been updated to support CAP-35 ([#407](https://github.com/stellar/js-stellar-base/pull/407)). 
+- The Typescript definitions have been updated to support CAP-35 ([#407](https://github.com/stellar/js-stellar-base/pull/407)).
 
 ## [v5.0.0](https://github.com/stellar/js-stellar-base/compare/v4.0.3..v5.0.0)
 

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -1,7 +1,7 @@
 const webpackConfig = require('./webpack.config.browser.js');
 
 delete webpackConfig.output;
-webpackConfig.entry = {}; // karma fills these in
+delete webpackConfig.entry; // karma fills these in
 webpackConfig.plugins.shift(); // drop eslinter plugin
 
 module.exports = function (config) {

--- a/config/webpack.config.browser.js
+++ b/config/webpack.config.browser.js
@@ -27,7 +27,7 @@ const config = {
     path: path.resolve(__dirname, '../dist')
   },
   mode: process.env.NODE_ENV ?? 'development',
-  devtool: process.env.NODE_ENV === 'production' ? false : 'inline-source-map',
+  devtool: process.env.NODE_ENV === 'production' ? false : 'source-map',
   module: {
     rules: [
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "8.2.2-soroban.12",
+  "version": "9.0.0-soroban.0",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",
@@ -12,11 +12,11 @@
     "build:browser:prod": "cross-env NODE_ENV=production yarn build:browser",
     "build:prod": "cross-env NODE_ENV=production yarn build",
     "test": "yarn build && yarn test:node && yarn test:browser",
-    "test:node": "nyc --nycrc-path ./config/.nycrc mocha --recursive",
+    "test:node": "nyc --nycrc-path ./config/.nycrc mocha",
     "test:browser": "karma start ./config/karma.conf.js",
     "docs": "jsdoc -c ./config/.jsdoc.json --verbose",
     "lint": "eslint -c ./config/.eslintrc.js src/ && dtslint --localTs node_modules/typescript/lib types/",
-    "preversion": "yarn clean && yarn pretty && yarn lint && yarn build:prod && yarn test",
+    "preversion": "yarn clean && yarn fmt && yarn lint && yarn build:prod && yarn test",
     "fmt": "prettier --config ./config/prettier.config.js --ignore-path ./config/.prettierignore --write './**/*.js'",
     "prepare": "yarn build:prod",
     "clean": "rm -rf lib/ dist/ coverage/ .nyc_output/"
@@ -27,6 +27,7 @@
       "./test/test-helper.js"
     ],
     "reporter": "dot",
+    "recursive": true,
     "timeout": 5000
   },
   "nyc": {
@@ -90,6 +91,7 @@
     "eslint-plugin-prefer-import": "^0.0.1",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-webpack-plugin": "^4.0.0",
+    "ghooks": "^2.0.4",
     "husky": "^8.0.3",
     "jsdoc": "^4.0.2",
     "karma": "^6.4.1",
@@ -111,9 +113,8 @@
     "taffydb": "^2.7.3",
     "terser-webpack-plugin": "^5.3.7",
     "ts-node": "^10.9.1",
-    "webpack": "^5.77.0",
-    "ghooks": "^2.0.4",
     "typescript": "^5.0.3",
+    "webpack": "^5.77.0",
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
@@ -121,12 +122,12 @@
     "bignumber.js": "^9.1.1",
     "crc": "^4.3.2",
     "crypto-browserify": "^3.12.0",
-    "js-xdr": "^1.1.3",
+    "js-xdr": "^1.3.0",
     "lodash": "^4.17.21",
     "sha.js": "^2.3.6",
     "tweetnacl": "^1.0.3"
   },
   "optionalDependencies": {
-    "sodium-native": "^3.3.0"
+    "sodium-native": "^4.0.1"
   }
 }

--- a/src/generated/curr_generated.js
+++ b/src/generated/curr_generated.js
@@ -4,7154 +4,7090 @@
 /* jshint maxstatements:2147483647  */
 /* jshint esnext:true  */
 
-import * as XDR from 'js-xdr';
-
-
-var types = XDR.config(xdr => {
-
-// === xdr source ============================================================
-//
-//   typedef opaque Value<>;
-//
-// ===========================================================================
-xdr.typedef("Value", xdr.varOpaque());
-
-// === xdr source ============================================================
-//
-//   struct SCPBallot
-//   {
-//       uint32 counter; // n
-//       Value value;    // x
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpBallot", [
-  ["counter", xdr.lookup("Uint32")],
-  ["value", xdr.lookup("Value")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum SCPStatementType
-//   {
-//       SCP_ST_PREPARE = 0,
-//       SCP_ST_CONFIRM = 1,
-//       SCP_ST_EXTERNALIZE = 2,
-//       SCP_ST_NOMINATE = 3
-//   };
-//
-// ===========================================================================
-xdr.enum("ScpStatementType", {
-  scpStPrepare: 0,
-  scpStConfirm: 1,
-  scpStExternalize: 2,
-  scpStNominate: 3,
-});
-
-// === xdr source ============================================================
-//
-//   struct SCPNomination
-//   {
-//       Hash quorumSetHash; // D
-//       Value votes<>;      // X
-//       Value accepted<>;   // Y
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpNomination", [
-  ["quorumSetHash", xdr.lookup("Hash")],
-  ["votes", xdr.varArray(xdr.lookup("Value"), 2147483647)],
-  ["accepted", xdr.varArray(xdr.lookup("Value"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               Hash quorumSetHash;       // D
-//               SCPBallot ballot;         // b
-//               SCPBallot* prepared;      // p
-//               SCPBallot* preparedPrime; // p'
-//               uint32 nC;                // c.n
-//               uint32 nH;                // h.n
-//           }
-//
-// ===========================================================================
-xdr.struct("ScpStatementPrepare", [
-  ["quorumSetHash", xdr.lookup("Hash")],
-  ["ballot", xdr.lookup("ScpBallot")],
-  ["prepared", xdr.option(xdr.lookup("ScpBallot"))],
-  ["preparedPrime", xdr.option(xdr.lookup("ScpBallot"))],
-  ["nC", xdr.lookup("Uint32")],
-  ["nH", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               SCPBallot ballot;   // b
-//               uint32 nPrepared;   // p.n
-//               uint32 nCommit;     // c.n
-//               uint32 nH;          // h.n
-//               Hash quorumSetHash; // D
-//           }
-//
-// ===========================================================================
-xdr.struct("ScpStatementConfirm", [
-  ["ballot", xdr.lookup("ScpBallot")],
-  ["nPrepared", xdr.lookup("Uint32")],
-  ["nCommit", xdr.lookup("Uint32")],
-  ["nH", xdr.lookup("Uint32")],
-  ["quorumSetHash", xdr.lookup("Hash")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               SCPBallot commit;         // c
-//               uint32 nH;                // h.n
-//               Hash commitQuorumSetHash; // D used before EXTERNALIZE
-//           }
-//
-// ===========================================================================
-xdr.struct("ScpStatementExternalize", [
-  ["commit", xdr.lookup("ScpBallot")],
-  ["nH", xdr.lookup("Uint32")],
-  ["commitQuorumSetHash", xdr.lookup("Hash")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (SCPStatementType type)
-//       {
-//       case SCP_ST_PREPARE:
-//           struct
-//           {
-//               Hash quorumSetHash;       // D
-//               SCPBallot ballot;         // b
-//               SCPBallot* prepared;      // p
-//               SCPBallot* preparedPrime; // p'
-//               uint32 nC;                // c.n
-//               uint32 nH;                // h.n
-//           } prepare;
-//       case SCP_ST_CONFIRM:
-//           struct
-//           {
-//               SCPBallot ballot;   // b
-//               uint32 nPrepared;   // p.n
-//               uint32 nCommit;     // c.n
-//               uint32 nH;          // h.n
-//               Hash quorumSetHash; // D
-//           } confirm;
-//       case SCP_ST_EXTERNALIZE:
-//           struct
-//           {
-//               SCPBallot commit;         // c
-//               uint32 nH;                // h.n
-//               Hash commitQuorumSetHash; // D used before EXTERNALIZE
-//           } externalize;
-//       case SCP_ST_NOMINATE:
-//           SCPNomination nominate;
-//       }
-//
-// ===========================================================================
-xdr.union("ScpStatementPledges", {
-  switchOn: xdr.lookup("ScpStatementType"),
-  switchName: "type",
-  switches: [
-    ["scpStPrepare", "prepare"],
-    ["scpStConfirm", "confirm"],
-    ["scpStExternalize", "externalize"],
-    ["scpStNominate", "nominate"],
-  ],
-  arms: {
-    prepare: xdr.lookup("ScpStatementPrepare"),
-    confirm: xdr.lookup("ScpStatementConfirm"),
-    externalize: xdr.lookup("ScpStatementExternalize"),
-    nominate: xdr.lookup("ScpNomination"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct SCPStatement
-//   {
-//       NodeID nodeID;    // v
-//       uint64 slotIndex; // i
-//   
-//       union switch (SCPStatementType type)
-//       {
-//       case SCP_ST_PREPARE:
-//           struct
-//           {
-//               Hash quorumSetHash;       // D
-//               SCPBallot ballot;         // b
-//               SCPBallot* prepared;      // p
-//               SCPBallot* preparedPrime; // p'
-//               uint32 nC;                // c.n
-//               uint32 nH;                // h.n
-//           } prepare;
-//       case SCP_ST_CONFIRM:
-//           struct
-//           {
-//               SCPBallot ballot;   // b
-//               uint32 nPrepared;   // p.n
-//               uint32 nCommit;     // c.n
-//               uint32 nH;          // h.n
-//               Hash quorumSetHash; // D
-//           } confirm;
-//       case SCP_ST_EXTERNALIZE:
-//           struct
-//           {
-//               SCPBallot commit;         // c
-//               uint32 nH;                // h.n
-//               Hash commitQuorumSetHash; // D used before EXTERNALIZE
-//           } externalize;
-//       case SCP_ST_NOMINATE:
-//           SCPNomination nominate;
-//       }
-//       pledges;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpStatement", [
-  ["nodeId", xdr.lookup("NodeId")],
-  ["slotIndex", xdr.lookup("Uint64")],
-  ["pledges", xdr.lookup("ScpStatementPledges")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCPEnvelope
-//   {
-//       SCPStatement statement;
-//       Signature signature;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpEnvelope", [
-  ["statement", xdr.lookup("ScpStatement")],
-  ["signature", xdr.lookup("Signature")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCPQuorumSet
-//   {
-//       uint32 threshold;
-//       NodeID validators<>;
-//       SCPQuorumSet innerSets<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpQuorumSet", [
-  ["threshold", xdr.lookup("Uint32")],
-  ["validators", xdr.varArray(xdr.lookup("NodeId"), 2147483647)],
-  ["innerSets", xdr.varArray(xdr.lookup("ScpQuorumSet"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   typedef PublicKey AccountID;
-//
-// ===========================================================================
-xdr.typedef("AccountId", xdr.lookup("PublicKey"));
-
-// === xdr source ============================================================
-//
-//   typedef opaque Thresholds[4];
-//
-// ===========================================================================
-xdr.typedef("Thresholds", xdr.opaque(4));
-
-// === xdr source ============================================================
-//
-//   typedef string string32<32>;
-//
-// ===========================================================================
-xdr.typedef("String32", xdr.string(32));
-
-// === xdr source ============================================================
-//
-//   typedef string string64<64>;
-//
-// ===========================================================================
-xdr.typedef("String64", xdr.string(64));
-
-// === xdr source ============================================================
-//
-//   typedef int64 SequenceNumber;
-//
-// ===========================================================================
-xdr.typedef("SequenceNumber", xdr.lookup("Int64"));
-
-// === xdr source ============================================================
-//
-//   typedef uint64 TimePoint;
-//
-// ===========================================================================
-xdr.typedef("TimePoint", xdr.lookup("Uint64"));
-
-// === xdr source ============================================================
-//
-//   typedef uint64 Duration;
-//
-// ===========================================================================
-xdr.typedef("Duration", xdr.lookup("Uint64"));
-
-// === xdr source ============================================================
-//
-//   typedef opaque DataValue<64>;
-//
-// ===========================================================================
-xdr.typedef("DataValue", xdr.varOpaque(64));
-
-// === xdr source ============================================================
-//
-//   typedef Hash PoolID;
-//
-// ===========================================================================
-xdr.typedef("PoolId", xdr.lookup("Hash"));
-
-// === xdr source ============================================================
-//
-//   typedef opaque AssetCode4[4];
-//
-// ===========================================================================
-xdr.typedef("AssetCode4", xdr.opaque(4));
-
-// === xdr source ============================================================
-//
-//   typedef opaque AssetCode12[12];
-//
-// ===========================================================================
-xdr.typedef("AssetCode12", xdr.opaque(12));
-
-// === xdr source ============================================================
-//
-//   enum AssetType
-//   {
-//       ASSET_TYPE_NATIVE = 0,
-//       ASSET_TYPE_CREDIT_ALPHANUM4 = 1,
-//       ASSET_TYPE_CREDIT_ALPHANUM12 = 2,
-//       ASSET_TYPE_POOL_SHARE = 3
-//   };
-//
-// ===========================================================================
-xdr.enum("AssetType", {
-  assetTypeNative: 0,
-  assetTypeCreditAlphanum4: 1,
-  assetTypeCreditAlphanum12: 2,
-  assetTypePoolShare: 3,
-});
-
-// === xdr source ============================================================
-//
-//   union AssetCode switch (AssetType type)
-//   {
-//   case ASSET_TYPE_CREDIT_ALPHANUM4:
-//       AssetCode4 assetCode4;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM12:
-//       AssetCode12 assetCode12;
-//   
-//       // add other asset types here in the future
-//   };
-//
-// ===========================================================================
-xdr.union("AssetCode", {
-  switchOn: xdr.lookup("AssetType"),
-  switchName: "type",
-  switches: [
-    ["assetTypeCreditAlphanum4", "assetCode4"],
-    ["assetTypeCreditAlphanum12", "assetCode12"],
-  ],
-  arms: {
-    assetCode4: xdr.lookup("AssetCode4"),
-    assetCode12: xdr.lookup("AssetCode12"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct AlphaNum4
-//   {
-//       AssetCode4 assetCode;
-//       AccountID issuer;
-//   };
-//
-// ===========================================================================
-xdr.struct("AlphaNum4", [
-  ["assetCode", xdr.lookup("AssetCode4")],
-  ["issuer", xdr.lookup("AccountId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct AlphaNum12
-//   {
-//       AssetCode12 assetCode;
-//       AccountID issuer;
-//   };
-//
-// ===========================================================================
-xdr.struct("AlphaNum12", [
-  ["assetCode", xdr.lookup("AssetCode12")],
-  ["issuer", xdr.lookup("AccountId")],
-]);
-
-// === xdr source ============================================================
-//
-//   union Asset switch (AssetType type)
-//   {
-//   case ASSET_TYPE_NATIVE: // Not credit
-//       void;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM4:
-//       AlphaNum4 alphaNum4;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM12:
-//       AlphaNum12 alphaNum12;
-//   
-//       // add other asset types here in the future
-//   };
-//
-// ===========================================================================
-xdr.union("Asset", {
-  switchOn: xdr.lookup("AssetType"),
-  switchName: "type",
-  switches: [
-    ["assetTypeNative", xdr.void()],
-    ["assetTypeCreditAlphanum4", "alphaNum4"],
-    ["assetTypeCreditAlphanum12", "alphaNum12"],
-  ],
-  arms: {
-    alphaNum4: xdr.lookup("AlphaNum4"),
-    alphaNum12: xdr.lookup("AlphaNum12"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct Price
-//   {
-//       int32 n; // numerator
-//       int32 d; // denominator
-//   };
-//
-// ===========================================================================
-xdr.struct("Price", [
-  ["n", xdr.lookup("Int32")],
-  ["d", xdr.lookup("Int32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct Liabilities
-//   {
-//       int64 buying;
-//       int64 selling;
-//   };
-//
-// ===========================================================================
-xdr.struct("Liabilities", [
-  ["buying", xdr.lookup("Int64")],
-  ["selling", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum ThresholdIndexes
-//   {
-//       THRESHOLD_MASTER_WEIGHT = 0,
-//       THRESHOLD_LOW = 1,
-//       THRESHOLD_MED = 2,
-//       THRESHOLD_HIGH = 3
-//   };
-//
-// ===========================================================================
-xdr.enum("ThresholdIndices", {
-  thresholdMasterWeight: 0,
-  thresholdLow: 1,
-  thresholdMed: 2,
-  thresholdHigh: 3,
-});
-
-// === xdr source ============================================================
-//
-//   enum LedgerEntryType
-//   {
-//       ACCOUNT = 0,
-//       TRUSTLINE = 1,
-//       OFFER = 2,
-//       DATA = 3,
-//       CLAIMABLE_BALANCE = 4,
-//       LIQUIDITY_POOL = 5
-//   };
-//
-// ===========================================================================
-xdr.enum("LedgerEntryType", {
-  account: 0,
-  trustline: 1,
-  offer: 2,
-  data: 3,
-  claimableBalance: 4,
-  liquidityPool: 5,
-});
-
-// === xdr source ============================================================
-//
-//   struct Signer
-//   {
-//       SignerKey key;
-//       uint32 weight; // really only need 1 byte
-//   };
-//
-// ===========================================================================
-xdr.struct("Signer", [
-  ["key", xdr.lookup("SignerKey")],
-  ["weight", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum AccountFlags
-//   { // masks for each flag
-//   
-//       // Flags set on issuer accounts
-//       // TrustLines are created with authorized set to "false" requiring
-//       // the issuer to set it for each TrustLine
-//       AUTH_REQUIRED_FLAG = 0x1,
-//       // If set, the authorized flag in TrustLines can be cleared
-//       // otherwise, authorization cannot be revoked
-//       AUTH_REVOCABLE_FLAG = 0x2,
-//       // Once set, causes all AUTH_* flags to be read-only
-//       AUTH_IMMUTABLE_FLAG = 0x4,
-//       // Trustlines are created with clawback enabled set to "true",
-//       // and claimable balances created from those trustlines are created
-//       // with clawback enabled set to "true"
-//       AUTH_CLAWBACK_ENABLED_FLAG = 0x8
-//   };
-//
-// ===========================================================================
-xdr.enum("AccountFlags", {
-  authRequiredFlag: 1,
-  authRevocableFlag: 2,
-  authImmutableFlag: 4,
-  authClawbackEnabledFlag: 8,
-});
-
-// === xdr source ============================================================
-//
-//   const MASK_ACCOUNT_FLAGS = 0x7;
-//
-// ===========================================================================
-xdr.const("MASK_ACCOUNT_FLAGS", 0x7);
-
-// === xdr source ============================================================
-//
-//   const MASK_ACCOUNT_FLAGS_V17 = 0xF;
-//
-// ===========================================================================
-xdr.const("MASK_ACCOUNT_FLAGS_V17", 0xF);
-
-// === xdr source ============================================================
-//
-//   const MAX_SIGNERS = 20;
-//
-// ===========================================================================
-xdr.const("MAX_SIGNERS", 20);
-
-// === xdr source ============================================================
-//
-//   typedef AccountID* SponsorshipDescriptor;
-//
-// ===========================================================================
-xdr.typedef("SponsorshipDescriptor", xdr.option(xdr.lookup("AccountId")));
-
-// === xdr source ============================================================
-//
-//   struct AccountEntryExtensionV3
-//   {
-//       // We can use this to add more fields, or because it is first, to
-//       // change AccountEntryExtensionV3 into a union.
-//       ExtensionPoint ext;
-//   
-//       // Ledger number at which `seqNum` took on its present value.
-//       uint32 seqLedger;
-//   
-//       // Time at which `seqNum` took on its present value.
-//       TimePoint seqTime;
-//   };
-//
-// ===========================================================================
-xdr.struct("AccountEntryExtensionV3", [
-  ["ext", xdr.lookup("ExtensionPoint")],
-  ["seqLedger", xdr.lookup("Uint32")],
-  ["seqTime", xdr.lookup("TimePoint")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 3:
-//           AccountEntryExtensionV3 v3;
-//       }
-//
-// ===========================================================================
-xdr.union("AccountEntryExtensionV2Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [3, "v3"],
-  ],
-  arms: {
-    v3: xdr.lookup("AccountEntryExtensionV3"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct AccountEntryExtensionV2
-//   {
-//       uint32 numSponsored;
-//       uint32 numSponsoring;
-//       SponsorshipDescriptor signerSponsoringIDs<MAX_SIGNERS>;
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 3:
-//           AccountEntryExtensionV3 v3;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("AccountEntryExtensionV2", [
-  ["numSponsored", xdr.lookup("Uint32")],
-  ["numSponsoring", xdr.lookup("Uint32")],
-  ["signerSponsoringIDs", xdr.varArray(xdr.lookup("SponsorshipDescriptor"), xdr.lookup("MAX_SIGNERS"))],
-  ["ext", xdr.lookup("AccountEntryExtensionV2Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 2:
-//           AccountEntryExtensionV2 v2;
-//       }
-//
-// ===========================================================================
-xdr.union("AccountEntryExtensionV1Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [2, "v2"],
-  ],
-  arms: {
-    v2: xdr.lookup("AccountEntryExtensionV2"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct AccountEntryExtensionV1
-//   {
-//       Liabilities liabilities;
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 2:
-//           AccountEntryExtensionV2 v2;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("AccountEntryExtensionV1", [
-  ["liabilities", xdr.lookup("Liabilities")],
-  ["ext", xdr.lookup("AccountEntryExtensionV1Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           AccountEntryExtensionV1 v1;
-//       }
-//
-// ===========================================================================
-xdr.union("AccountEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("AccountEntryExtensionV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct AccountEntry
-//   {
-//       AccountID accountID;      // master public key for this account
-//       int64 balance;            // in stroops
-//       SequenceNumber seqNum;    // last sequence number used for this account
-//       uint32 numSubEntries;     // number of sub-entries this account has
-//                                 // drives the reserve
-//       AccountID* inflationDest; // Account to vote for during inflation
-//       uint32 flags;             // see AccountFlags
-//   
-//       string32 homeDomain; // can be used for reverse federation and memo lookup
-//   
-//       // fields used for signatures
-//       // thresholds stores unsigned bytes: [weight of master|low|medium|high]
-//       Thresholds thresholds;
-//   
-//       Signer signers<MAX_SIGNERS>; // possible signers for this account
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           AccountEntryExtensionV1 v1;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("AccountEntry", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["balance", xdr.lookup("Int64")],
-  ["seqNum", xdr.lookup("SequenceNumber")],
-  ["numSubEntries", xdr.lookup("Uint32")],
-  ["inflationDest", xdr.option(xdr.lookup("AccountId"))],
-  ["flags", xdr.lookup("Uint32")],
-  ["homeDomain", xdr.lookup("String32")],
-  ["thresholds", xdr.lookup("Thresholds")],
-  ["signers", xdr.varArray(xdr.lookup("Signer"), xdr.lookup("MAX_SIGNERS"))],
-  ["ext", xdr.lookup("AccountEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum TrustLineFlags
-//   {
-//       // issuer has authorized account to perform transactions with its credit
-//       AUTHORIZED_FLAG = 1,
-//       // issuer has authorized account to maintain and reduce liabilities for its
-//       // credit
-//       AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
-//       // issuer has specified that it may clawback its credit, and that claimable
-//       // balances created with its credit may also be clawed back
-//       TRUSTLINE_CLAWBACK_ENABLED_FLAG = 4
-//   };
-//
-// ===========================================================================
-xdr.enum("TrustLineFlags", {
-  authorizedFlag: 1,
-  authorizedToMaintainLiabilitiesFlag: 2,
-  trustlineClawbackEnabledFlag: 4,
-});
-
-// === xdr source ============================================================
-//
-//   const MASK_TRUSTLINE_FLAGS = 1;
-//
-// ===========================================================================
-xdr.const("MASK_TRUSTLINE_FLAGS", 1);
-
-// === xdr source ============================================================
-//
-//   const MASK_TRUSTLINE_FLAGS_V13 = 3;
-//
-// ===========================================================================
-xdr.const("MASK_TRUSTLINE_FLAGS_V13", 3);
-
-// === xdr source ============================================================
-//
-//   const MASK_TRUSTLINE_FLAGS_V17 = 7;
-//
-// ===========================================================================
-xdr.const("MASK_TRUSTLINE_FLAGS_V17", 7);
-
-// === xdr source ============================================================
-//
-//   enum LiquidityPoolType
-//   {
-//       LIQUIDITY_POOL_CONSTANT_PRODUCT = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("LiquidityPoolType", {
-  liquidityPoolConstantProduct: 0,
-});
-
-// === xdr source ============================================================
-//
-//   union TrustLineAsset switch (AssetType type)
-//   {
-//   case ASSET_TYPE_NATIVE: // Not credit
-//       void;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM4:
-//       AlphaNum4 alphaNum4;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM12:
-//       AlphaNum12 alphaNum12;
-//   
-//   case ASSET_TYPE_POOL_SHARE:
-//       PoolID liquidityPoolID;
-//   
-//       // add other asset types here in the future
-//   };
-//
-// ===========================================================================
-xdr.union("TrustLineAsset", {
-  switchOn: xdr.lookup("AssetType"),
-  switchName: "type",
-  switches: [
-    ["assetTypeNative", xdr.void()],
-    ["assetTypeCreditAlphanum4", "alphaNum4"],
-    ["assetTypeCreditAlphanum12", "alphaNum12"],
-    ["assetTypePoolShare", "liquidityPoolId"],
-  ],
-  arms: {
-    alphaNum4: xdr.lookup("AlphaNum4"),
-    alphaNum12: xdr.lookup("AlphaNum12"),
-    liquidityPoolId: xdr.lookup("PoolId"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TrustLineEntryExtensionV2Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TrustLineEntryExtensionV2
-//   {
-//       int32 liquidityPoolUseCount;
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TrustLineEntryExtensionV2", [
-  ["liquidityPoolUseCount", xdr.lookup("Int32")],
-  ["ext", xdr.lookup("TrustLineEntryExtensionV2Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//               {
-//               case 0:
-//                   void;
-//               case 2:
-//                   TrustLineEntryExtensionV2 v2;
-//               }
-//
-// ===========================================================================
-xdr.union("TrustLineEntryV1Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [2, "v2"],
-  ],
-  arms: {
-    v2: xdr.lookup("TrustLineEntryExtensionV2"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               Liabilities liabilities;
-//   
-//               union switch (int v)
-//               {
-//               case 0:
-//                   void;
-//               case 2:
-//                   TrustLineEntryExtensionV2 v2;
-//               }
-//               ext;
-//           }
-//
-// ===========================================================================
-xdr.struct("TrustLineEntryV1", [
-  ["liabilities", xdr.lookup("Liabilities")],
-  ["ext", xdr.lookup("TrustLineEntryV1Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           struct
-//           {
-//               Liabilities liabilities;
-//   
-//               union switch (int v)
-//               {
-//               case 0:
-//                   void;
-//               case 2:
-//                   TrustLineEntryExtensionV2 v2;
-//               }
-//               ext;
-//           } v1;
-//       }
-//
-// ===========================================================================
-xdr.union("TrustLineEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("TrustLineEntryV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TrustLineEntry
-//   {
-//       AccountID accountID;  // account this trustline belongs to
-//       TrustLineAsset asset; // type of asset (with issuer)
-//       int64 balance;        // how much of this asset the user has.
-//                             // Asset defines the unit for this;
-//   
-//       int64 limit;  // balance cannot be above this
-//       uint32 flags; // see TrustLineFlags
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           struct
-//           {
-//               Liabilities liabilities;
-//   
-//               union switch (int v)
-//               {
-//               case 0:
-//                   void;
-//               case 2:
-//                   TrustLineEntryExtensionV2 v2;
-//               }
-//               ext;
-//           } v1;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TrustLineEntry", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["asset", xdr.lookup("TrustLineAsset")],
-  ["balance", xdr.lookup("Int64")],
-  ["limit", xdr.lookup("Int64")],
-  ["flags", xdr.lookup("Uint32")],
-  ["ext", xdr.lookup("TrustLineEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum OfferEntryFlags
-//   {
-//       // an offer with this flag will not act on and take a reverse offer of equal
-//       // price
-//       PASSIVE_FLAG = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("OfferEntryFlags", {
-  passiveFlag: 1,
-});
-
-// === xdr source ============================================================
-//
-//   const MASK_OFFERENTRY_FLAGS = 1;
-//
-// ===========================================================================
-xdr.const("MASK_OFFERENTRY_FLAGS", 1);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("OfferEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct OfferEntry
-//   {
-//       AccountID sellerID;
-//       int64 offerID;
-//       Asset selling; // A
-//       Asset buying;  // B
-//       int64 amount;  // amount of A
-//   
-//       /* price for this offer:
-//           price of A in terms of B
-//           price=AmountB/AmountA=priceNumerator/priceDenominator
-//           price is after fees
-//       */
-//       Price price;
-//       uint32 flags; // see OfferEntryFlags
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("OfferEntry", [
-  ["sellerId", xdr.lookup("AccountId")],
-  ["offerId", xdr.lookup("Int64")],
-  ["selling", xdr.lookup("Asset")],
-  ["buying", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-  ["price", xdr.lookup("Price")],
-  ["flags", xdr.lookup("Uint32")],
-  ["ext", xdr.lookup("OfferEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("DataEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct DataEntry
-//   {
-//       AccountID accountID; // account this data belongs to
-//       string64 dataName;
-//       DataValue dataValue;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("DataEntry", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["dataName", xdr.lookup("String64")],
-  ["dataValue", xdr.lookup("DataValue")],
-  ["ext", xdr.lookup("DataEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum ClaimPredicateType
-//   {
-//       CLAIM_PREDICATE_UNCONDITIONAL = 0,
-//       CLAIM_PREDICATE_AND = 1,
-//       CLAIM_PREDICATE_OR = 2,
-//       CLAIM_PREDICATE_NOT = 3,
-//       CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
-//       CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimPredicateType", {
-  claimPredicateUnconditional: 0,
-  claimPredicateAnd: 1,
-  claimPredicateOr: 2,
-  claimPredicateNot: 3,
-  claimPredicateBeforeAbsoluteTime: 4,
-  claimPredicateBeforeRelativeTime: 5,
-});
-
-// === xdr source ============================================================
-//
-//   union ClaimPredicate switch (ClaimPredicateType type)
-//   {
-//   case CLAIM_PREDICATE_UNCONDITIONAL:
-//       void;
-//   case CLAIM_PREDICATE_AND:
-//       ClaimPredicate andPredicates<2>;
-//   case CLAIM_PREDICATE_OR:
-//       ClaimPredicate orPredicates<2>;
-//   case CLAIM_PREDICATE_NOT:
-//       ClaimPredicate* notPredicate;
-//   case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
-//       int64 absBefore; // Predicate will be true if closeTime < absBefore
-//   case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
-//       int64 relBefore; // Seconds since closeTime of the ledger in which the
-//                        // ClaimableBalanceEntry was created
-//   };
-//
-// ===========================================================================
-xdr.union("ClaimPredicate", {
-  switchOn: xdr.lookup("ClaimPredicateType"),
-  switchName: "type",
-  switches: [
-    ["claimPredicateUnconditional", xdr.void()],
-    ["claimPredicateAnd", "andPredicates"],
-    ["claimPredicateOr", "orPredicates"],
-    ["claimPredicateNot", "notPredicate"],
-    ["claimPredicateBeforeAbsoluteTime", "absBefore"],
-    ["claimPredicateBeforeRelativeTime", "relBefore"],
-  ],
-  arms: {
-    andPredicates: xdr.varArray(xdr.lookup("ClaimPredicate"), 2),
-    orPredicates: xdr.varArray(xdr.lookup("ClaimPredicate"), 2),
-    notPredicate: xdr.option(xdr.lookup("ClaimPredicate")),
-    absBefore: xdr.lookup("Int64"),
-    relBefore: xdr.lookup("Int64"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClaimantType
-//   {
-//       CLAIMANT_TYPE_V0 = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimantType", {
-  claimantTypeV0: 0,
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID destination;    // The account that can use this condition
-//           ClaimPredicate predicate; // Claimable if predicate is true
-//       }
-//
-// ===========================================================================
-xdr.struct("ClaimantV0", [
-  ["destination", xdr.lookup("AccountId")],
-  ["predicate", xdr.lookup("ClaimPredicate")],
-]);
-
-// === xdr source ============================================================
-//
-//   union Claimant switch (ClaimantType type)
-//   {
-//   case CLAIMANT_TYPE_V0:
-//       struct
-//       {
-//           AccountID destination;    // The account that can use this condition
-//           ClaimPredicate predicate; // Claimable if predicate is true
-//       } v0;
-//   };
-//
-// ===========================================================================
-xdr.union("Claimant", {
-  switchOn: xdr.lookup("ClaimantType"),
-  switchName: "type",
-  switches: [
-    ["claimantTypeV0", "v0"],
-  ],
-  arms: {
-    v0: xdr.lookup("ClaimantV0"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClaimableBalanceIDType
-//   {
-//       CLAIMABLE_BALANCE_ID_TYPE_V0 = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimableBalanceIdType", {
-  claimableBalanceIdTypeV0: 0,
-});
-
-// === xdr source ============================================================
-//
-//   union ClaimableBalanceID switch (ClaimableBalanceIDType type)
-//   {
-//   case CLAIMABLE_BALANCE_ID_TYPE_V0:
-//       Hash v0;
-//   };
-//
-// ===========================================================================
-xdr.union("ClaimableBalanceId", {
-  switchOn: xdr.lookup("ClaimableBalanceIdType"),
-  switchName: "type",
-  switches: [
-    ["claimableBalanceIdTypeV0", "v0"],
-  ],
-  arms: {
-    v0: xdr.lookup("Hash"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClaimableBalanceFlags
-//   {
-//       // If set, the issuer account of the asset held by the claimable balance may
-//       // clawback the claimable balance
-//       CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG = 0x1
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimableBalanceFlags", {
-  claimableBalanceClawbackEnabledFlag: 1,
-});
-
-// === xdr source ============================================================
-//
-//   const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1;
-//
-// ===========================================================================
-xdr.const("MASK_CLAIMABLE_BALANCE_FLAGS", 0x1);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("ClaimableBalanceEntryExtensionV1Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ClaimableBalanceEntryExtensionV1
-//   {
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   
-//       uint32 flags; // see ClaimableBalanceFlags
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimableBalanceEntryExtensionV1", [
-  ["ext", xdr.lookup("ClaimableBalanceEntryExtensionV1Ext")],
-  ["flags", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           ClaimableBalanceEntryExtensionV1 v1;
-//       }
-//
-// ===========================================================================
-xdr.union("ClaimableBalanceEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("ClaimableBalanceEntryExtensionV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ClaimableBalanceEntry
-//   {
-//       // Unique identifier for this ClaimableBalanceEntry
-//       ClaimableBalanceID balanceID;
-//   
-//       // List of claimants with associated predicate
-//       Claimant claimants<10>;
-//   
-//       // Any asset including native
-//       Asset asset;
-//   
-//       // Amount of asset
-//       int64 amount;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           ClaimableBalanceEntryExtensionV1 v1;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimableBalanceEntry", [
-  ["balanceId", xdr.lookup("ClaimableBalanceId")],
-  ["claimants", xdr.varArray(xdr.lookup("Claimant"), 10)],
-  ["asset", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-  ["ext", xdr.lookup("ClaimableBalanceEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LiquidityPoolConstantProductParameters
-//   {
-//       Asset assetA; // assetA < assetB
-//       Asset assetB;
-//       int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
-//   };
-//
-// ===========================================================================
-xdr.struct("LiquidityPoolConstantProductParameters", [
-  ["assetA", xdr.lookup("Asset")],
-  ["assetB", xdr.lookup("Asset")],
-  ["fee", xdr.lookup("Int32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               LiquidityPoolConstantProductParameters params;
-//   
-//               int64 reserveA;        // amount of A in the pool
-//               int64 reserveB;        // amount of B in the pool
-//               int64 totalPoolShares; // total number of pool shares issued
-//               int64 poolSharesTrustLineCount; // number of trust lines for the
-//                                               // associated pool shares
-//           }
-//
-// ===========================================================================
-xdr.struct("LiquidityPoolEntryConstantProduct", [
-  ["params", xdr.lookup("LiquidityPoolConstantProductParameters")],
-  ["reserveA", xdr.lookup("Int64")],
-  ["reserveB", xdr.lookup("Int64")],
-  ["totalPoolShares", xdr.lookup("Int64")],
-  ["poolSharesTrustLineCount", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (LiquidityPoolType type)
-//       {
-//       case LIQUIDITY_POOL_CONSTANT_PRODUCT:
-//           struct
-//           {
-//               LiquidityPoolConstantProductParameters params;
-//   
-//               int64 reserveA;        // amount of A in the pool
-//               int64 reserveB;        // amount of B in the pool
-//               int64 totalPoolShares; // total number of pool shares issued
-//               int64 poolSharesTrustLineCount; // number of trust lines for the
-//                                               // associated pool shares
-//           } constantProduct;
-//       }
-//
-// ===========================================================================
-xdr.union("LiquidityPoolEntryBody", {
-  switchOn: xdr.lookup("LiquidityPoolType"),
-  switchName: "type",
-  switches: [
-    ["liquidityPoolConstantProduct", "constantProduct"],
-  ],
-  arms: {
-    constantProduct: xdr.lookup("LiquidityPoolEntryConstantProduct"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LiquidityPoolEntry
-//   {
-//       PoolID liquidityPoolID;
-//   
-//       union switch (LiquidityPoolType type)
-//       {
-//       case LIQUIDITY_POOL_CONSTANT_PRODUCT:
-//           struct
-//           {
-//               LiquidityPoolConstantProductParameters params;
-//   
-//               int64 reserveA;        // amount of A in the pool
-//               int64 reserveB;        // amount of B in the pool
-//               int64 totalPoolShares; // total number of pool shares issued
-//               int64 poolSharesTrustLineCount; // number of trust lines for the
-//                                               // associated pool shares
-//           } constantProduct;
-//       }
-//       body;
-//   };
-//
-// ===========================================================================
-xdr.struct("LiquidityPoolEntry", [
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-  ["body", xdr.lookup("LiquidityPoolEntryBody")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerEntryExtensionV1Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerEntryExtensionV1
-//   {
-//       SponsorshipDescriptor sponsoringID;
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerEntryExtensionV1", [
-  ["sponsoringId", xdr.lookup("SponsorshipDescriptor")],
-  ["ext", xdr.lookup("LedgerEntryExtensionV1Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (LedgerEntryType type)
-//       {
-//       case ACCOUNT:
-//           AccountEntry account;
-//       case TRUSTLINE:
-//           TrustLineEntry trustLine;
-//       case OFFER:
-//           OfferEntry offer;
-//       case DATA:
-//           DataEntry data;
-//       case CLAIMABLE_BALANCE:
-//           ClaimableBalanceEntry claimableBalance;
-//       case LIQUIDITY_POOL:
-//           LiquidityPoolEntry liquidityPool;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerEntryData", {
-  switchOn: xdr.lookup("LedgerEntryType"),
-  switchName: "type",
-  switches: [
-    ["account", "account"],
-    ["trustline", "trustLine"],
-    ["offer", "offer"],
-    ["data", "data"],
-    ["claimableBalance", "claimableBalance"],
-    ["liquidityPool", "liquidityPool"],
-  ],
-  arms: {
-    account: xdr.lookup("AccountEntry"),
-    trustLine: xdr.lookup("TrustLineEntry"),
-    offer: xdr.lookup("OfferEntry"),
-    data: xdr.lookup("DataEntry"),
-    claimableBalance: xdr.lookup("ClaimableBalanceEntry"),
-    liquidityPool: xdr.lookup("LiquidityPoolEntry"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           LedgerEntryExtensionV1 v1;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("LedgerEntryExtensionV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerEntry
-//   {
-//       uint32 lastModifiedLedgerSeq; // ledger the LedgerEntry was last changed
-//   
-//       union switch (LedgerEntryType type)
-//       {
-//       case ACCOUNT:
-//           AccountEntry account;
-//       case TRUSTLINE:
-//           TrustLineEntry trustLine;
-//       case OFFER:
-//           OfferEntry offer;
-//       case DATA:
-//           DataEntry data;
-//       case CLAIMABLE_BALANCE:
-//           ClaimableBalanceEntry claimableBalance;
-//       case LIQUIDITY_POOL:
-//           LiquidityPoolEntry liquidityPool;
-//       }
-//       data;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           LedgerEntryExtensionV1 v1;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerEntry", [
-  ["lastModifiedLedgerSeq", xdr.lookup("Uint32")],
-  ["data", xdr.lookup("LedgerEntryData")],
-  ["ext", xdr.lookup("LedgerEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID accountID;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyAccount", [
-  ["accountId", xdr.lookup("AccountId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID accountID;
-//           TrustLineAsset asset;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyTrustLine", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["asset", xdr.lookup("TrustLineAsset")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID sellerID;
-//           int64 offerID;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyOffer", [
-  ["sellerId", xdr.lookup("AccountId")],
-  ["offerId", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID accountID;
-//           string64 dataName;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyData", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["dataName", xdr.lookup("String64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           ClaimableBalanceID balanceID;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyClaimableBalance", [
-  ["balanceId", xdr.lookup("ClaimableBalanceId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           PoolID liquidityPoolID;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyLiquidityPool", [
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-]);
-
-// === xdr source ============================================================
-//
-//   union LedgerKey switch (LedgerEntryType type)
-//   {
-//   case ACCOUNT:
-//       struct
-//       {
-//           AccountID accountID;
-//       } account;
-//   
-//   case TRUSTLINE:
-//       struct
-//       {
-//           AccountID accountID;
-//           TrustLineAsset asset;
-//       } trustLine;
-//   
-//   case OFFER:
-//       struct
-//       {
-//           AccountID sellerID;
-//           int64 offerID;
-//       } offer;
-//   
-//   case DATA:
-//       struct
-//       {
-//           AccountID accountID;
-//           string64 dataName;
-//       } data;
-//   
-//   case CLAIMABLE_BALANCE:
-//       struct
-//       {
-//           ClaimableBalanceID balanceID;
-//       } claimableBalance;
-//   
-//   case LIQUIDITY_POOL:
-//       struct
-//       {
-//           PoolID liquidityPoolID;
-//       } liquidityPool;
-//   };
-//
-// ===========================================================================
-xdr.union("LedgerKey", {
-  switchOn: xdr.lookup("LedgerEntryType"),
-  switchName: "type",
-  switches: [
-    ["account", "account"],
-    ["trustline", "trustLine"],
-    ["offer", "offer"],
-    ["data", "data"],
-    ["claimableBalance", "claimableBalance"],
-    ["liquidityPool", "liquidityPool"],
-  ],
-  arms: {
-    account: xdr.lookup("LedgerKeyAccount"),
-    trustLine: xdr.lookup("LedgerKeyTrustLine"),
-    offer: xdr.lookup("LedgerKeyOffer"),
-    data: xdr.lookup("LedgerKeyData"),
-    claimableBalance: xdr.lookup("LedgerKeyClaimableBalance"),
-    liquidityPool: xdr.lookup("LedgerKeyLiquidityPool"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum EnvelopeType
-//   {
-//       ENVELOPE_TYPE_TX_V0 = 0,
-//       ENVELOPE_TYPE_SCP = 1,
-//       ENVELOPE_TYPE_TX = 2,
-//       ENVELOPE_TYPE_AUTH = 3,
-//       ENVELOPE_TYPE_SCPVALUE = 4,
-//       ENVELOPE_TYPE_TX_FEE_BUMP = 5,
-//       ENVELOPE_TYPE_OP_ID = 6,
-//       ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7
-//   };
-//
-// ===========================================================================
-xdr.enum("EnvelopeType", {
-  envelopeTypeTxV0: 0,
-  envelopeTypeScp: 1,
-  envelopeTypeTx: 2,
-  envelopeTypeAuth: 3,
-  envelopeTypeScpvalue: 4,
-  envelopeTypeTxFeeBump: 5,
-  envelopeTypeOpId: 6,
-  envelopeTypePoolRevokeOpId: 7,
-});
-
-// === xdr source ============================================================
-//
-//   typedef opaque UpgradeType<128>;
-//
-// ===========================================================================
-xdr.typedef("UpgradeType", xdr.varOpaque(128));
-
-// === xdr source ============================================================
-//
-//   enum StellarValueType
-//   {
-//       STELLAR_VALUE_BASIC = 0,
-//       STELLAR_VALUE_SIGNED = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("StellarValueType", {
-  stellarValueBasic: 0,
-  stellarValueSigned: 1,
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerCloseValueSignature
-//   {
-//       NodeID nodeID;       // which node introduced the value
-//       Signature signature; // nodeID's signature
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerCloseValueSignature", [
-  ["nodeId", xdr.lookup("NodeId")],
-  ["signature", xdr.lookup("Signature")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (StellarValueType v)
-//       {
-//       case STELLAR_VALUE_BASIC:
-//           void;
-//       case STELLAR_VALUE_SIGNED:
-//           LedgerCloseValueSignature lcValueSignature;
-//       }
-//
-// ===========================================================================
-xdr.union("StellarValueExt", {
-  switchOn: xdr.lookup("StellarValueType"),
-  switchName: "v",
-  switches: [
-    ["stellarValueBasic", xdr.void()],
-    ["stellarValueSigned", "lcValueSignature"],
-  ],
-  arms: {
-    lcValueSignature: xdr.lookup("LedgerCloseValueSignature"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct StellarValue
-//   {
-//       Hash txSetHash;      // transaction set to apply to previous ledger
-//       TimePoint closeTime; // network close time
-//   
-//       // upgrades to apply to the previous ledger (usually empty)
-//       // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
-//       // unknown steps during consensus if needed.
-//       // see notes below on 'LedgerUpgrade' for more detail
-//       // max size is dictated by number of upgrade types (+ room for future)
-//       UpgradeType upgrades<6>;
-//   
-//       // reserved for future use
-//       union switch (StellarValueType v)
-//       {
-//       case STELLAR_VALUE_BASIC:
-//           void;
-//       case STELLAR_VALUE_SIGNED:
-//           LedgerCloseValueSignature lcValueSignature;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("StellarValue", [
-  ["txSetHash", xdr.lookup("Hash")],
-  ["closeTime", xdr.lookup("TimePoint")],
-  ["upgrades", xdr.varArray(xdr.lookup("UpgradeType"), 6)],
-  ["ext", xdr.lookup("StellarValueExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   const MASK_LEDGER_HEADER_FLAGS = 0x7;
-//
-// ===========================================================================
-xdr.const("MASK_LEDGER_HEADER_FLAGS", 0x7);
-
-// === xdr source ============================================================
-//
-//   enum LedgerHeaderFlags
-//   {
-//       DISABLE_LIQUIDITY_POOL_TRADING_FLAG = 0x1,
-//       DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG = 0x2,
-//       DISABLE_LIQUIDITY_POOL_WITHDRAWAL_FLAG = 0x4
-//   };
-//
-// ===========================================================================
-xdr.enum("LedgerHeaderFlags", {
-  disableLiquidityPoolTradingFlag: 1,
-  disableLiquidityPoolDepositFlag: 2,
-  disableLiquidityPoolWithdrawalFlag: 4,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerHeaderExtensionV1Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerHeaderExtensionV1
-//   {
-//       uint32 flags; // LedgerHeaderFlags
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerHeaderExtensionV1", [
-  ["flags", xdr.lookup("Uint32")],
-  ["ext", xdr.lookup("LedgerHeaderExtensionV1Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           LedgerHeaderExtensionV1 v1;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerHeaderExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("LedgerHeaderExtensionV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerHeader
-//   {
-//       uint32 ledgerVersion;    // the protocol version of the ledger
-//       Hash previousLedgerHash; // hash of the previous ledger header
-//       StellarValue scpValue;   // what consensus agreed to
-//       Hash txSetResultHash;    // the TransactionResultSet that led to this ledger
-//       Hash bucketListHash;     // hash of the ledger state
-//   
-//       uint32 ledgerSeq; // sequence number of this ledger
-//   
-//       int64 totalCoins; // total number of stroops in existence.
-//                         // 10,000,000 stroops in 1 XLM
-//   
-//       int64 feePool;       // fees burned since last inflation run
-//       uint32 inflationSeq; // inflation sequence number
-//   
-//       uint64 idPool; // last used global ID, used for generating objects
-//   
-//       uint32 baseFee;     // base fee per operation in stroops
-//       uint32 baseReserve; // account base reserve in stroops
-//   
-//       uint32 maxTxSetSize; // maximum size a transaction set can be
-//   
-//       Hash skipList[4]; // hashes of ledgers in the past. allows you to jump back
-//                         // in time without walking the chain back ledger by ledger
-//                         // each slot contains the oldest ledger that is mod of
-//                         // either 50  5000  50000 or 500000 depending on index
-//                         // skipList[0] mod(50), skipList[1] mod(5000), etc
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           LedgerHeaderExtensionV1 v1;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerHeader", [
-  ["ledgerVersion", xdr.lookup("Uint32")],
-  ["previousLedgerHash", xdr.lookup("Hash")],
-  ["scpValue", xdr.lookup("StellarValue")],
-  ["txSetResultHash", xdr.lookup("Hash")],
-  ["bucketListHash", xdr.lookup("Hash")],
-  ["ledgerSeq", xdr.lookup("Uint32")],
-  ["totalCoins", xdr.lookup("Int64")],
-  ["feePool", xdr.lookup("Int64")],
-  ["inflationSeq", xdr.lookup("Uint32")],
-  ["idPool", xdr.lookup("Uint64")],
-  ["baseFee", xdr.lookup("Uint32")],
-  ["baseReserve", xdr.lookup("Uint32")],
-  ["maxTxSetSize", xdr.lookup("Uint32")],
-  ["skipList", xdr.array(xdr.lookup("Hash"), 4)],
-  ["ext", xdr.lookup("LedgerHeaderExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum LedgerUpgradeType
-//   {
-//       LEDGER_UPGRADE_VERSION = 1,
-//       LEDGER_UPGRADE_BASE_FEE = 2,
-//       LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3,
-//       LEDGER_UPGRADE_BASE_RESERVE = 4,
-//       LEDGER_UPGRADE_FLAGS = 5
-//   };
-//
-// ===========================================================================
-xdr.enum("LedgerUpgradeType", {
-  ledgerUpgradeVersion: 1,
-  ledgerUpgradeBaseFee: 2,
-  ledgerUpgradeMaxTxSetSize: 3,
-  ledgerUpgradeBaseReserve: 4,
-  ledgerUpgradeFlags: 5,
-});
-
-// === xdr source ============================================================
-//
-//   union LedgerUpgrade switch (LedgerUpgradeType type)
-//   {
-//   case LEDGER_UPGRADE_VERSION:
-//       uint32 newLedgerVersion; // update ledgerVersion
-//   case LEDGER_UPGRADE_BASE_FEE:
-//       uint32 newBaseFee; // update baseFee
-//   case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
-//       uint32 newMaxTxSetSize; // update maxTxSetSize
-//   case LEDGER_UPGRADE_BASE_RESERVE:
-//       uint32 newBaseReserve; // update baseReserve
-//   case LEDGER_UPGRADE_FLAGS:
-//       uint32 newFlags; // update flags
-//   };
-//
-// ===========================================================================
-xdr.union("LedgerUpgrade", {
-  switchOn: xdr.lookup("LedgerUpgradeType"),
-  switchName: "type",
-  switches: [
-    ["ledgerUpgradeVersion", "newLedgerVersion"],
-    ["ledgerUpgradeBaseFee", "newBaseFee"],
-    ["ledgerUpgradeMaxTxSetSize", "newMaxTxSetSize"],
-    ["ledgerUpgradeBaseReserve", "newBaseReserve"],
-    ["ledgerUpgradeFlags", "newFlags"],
-  ],
-  arms: {
-    newLedgerVersion: xdr.lookup("Uint32"),
-    newBaseFee: xdr.lookup("Uint32"),
-    newMaxTxSetSize: xdr.lookup("Uint32"),
-    newBaseReserve: xdr.lookup("Uint32"),
-    newFlags: xdr.lookup("Uint32"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum BucketEntryType
-//   {
-//       METAENTRY =
-//           -1, // At-and-after protocol 11: bucket metadata, should come first.
-//       LIVEENTRY = 0, // Before protocol 11: created-or-updated;
-//                      // At-and-after protocol 11: only updated.
-//       DEADENTRY = 1,
-//       INITENTRY = 2 // At-and-after protocol 11: only created.
-//   };
-//
-// ===========================================================================
-xdr.enum("BucketEntryType", {
-  metaentry: -1,
-  liveentry: 0,
-  deadentry: 1,
-  initentry: 2,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("BucketMetadataExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct BucketMetadata
-//   {
-//       // Indicates the protocol version used to create / merge this bucket.
-//       uint32 ledgerVersion;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("BucketMetadata", [
-  ["ledgerVersion", xdr.lookup("Uint32")],
-  ["ext", xdr.lookup("BucketMetadataExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   union BucketEntry switch (BucketEntryType type)
-//   {
-//   case LIVEENTRY:
-//   case INITENTRY:
-//       LedgerEntry liveEntry;
-//   
-//   case DEADENTRY:
-//       LedgerKey deadEntry;
-//   case METAENTRY:
-//       BucketMetadata metaEntry;
-//   };
-//
-// ===========================================================================
-xdr.union("BucketEntry", {
-  switchOn: xdr.lookup("BucketEntryType"),
-  switchName: "type",
-  switches: [
-    ["liveentry", "liveEntry"],
-    ["initentry", "liveEntry"],
-    ["deadentry", "deadEntry"],
-    ["metaentry", "metaEntry"],
-  ],
-  arms: {
-    liveEntry: xdr.lookup("LedgerEntry"),
-    deadEntry: xdr.lookup("LedgerKey"),
-    metaEntry: xdr.lookup("BucketMetadata"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum TxSetComponentType
-//   {
-//     // txs with effective fee <= bid derived from a base fee (if any).
-//     // If base fee is not specified, no discount is applied.
-//     TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("TxSetComponentType", {
-  txsetCompTxsMaybeDiscountedFee: 0,
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//     {
-//       int64* baseFee;
-//       TransactionEnvelope txs<>;
-//     }
-//
-// ===========================================================================
-xdr.struct("TxSetComponentTxsMaybeDiscountedFee", [
-  ["baseFee", xdr.option(xdr.lookup("Int64"))],
-  ["txes", xdr.varArray(xdr.lookup("TransactionEnvelope"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union TxSetComponent switch (TxSetComponentType type)
-//   {
-//   case TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE:
-//     struct
-//     {
-//       int64* baseFee;
-//       TransactionEnvelope txs<>;
-//     } txsMaybeDiscountedFee;
-//   };
-//
-// ===========================================================================
-xdr.union("TxSetComponent", {
-  switchOn: xdr.lookup("TxSetComponentType"),
-  switchName: "type",
-  switches: [
-    ["txsetCompTxsMaybeDiscountedFee", "txsMaybeDiscountedFee"],
-  ],
-  arms: {
-    txsMaybeDiscountedFee: xdr.lookup("TxSetComponentTxsMaybeDiscountedFee"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union TransactionPhase switch (int v)
-//   {
-//   case 0:
-//       TxSetComponent v0Components<>;
-//   };
-//
-// ===========================================================================
-xdr.union("TransactionPhase", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, "v0Components"],
-  ],
-  arms: {
-    v0Components: xdr.varArray(xdr.lookup("TxSetComponent"), 2147483647),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionSet
-//   {
-//       Hash previousLedgerHash;
-//       TransactionEnvelope txs<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionSet", [
-  ["previousLedgerHash", xdr.lookup("Hash")],
-  ["txes", xdr.varArray(xdr.lookup("TransactionEnvelope"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionSetV1
-//   {
-//       Hash previousLedgerHash;
-//       TransactionPhase phases<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionSetV1", [
-  ["previousLedgerHash", xdr.lookup("Hash")],
-  ["phases", xdr.varArray(xdr.lookup("TransactionPhase"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union GeneralizedTransactionSet switch (int v)
-//   {
-//   // We consider the legacy TransactionSet to be v0.
-//   case 1:
-//       TransactionSetV1 v1TxSet;
-//   };
-//
-// ===========================================================================
-xdr.union("GeneralizedTransactionSet", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [1, "v1TxSet"],
-  ],
-  arms: {
-    v1TxSet: xdr.lookup("TransactionSetV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionResultPair
-//   {
-//       Hash transactionHash;
-//       TransactionResult result; // result for the transaction
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResultPair", [
-  ["transactionHash", xdr.lookup("Hash")],
-  ["result", xdr.lookup("TransactionResult")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionResultSet
-//   {
-//       TransactionResultPair results<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResultSet", [
-  ["results", xdr.varArray(xdr.lookup("TransactionResultPair"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           GeneralizedTransactionSet generalizedTxSet;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionHistoryEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "generalizedTxSet"],
-  ],
-  arms: {
-    generalizedTxSet: xdr.lookup("GeneralizedTransactionSet"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionHistoryEntry
-//   {
-//       uint32 ledgerSeq;
-//       TransactionSet txSet;
-//   
-//       // when v != 0, txSet must be empty
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           GeneralizedTransactionSet generalizedTxSet;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionHistoryEntry", [
-  ["ledgerSeq", xdr.lookup("Uint32")],
-  ["txSet", xdr.lookup("TransactionSet")],
-  ["ext", xdr.lookup("TransactionHistoryEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionHistoryResultEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionHistoryResultEntry
-//   {
-//       uint32 ledgerSeq;
-//       TransactionResultSet txResultSet;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionHistoryResultEntry", [
-  ["ledgerSeq", xdr.lookup("Uint32")],
-  ["txResultSet", xdr.lookup("TransactionResultSet")],
-  ["ext", xdr.lookup("TransactionHistoryResultEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerHeaderHistoryEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerHeaderHistoryEntry
-//   {
-//       Hash hash;
-//       LedgerHeader header;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerHeaderHistoryEntry", [
-  ["hash", xdr.lookup("Hash")],
-  ["header", xdr.lookup("LedgerHeader")],
-  ["ext", xdr.lookup("LedgerHeaderHistoryEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LedgerSCPMessages
-//   {
-//       uint32 ledgerSeq;
-//       SCPEnvelope messages<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerScpMessages", [
-  ["ledgerSeq", xdr.lookup("Uint32")],
-  ["messages", xdr.varArray(xdr.lookup("ScpEnvelope"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCPHistoryEntryV0
-//   {
-//       SCPQuorumSet quorumSets<>; // additional quorum sets used by ledgerMessages
-//       LedgerSCPMessages ledgerMessages;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpHistoryEntryV0", [
-  ["quorumSets", xdr.varArray(xdr.lookup("ScpQuorumSet"), 2147483647)],
-  ["ledgerMessages", xdr.lookup("LedgerScpMessages")],
-]);
-
-// === xdr source ============================================================
-//
-//   union SCPHistoryEntry switch (int v)
-//   {
-//   case 0:
-//       SCPHistoryEntryV0 v0;
-//   };
-//
-// ===========================================================================
-xdr.union("ScpHistoryEntry", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, "v0"],
-  ],
-  arms: {
-    v0: xdr.lookup("ScpHistoryEntryV0"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum LedgerEntryChangeType
-//   {
-//       LEDGER_ENTRY_CREATED = 0, // entry was added to the ledger
-//       LEDGER_ENTRY_UPDATED = 1, // entry was modified in the ledger
-//       LEDGER_ENTRY_REMOVED = 2, // entry was removed from the ledger
-//       LEDGER_ENTRY_STATE = 3    // value of the entry
-//   };
-//
-// ===========================================================================
-xdr.enum("LedgerEntryChangeType", {
-  ledgerEntryCreated: 0,
-  ledgerEntryUpdated: 1,
-  ledgerEntryRemoved: 2,
-  ledgerEntryState: 3,
-});
-
-// === xdr source ============================================================
-//
-//   union LedgerEntryChange switch (LedgerEntryChangeType type)
-//   {
-//   case LEDGER_ENTRY_CREATED:
-//       LedgerEntry created;
-//   case LEDGER_ENTRY_UPDATED:
-//       LedgerEntry updated;
-//   case LEDGER_ENTRY_REMOVED:
-//       LedgerKey removed;
-//   case LEDGER_ENTRY_STATE:
-//       LedgerEntry state;
-//   };
-//
-// ===========================================================================
-xdr.union("LedgerEntryChange", {
-  switchOn: xdr.lookup("LedgerEntryChangeType"),
-  switchName: "type",
-  switches: [
-    ["ledgerEntryCreated", "created"],
-    ["ledgerEntryUpdated", "updated"],
-    ["ledgerEntryRemoved", "removed"],
-    ["ledgerEntryState", "state"],
-  ],
-  arms: {
-    created: xdr.lookup("LedgerEntry"),
-    updated: xdr.lookup("LedgerEntry"),
-    removed: xdr.lookup("LedgerKey"),
-    state: xdr.lookup("LedgerEntry"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   typedef LedgerEntryChange LedgerEntryChanges<>;
-//
-// ===========================================================================
-xdr.typedef("LedgerEntryChanges", xdr.varArray(xdr.lookup("LedgerEntryChange"), 2147483647));
-
-// === xdr source ============================================================
-//
-//   struct OperationMeta
-//   {
-//       LedgerEntryChanges changes;
-//   };
-//
-// ===========================================================================
-xdr.struct("OperationMeta", [
-  ["changes", xdr.lookup("LedgerEntryChanges")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionMetaV1
-//   {
-//       LedgerEntryChanges txChanges; // tx level changes if any
-//       OperationMeta operations<>;   // meta for each operation
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionMetaV1", [
-  ["txChanges", xdr.lookup("LedgerEntryChanges")],
-  ["operations", xdr.varArray(xdr.lookup("OperationMeta"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionMetaV2
-//   {
-//       LedgerEntryChanges txChangesBefore; // tx level changes before operations
-//                                           // are applied if any
-//       OperationMeta operations<>;         // meta for each operation
-//       LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
-//                                           // applied if any
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionMetaV2", [
-  ["txChangesBefore", xdr.lookup("LedgerEntryChanges")],
-  ["operations", xdr.varArray(xdr.lookup("OperationMeta"), 2147483647)],
-  ["txChangesAfter", xdr.lookup("LedgerEntryChanges")],
-]);
-
-// === xdr source ============================================================
-//
-//   union TransactionMeta switch (int v)
-//   {
-//   case 0:
-//       OperationMeta operations<>;
-//   case 1:
-//       TransactionMetaV1 v1;
-//   case 2:
-//       TransactionMetaV2 v2;
-//   };
-//
-// ===========================================================================
-xdr.union("TransactionMeta", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, "operations"],
-    [1, "v1"],
-    [2, "v2"],
-  ],
-  arms: {
-    operations: xdr.varArray(xdr.lookup("OperationMeta"), 2147483647),
-    v1: xdr.lookup("TransactionMetaV1"),
-    v2: xdr.lookup("TransactionMetaV2"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionResultMeta
-//   {
-//       TransactionResultPair result;
-//       LedgerEntryChanges feeProcessing;
-//       TransactionMeta txApplyProcessing;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResultMeta", [
-  ["result", xdr.lookup("TransactionResultPair")],
-  ["feeProcessing", xdr.lookup("LedgerEntryChanges")],
-  ["txApplyProcessing", xdr.lookup("TransactionMeta")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct UpgradeEntryMeta
-//   {
-//       LedgerUpgrade upgrade;
-//       LedgerEntryChanges changes;
-//   };
-//
-// ===========================================================================
-xdr.struct("UpgradeEntryMeta", [
-  ["upgrade", xdr.lookup("LedgerUpgrade")],
-  ["changes", xdr.lookup("LedgerEntryChanges")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LedgerCloseMetaV0
-//   {
-//       LedgerHeaderHistoryEntry ledgerHeader;
-//       // NB: txSet is sorted in "Hash order"
-//       TransactionSet txSet;
-//   
-//       // NB: transactions are sorted in apply order here
-//       // fees for all transactions are processed first
-//       // followed by applying transactions
-//       TransactionResultMeta txProcessing<>;
-//   
-//       // upgrades are applied last
-//       UpgradeEntryMeta upgradesProcessing<>;
-//   
-//       // other misc information attached to the ledger close
-//       SCPHistoryEntry scpInfo<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerCloseMetaV0", [
-  ["ledgerHeader", xdr.lookup("LedgerHeaderHistoryEntry")],
-  ["txSet", xdr.lookup("TransactionSet")],
-  ["txProcessing", xdr.varArray(xdr.lookup("TransactionResultMeta"), 2147483647)],
-  ["upgradesProcessing", xdr.varArray(xdr.lookup("UpgradeEntryMeta"), 2147483647)],
-  ["scpInfo", xdr.varArray(xdr.lookup("ScpHistoryEntry"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LedgerCloseMetaV1
-//   {
-//       LedgerHeaderHistoryEntry ledgerHeader;
-//   
-//       GeneralizedTransactionSet txSet;
-//   
-//       // NB: transactions are sorted in apply order here
-//       // fees for all transactions are processed first
-//       // followed by applying transactions
-//       TransactionResultMeta txProcessing<>;
-//   
-//       // upgrades are applied last
-//       UpgradeEntryMeta upgradesProcessing<>;
-//   
-//       // other misc information attached to the ledger close
-//       SCPHistoryEntry scpInfo<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerCloseMetaV1", [
-  ["ledgerHeader", xdr.lookup("LedgerHeaderHistoryEntry")],
-  ["txSet", xdr.lookup("GeneralizedTransactionSet")],
-  ["txProcessing", xdr.varArray(xdr.lookup("TransactionResultMeta"), 2147483647)],
-  ["upgradesProcessing", xdr.varArray(xdr.lookup("UpgradeEntryMeta"), 2147483647)],
-  ["scpInfo", xdr.varArray(xdr.lookup("ScpHistoryEntry"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union LedgerCloseMeta switch (int v)
-//   {
-//   case 0:
-//       LedgerCloseMetaV0 v0;
-//   case 1:
-//       LedgerCloseMetaV1 v1;
-//   };
-//
-// ===========================================================================
-xdr.union("LedgerCloseMeta", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, "v0"],
-    [1, "v1"],
-  ],
-  arms: {
-    v0: xdr.lookup("LedgerCloseMetaV0"),
-    v1: xdr.lookup("LedgerCloseMetaV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ErrorCode
-//   {
-//       ERR_MISC = 0, // Unspecific error
-//       ERR_DATA = 1, // Malformed data
-//       ERR_CONF = 2, // Misconfiguration error
-//       ERR_AUTH = 3, // Authentication failure
-//       ERR_LOAD = 4  // System overloaded
-//   };
-//
-// ===========================================================================
-xdr.enum("ErrorCode", {
-  errMisc: 0,
-  errData: 1,
-  errConf: 2,
-  errAuth: 3,
-  errLoad: 4,
-});
-
-// === xdr source ============================================================
-//
-//   struct Error
-//   {
-//       ErrorCode code;
-//       string msg<100>;
-//   };
-//
-// ===========================================================================
-xdr.struct("Error", [
-  ["code", xdr.lookup("ErrorCode")],
-  ["msg", xdr.string(100)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SendMore
-//   {
-//       uint32 numMessages;
-//   };
-//
-// ===========================================================================
-xdr.struct("SendMore", [
-  ["numMessages", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct AuthCert
-//   {
-//       Curve25519Public pubkey;
-//       uint64 expiration;
-//       Signature sig;
-//   };
-//
-// ===========================================================================
-xdr.struct("AuthCert", [
-  ["pubkey", xdr.lookup("Curve25519Public")],
-  ["expiration", xdr.lookup("Uint64")],
-  ["sig", xdr.lookup("Signature")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct Hello
-//   {
-//       uint32 ledgerVersion;
-//       uint32 overlayVersion;
-//       uint32 overlayMinVersion;
-//       Hash networkID;
-//       string versionStr<100>;
-//       int listeningPort;
-//       NodeID peerID;
-//       AuthCert cert;
-//       uint256 nonce;
-//   };
-//
-// ===========================================================================
-xdr.struct("Hello", [
-  ["ledgerVersion", xdr.lookup("Uint32")],
-  ["overlayVersion", xdr.lookup("Uint32")],
-  ["overlayMinVersion", xdr.lookup("Uint32")],
-  ["networkId", xdr.lookup("Hash")],
-  ["versionStr", xdr.string(100)],
-  ["listeningPort", xdr.int()],
-  ["peerId", xdr.lookup("NodeId")],
-  ["cert", xdr.lookup("AuthCert")],
-  ["nonce", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   const AUTH_MSG_FLAG_PULL_MODE_REQUESTED = 100;
-//
-// ===========================================================================
-xdr.const("AUTH_MSG_FLAG_PULL_MODE_REQUESTED", 100);
-
-// === xdr source ============================================================
-//
-//   struct Auth
-//   {
-//       int flags;
-//   };
-//
-// ===========================================================================
-xdr.struct("Auth", [
-  ["flags", xdr.int()],
-]);
-
-// === xdr source ============================================================
-//
-//   enum IPAddrType
-//   {
-//       IPv4 = 0,
-//       IPv6 = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("IpAddrType", {
-  iPv4: 0,
-  iPv6: 1,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (IPAddrType type)
-//       {
-//       case IPv4:
-//           opaque ipv4[4];
-//       case IPv6:
-//           opaque ipv6[16];
-//       }
-//
-// ===========================================================================
-xdr.union("PeerAddressIp", {
-  switchOn: xdr.lookup("IpAddrType"),
-  switchName: "type",
-  switches: [
-    ["iPv4", "ipv4"],
-    ["iPv6", "ipv6"],
-  ],
-  arms: {
-    ipv4: xdr.opaque(4),
-    ipv6: xdr.opaque(16),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct PeerAddress
-//   {
-//       union switch (IPAddrType type)
-//       {
-//       case IPv4:
-//           opaque ipv4[4];
-//       case IPv6:
-//           opaque ipv6[16];
-//       }
-//       ip;
-//       uint32 port;
-//       uint32 numFailures;
-//   };
-//
-// ===========================================================================
-xdr.struct("PeerAddress", [
-  ["ip", xdr.lookup("PeerAddressIp")],
-  ["port", xdr.lookup("Uint32")],
-  ["numFailures", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum MessageType
-//   {
-//       ERROR_MSG = 0,
-//       AUTH = 2,
-//       DONT_HAVE = 3,
-//   
-//       GET_PEERS = 4, // gets a list of peers this guy knows about
-//       PEERS = 5,
-//   
-//       GET_TX_SET = 6, // gets a particular txset by hash
-//       TX_SET = 7,
-//       GENERALIZED_TX_SET = 17,
-//   
-//       TRANSACTION = 8, // pass on a tx you have heard about
-//   
-//       // SCP
-//       GET_SCP_QUORUMSET = 9,
-//       SCP_QUORUMSET = 10,
-//       SCP_MESSAGE = 11,
-//       GET_SCP_STATE = 12,
-//   
-//       // new messages
-//       HELLO = 13,
-//   
-//       SURVEY_REQUEST = 14,
-//       SURVEY_RESPONSE = 15,
-//   
-//       SEND_MORE = 16,
-//       FLOOD_ADVERT = 18,
-//       FLOOD_DEMAND = 19
-//   };
-//
-// ===========================================================================
-xdr.enum("MessageType", {
-  errorMsg: 0,
-  auth: 2,
-  dontHave: 3,
-  getPeers: 4,
-  peers: 5,
-  getTxSet: 6,
-  txSet: 7,
-  generalizedTxSet: 17,
-  transaction: 8,
-  getScpQuorumset: 9,
-  scpQuorumset: 10,
-  scpMessage: 11,
-  getScpState: 12,
-  hello: 13,
-  surveyRequest: 14,
-  surveyResponse: 15,
-  sendMore: 16,
-  floodAdvert: 18,
-  floodDemand: 19,
-});
-
-// === xdr source ============================================================
-//
-//   struct DontHave
-//   {
-//       MessageType type;
-//       uint256 reqHash;
-//   };
-//
-// ===========================================================================
-xdr.struct("DontHave", [
-  ["type", xdr.lookup("MessageType")],
-  ["reqHash", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum SurveyMessageCommandType
-//   {
-//       SURVEY_TOPOLOGY = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("SurveyMessageCommandType", {
-  surveyTopology: 0,
-});
-
-// === xdr source ============================================================
-//
-//   struct SurveyRequestMessage
-//   {
-//       NodeID surveyorPeerID;
-//       NodeID surveyedPeerID;
-//       uint32 ledgerNum;
-//       Curve25519Public encryptionKey;
-//       SurveyMessageCommandType commandType;
-//   };
-//
-// ===========================================================================
-xdr.struct("SurveyRequestMessage", [
-  ["surveyorPeerId", xdr.lookup("NodeId")],
-  ["surveyedPeerId", xdr.lookup("NodeId")],
-  ["ledgerNum", xdr.lookup("Uint32")],
-  ["encryptionKey", xdr.lookup("Curve25519Public")],
-  ["commandType", xdr.lookup("SurveyMessageCommandType")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SignedSurveyRequestMessage
-//   {
-//       Signature requestSignature;
-//       SurveyRequestMessage request;
-//   };
-//
-// ===========================================================================
-xdr.struct("SignedSurveyRequestMessage", [
-  ["requestSignature", xdr.lookup("Signature")],
-  ["request", xdr.lookup("SurveyRequestMessage")],
-]);
-
-// === xdr source ============================================================
-//
-//   typedef opaque EncryptedBody<64000>;
-//
-// ===========================================================================
-xdr.typedef("EncryptedBody", xdr.varOpaque(64000));
-
-// === xdr source ============================================================
-//
-//   struct SurveyResponseMessage
-//   {
-//       NodeID surveyorPeerID;
-//       NodeID surveyedPeerID;
-//       uint32 ledgerNum;
-//       SurveyMessageCommandType commandType;
-//       EncryptedBody encryptedBody;
-//   };
-//
-// ===========================================================================
-xdr.struct("SurveyResponseMessage", [
-  ["surveyorPeerId", xdr.lookup("NodeId")],
-  ["surveyedPeerId", xdr.lookup("NodeId")],
-  ["ledgerNum", xdr.lookup("Uint32")],
-  ["commandType", xdr.lookup("SurveyMessageCommandType")],
-  ["encryptedBody", xdr.lookup("EncryptedBody")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SignedSurveyResponseMessage
-//   {
-//       Signature responseSignature;
-//       SurveyResponseMessage response;
-//   };
-//
-// ===========================================================================
-xdr.struct("SignedSurveyResponseMessage", [
-  ["responseSignature", xdr.lookup("Signature")],
-  ["response", xdr.lookup("SurveyResponseMessage")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct PeerStats
-//   {
-//       NodeID id;
-//       string versionStr<100>;
-//       uint64 messagesRead;
-//       uint64 messagesWritten;
-//       uint64 bytesRead;
-//       uint64 bytesWritten;
-//       uint64 secondsConnected;
-//   
-//       uint64 uniqueFloodBytesRecv;
-//       uint64 duplicateFloodBytesRecv;
-//       uint64 uniqueFetchBytesRecv;
-//       uint64 duplicateFetchBytesRecv;
-//   
-//       uint64 uniqueFloodMessageRecv;
-//       uint64 duplicateFloodMessageRecv;
-//       uint64 uniqueFetchMessageRecv;
-//       uint64 duplicateFetchMessageRecv;
-//   };
-//
-// ===========================================================================
-xdr.struct("PeerStats", [
-  ["id", xdr.lookup("NodeId")],
-  ["versionStr", xdr.string(100)],
-  ["messagesRead", xdr.lookup("Uint64")],
-  ["messagesWritten", xdr.lookup("Uint64")],
-  ["bytesRead", xdr.lookup("Uint64")],
-  ["bytesWritten", xdr.lookup("Uint64")],
-  ["secondsConnected", xdr.lookup("Uint64")],
-  ["uniqueFloodBytesRecv", xdr.lookup("Uint64")],
-  ["duplicateFloodBytesRecv", xdr.lookup("Uint64")],
-  ["uniqueFetchBytesRecv", xdr.lookup("Uint64")],
-  ["duplicateFetchBytesRecv", xdr.lookup("Uint64")],
-  ["uniqueFloodMessageRecv", xdr.lookup("Uint64")],
-  ["duplicateFloodMessageRecv", xdr.lookup("Uint64")],
-  ["uniqueFetchMessageRecv", xdr.lookup("Uint64")],
-  ["duplicateFetchMessageRecv", xdr.lookup("Uint64")],
-]);
-
-// === xdr source ============================================================
-//
-//   typedef PeerStats PeerStatList<25>;
-//
-// ===========================================================================
-xdr.typedef("PeerStatList", xdr.varArray(xdr.lookup("PeerStats"), 25));
-
-// === xdr source ============================================================
-//
-//   struct TopologyResponseBody
-//   {
-//       PeerStatList inboundPeers;
-//       PeerStatList outboundPeers;
-//   
-//       uint32 totalInboundPeerCount;
-//       uint32 totalOutboundPeerCount;
-//   };
-//
-// ===========================================================================
-xdr.struct("TopologyResponseBody", [
-  ["inboundPeers", xdr.lookup("PeerStatList")],
-  ["outboundPeers", xdr.lookup("PeerStatList")],
-  ["totalInboundPeerCount", xdr.lookup("Uint32")],
-  ["totalOutboundPeerCount", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   union SurveyResponseBody switch (SurveyMessageCommandType type)
-//   {
-//   case SURVEY_TOPOLOGY:
-//       TopologyResponseBody topologyResponseBody;
-//   };
-//
-// ===========================================================================
-xdr.union("SurveyResponseBody", {
-  switchOn: xdr.lookup("SurveyMessageCommandType"),
-  switchName: "type",
-  switches: [
-    ["surveyTopology", "topologyResponseBody"],
-  ],
-  arms: {
-    topologyResponseBody: xdr.lookup("TopologyResponseBody"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
-//
-// ===========================================================================
-xdr.const("TX_ADVERT_VECTOR_MAX_SIZE", 1000);
-
-// === xdr source ============================================================
-//
-//   typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
-//
-// ===========================================================================
-xdr.typedef("TxAdvertVector", xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_ADVERT_VECTOR_MAX_SIZE")));
-
-// === xdr source ============================================================
-//
-//   struct FloodAdvert
-//   {
-//       TxAdvertVector txHashes;
-//   };
-//
-// ===========================================================================
-xdr.struct("FloodAdvert", [
-  ["txHashes", xdr.lookup("TxAdvertVector")],
-]);
-
-// === xdr source ============================================================
-//
-//   const TX_DEMAND_VECTOR_MAX_SIZE = 1000;
-//
-// ===========================================================================
-xdr.const("TX_DEMAND_VECTOR_MAX_SIZE", 1000);
-
-// === xdr source ============================================================
-//
-//   typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
-//
-// ===========================================================================
-xdr.typedef("TxDemandVector", xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_DEMAND_VECTOR_MAX_SIZE")));
-
-// === xdr source ============================================================
-//
-//   struct FloodDemand
-//   {
-//       TxDemandVector txHashes;
-//   };
-//
-// ===========================================================================
-xdr.struct("FloodDemand", [
-  ["txHashes", xdr.lookup("TxDemandVector")],
-]);
-
-// === xdr source ============================================================
-//
-//   union StellarMessage switch (MessageType type)
-//   {
-//   case ERROR_MSG:
-//       Error error;
-//   case HELLO:
-//       Hello hello;
-//   case AUTH:
-//       Auth auth;
-//   case DONT_HAVE:
-//       DontHave dontHave;
-//   case GET_PEERS:
-//       void;
-//   case PEERS:
-//       PeerAddress peers<100>;
-//   
-//   case GET_TX_SET:
-//       uint256 txSetHash;
-//   case TX_SET:
-//       TransactionSet txSet;
-//   case GENERALIZED_TX_SET:
-//       GeneralizedTransactionSet generalizedTxSet;
-//   
-//   case TRANSACTION:
-//       TransactionEnvelope transaction;
-//   
-//   case SURVEY_REQUEST:
-//       SignedSurveyRequestMessage signedSurveyRequestMessage;
-//   
-//   case SURVEY_RESPONSE:
-//       SignedSurveyResponseMessage signedSurveyResponseMessage;
-//   
-//   // SCP
-//   case GET_SCP_QUORUMSET:
-//       uint256 qSetHash;
-//   case SCP_QUORUMSET:
-//       SCPQuorumSet qSet;
-//   case SCP_MESSAGE:
-//       SCPEnvelope envelope;
-//   case GET_SCP_STATE:
-//       uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
-//   case SEND_MORE:
-//       SendMore sendMoreMessage;
-//   
-//   // Pull mode
-//   case FLOOD_ADVERT:
-//        FloodAdvert floodAdvert;
-//   case FLOOD_DEMAND:
-//        FloodDemand floodDemand;
-//   };
-//
-// ===========================================================================
-xdr.union("StellarMessage", {
-  switchOn: xdr.lookup("MessageType"),
-  switchName: "type",
-  switches: [
-    ["errorMsg", "error"],
-    ["hello", "hello"],
-    ["auth", "auth"],
-    ["dontHave", "dontHave"],
-    ["getPeers", xdr.void()],
-    ["peers", "peers"],
-    ["getTxSet", "txSetHash"],
-    ["txSet", "txSet"],
-    ["generalizedTxSet", "generalizedTxSet"],
-    ["transaction", "transaction"],
-    ["surveyRequest", "signedSurveyRequestMessage"],
-    ["surveyResponse", "signedSurveyResponseMessage"],
-    ["getScpQuorumset", "qSetHash"],
-    ["scpQuorumset", "qSet"],
-    ["scpMessage", "envelope"],
-    ["getScpState", "getScpLedgerSeq"],
-    ["sendMore", "sendMoreMessage"],
-    ["floodAdvert", "floodAdvert"],
-    ["floodDemand", "floodDemand"],
-  ],
-  arms: {
-    error: xdr.lookup("Error"),
-    hello: xdr.lookup("Hello"),
-    auth: xdr.lookup("Auth"),
-    dontHave: xdr.lookup("DontHave"),
-    peers: xdr.varArray(xdr.lookup("PeerAddress"), 100),
-    txSetHash: xdr.lookup("Uint256"),
-    txSet: xdr.lookup("TransactionSet"),
-    generalizedTxSet: xdr.lookup("GeneralizedTransactionSet"),
-    transaction: xdr.lookup("TransactionEnvelope"),
-    signedSurveyRequestMessage: xdr.lookup("SignedSurveyRequestMessage"),
-    signedSurveyResponseMessage: xdr.lookup("SignedSurveyResponseMessage"),
-    qSetHash: xdr.lookup("Uint256"),
-    qSet: xdr.lookup("ScpQuorumSet"),
-    envelope: xdr.lookup("ScpEnvelope"),
-    getScpLedgerSeq: xdr.lookup("Uint32"),
-    sendMoreMessage: xdr.lookup("SendMore"),
-    floodAdvert: xdr.lookup("FloodAdvert"),
-    floodDemand: xdr.lookup("FloodDemand"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           uint64 sequence;
-//           StellarMessage message;
-//           HmacSha256Mac mac;
-//       }
-//
-// ===========================================================================
-xdr.struct("AuthenticatedMessageV0", [
-  ["sequence", xdr.lookup("Uint64")],
-  ["message", xdr.lookup("StellarMessage")],
-  ["mac", xdr.lookup("HmacSha256Mac")],
-]);
-
-// === xdr source ============================================================
-//
-//   union AuthenticatedMessage switch (uint32 v)
-//   {
-//   case 0:
-//       struct
-//       {
-//           uint64 sequence;
-//           StellarMessage message;
-//           HmacSha256Mac mac;
-//       } v0;
-//   };
-//
-// ===========================================================================
-xdr.union("AuthenticatedMessage", {
-  switchOn: xdr.lookup("Uint32"),
-  switchName: "v",
-  switches: [
-    [0, "v0"],
-  ],
-  arms: {
-    v0: xdr.lookup("AuthenticatedMessageV0"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union LiquidityPoolParameters switch (LiquidityPoolType type)
-//   {
-//   case LIQUIDITY_POOL_CONSTANT_PRODUCT:
-//       LiquidityPoolConstantProductParameters constantProduct;
-//   };
-//
-// ===========================================================================
-xdr.union("LiquidityPoolParameters", {
-  switchOn: xdr.lookup("LiquidityPoolType"),
-  switchName: "type",
-  switches: [
-    ["liquidityPoolConstantProduct", "constantProduct"],
-  ],
-  arms: {
-    constantProduct: xdr.lookup("LiquidityPoolConstantProductParameters"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           uint64 id;
-//           uint256 ed25519;
-//       }
-//
-// ===========================================================================
-xdr.struct("MuxedAccountMed25519", [
-  ["id", xdr.lookup("Uint64")],
-  ["ed25519", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   union MuxedAccount switch (CryptoKeyType type)
-//   {
-//   case KEY_TYPE_ED25519:
-//       uint256 ed25519;
-//   case KEY_TYPE_MUXED_ED25519:
-//       struct
-//       {
-//           uint64 id;
-//           uint256 ed25519;
-//       } med25519;
-//   };
-//
-// ===========================================================================
-xdr.union("MuxedAccount", {
-  switchOn: xdr.lookup("CryptoKeyType"),
-  switchName: "type",
-  switches: [
-    ["keyTypeEd25519", "ed25519"],
-    ["keyTypeMuxedEd25519", "med25519"],
-  ],
-  arms: {
-    ed25519: xdr.lookup("Uint256"),
-    med25519: xdr.lookup("MuxedAccountMed25519"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct DecoratedSignature
-//   {
-//       SignatureHint hint;  // last 4 bytes of the public key, used as a hint
-//       Signature signature; // actual signature
-//   };
-//
-// ===========================================================================
-xdr.struct("DecoratedSignature", [
-  ["hint", xdr.lookup("SignatureHint")],
-  ["signature", xdr.lookup("Signature")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum OperationType
-//   {
-//       CREATE_ACCOUNT = 0,
-//       PAYMENT = 1,
-//       PATH_PAYMENT_STRICT_RECEIVE = 2,
-//       MANAGE_SELL_OFFER = 3,
-//       CREATE_PASSIVE_SELL_OFFER = 4,
-//       SET_OPTIONS = 5,
-//       CHANGE_TRUST = 6,
-//       ALLOW_TRUST = 7,
-//       ACCOUNT_MERGE = 8,
-//       INFLATION = 9,
-//       MANAGE_DATA = 10,
-//       BUMP_SEQUENCE = 11,
-//       MANAGE_BUY_OFFER = 12,
-//       PATH_PAYMENT_STRICT_SEND = 13,
-//       CREATE_CLAIMABLE_BALANCE = 14,
-//       CLAIM_CLAIMABLE_BALANCE = 15,
-//       BEGIN_SPONSORING_FUTURE_RESERVES = 16,
-//       END_SPONSORING_FUTURE_RESERVES = 17,
-//       REVOKE_SPONSORSHIP = 18,
-//       CLAWBACK = 19,
-//       CLAWBACK_CLAIMABLE_BALANCE = 20,
-//       SET_TRUST_LINE_FLAGS = 21,
-//       LIQUIDITY_POOL_DEPOSIT = 22,
-//       LIQUIDITY_POOL_WITHDRAW = 23
-//   };
-//
-// ===========================================================================
-xdr.enum("OperationType", {
-  createAccount: 0,
-  payment: 1,
-  pathPaymentStrictReceive: 2,
-  manageSellOffer: 3,
-  createPassiveSellOffer: 4,
-  setOptions: 5,
-  changeTrust: 6,
-  allowTrust: 7,
-  accountMerge: 8,
-  inflation: 9,
-  manageData: 10,
-  bumpSequence: 11,
-  manageBuyOffer: 12,
-  pathPaymentStrictSend: 13,
-  createClaimableBalance: 14,
-  claimClaimableBalance: 15,
-  beginSponsoringFutureReserves: 16,
-  endSponsoringFutureReserves: 17,
-  revokeSponsorship: 18,
-  clawback: 19,
-  clawbackClaimableBalance: 20,
-  setTrustLineFlags: 21,
-  liquidityPoolDeposit: 22,
-  liquidityPoolWithdraw: 23,
-});
-
-// === xdr source ============================================================
-//
-//   struct CreateAccountOp
-//   {
-//       AccountID destination; // account to create
-//       int64 startingBalance; // amount they end up with
-//   };
-//
-// ===========================================================================
-xdr.struct("CreateAccountOp", [
-  ["destination", xdr.lookup("AccountId")],
-  ["startingBalance", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct PaymentOp
-//   {
-//       MuxedAccount destination; // recipient of the payment
-//       Asset asset;              // what they end up with
-//       int64 amount;             // amount they end up with
-//   };
-//
-// ===========================================================================
-xdr.struct("PaymentOp", [
-  ["destination", xdr.lookup("MuxedAccount")],
-  ["asset", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct PathPaymentStrictReceiveOp
-//   {
-//       Asset sendAsset; // asset we pay with
-//       int64 sendMax;   // the maximum amount of sendAsset to
-//                        // send (excluding fees).
-//                        // The operation will fail if can't be met
-//   
-//       MuxedAccount destination; // recipient of the payment
-//       Asset destAsset;          // what they end up with
-//       int64 destAmount;         // amount they end up with
-//   
-//       Asset path<5>; // additional hops it must go through to get there
-//   };
-//
-// ===========================================================================
-xdr.struct("PathPaymentStrictReceiveOp", [
-  ["sendAsset", xdr.lookup("Asset")],
-  ["sendMax", xdr.lookup("Int64")],
-  ["destination", xdr.lookup("MuxedAccount")],
-  ["destAsset", xdr.lookup("Asset")],
-  ["destAmount", xdr.lookup("Int64")],
-  ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct PathPaymentStrictSendOp
-//   {
-//       Asset sendAsset;  // asset we pay with
-//       int64 sendAmount; // amount of sendAsset to send (excluding fees)
-//   
-//       MuxedAccount destination; // recipient of the payment
-//       Asset destAsset;          // what they end up with
-//       int64 destMin;            // the minimum amount of dest asset to
-//                                 // be received
-//                                 // The operation will fail if it can't be met
-//   
-//       Asset path<5>; // additional hops it must go through to get there
-//   };
-//
-// ===========================================================================
-xdr.struct("PathPaymentStrictSendOp", [
-  ["sendAsset", xdr.lookup("Asset")],
-  ["sendAmount", xdr.lookup("Int64")],
-  ["destination", xdr.lookup("MuxedAccount")],
-  ["destAsset", xdr.lookup("Asset")],
-  ["destMin", xdr.lookup("Int64")],
-  ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ManageSellOfferOp
-//   {
-//       Asset selling;
-//       Asset buying;
-//       int64 amount; // amount being sold. if set to 0, delete the offer
-//       Price price;  // price of thing being sold in terms of what you are buying
-//   
-//       // 0=create a new offer, otherwise edit an existing offer
-//       int64 offerID;
-//   };
-//
-// ===========================================================================
-xdr.struct("ManageSellOfferOp", [
-  ["selling", xdr.lookup("Asset")],
-  ["buying", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-  ["price", xdr.lookup("Price")],
-  ["offerId", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ManageBuyOfferOp
-//   {
-//       Asset selling;
-//       Asset buying;
-//       int64 buyAmount; // amount being bought. if set to 0, delete the offer
-//       Price price;     // price of thing being bought in terms of what you are
-//                        // selling
-//   
-//       // 0=create a new offer, otherwise edit an existing offer
-//       int64 offerID;
-//   };
-//
-// ===========================================================================
-xdr.struct("ManageBuyOfferOp", [
-  ["selling", xdr.lookup("Asset")],
-  ["buying", xdr.lookup("Asset")],
-  ["buyAmount", xdr.lookup("Int64")],
-  ["price", xdr.lookup("Price")],
-  ["offerId", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct CreatePassiveSellOfferOp
-//   {
-//       Asset selling; // A
-//       Asset buying;  // B
-//       int64 amount;  // amount taker gets
-//       Price price;   // cost of A in terms of B
-//   };
-//
-// ===========================================================================
-xdr.struct("CreatePassiveSellOfferOp", [
-  ["selling", xdr.lookup("Asset")],
-  ["buying", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-  ["price", xdr.lookup("Price")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SetOptionsOp
-//   {
-//       AccountID* inflationDest; // sets the inflation destination
-//   
-//       uint32* clearFlags; // which flags to clear
-//       uint32* setFlags;   // which flags to set
-//   
-//       // account threshold manipulation
-//       uint32* masterWeight; // weight of the master account
-//       uint32* lowThreshold;
-//       uint32* medThreshold;
-//       uint32* highThreshold;
-//   
-//       string32* homeDomain; // sets the home domain
-//   
-//       // Add, update or remove a signer for the account
-//       // signer is deleted if the weight is 0
-//       Signer* signer;
-//   };
-//
-// ===========================================================================
-xdr.struct("SetOptionsOp", [
-  ["inflationDest", xdr.option(xdr.lookup("AccountId"))],
-  ["clearFlags", xdr.option(xdr.lookup("Uint32"))],
-  ["setFlags", xdr.option(xdr.lookup("Uint32"))],
-  ["masterWeight", xdr.option(xdr.lookup("Uint32"))],
-  ["lowThreshold", xdr.option(xdr.lookup("Uint32"))],
-  ["medThreshold", xdr.option(xdr.lookup("Uint32"))],
-  ["highThreshold", xdr.option(xdr.lookup("Uint32"))],
-  ["homeDomain", xdr.option(xdr.lookup("String32"))],
-  ["signer", xdr.option(xdr.lookup("Signer"))],
-]);
-
-// === xdr source ============================================================
-//
-//   union ChangeTrustAsset switch (AssetType type)
-//   {
-//   case ASSET_TYPE_NATIVE: // Not credit
-//       void;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM4:
-//       AlphaNum4 alphaNum4;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM12:
-//       AlphaNum12 alphaNum12;
-//   
-//   case ASSET_TYPE_POOL_SHARE:
-//       LiquidityPoolParameters liquidityPool;
-//   
-//       // add other asset types here in the future
-//   };
-//
-// ===========================================================================
-xdr.union("ChangeTrustAsset", {
-  switchOn: xdr.lookup("AssetType"),
-  switchName: "type",
-  switches: [
-    ["assetTypeNative", xdr.void()],
-    ["assetTypeCreditAlphanum4", "alphaNum4"],
-    ["assetTypeCreditAlphanum12", "alphaNum12"],
-    ["assetTypePoolShare", "liquidityPool"],
-  ],
-  arms: {
-    alphaNum4: xdr.lookup("AlphaNum4"),
-    alphaNum12: xdr.lookup("AlphaNum12"),
-    liquidityPool: xdr.lookup("LiquidityPoolParameters"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ChangeTrustOp
-//   {
-//       ChangeTrustAsset line;
-//   
-//       // if limit is set to 0, deletes the trust line
-//       int64 limit;
-//   };
-//
-// ===========================================================================
-xdr.struct("ChangeTrustOp", [
-  ["line", xdr.lookup("ChangeTrustAsset")],
-  ["limit", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct AllowTrustOp
-//   {
-//       AccountID trustor;
-//       AssetCode asset;
-//   
-//       // One of 0, AUTHORIZED_FLAG, or AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG
-//       uint32 authorize;
-//   };
-//
-// ===========================================================================
-xdr.struct("AllowTrustOp", [
-  ["trustor", xdr.lookup("AccountId")],
-  ["asset", xdr.lookup("AssetCode")],
-  ["authorize", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ManageDataOp
-//   {
-//       string64 dataName;
-//       DataValue* dataValue; // set to null to clear
-//   };
-//
-// ===========================================================================
-xdr.struct("ManageDataOp", [
-  ["dataName", xdr.lookup("String64")],
-  ["dataValue", xdr.option(xdr.lookup("DataValue"))],
-]);
-
-// === xdr source ============================================================
-//
-//   struct BumpSequenceOp
-//   {
-//       SequenceNumber bumpTo;
-//   };
-//
-// ===========================================================================
-xdr.struct("BumpSequenceOp", [
-  ["bumpTo", xdr.lookup("SequenceNumber")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct CreateClaimableBalanceOp
-//   {
-//       Asset asset;
-//       int64 amount;
-//       Claimant claimants<10>;
-//   };
-//
-// ===========================================================================
-xdr.struct("CreateClaimableBalanceOp", [
-  ["asset", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-  ["claimants", xdr.varArray(xdr.lookup("Claimant"), 10)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ClaimClaimableBalanceOp
-//   {
-//       ClaimableBalanceID balanceID;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimClaimableBalanceOp", [
-  ["balanceId", xdr.lookup("ClaimableBalanceId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct BeginSponsoringFutureReservesOp
-//   {
-//       AccountID sponsoredID;
-//   };
-//
-// ===========================================================================
-xdr.struct("BeginSponsoringFutureReservesOp", [
-  ["sponsoredId", xdr.lookup("AccountId")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum RevokeSponsorshipType
-//   {
-//       REVOKE_SPONSORSHIP_LEDGER_ENTRY = 0,
-//       REVOKE_SPONSORSHIP_SIGNER = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("RevokeSponsorshipType", {
-  revokeSponsorshipLedgerEntry: 0,
-  revokeSponsorshipSigner: 1,
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID accountID;
-//           SignerKey signerKey;
-//       }
-//
-// ===========================================================================
-xdr.struct("RevokeSponsorshipOpSigner", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["signerKey", xdr.lookup("SignerKey")],
-]);
-
-// === xdr source ============================================================
-//
-//   union RevokeSponsorshipOp switch (RevokeSponsorshipType type)
-//   {
-//   case REVOKE_SPONSORSHIP_LEDGER_ENTRY:
-//       LedgerKey ledgerKey;
-//   case REVOKE_SPONSORSHIP_SIGNER:
-//       struct
-//       {
-//           AccountID accountID;
-//           SignerKey signerKey;
-//       } signer;
-//   };
-//
-// ===========================================================================
-xdr.union("RevokeSponsorshipOp", {
-  switchOn: xdr.lookup("RevokeSponsorshipType"),
-  switchName: "type",
-  switches: [
-    ["revokeSponsorshipLedgerEntry", "ledgerKey"],
-    ["revokeSponsorshipSigner", "signer"],
-  ],
-  arms: {
-    ledgerKey: xdr.lookup("LedgerKey"),
-    signer: xdr.lookup("RevokeSponsorshipOpSigner"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ClawbackOp
-//   {
-//       Asset asset;
-//       MuxedAccount from;
-//       int64 amount;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClawbackOp", [
-  ["asset", xdr.lookup("Asset")],
-  ["from", xdr.lookup("MuxedAccount")],
-  ["amount", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ClawbackClaimableBalanceOp
-//   {
-//       ClaimableBalanceID balanceID;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClawbackClaimableBalanceOp", [
-  ["balanceId", xdr.lookup("ClaimableBalanceId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SetTrustLineFlagsOp
-//   {
-//       AccountID trustor;
-//       Asset asset;
-//   
-//       uint32 clearFlags; // which flags to clear
-//       uint32 setFlags;   // which flags to set
-//   };
-//
-// ===========================================================================
-xdr.struct("SetTrustLineFlagsOp", [
-  ["trustor", xdr.lookup("AccountId")],
-  ["asset", xdr.lookup("Asset")],
-  ["clearFlags", xdr.lookup("Uint32")],
-  ["setFlags", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   const LIQUIDITY_POOL_FEE_V18 = 30;
-//
-// ===========================================================================
-xdr.const("LIQUIDITY_POOL_FEE_V18", 30);
-
-// === xdr source ============================================================
-//
-//   struct LiquidityPoolDepositOp
-//   {
-//       PoolID liquidityPoolID;
-//       int64 maxAmountA; // maximum amount of first asset to deposit
-//       int64 maxAmountB; // maximum amount of second asset to deposit
-//       Price minPrice;   // minimum depositA/depositB
-//       Price maxPrice;   // maximum depositA/depositB
-//   };
-//
-// ===========================================================================
-xdr.struct("LiquidityPoolDepositOp", [
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-  ["maxAmountA", xdr.lookup("Int64")],
-  ["maxAmountB", xdr.lookup("Int64")],
-  ["minPrice", xdr.lookup("Price")],
-  ["maxPrice", xdr.lookup("Price")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LiquidityPoolWithdrawOp
-//   {
-//       PoolID liquidityPoolID;
-//       int64 amount;     // amount of pool shares to withdraw
-//       int64 minAmountA; // minimum amount of first asset to withdraw
-//       int64 minAmountB; // minimum amount of second asset to withdraw
-//   };
-//
-// ===========================================================================
-xdr.struct("LiquidityPoolWithdrawOp", [
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-  ["amount", xdr.lookup("Int64")],
-  ["minAmountA", xdr.lookup("Int64")],
-  ["minAmountB", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (OperationType type)
-//       {
-//       case CREATE_ACCOUNT:
-//           CreateAccountOp createAccountOp;
-//       case PAYMENT:
-//           PaymentOp paymentOp;
-//       case PATH_PAYMENT_STRICT_RECEIVE:
-//           PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
-//       case MANAGE_SELL_OFFER:
-//           ManageSellOfferOp manageSellOfferOp;
-//       case CREATE_PASSIVE_SELL_OFFER:
-//           CreatePassiveSellOfferOp createPassiveSellOfferOp;
-//       case SET_OPTIONS:
-//           SetOptionsOp setOptionsOp;
-//       case CHANGE_TRUST:
-//           ChangeTrustOp changeTrustOp;
-//       case ALLOW_TRUST:
-//           AllowTrustOp allowTrustOp;
-//       case ACCOUNT_MERGE:
-//           MuxedAccount destination;
-//       case INFLATION:
-//           void;
-//       case MANAGE_DATA:
-//           ManageDataOp manageDataOp;
-//       case BUMP_SEQUENCE:
-//           BumpSequenceOp bumpSequenceOp;
-//       case MANAGE_BUY_OFFER:
-//           ManageBuyOfferOp manageBuyOfferOp;
-//       case PATH_PAYMENT_STRICT_SEND:
-//           PathPaymentStrictSendOp pathPaymentStrictSendOp;
-//       case CREATE_CLAIMABLE_BALANCE:
-//           CreateClaimableBalanceOp createClaimableBalanceOp;
-//       case CLAIM_CLAIMABLE_BALANCE:
-//           ClaimClaimableBalanceOp claimClaimableBalanceOp;
-//       case BEGIN_SPONSORING_FUTURE_RESERVES:
-//           BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
-//       case END_SPONSORING_FUTURE_RESERVES:
-//           void;
-//       case REVOKE_SPONSORSHIP:
-//           RevokeSponsorshipOp revokeSponsorshipOp;
-//       case CLAWBACK:
-//           ClawbackOp clawbackOp;
-//       case CLAWBACK_CLAIMABLE_BALANCE:
-//           ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
-//       case SET_TRUST_LINE_FLAGS:
-//           SetTrustLineFlagsOp setTrustLineFlagsOp;
-//       case LIQUIDITY_POOL_DEPOSIT:
-//           LiquidityPoolDepositOp liquidityPoolDepositOp;
-//       case LIQUIDITY_POOL_WITHDRAW:
-//           LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
-//       }
-//
-// ===========================================================================
-xdr.union("OperationBody", {
-  switchOn: xdr.lookup("OperationType"),
-  switchName: "type",
-  switches: [
-    ["createAccount", "createAccountOp"],
-    ["payment", "paymentOp"],
-    ["pathPaymentStrictReceive", "pathPaymentStrictReceiveOp"],
-    ["manageSellOffer", "manageSellOfferOp"],
-    ["createPassiveSellOffer", "createPassiveSellOfferOp"],
-    ["setOptions", "setOptionsOp"],
-    ["changeTrust", "changeTrustOp"],
-    ["allowTrust", "allowTrustOp"],
-    ["accountMerge", "destination"],
-    ["inflation", xdr.void()],
-    ["manageData", "manageDataOp"],
-    ["bumpSequence", "bumpSequenceOp"],
-    ["manageBuyOffer", "manageBuyOfferOp"],
-    ["pathPaymentStrictSend", "pathPaymentStrictSendOp"],
-    ["createClaimableBalance", "createClaimableBalanceOp"],
-    ["claimClaimableBalance", "claimClaimableBalanceOp"],
-    ["beginSponsoringFutureReserves", "beginSponsoringFutureReservesOp"],
-    ["endSponsoringFutureReserves", xdr.void()],
-    ["revokeSponsorship", "revokeSponsorshipOp"],
-    ["clawback", "clawbackOp"],
-    ["clawbackClaimableBalance", "clawbackClaimableBalanceOp"],
-    ["setTrustLineFlags", "setTrustLineFlagsOp"],
-    ["liquidityPoolDeposit", "liquidityPoolDepositOp"],
-    ["liquidityPoolWithdraw", "liquidityPoolWithdrawOp"],
-  ],
-  arms: {
-    createAccountOp: xdr.lookup("CreateAccountOp"),
-    paymentOp: xdr.lookup("PaymentOp"),
-    pathPaymentStrictReceiveOp: xdr.lookup("PathPaymentStrictReceiveOp"),
-    manageSellOfferOp: xdr.lookup("ManageSellOfferOp"),
-    createPassiveSellOfferOp: xdr.lookup("CreatePassiveSellOfferOp"),
-    setOptionsOp: xdr.lookup("SetOptionsOp"),
-    changeTrustOp: xdr.lookup("ChangeTrustOp"),
-    allowTrustOp: xdr.lookup("AllowTrustOp"),
-    destination: xdr.lookup("MuxedAccount"),
-    manageDataOp: xdr.lookup("ManageDataOp"),
-    bumpSequenceOp: xdr.lookup("BumpSequenceOp"),
-    manageBuyOfferOp: xdr.lookup("ManageBuyOfferOp"),
-    pathPaymentStrictSendOp: xdr.lookup("PathPaymentStrictSendOp"),
-    createClaimableBalanceOp: xdr.lookup("CreateClaimableBalanceOp"),
-    claimClaimableBalanceOp: xdr.lookup("ClaimClaimableBalanceOp"),
-    beginSponsoringFutureReservesOp: xdr.lookup("BeginSponsoringFutureReservesOp"),
-    revokeSponsorshipOp: xdr.lookup("RevokeSponsorshipOp"),
-    clawbackOp: xdr.lookup("ClawbackOp"),
-    clawbackClaimableBalanceOp: xdr.lookup("ClawbackClaimableBalanceOp"),
-    setTrustLineFlagsOp: xdr.lookup("SetTrustLineFlagsOp"),
-    liquidityPoolDepositOp: xdr.lookup("LiquidityPoolDepositOp"),
-    liquidityPoolWithdrawOp: xdr.lookup("LiquidityPoolWithdrawOp"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct Operation
-//   {
-//       // sourceAccount is the account used to run the operation
-//       // if not set, the runtime defaults to "sourceAccount" specified at
-//       // the transaction level
-//       MuxedAccount* sourceAccount;
-//   
-//       union switch (OperationType type)
-//       {
-//       case CREATE_ACCOUNT:
-//           CreateAccountOp createAccountOp;
-//       case PAYMENT:
-//           PaymentOp paymentOp;
-//       case PATH_PAYMENT_STRICT_RECEIVE:
-//           PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
-//       case MANAGE_SELL_OFFER:
-//           ManageSellOfferOp manageSellOfferOp;
-//       case CREATE_PASSIVE_SELL_OFFER:
-//           CreatePassiveSellOfferOp createPassiveSellOfferOp;
-//       case SET_OPTIONS:
-//           SetOptionsOp setOptionsOp;
-//       case CHANGE_TRUST:
-//           ChangeTrustOp changeTrustOp;
-//       case ALLOW_TRUST:
-//           AllowTrustOp allowTrustOp;
-//       case ACCOUNT_MERGE:
-//           MuxedAccount destination;
-//       case INFLATION:
-//           void;
-//       case MANAGE_DATA:
-//           ManageDataOp manageDataOp;
-//       case BUMP_SEQUENCE:
-//           BumpSequenceOp bumpSequenceOp;
-//       case MANAGE_BUY_OFFER:
-//           ManageBuyOfferOp manageBuyOfferOp;
-//       case PATH_PAYMENT_STRICT_SEND:
-//           PathPaymentStrictSendOp pathPaymentStrictSendOp;
-//       case CREATE_CLAIMABLE_BALANCE:
-//           CreateClaimableBalanceOp createClaimableBalanceOp;
-//       case CLAIM_CLAIMABLE_BALANCE:
-//           ClaimClaimableBalanceOp claimClaimableBalanceOp;
-//       case BEGIN_SPONSORING_FUTURE_RESERVES:
-//           BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
-//       case END_SPONSORING_FUTURE_RESERVES:
-//           void;
-//       case REVOKE_SPONSORSHIP:
-//           RevokeSponsorshipOp revokeSponsorshipOp;
-//       case CLAWBACK:
-//           ClawbackOp clawbackOp;
-//       case CLAWBACK_CLAIMABLE_BALANCE:
-//           ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
-//       case SET_TRUST_LINE_FLAGS:
-//           SetTrustLineFlagsOp setTrustLineFlagsOp;
-//       case LIQUIDITY_POOL_DEPOSIT:
-//           LiquidityPoolDepositOp liquidityPoolDepositOp;
-//       case LIQUIDITY_POOL_WITHDRAW:
-//           LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
-//       }
-//       body;
-//   };
-//
-// ===========================================================================
-xdr.struct("Operation", [
-  ["sourceAccount", xdr.option(xdr.lookup("MuxedAccount"))],
-  ["body", xdr.lookup("OperationBody")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID sourceAccount;
-//           SequenceNumber seqNum;
-//           uint32 opNum;
-//       }
-//
-// ===========================================================================
-xdr.struct("HashIdPreimageOperationId", [
-  ["sourceAccount", xdr.lookup("AccountId")],
-  ["seqNum", xdr.lookup("SequenceNumber")],
-  ["opNum", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID sourceAccount;
-//           SequenceNumber seqNum;
-//           uint32 opNum;
-//           PoolID liquidityPoolID;
-//           Asset asset;
-//       }
-//
-// ===========================================================================
-xdr.struct("HashIdPreimageRevokeId", [
-  ["sourceAccount", xdr.lookup("AccountId")],
-  ["seqNum", xdr.lookup("SequenceNumber")],
-  ["opNum", xdr.lookup("Uint32")],
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-  ["asset", xdr.lookup("Asset")],
-]);
-
-// === xdr source ============================================================
-//
-//   union HashIDPreimage switch (EnvelopeType type)
-//   {
-//   case ENVELOPE_TYPE_OP_ID:
-//       struct
-//       {
-//           AccountID sourceAccount;
-//           SequenceNumber seqNum;
-//           uint32 opNum;
-//       } operationID;
-//   case ENVELOPE_TYPE_POOL_REVOKE_OP_ID:
-//       struct
-//       {
-//           AccountID sourceAccount;
-//           SequenceNumber seqNum;
-//           uint32 opNum;
-//           PoolID liquidityPoolID;
-//           Asset asset;
-//       } revokeID;
-//   };
-//
-// ===========================================================================
-xdr.union("HashIdPreimage", {
-  switchOn: xdr.lookup("EnvelopeType"),
-  switchName: "type",
-  switches: [
-    ["envelopeTypeOpId", "operationId"],
-    ["envelopeTypePoolRevokeOpId", "revokeId"],
-  ],
-  arms: {
-    operationId: xdr.lookup("HashIdPreimageOperationId"),
-    revokeId: xdr.lookup("HashIdPreimageRevokeId"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum MemoType
-//   {
-//       MEMO_NONE = 0,
-//       MEMO_TEXT = 1,
-//       MEMO_ID = 2,
-//       MEMO_HASH = 3,
-//       MEMO_RETURN = 4
-//   };
-//
-// ===========================================================================
-xdr.enum("MemoType", {
-  memoNone: 0,
-  memoText: 1,
-  memoId: 2,
-  memoHash: 3,
-  memoReturn: 4,
-});
-
-// === xdr source ============================================================
-//
-//   union Memo switch (MemoType type)
-//   {
-//   case MEMO_NONE:
-//       void;
-//   case MEMO_TEXT:
-//       string text<28>;
-//   case MEMO_ID:
-//       uint64 id;
-//   case MEMO_HASH:
-//       Hash hash; // the hash of what to pull from the content server
-//   case MEMO_RETURN:
-//       Hash retHash; // the hash of the tx you are rejecting
-//   };
-//
-// ===========================================================================
-xdr.union("Memo", {
-  switchOn: xdr.lookup("MemoType"),
-  switchName: "type",
-  switches: [
-    ["memoNone", xdr.void()],
-    ["memoText", "text"],
-    ["memoId", "id"],
-    ["memoHash", "hash"],
-    ["memoReturn", "retHash"],
-  ],
-  arms: {
-    text: xdr.string(28),
-    id: xdr.lookup("Uint64"),
-    hash: xdr.lookup("Hash"),
-    retHash: xdr.lookup("Hash"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TimeBounds
-//   {
-//       TimePoint minTime;
-//       TimePoint maxTime; // 0 here means no maxTime
-//   };
-//
-// ===========================================================================
-xdr.struct("TimeBounds", [
-  ["minTime", xdr.lookup("TimePoint")],
-  ["maxTime", xdr.lookup("TimePoint")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LedgerBounds
-//   {
-//       uint32 minLedger;
-//       uint32 maxLedger; // 0 here means no maxLedger
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerBounds", [
-  ["minLedger", xdr.lookup("Uint32")],
-  ["maxLedger", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct PreconditionsV2
-//   {
-//       TimeBounds* timeBounds;
-//   
-//       // Transaction only valid for ledger numbers n such that
-//       // minLedger <= n < maxLedger (if maxLedger == 0, then
-//       // only minLedger is checked)
-//       LedgerBounds* ledgerBounds;
-//   
-//       // If NULL, only valid when sourceAccount's sequence number
-//       // is seqNum - 1.  Otherwise, valid when sourceAccount's
-//       // sequence number n satisfies minSeqNum <= n < tx.seqNum.
-//       // Note that after execution the account's sequence number
-//       // is always raised to tx.seqNum, and a transaction is not
-//       // valid if tx.seqNum is too high to ensure replay protection.
-//       SequenceNumber* minSeqNum;
-//   
-//       // For the transaction to be valid, the current ledger time must
-//       // be at least minSeqAge greater than sourceAccount's seqTime.
-//       Duration minSeqAge;
-//   
-//       // For the transaction to be valid, the current ledger number
-//       // must be at least minSeqLedgerGap greater than sourceAccount's
-//       // seqLedger.
-//       uint32 minSeqLedgerGap;
-//   
-//       // For the transaction to be valid, there must be a signature
-//       // corresponding to every Signer in this array, even if the
-//       // signature is not otherwise required by the sourceAccount or
-//       // operations.
-//       SignerKey extraSigners<2>;
-//   };
-//
-// ===========================================================================
-xdr.struct("PreconditionsV2", [
-  ["timeBounds", xdr.option(xdr.lookup("TimeBounds"))],
-  ["ledgerBounds", xdr.option(xdr.lookup("LedgerBounds"))],
-  ["minSeqNum", xdr.option(xdr.lookup("SequenceNumber"))],
-  ["minSeqAge", xdr.lookup("Duration")],
-  ["minSeqLedgerGap", xdr.lookup("Uint32")],
-  ["extraSigners", xdr.varArray(xdr.lookup("SignerKey"), 2)],
-]);
-
-// === xdr source ============================================================
-//
-//   enum PreconditionType
-//   {
-//       PRECOND_NONE = 0,
-//       PRECOND_TIME = 1,
-//       PRECOND_V2 = 2
-//   };
-//
-// ===========================================================================
-xdr.enum("PreconditionType", {
-  precondNone: 0,
-  precondTime: 1,
-  precondV2: 2,
-});
-
-// === xdr source ============================================================
-//
-//   union Preconditions switch (PreconditionType type)
-//   {
-//   case PRECOND_NONE:
-//       void;
-//   case PRECOND_TIME:
-//       TimeBounds timeBounds;
-//   case PRECOND_V2:
-//       PreconditionsV2 v2;
-//   };
-//
-// ===========================================================================
-xdr.union("Preconditions", {
-  switchOn: xdr.lookup("PreconditionType"),
-  switchName: "type",
-  switches: [
-    ["precondNone", xdr.void()],
-    ["precondTime", "timeBounds"],
-    ["precondV2", "v2"],
-  ],
-  arms: {
-    timeBounds: xdr.lookup("TimeBounds"),
-    v2: xdr.lookup("PreconditionsV2"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   const MAX_OPS_PER_TX = 100;
-//
-// ===========================================================================
-xdr.const("MAX_OPS_PER_TX", 100);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionV0Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionV0
-//   {
-//       uint256 sourceAccountEd25519;
-//       uint32 fee;
-//       SequenceNumber seqNum;
-//       TimeBounds* timeBounds;
-//       Memo memo;
-//       Operation operations<MAX_OPS_PER_TX>;
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionV0", [
-  ["sourceAccountEd25519", xdr.lookup("Uint256")],
-  ["fee", xdr.lookup("Uint32")],
-  ["seqNum", xdr.lookup("SequenceNumber")],
-  ["timeBounds", xdr.option(xdr.lookup("TimeBounds"))],
-  ["memo", xdr.lookup("Memo")],
-  ["operations", xdr.varArray(xdr.lookup("Operation"), xdr.lookup("MAX_OPS_PER_TX"))],
-  ["ext", xdr.lookup("TransactionV0Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionV0Envelope
-//   {
-//       TransactionV0 tx;
-//       /* Each decorated signature is a signature over the SHA256 hash of
-//        * a TransactionSignaturePayload */
-//       DecoratedSignature signatures<20>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionV0Envelope", [
-  ["tx", xdr.lookup("TransactionV0")],
-  ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct Transaction
-//   {
-//       // account used to run the transaction
-//       MuxedAccount sourceAccount;
-//   
-//       // the fee the sourceAccount will pay
-//       uint32 fee;
-//   
-//       // sequence number to consume in the account
-//       SequenceNumber seqNum;
-//   
-//       // validity conditions
-//       Preconditions cond;
-//   
-//       Memo memo;
-//   
-//       Operation operations<MAX_OPS_PER_TX>;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("Transaction", [
-  ["sourceAccount", xdr.lookup("MuxedAccount")],
-  ["fee", xdr.lookup("Uint32")],
-  ["seqNum", xdr.lookup("SequenceNumber")],
-  ["cond", xdr.lookup("Preconditions")],
-  ["memo", xdr.lookup("Memo")],
-  ["operations", xdr.varArray(xdr.lookup("Operation"), xdr.lookup("MAX_OPS_PER_TX"))],
-  ["ext", xdr.lookup("TransactionExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionV1Envelope
-//   {
-//       Transaction tx;
-//       /* Each decorated signature is a signature over the SHA256 hash of
-//        * a TransactionSignaturePayload */
-//       DecoratedSignature signatures<20>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionV1Envelope", [
-  ["tx", xdr.lookup("Transaction")],
-  ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (EnvelopeType type)
-//       {
-//       case ENVELOPE_TYPE_TX:
-//           TransactionV1Envelope v1;
-//       }
-//
-// ===========================================================================
-xdr.union("FeeBumpTransactionInnerTx", {
-  switchOn: xdr.lookup("EnvelopeType"),
-  switchName: "type",
-  switches: [
-    ["envelopeTypeTx", "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("TransactionV1Envelope"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("FeeBumpTransactionExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct FeeBumpTransaction
-//   {
-//       MuxedAccount feeSource;
-//       int64 fee;
-//       union switch (EnvelopeType type)
-//       {
-//       case ENVELOPE_TYPE_TX:
-//           TransactionV1Envelope v1;
-//       }
-//       innerTx;
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("FeeBumpTransaction", [
-  ["feeSource", xdr.lookup("MuxedAccount")],
-  ["fee", xdr.lookup("Int64")],
-  ["innerTx", xdr.lookup("FeeBumpTransactionInnerTx")],
-  ["ext", xdr.lookup("FeeBumpTransactionExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct FeeBumpTransactionEnvelope
-//   {
-//       FeeBumpTransaction tx;
-//       /* Each decorated signature is a signature over the SHA256 hash of
-//        * a TransactionSignaturePayload */
-//       DecoratedSignature signatures<20>;
-//   };
-//
-// ===========================================================================
-xdr.struct("FeeBumpTransactionEnvelope", [
-  ["tx", xdr.lookup("FeeBumpTransaction")],
-  ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
-]);
-
-// === xdr source ============================================================
-//
-//   union TransactionEnvelope switch (EnvelopeType type)
-//   {
-//   case ENVELOPE_TYPE_TX_V0:
-//       TransactionV0Envelope v0;
-//   case ENVELOPE_TYPE_TX:
-//       TransactionV1Envelope v1;
-//   case ENVELOPE_TYPE_TX_FEE_BUMP:
-//       FeeBumpTransactionEnvelope feeBump;
-//   };
-//
-// ===========================================================================
-xdr.union("TransactionEnvelope", {
-  switchOn: xdr.lookup("EnvelopeType"),
-  switchName: "type",
-  switches: [
-    ["envelopeTypeTxV0", "v0"],
-    ["envelopeTypeTx", "v1"],
-    ["envelopeTypeTxFeeBump", "feeBump"],
-  ],
-  arms: {
-    v0: xdr.lookup("TransactionV0Envelope"),
-    v1: xdr.lookup("TransactionV1Envelope"),
-    feeBump: xdr.lookup("FeeBumpTransactionEnvelope"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (EnvelopeType type)
-//       {
-//       // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
-//       case ENVELOPE_TYPE_TX:
-//           Transaction tx;
-//       case ENVELOPE_TYPE_TX_FEE_BUMP:
-//           FeeBumpTransaction feeBump;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionSignaturePayloadTaggedTransaction", {
-  switchOn: xdr.lookup("EnvelopeType"),
-  switchName: "type",
-  switches: [
-    ["envelopeTypeTx", "tx"],
-    ["envelopeTypeTxFeeBump", "feeBump"],
-  ],
-  arms: {
-    tx: xdr.lookup("Transaction"),
-    feeBump: xdr.lookup("FeeBumpTransaction"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionSignaturePayload
-//   {
-//       Hash networkId;
-//       union switch (EnvelopeType type)
-//       {
-//       // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
-//       case ENVELOPE_TYPE_TX:
-//           Transaction tx;
-//       case ENVELOPE_TYPE_TX_FEE_BUMP:
-//           FeeBumpTransaction feeBump;
-//       }
-//       taggedTransaction;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionSignaturePayload", [
-  ["networkId", xdr.lookup("Hash")],
-  ["taggedTransaction", xdr.lookup("TransactionSignaturePayloadTaggedTransaction")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum ClaimAtomType
-//   {
-//       CLAIM_ATOM_TYPE_V0 = 0,
-//       CLAIM_ATOM_TYPE_ORDER_BOOK = 1,
-//       CLAIM_ATOM_TYPE_LIQUIDITY_POOL = 2
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimAtomType", {
-  claimAtomTypeV0: 0,
-  claimAtomTypeOrderBook: 1,
-  claimAtomTypeLiquidityPool: 2,
-});
-
-// === xdr source ============================================================
-//
-//   struct ClaimOfferAtomV0
-//   {
-//       // emitted to identify the offer
-//       uint256 sellerEd25519; // Account that owns the offer
-//       int64 offerID;
-//   
-//       // amount and asset taken from the owner
-//       Asset assetSold;
-//       int64 amountSold;
-//   
-//       // amount and asset sent to the owner
-//       Asset assetBought;
-//       int64 amountBought;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimOfferAtomV0", [
-  ["sellerEd25519", xdr.lookup("Uint256")],
-  ["offerId", xdr.lookup("Int64")],
-  ["assetSold", xdr.lookup("Asset")],
-  ["amountSold", xdr.lookup("Int64")],
-  ["assetBought", xdr.lookup("Asset")],
-  ["amountBought", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ClaimOfferAtom
-//   {
-//       // emitted to identify the offer
-//       AccountID sellerID; // Account that owns the offer
-//       int64 offerID;
-//   
-//       // amount and asset taken from the owner
-//       Asset assetSold;
-//       int64 amountSold;
-//   
-//       // amount and asset sent to the owner
-//       Asset assetBought;
-//       int64 amountBought;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimOfferAtom", [
-  ["sellerId", xdr.lookup("AccountId")],
-  ["offerId", xdr.lookup("Int64")],
-  ["assetSold", xdr.lookup("Asset")],
-  ["amountSold", xdr.lookup("Int64")],
-  ["assetBought", xdr.lookup("Asset")],
-  ["amountBought", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ClaimLiquidityAtom
-//   {
-//       PoolID liquidityPoolID;
-//   
-//       // amount and asset taken from the pool
-//       Asset assetSold;
-//       int64 amountSold;
-//   
-//       // amount and asset sent to the pool
-//       Asset assetBought;
-//       int64 amountBought;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimLiquidityAtom", [
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-  ["assetSold", xdr.lookup("Asset")],
-  ["amountSold", xdr.lookup("Int64")],
-  ["assetBought", xdr.lookup("Asset")],
-  ["amountBought", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   union ClaimAtom switch (ClaimAtomType type)
-//   {
-//   case CLAIM_ATOM_TYPE_V0:
-//       ClaimOfferAtomV0 v0;
-//   case CLAIM_ATOM_TYPE_ORDER_BOOK:
-//       ClaimOfferAtom orderBook;
-//   case CLAIM_ATOM_TYPE_LIQUIDITY_POOL:
-//       ClaimLiquidityAtom liquidityPool;
-//   };
-//
-// ===========================================================================
-xdr.union("ClaimAtom", {
-  switchOn: xdr.lookup("ClaimAtomType"),
-  switchName: "type",
-  switches: [
-    ["claimAtomTypeV0", "v0"],
-    ["claimAtomTypeOrderBook", "orderBook"],
-    ["claimAtomTypeLiquidityPool", "liquidityPool"],
-  ],
-  arms: {
-    v0: xdr.lookup("ClaimOfferAtomV0"),
-    orderBook: xdr.lookup("ClaimOfferAtom"),
-    liquidityPool: xdr.lookup("ClaimLiquidityAtom"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum CreateAccountResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       CREATE_ACCOUNT_SUCCESS = 0, // account was created
-//   
-//       // codes considered as "failure" for the operation
-//       CREATE_ACCOUNT_MALFORMED = -1,   // invalid destination
-//       CREATE_ACCOUNT_UNDERFUNDED = -2, // not enough funds in source account
-//       CREATE_ACCOUNT_LOW_RESERVE =
-//           -3, // would create an account below the min reserve
-//       CREATE_ACCOUNT_ALREADY_EXIST = -4 // account already exists
-//   };
-//
-// ===========================================================================
-xdr.enum("CreateAccountResultCode", {
-  createAccountSuccess: 0,
-  createAccountMalformed: -1,
-  createAccountUnderfunded: -2,
-  createAccountLowReserve: -3,
-  createAccountAlreadyExist: -4,
-});
-
-// === xdr source ============================================================
-//
-//   union CreateAccountResult switch (CreateAccountResultCode code)
-//   {
-//   case CREATE_ACCOUNT_SUCCESS:
-//       void;
-//   case CREATE_ACCOUNT_MALFORMED:
-//   case CREATE_ACCOUNT_UNDERFUNDED:
-//   case CREATE_ACCOUNT_LOW_RESERVE:
-//   case CREATE_ACCOUNT_ALREADY_EXIST:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("CreateAccountResult", {
-  switchOn: xdr.lookup("CreateAccountResultCode"),
-  switchName: "code",
-  switches: [
-    ["createAccountSuccess", xdr.void()],
-    ["createAccountMalformed", xdr.void()],
-    ["createAccountUnderfunded", xdr.void()],
-    ["createAccountLowReserve", xdr.void()],
-    ["createAccountAlreadyExist", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum PaymentResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       PAYMENT_SUCCESS = 0, // payment successfully completed
-//   
-//       // codes considered as "failure" for the operation
-//       PAYMENT_MALFORMED = -1,          // bad input
-//       PAYMENT_UNDERFUNDED = -2,        // not enough funds in source account
-//       PAYMENT_SRC_NO_TRUST = -3,       // no trust line on source account
-//       PAYMENT_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-//       PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
-//       PAYMENT_NO_TRUST = -6,       // destination missing a trust line for asset
-//       PAYMENT_NOT_AUTHORIZED = -7, // destination not authorized to hold asset
-//       PAYMENT_LINE_FULL = -8,      // destination would go above their limit
-//       PAYMENT_NO_ISSUER = -9       // missing issuer on asset
-//   };
-//
-// ===========================================================================
-xdr.enum("PaymentResultCode", {
-  paymentSuccess: 0,
-  paymentMalformed: -1,
-  paymentUnderfunded: -2,
-  paymentSrcNoTrust: -3,
-  paymentSrcNotAuthorized: -4,
-  paymentNoDestination: -5,
-  paymentNoTrust: -6,
-  paymentNotAuthorized: -7,
-  paymentLineFull: -8,
-  paymentNoIssuer: -9,
-});
-
-// === xdr source ============================================================
-//
-//   union PaymentResult switch (PaymentResultCode code)
-//   {
-//   case PAYMENT_SUCCESS:
-//       void;
-//   case PAYMENT_MALFORMED:
-//   case PAYMENT_UNDERFUNDED:
-//   case PAYMENT_SRC_NO_TRUST:
-//   case PAYMENT_SRC_NOT_AUTHORIZED:
-//   case PAYMENT_NO_DESTINATION:
-//   case PAYMENT_NO_TRUST:
-//   case PAYMENT_NOT_AUTHORIZED:
-//   case PAYMENT_LINE_FULL:
-//   case PAYMENT_NO_ISSUER:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("PaymentResult", {
-  switchOn: xdr.lookup("PaymentResultCode"),
-  switchName: "code",
-  switches: [
-    ["paymentSuccess", xdr.void()],
-    ["paymentMalformed", xdr.void()],
-    ["paymentUnderfunded", xdr.void()],
-    ["paymentSrcNoTrust", xdr.void()],
-    ["paymentSrcNotAuthorized", xdr.void()],
-    ["paymentNoDestination", xdr.void()],
-    ["paymentNoTrust", xdr.void()],
-    ["paymentNotAuthorized", xdr.void()],
-    ["paymentLineFull", xdr.void()],
-    ["paymentNoIssuer", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum PathPaymentStrictReceiveResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
-//   
-//       // codes considered as "failure" for the operation
-//       PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1, // bad input
-//       PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED =
-//           -2, // not enough funds in source account
-//       PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST =
-//           -3, // no trust line on source account
-//       PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED =
-//           -4, // source not authorized to transfer
-//       PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION =
-//           -5, // destination account does not exist
-//       PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST =
-//           -6, // dest missing a trust line for asset
-//       PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED =
-//           -7, // dest not authorized to hold asset
-//       PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL =
-//           -8, // dest would go above their limit
-//       PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9, // missing issuer on one asset
-//       PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS =
-//           -10, // not enough offers to satisfy path
-//       PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF =
-//           -11, // would cross one of its own offers
-//       PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12 // could not satisfy sendmax
-//   };
-//
-// ===========================================================================
-xdr.enum("PathPaymentStrictReceiveResultCode", {
-  pathPaymentStrictReceiveSuccess: 0,
-  pathPaymentStrictReceiveMalformed: -1,
-  pathPaymentStrictReceiveUnderfunded: -2,
-  pathPaymentStrictReceiveSrcNoTrust: -3,
-  pathPaymentStrictReceiveSrcNotAuthorized: -4,
-  pathPaymentStrictReceiveNoDestination: -5,
-  pathPaymentStrictReceiveNoTrust: -6,
-  pathPaymentStrictReceiveNotAuthorized: -7,
-  pathPaymentStrictReceiveLineFull: -8,
-  pathPaymentStrictReceiveNoIssuer: -9,
-  pathPaymentStrictReceiveTooFewOffers: -10,
-  pathPaymentStrictReceiveOfferCrossSelf: -11,
-  pathPaymentStrictReceiveOverSendmax: -12,
-});
-
-// === xdr source ============================================================
-//
-//   struct SimplePaymentResult
-//   {
-//       AccountID destination;
-//       Asset asset;
-//       int64 amount;
-//   };
-//
-// ===========================================================================
-xdr.struct("SimplePaymentResult", [
-  ["destination", xdr.lookup("AccountId")],
-  ["asset", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           ClaimAtom offers<>;
-//           SimplePaymentResult last;
-//       }
-//
-// ===========================================================================
-xdr.struct("PathPaymentStrictReceiveResultSuccess", [
-  ["offers", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
-  ["last", xdr.lookup("SimplePaymentResult")],
-]);
-
-// === xdr source ============================================================
-//
-//   union PathPaymentStrictReceiveResult switch (
-//       PathPaymentStrictReceiveResultCode code)
-//   {
-//   case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
-//       struct
-//       {
-//           ClaimAtom offers<>;
-//           SimplePaymentResult last;
-//       } success;
-//   case PATH_PAYMENT_STRICT_RECEIVE_MALFORMED:
-//   case PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED:
-//   case PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST:
-//   case PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED:
-//   case PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION:
-//   case PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST:
-//   case PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED:
-//   case PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL:
-//       void;
-//   case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
-//       Asset noIssuer; // the asset that caused the error
-//   case PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS:
-//   case PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF:
-//   case PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("PathPaymentStrictReceiveResult", {
-  switchOn: xdr.lookup("PathPaymentStrictReceiveResultCode"),
-  switchName: "code",
-  switches: [
-    ["pathPaymentStrictReceiveSuccess", "success"],
-    ["pathPaymentStrictReceiveMalformed", xdr.void()],
-    ["pathPaymentStrictReceiveUnderfunded", xdr.void()],
-    ["pathPaymentStrictReceiveSrcNoTrust", xdr.void()],
-    ["pathPaymentStrictReceiveSrcNotAuthorized", xdr.void()],
-    ["pathPaymentStrictReceiveNoDestination", xdr.void()],
-    ["pathPaymentStrictReceiveNoTrust", xdr.void()],
-    ["pathPaymentStrictReceiveNotAuthorized", xdr.void()],
-    ["pathPaymentStrictReceiveLineFull", xdr.void()],
-    ["pathPaymentStrictReceiveNoIssuer", "noIssuer"],
-    ["pathPaymentStrictReceiveTooFewOffers", xdr.void()],
-    ["pathPaymentStrictReceiveOfferCrossSelf", xdr.void()],
-    ["pathPaymentStrictReceiveOverSendmax", xdr.void()],
-  ],
-  arms: {
-    success: xdr.lookup("PathPaymentStrictReceiveResultSuccess"),
-    noIssuer: xdr.lookup("Asset"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum PathPaymentStrictSendResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
-//   
-//       // codes considered as "failure" for the operation
-//       PATH_PAYMENT_STRICT_SEND_MALFORMED = -1, // bad input
-//       PATH_PAYMENT_STRICT_SEND_UNDERFUNDED =
-//           -2, // not enough funds in source account
-//       PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST =
-//           -3, // no trust line on source account
-//       PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED =
-//           -4, // source not authorized to transfer
-//       PATH_PAYMENT_STRICT_SEND_NO_DESTINATION =
-//           -5, // destination account does not exist
-//       PATH_PAYMENT_STRICT_SEND_NO_TRUST =
-//           -6, // dest missing a trust line for asset
-//       PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED =
-//           -7, // dest not authorized to hold asset
-//       PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8, // dest would go above their limit
-//       PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9, // missing issuer on one asset
-//       PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS =
-//           -10, // not enough offers to satisfy path
-//       PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF =
-//           -11, // would cross one of its own offers
-//       PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12 // could not satisfy destMin
-//   };
-//
-// ===========================================================================
-xdr.enum("PathPaymentStrictSendResultCode", {
-  pathPaymentStrictSendSuccess: 0,
-  pathPaymentStrictSendMalformed: -1,
-  pathPaymentStrictSendUnderfunded: -2,
-  pathPaymentStrictSendSrcNoTrust: -3,
-  pathPaymentStrictSendSrcNotAuthorized: -4,
-  pathPaymentStrictSendNoDestination: -5,
-  pathPaymentStrictSendNoTrust: -6,
-  pathPaymentStrictSendNotAuthorized: -7,
-  pathPaymentStrictSendLineFull: -8,
-  pathPaymentStrictSendNoIssuer: -9,
-  pathPaymentStrictSendTooFewOffers: -10,
-  pathPaymentStrictSendOfferCrossSelf: -11,
-  pathPaymentStrictSendUnderDestmin: -12,
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           ClaimAtom offers<>;
-//           SimplePaymentResult last;
-//       }
-//
-// ===========================================================================
-xdr.struct("PathPaymentStrictSendResultSuccess", [
-  ["offers", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
-  ["last", xdr.lookup("SimplePaymentResult")],
-]);
-
-// === xdr source ============================================================
-//
-//   union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
-//   {
-//   case PATH_PAYMENT_STRICT_SEND_SUCCESS:
-//       struct
-//       {
-//           ClaimAtom offers<>;
-//           SimplePaymentResult last;
-//       } success;
-//   case PATH_PAYMENT_STRICT_SEND_MALFORMED:
-//   case PATH_PAYMENT_STRICT_SEND_UNDERFUNDED:
-//   case PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST:
-//   case PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED:
-//   case PATH_PAYMENT_STRICT_SEND_NO_DESTINATION:
-//   case PATH_PAYMENT_STRICT_SEND_NO_TRUST:
-//   case PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED:
-//   case PATH_PAYMENT_STRICT_SEND_LINE_FULL:
-//       void;
-//   case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
-//       Asset noIssuer; // the asset that caused the error
-//   case PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS:
-//   case PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF:
-//   case PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("PathPaymentStrictSendResult", {
-  switchOn: xdr.lookup("PathPaymentStrictSendResultCode"),
-  switchName: "code",
-  switches: [
-    ["pathPaymentStrictSendSuccess", "success"],
-    ["pathPaymentStrictSendMalformed", xdr.void()],
-    ["pathPaymentStrictSendUnderfunded", xdr.void()],
-    ["pathPaymentStrictSendSrcNoTrust", xdr.void()],
-    ["pathPaymentStrictSendSrcNotAuthorized", xdr.void()],
-    ["pathPaymentStrictSendNoDestination", xdr.void()],
-    ["pathPaymentStrictSendNoTrust", xdr.void()],
-    ["pathPaymentStrictSendNotAuthorized", xdr.void()],
-    ["pathPaymentStrictSendLineFull", xdr.void()],
-    ["pathPaymentStrictSendNoIssuer", "noIssuer"],
-    ["pathPaymentStrictSendTooFewOffers", xdr.void()],
-    ["pathPaymentStrictSendOfferCrossSelf", xdr.void()],
-    ["pathPaymentStrictSendUnderDestmin", xdr.void()],
-  ],
-  arms: {
-    success: xdr.lookup("PathPaymentStrictSendResultSuccess"),
-    noIssuer: xdr.lookup("Asset"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ManageSellOfferResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       MANAGE_SELL_OFFER_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       MANAGE_SELL_OFFER_MALFORMED = -1, // generated offer would be invalid
-//       MANAGE_SELL_OFFER_SELL_NO_TRUST =
-//           -2,                              // no trust line for what we're selling
-//       MANAGE_SELL_OFFER_BUY_NO_TRUST = -3, // no trust line for what we're buying
-//       MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
-//       MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-//       MANAGE_SELL_OFFER_LINE_FULL = -6, // can't receive more of what it's buying
-//       MANAGE_SELL_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
-//       MANAGE_SELL_OFFER_CROSS_SELF =
-//           -8, // would cross an offer from the same user
-//       MANAGE_SELL_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
-//       MANAGE_SELL_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
-//   
-//       // update errors
-//       MANAGE_SELL_OFFER_NOT_FOUND =
-//           -11, // offerID does not match an existing offer
-//   
-//       MANAGE_SELL_OFFER_LOW_RESERVE =
-//           -12 // not enough funds to create a new Offer
-//   };
-//
-// ===========================================================================
-xdr.enum("ManageSellOfferResultCode", {
-  manageSellOfferSuccess: 0,
-  manageSellOfferMalformed: -1,
-  manageSellOfferSellNoTrust: -2,
-  manageSellOfferBuyNoTrust: -3,
-  manageSellOfferSellNotAuthorized: -4,
-  manageSellOfferBuyNotAuthorized: -5,
-  manageSellOfferLineFull: -6,
-  manageSellOfferUnderfunded: -7,
-  manageSellOfferCrossSelf: -8,
-  manageSellOfferSellNoIssuer: -9,
-  manageSellOfferBuyNoIssuer: -10,
-  manageSellOfferNotFound: -11,
-  manageSellOfferLowReserve: -12,
-});
-
-// === xdr source ============================================================
-//
-//   enum ManageOfferEffect
-//   {
-//       MANAGE_OFFER_CREATED = 0,
-//       MANAGE_OFFER_UPDATED = 1,
-//       MANAGE_OFFER_DELETED = 2
-//   };
-//
-// ===========================================================================
-xdr.enum("ManageOfferEffect", {
-  manageOfferCreated: 0,
-  manageOfferUpdated: 1,
-  manageOfferDeleted: 2,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (ManageOfferEffect effect)
-//       {
-//       case MANAGE_OFFER_CREATED:
-//       case MANAGE_OFFER_UPDATED:
-//           OfferEntry offer;
-//       case MANAGE_OFFER_DELETED:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("ManageOfferSuccessResultOffer", {
-  switchOn: xdr.lookup("ManageOfferEffect"),
-  switchName: "effect",
-  switches: [
-    ["manageOfferCreated", "offer"],
-    ["manageOfferUpdated", "offer"],
-    ["manageOfferDeleted", xdr.void()],
-  ],
-  arms: {
-    offer: xdr.lookup("OfferEntry"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ManageOfferSuccessResult
-//   {
-//       // offers that got claimed while creating this offer
-//       ClaimAtom offersClaimed<>;
-//   
-//       union switch (ManageOfferEffect effect)
-//       {
-//       case MANAGE_OFFER_CREATED:
-//       case MANAGE_OFFER_UPDATED:
-//           OfferEntry offer;
-//       case MANAGE_OFFER_DELETED:
-//           void;
-//       }
-//       offer;
-//   };
-//
-// ===========================================================================
-xdr.struct("ManageOfferSuccessResult", [
-  ["offersClaimed", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
-  ["offer", xdr.lookup("ManageOfferSuccessResultOffer")],
-]);
-
-// === xdr source ============================================================
-//
-//   union ManageSellOfferResult switch (ManageSellOfferResultCode code)
-//   {
-//   case MANAGE_SELL_OFFER_SUCCESS:
-//       ManageOfferSuccessResult success;
-//   case MANAGE_SELL_OFFER_MALFORMED:
-//   case MANAGE_SELL_OFFER_SELL_NO_TRUST:
-//   case MANAGE_SELL_OFFER_BUY_NO_TRUST:
-//   case MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED:
-//   case MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED:
-//   case MANAGE_SELL_OFFER_LINE_FULL:
-//   case MANAGE_SELL_OFFER_UNDERFUNDED:
-//   case MANAGE_SELL_OFFER_CROSS_SELF:
-//   case MANAGE_SELL_OFFER_SELL_NO_ISSUER:
-//   case MANAGE_SELL_OFFER_BUY_NO_ISSUER:
-//   case MANAGE_SELL_OFFER_NOT_FOUND:
-//   case MANAGE_SELL_OFFER_LOW_RESERVE:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ManageSellOfferResult", {
-  switchOn: xdr.lookup("ManageSellOfferResultCode"),
-  switchName: "code",
-  switches: [
-    ["manageSellOfferSuccess", "success"],
-    ["manageSellOfferMalformed", xdr.void()],
-    ["manageSellOfferSellNoTrust", xdr.void()],
-    ["manageSellOfferBuyNoTrust", xdr.void()],
-    ["manageSellOfferSellNotAuthorized", xdr.void()],
-    ["manageSellOfferBuyNotAuthorized", xdr.void()],
-    ["manageSellOfferLineFull", xdr.void()],
-    ["manageSellOfferUnderfunded", xdr.void()],
-    ["manageSellOfferCrossSelf", xdr.void()],
-    ["manageSellOfferSellNoIssuer", xdr.void()],
-    ["manageSellOfferBuyNoIssuer", xdr.void()],
-    ["manageSellOfferNotFound", xdr.void()],
-    ["manageSellOfferLowReserve", xdr.void()],
-  ],
-  arms: {
-    success: xdr.lookup("ManageOfferSuccessResult"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ManageBuyOfferResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       MANAGE_BUY_OFFER_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       MANAGE_BUY_OFFER_MALFORMED = -1,     // generated offer would be invalid
-//       MANAGE_BUY_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
-//       MANAGE_BUY_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
-//       MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
-//       MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-//       MANAGE_BUY_OFFER_LINE_FULL = -6,   // can't receive more of what it's buying
-//       MANAGE_BUY_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
-//       MANAGE_BUY_OFFER_CROSS_SELF = -8, // would cross an offer from the same user
-//       MANAGE_BUY_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
-//       MANAGE_BUY_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
-//   
-//       // update errors
-//       MANAGE_BUY_OFFER_NOT_FOUND =
-//           -11, // offerID does not match an existing offer
-//   
-//       MANAGE_BUY_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
-//   };
-//
-// ===========================================================================
-xdr.enum("ManageBuyOfferResultCode", {
-  manageBuyOfferSuccess: 0,
-  manageBuyOfferMalformed: -1,
-  manageBuyOfferSellNoTrust: -2,
-  manageBuyOfferBuyNoTrust: -3,
-  manageBuyOfferSellNotAuthorized: -4,
-  manageBuyOfferBuyNotAuthorized: -5,
-  manageBuyOfferLineFull: -6,
-  manageBuyOfferUnderfunded: -7,
-  manageBuyOfferCrossSelf: -8,
-  manageBuyOfferSellNoIssuer: -9,
-  manageBuyOfferBuyNoIssuer: -10,
-  manageBuyOfferNotFound: -11,
-  manageBuyOfferLowReserve: -12,
-});
-
-// === xdr source ============================================================
-//
-//   union ManageBuyOfferResult switch (ManageBuyOfferResultCode code)
-//   {
-//   case MANAGE_BUY_OFFER_SUCCESS:
-//       ManageOfferSuccessResult success;
-//   case MANAGE_BUY_OFFER_MALFORMED:
-//   case MANAGE_BUY_OFFER_SELL_NO_TRUST:
-//   case MANAGE_BUY_OFFER_BUY_NO_TRUST:
-//   case MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED:
-//   case MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED:
-//   case MANAGE_BUY_OFFER_LINE_FULL:
-//   case MANAGE_BUY_OFFER_UNDERFUNDED:
-//   case MANAGE_BUY_OFFER_CROSS_SELF:
-//   case MANAGE_BUY_OFFER_SELL_NO_ISSUER:
-//   case MANAGE_BUY_OFFER_BUY_NO_ISSUER:
-//   case MANAGE_BUY_OFFER_NOT_FOUND:
-//   case MANAGE_BUY_OFFER_LOW_RESERVE:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ManageBuyOfferResult", {
-  switchOn: xdr.lookup("ManageBuyOfferResultCode"),
-  switchName: "code",
-  switches: [
-    ["manageBuyOfferSuccess", "success"],
-    ["manageBuyOfferMalformed", xdr.void()],
-    ["manageBuyOfferSellNoTrust", xdr.void()],
-    ["manageBuyOfferBuyNoTrust", xdr.void()],
-    ["manageBuyOfferSellNotAuthorized", xdr.void()],
-    ["manageBuyOfferBuyNotAuthorized", xdr.void()],
-    ["manageBuyOfferLineFull", xdr.void()],
-    ["manageBuyOfferUnderfunded", xdr.void()],
-    ["manageBuyOfferCrossSelf", xdr.void()],
-    ["manageBuyOfferSellNoIssuer", xdr.void()],
-    ["manageBuyOfferBuyNoIssuer", xdr.void()],
-    ["manageBuyOfferNotFound", xdr.void()],
-    ["manageBuyOfferLowReserve", xdr.void()],
-  ],
-  arms: {
-    success: xdr.lookup("ManageOfferSuccessResult"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum SetOptionsResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       SET_OPTIONS_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       SET_OPTIONS_LOW_RESERVE = -1,      // not enough funds to add a signer
-//       SET_OPTIONS_TOO_MANY_SIGNERS = -2, // max number of signers already reached
-//       SET_OPTIONS_BAD_FLAGS = -3,        // invalid combination of clear/set flags
-//       SET_OPTIONS_INVALID_INFLATION = -4,      // inflation account does not exist
-//       SET_OPTIONS_CANT_CHANGE = -5,            // can no longer change this option
-//       SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
-//       SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
-//       SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
-//       SET_OPTIONS_INVALID_HOME_DOMAIN = -9,    // malformed home domain
-//       SET_OPTIONS_AUTH_REVOCABLE_REQUIRED =
-//           -10 // auth revocable is required for clawback
-//   };
-//
-// ===========================================================================
-xdr.enum("SetOptionsResultCode", {
-  setOptionsSuccess: 0,
-  setOptionsLowReserve: -1,
-  setOptionsTooManySigners: -2,
-  setOptionsBadFlags: -3,
-  setOptionsInvalidInflation: -4,
-  setOptionsCantChange: -5,
-  setOptionsUnknownFlag: -6,
-  setOptionsThresholdOutOfRange: -7,
-  setOptionsBadSigner: -8,
-  setOptionsInvalidHomeDomain: -9,
-  setOptionsAuthRevocableRequired: -10,
-});
-
-// === xdr source ============================================================
-//
-//   union SetOptionsResult switch (SetOptionsResultCode code)
-//   {
-//   case SET_OPTIONS_SUCCESS:
-//       void;
-//   case SET_OPTIONS_LOW_RESERVE:
-//   case SET_OPTIONS_TOO_MANY_SIGNERS:
-//   case SET_OPTIONS_BAD_FLAGS:
-//   case SET_OPTIONS_INVALID_INFLATION:
-//   case SET_OPTIONS_CANT_CHANGE:
-//   case SET_OPTIONS_UNKNOWN_FLAG:
-//   case SET_OPTIONS_THRESHOLD_OUT_OF_RANGE:
-//   case SET_OPTIONS_BAD_SIGNER:
-//   case SET_OPTIONS_INVALID_HOME_DOMAIN:
-//   case SET_OPTIONS_AUTH_REVOCABLE_REQUIRED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("SetOptionsResult", {
-  switchOn: xdr.lookup("SetOptionsResultCode"),
-  switchName: "code",
-  switches: [
-    ["setOptionsSuccess", xdr.void()],
-    ["setOptionsLowReserve", xdr.void()],
-    ["setOptionsTooManySigners", xdr.void()],
-    ["setOptionsBadFlags", xdr.void()],
-    ["setOptionsInvalidInflation", xdr.void()],
-    ["setOptionsCantChange", xdr.void()],
-    ["setOptionsUnknownFlag", xdr.void()],
-    ["setOptionsThresholdOutOfRange", xdr.void()],
-    ["setOptionsBadSigner", xdr.void()],
-    ["setOptionsInvalidHomeDomain", xdr.void()],
-    ["setOptionsAuthRevocableRequired", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ChangeTrustResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       CHANGE_TRUST_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       CHANGE_TRUST_MALFORMED = -1,     // bad input
-//       CHANGE_TRUST_NO_ISSUER = -2,     // could not find issuer
-//       CHANGE_TRUST_INVALID_LIMIT = -3, // cannot drop limit below balance
-//                                        // cannot create with a limit of 0
-//       CHANGE_TRUST_LOW_RESERVE =
-//           -4, // not enough funds to create a new trust line,
-//       CHANGE_TRUST_SELF_NOT_ALLOWED = -5,   // trusting self is not allowed
-//       CHANGE_TRUST_TRUST_LINE_MISSING = -6, // Asset trustline is missing for pool
-//       CHANGE_TRUST_CANNOT_DELETE =
-//           -7, // Asset trustline is still referenced in a pool
-//       CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES =
-//           -8 // Asset trustline is deauthorized
-//   };
-//
-// ===========================================================================
-xdr.enum("ChangeTrustResultCode", {
-  changeTrustSuccess: 0,
-  changeTrustMalformed: -1,
-  changeTrustNoIssuer: -2,
-  changeTrustInvalidLimit: -3,
-  changeTrustLowReserve: -4,
-  changeTrustSelfNotAllowed: -5,
-  changeTrustTrustLineMissing: -6,
-  changeTrustCannotDelete: -7,
-  changeTrustNotAuthMaintainLiabilities: -8,
-});
-
-// === xdr source ============================================================
-//
-//   union ChangeTrustResult switch (ChangeTrustResultCode code)
-//   {
-//   case CHANGE_TRUST_SUCCESS:
-//       void;
-//   case CHANGE_TRUST_MALFORMED:
-//   case CHANGE_TRUST_NO_ISSUER:
-//   case CHANGE_TRUST_INVALID_LIMIT:
-//   case CHANGE_TRUST_LOW_RESERVE:
-//   case CHANGE_TRUST_SELF_NOT_ALLOWED:
-//   case CHANGE_TRUST_TRUST_LINE_MISSING:
-//   case CHANGE_TRUST_CANNOT_DELETE:
-//   case CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ChangeTrustResult", {
-  switchOn: xdr.lookup("ChangeTrustResultCode"),
-  switchName: "code",
-  switches: [
-    ["changeTrustSuccess", xdr.void()],
-    ["changeTrustMalformed", xdr.void()],
-    ["changeTrustNoIssuer", xdr.void()],
-    ["changeTrustInvalidLimit", xdr.void()],
-    ["changeTrustLowReserve", xdr.void()],
-    ["changeTrustSelfNotAllowed", xdr.void()],
-    ["changeTrustTrustLineMissing", xdr.void()],
-    ["changeTrustCannotDelete", xdr.void()],
-    ["changeTrustNotAuthMaintainLiabilities", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum AllowTrustResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       ALLOW_TRUST_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       ALLOW_TRUST_MALFORMED = -1,     // asset is not ASSET_TYPE_ALPHANUM
-//       ALLOW_TRUST_NO_TRUST_LINE = -2, // trustor does not have a trustline
-//                                       // source account does not require trust
-//       ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
-//       ALLOW_TRUST_CANT_REVOKE = -4,      // source account can't revoke trust,
-//       ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
-//       ALLOW_TRUST_LOW_RESERVE = -6       // claimable balances can't be created
-//                                          // on revoke due to low reserves
-//   };
-//
-// ===========================================================================
-xdr.enum("AllowTrustResultCode", {
-  allowTrustSuccess: 0,
-  allowTrustMalformed: -1,
-  allowTrustNoTrustLine: -2,
-  allowTrustTrustNotRequired: -3,
-  allowTrustCantRevoke: -4,
-  allowTrustSelfNotAllowed: -5,
-  allowTrustLowReserve: -6,
-});
-
-// === xdr source ============================================================
-//
-//   union AllowTrustResult switch (AllowTrustResultCode code)
-//   {
-//   case ALLOW_TRUST_SUCCESS:
-//       void;
-//   case ALLOW_TRUST_MALFORMED:
-//   case ALLOW_TRUST_NO_TRUST_LINE:
-//   case ALLOW_TRUST_TRUST_NOT_REQUIRED:
-//   case ALLOW_TRUST_CANT_REVOKE:
-//   case ALLOW_TRUST_SELF_NOT_ALLOWED:
-//   case ALLOW_TRUST_LOW_RESERVE:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("AllowTrustResult", {
-  switchOn: xdr.lookup("AllowTrustResultCode"),
-  switchName: "code",
-  switches: [
-    ["allowTrustSuccess", xdr.void()],
-    ["allowTrustMalformed", xdr.void()],
-    ["allowTrustNoTrustLine", xdr.void()],
-    ["allowTrustTrustNotRequired", xdr.void()],
-    ["allowTrustCantRevoke", xdr.void()],
-    ["allowTrustSelfNotAllowed", xdr.void()],
-    ["allowTrustLowReserve", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum AccountMergeResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       ACCOUNT_MERGE_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       ACCOUNT_MERGE_MALFORMED = -1,       // can't merge onto itself
-//       ACCOUNT_MERGE_NO_ACCOUNT = -2,      // destination does not exist
-//       ACCOUNT_MERGE_IMMUTABLE_SET = -3,   // source account has AUTH_IMMUTABLE set
-//       ACCOUNT_MERGE_HAS_SUB_ENTRIES = -4, // account has trust lines/offers
-//       ACCOUNT_MERGE_SEQNUM_TOO_FAR = -5,  // sequence number is over max allowed
-//       ACCOUNT_MERGE_DEST_FULL = -6,       // can't add source balance to
-//                                           // destination balance
-//       ACCOUNT_MERGE_IS_SPONSOR = -7       // can't merge account that is a sponsor
-//   };
-//
-// ===========================================================================
-xdr.enum("AccountMergeResultCode", {
-  accountMergeSuccess: 0,
-  accountMergeMalformed: -1,
-  accountMergeNoAccount: -2,
-  accountMergeImmutableSet: -3,
-  accountMergeHasSubEntries: -4,
-  accountMergeSeqnumTooFar: -5,
-  accountMergeDestFull: -6,
-  accountMergeIsSponsor: -7,
-});
-
-// === xdr source ============================================================
-//
-//   union AccountMergeResult switch (AccountMergeResultCode code)
-//   {
-//   case ACCOUNT_MERGE_SUCCESS:
-//       int64 sourceAccountBalance; // how much got transferred from source account
-//   case ACCOUNT_MERGE_MALFORMED:
-//   case ACCOUNT_MERGE_NO_ACCOUNT:
-//   case ACCOUNT_MERGE_IMMUTABLE_SET:
-//   case ACCOUNT_MERGE_HAS_SUB_ENTRIES:
-//   case ACCOUNT_MERGE_SEQNUM_TOO_FAR:
-//   case ACCOUNT_MERGE_DEST_FULL:
-//   case ACCOUNT_MERGE_IS_SPONSOR:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("AccountMergeResult", {
-  switchOn: xdr.lookup("AccountMergeResultCode"),
-  switchName: "code",
-  switches: [
-    ["accountMergeSuccess", "sourceAccountBalance"],
-    ["accountMergeMalformed", xdr.void()],
-    ["accountMergeNoAccount", xdr.void()],
-    ["accountMergeImmutableSet", xdr.void()],
-    ["accountMergeHasSubEntries", xdr.void()],
-    ["accountMergeSeqnumTooFar", xdr.void()],
-    ["accountMergeDestFull", xdr.void()],
-    ["accountMergeIsSponsor", xdr.void()],
-  ],
-  arms: {
-    sourceAccountBalance: xdr.lookup("Int64"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum InflationResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       INFLATION_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       INFLATION_NOT_TIME = -1
-//   };
-//
-// ===========================================================================
-xdr.enum("InflationResultCode", {
-  inflationSuccess: 0,
-  inflationNotTime: -1,
-});
-
-// === xdr source ============================================================
-//
-//   struct InflationPayout // or use PaymentResultAtom to limit types?
-//   {
-//       AccountID destination;
-//       int64 amount;
-//   };
-//
-// ===========================================================================
-xdr.struct("InflationPayout", [
-  ["destination", xdr.lookup("AccountId")],
-  ["amount", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   union InflationResult switch (InflationResultCode code)
-//   {
-//   case INFLATION_SUCCESS:
-//       InflationPayout payouts<>;
-//   case INFLATION_NOT_TIME:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("InflationResult", {
-  switchOn: xdr.lookup("InflationResultCode"),
-  switchName: "code",
-  switches: [
-    ["inflationSuccess", "payouts"],
-    ["inflationNotTime", xdr.void()],
-  ],
-  arms: {
-    payouts: xdr.varArray(xdr.lookup("InflationPayout"), 2147483647),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ManageDataResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       MANAGE_DATA_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       MANAGE_DATA_NOT_SUPPORTED_YET =
-//           -1, // The network hasn't moved to this protocol change yet
-//       MANAGE_DATA_NAME_NOT_FOUND =
-//           -2, // Trying to remove a Data Entry that isn't there
-//       MANAGE_DATA_LOW_RESERVE = -3, // not enough funds to create a new Data Entry
-//       MANAGE_DATA_INVALID_NAME = -4 // Name not a valid string
-//   };
-//
-// ===========================================================================
-xdr.enum("ManageDataResultCode", {
-  manageDataSuccess: 0,
-  manageDataNotSupportedYet: -1,
-  manageDataNameNotFound: -2,
-  manageDataLowReserve: -3,
-  manageDataInvalidName: -4,
-});
-
-// === xdr source ============================================================
-//
-//   union ManageDataResult switch (ManageDataResultCode code)
-//   {
-//   case MANAGE_DATA_SUCCESS:
-//       void;
-//   case MANAGE_DATA_NOT_SUPPORTED_YET:
-//   case MANAGE_DATA_NAME_NOT_FOUND:
-//   case MANAGE_DATA_LOW_RESERVE:
-//   case MANAGE_DATA_INVALID_NAME:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ManageDataResult", {
-  switchOn: xdr.lookup("ManageDataResultCode"),
-  switchName: "code",
-  switches: [
-    ["manageDataSuccess", xdr.void()],
-    ["manageDataNotSupportedYet", xdr.void()],
-    ["manageDataNameNotFound", xdr.void()],
-    ["manageDataLowReserve", xdr.void()],
-    ["manageDataInvalidName", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum BumpSequenceResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       BUMP_SEQUENCE_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       BUMP_SEQUENCE_BAD_SEQ = -1 // `bumpTo` is not within bounds
-//   };
-//
-// ===========================================================================
-xdr.enum("BumpSequenceResultCode", {
-  bumpSequenceSuccess: 0,
-  bumpSequenceBadSeq: -1,
-});
-
-// === xdr source ============================================================
-//
-//   union BumpSequenceResult switch (BumpSequenceResultCode code)
-//   {
-//   case BUMP_SEQUENCE_SUCCESS:
-//       void;
-//   case BUMP_SEQUENCE_BAD_SEQ:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("BumpSequenceResult", {
-  switchOn: xdr.lookup("BumpSequenceResultCode"),
-  switchName: "code",
-  switches: [
-    ["bumpSequenceSuccess", xdr.void()],
-    ["bumpSequenceBadSeq", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum CreateClaimableBalanceResultCode
-//   {
-//       CREATE_CLAIMABLE_BALANCE_SUCCESS = 0,
-//       CREATE_CLAIMABLE_BALANCE_MALFORMED = -1,
-//       CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
-//       CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
-//       CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
-//       CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5
-//   };
-//
-// ===========================================================================
-xdr.enum("CreateClaimableBalanceResultCode", {
-  createClaimableBalanceSuccess: 0,
-  createClaimableBalanceMalformed: -1,
-  createClaimableBalanceLowReserve: -2,
-  createClaimableBalanceNoTrust: -3,
-  createClaimableBalanceNotAuthorized: -4,
-  createClaimableBalanceUnderfunded: -5,
-});
-
-// === xdr source ============================================================
-//
-//   union CreateClaimableBalanceResult switch (
-//       CreateClaimableBalanceResultCode code)
-//   {
-//   case CREATE_CLAIMABLE_BALANCE_SUCCESS:
-//       ClaimableBalanceID balanceID;
-//   case CREATE_CLAIMABLE_BALANCE_MALFORMED:
-//   case CREATE_CLAIMABLE_BALANCE_LOW_RESERVE:
-//   case CREATE_CLAIMABLE_BALANCE_NO_TRUST:
-//   case CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
-//   case CREATE_CLAIMABLE_BALANCE_UNDERFUNDED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("CreateClaimableBalanceResult", {
-  switchOn: xdr.lookup("CreateClaimableBalanceResultCode"),
-  switchName: "code",
-  switches: [
-    ["createClaimableBalanceSuccess", "balanceId"],
-    ["createClaimableBalanceMalformed", xdr.void()],
-    ["createClaimableBalanceLowReserve", xdr.void()],
-    ["createClaimableBalanceNoTrust", xdr.void()],
-    ["createClaimableBalanceNotAuthorized", xdr.void()],
-    ["createClaimableBalanceUnderfunded", xdr.void()],
-  ],
-  arms: {
-    balanceId: xdr.lookup("ClaimableBalanceId"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClaimClaimableBalanceResultCode
-//   {
-//       CLAIM_CLAIMABLE_BALANCE_SUCCESS = 0,
-//       CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
-//       CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM = -2,
-//       CLAIM_CLAIMABLE_BALANCE_LINE_FULL = -3,
-//       CLAIM_CLAIMABLE_BALANCE_NO_TRUST = -4,
-//       CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -5
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimClaimableBalanceResultCode", {
-  claimClaimableBalanceSuccess: 0,
-  claimClaimableBalanceDoesNotExist: -1,
-  claimClaimableBalanceCannotClaim: -2,
-  claimClaimableBalanceLineFull: -3,
-  claimClaimableBalanceNoTrust: -4,
-  claimClaimableBalanceNotAuthorized: -5,
-});
-
-// === xdr source ============================================================
-//
-//   union ClaimClaimableBalanceResult switch (ClaimClaimableBalanceResultCode code)
-//   {
-//   case CLAIM_CLAIMABLE_BALANCE_SUCCESS:
-//       void;
-//   case CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
-//   case CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM:
-//   case CLAIM_CLAIMABLE_BALANCE_LINE_FULL:
-//   case CLAIM_CLAIMABLE_BALANCE_NO_TRUST:
-//   case CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ClaimClaimableBalanceResult", {
-  switchOn: xdr.lookup("ClaimClaimableBalanceResultCode"),
-  switchName: "code",
-  switches: [
-    ["claimClaimableBalanceSuccess", xdr.void()],
-    ["claimClaimableBalanceDoesNotExist", xdr.void()],
-    ["claimClaimableBalanceCannotClaim", xdr.void()],
-    ["claimClaimableBalanceLineFull", xdr.void()],
-    ["claimClaimableBalanceNoTrust", xdr.void()],
-    ["claimClaimableBalanceNotAuthorized", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum BeginSponsoringFutureReservesResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED = -1,
-//       BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED = -2,
-//       BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE = -3
-//   };
-//
-// ===========================================================================
-xdr.enum("BeginSponsoringFutureReservesResultCode", {
-  beginSponsoringFutureReservesSuccess: 0,
-  beginSponsoringFutureReservesMalformed: -1,
-  beginSponsoringFutureReservesAlreadySponsored: -2,
-  beginSponsoringFutureReservesRecursive: -3,
-});
-
-// === xdr source ============================================================
-//
-//   union BeginSponsoringFutureReservesResult switch (
-//       BeginSponsoringFutureReservesResultCode code)
-//   {
-//   case BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS:
-//       void;
-//   case BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED:
-//   case BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED:
-//   case BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("BeginSponsoringFutureReservesResult", {
-  switchOn: xdr.lookup("BeginSponsoringFutureReservesResultCode"),
-  switchName: "code",
-  switches: [
-    ["beginSponsoringFutureReservesSuccess", xdr.void()],
-    ["beginSponsoringFutureReservesMalformed", xdr.void()],
-    ["beginSponsoringFutureReservesAlreadySponsored", xdr.void()],
-    ["beginSponsoringFutureReservesRecursive", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum EndSponsoringFutureReservesResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       END_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED = -1
-//   };
-//
-// ===========================================================================
-xdr.enum("EndSponsoringFutureReservesResultCode", {
-  endSponsoringFutureReservesSuccess: 0,
-  endSponsoringFutureReservesNotSponsored: -1,
-});
-
-// === xdr source ============================================================
-//
-//   union EndSponsoringFutureReservesResult switch (
-//       EndSponsoringFutureReservesResultCode code)
-//   {
-//   case END_SPONSORING_FUTURE_RESERVES_SUCCESS:
-//       void;
-//   case END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("EndSponsoringFutureReservesResult", {
-  switchOn: xdr.lookup("EndSponsoringFutureReservesResultCode"),
-  switchName: "code",
-  switches: [
-    ["endSponsoringFutureReservesSuccess", xdr.void()],
-    ["endSponsoringFutureReservesNotSponsored", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum RevokeSponsorshipResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       REVOKE_SPONSORSHIP_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       REVOKE_SPONSORSHIP_DOES_NOT_EXIST = -1,
-//       REVOKE_SPONSORSHIP_NOT_SPONSOR = -2,
-//       REVOKE_SPONSORSHIP_LOW_RESERVE = -3,
-//       REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE = -4,
-//       REVOKE_SPONSORSHIP_MALFORMED = -5
-//   };
-//
-// ===========================================================================
-xdr.enum("RevokeSponsorshipResultCode", {
-  revokeSponsorshipSuccess: 0,
-  revokeSponsorshipDoesNotExist: -1,
-  revokeSponsorshipNotSponsor: -2,
-  revokeSponsorshipLowReserve: -3,
-  revokeSponsorshipOnlyTransferable: -4,
-  revokeSponsorshipMalformed: -5,
-});
-
-// === xdr source ============================================================
-//
-//   union RevokeSponsorshipResult switch (RevokeSponsorshipResultCode code)
-//   {
-//   case REVOKE_SPONSORSHIP_SUCCESS:
-//       void;
-//   case REVOKE_SPONSORSHIP_DOES_NOT_EXIST:
-//   case REVOKE_SPONSORSHIP_NOT_SPONSOR:
-//   case REVOKE_SPONSORSHIP_LOW_RESERVE:
-//   case REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE:
-//   case REVOKE_SPONSORSHIP_MALFORMED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("RevokeSponsorshipResult", {
-  switchOn: xdr.lookup("RevokeSponsorshipResultCode"),
-  switchName: "code",
-  switches: [
-    ["revokeSponsorshipSuccess", xdr.void()],
-    ["revokeSponsorshipDoesNotExist", xdr.void()],
-    ["revokeSponsorshipNotSponsor", xdr.void()],
-    ["revokeSponsorshipLowReserve", xdr.void()],
-    ["revokeSponsorshipOnlyTransferable", xdr.void()],
-    ["revokeSponsorshipMalformed", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClawbackResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       CLAWBACK_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       CLAWBACK_MALFORMED = -1,
-//       CLAWBACK_NOT_CLAWBACK_ENABLED = -2,
-//       CLAWBACK_NO_TRUST = -3,
-//       CLAWBACK_UNDERFUNDED = -4
-//   };
-//
-// ===========================================================================
-xdr.enum("ClawbackResultCode", {
-  clawbackSuccess: 0,
-  clawbackMalformed: -1,
-  clawbackNotClawbackEnabled: -2,
-  clawbackNoTrust: -3,
-  clawbackUnderfunded: -4,
-});
-
-// === xdr source ============================================================
-//
-//   union ClawbackResult switch (ClawbackResultCode code)
-//   {
-//   case CLAWBACK_SUCCESS:
-//       void;
-//   case CLAWBACK_MALFORMED:
-//   case CLAWBACK_NOT_CLAWBACK_ENABLED:
-//   case CLAWBACK_NO_TRUST:
-//   case CLAWBACK_UNDERFUNDED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ClawbackResult", {
-  switchOn: xdr.lookup("ClawbackResultCode"),
-  switchName: "code",
-  switches: [
-    ["clawbackSuccess", xdr.void()],
-    ["clawbackMalformed", xdr.void()],
-    ["clawbackNotClawbackEnabled", xdr.void()],
-    ["clawbackNoTrust", xdr.void()],
-    ["clawbackUnderfunded", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClawbackClaimableBalanceResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       CLAWBACK_CLAIMABLE_BALANCE_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
-//       CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER = -2,
-//       CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED = -3
-//   };
-//
-// ===========================================================================
-xdr.enum("ClawbackClaimableBalanceResultCode", {
-  clawbackClaimableBalanceSuccess: 0,
-  clawbackClaimableBalanceDoesNotExist: -1,
-  clawbackClaimableBalanceNotIssuer: -2,
-  clawbackClaimableBalanceNotClawbackEnabled: -3,
-});
-
-// === xdr source ============================================================
-//
-//   union ClawbackClaimableBalanceResult switch (
-//       ClawbackClaimableBalanceResultCode code)
-//   {
-//   case CLAWBACK_CLAIMABLE_BALANCE_SUCCESS:
-//       void;
-//   case CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
-//   case CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER:
-//   case CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ClawbackClaimableBalanceResult", {
-  switchOn: xdr.lookup("ClawbackClaimableBalanceResultCode"),
-  switchName: "code",
-  switches: [
-    ["clawbackClaimableBalanceSuccess", xdr.void()],
-    ["clawbackClaimableBalanceDoesNotExist", xdr.void()],
-    ["clawbackClaimableBalanceNotIssuer", xdr.void()],
-    ["clawbackClaimableBalanceNotClawbackEnabled", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum SetTrustLineFlagsResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       SET_TRUST_LINE_FLAGS_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       SET_TRUST_LINE_FLAGS_MALFORMED = -1,
-//       SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
-//       SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
-//       SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
-//       SET_TRUST_LINE_FLAGS_LOW_RESERVE = -5 // claimable balances can't be created
-//                                             // on revoke due to low reserves
-//   };
-//
-// ===========================================================================
-xdr.enum("SetTrustLineFlagsResultCode", {
-  setTrustLineFlagsSuccess: 0,
-  setTrustLineFlagsMalformed: -1,
-  setTrustLineFlagsNoTrustLine: -2,
-  setTrustLineFlagsCantRevoke: -3,
-  setTrustLineFlagsInvalidState: -4,
-  setTrustLineFlagsLowReserve: -5,
-});
-
-// === xdr source ============================================================
-//
-//   union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
-//   {
-//   case SET_TRUST_LINE_FLAGS_SUCCESS:
-//       void;
-//   case SET_TRUST_LINE_FLAGS_MALFORMED:
-//   case SET_TRUST_LINE_FLAGS_NO_TRUST_LINE:
-//   case SET_TRUST_LINE_FLAGS_CANT_REVOKE:
-//   case SET_TRUST_LINE_FLAGS_INVALID_STATE:
-//   case SET_TRUST_LINE_FLAGS_LOW_RESERVE:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("SetTrustLineFlagsResult", {
-  switchOn: xdr.lookup("SetTrustLineFlagsResultCode"),
-  switchName: "code",
-  switches: [
-    ["setTrustLineFlagsSuccess", xdr.void()],
-    ["setTrustLineFlagsMalformed", xdr.void()],
-    ["setTrustLineFlagsNoTrustLine", xdr.void()],
-    ["setTrustLineFlagsCantRevoke", xdr.void()],
-    ["setTrustLineFlagsInvalidState", xdr.void()],
-    ["setTrustLineFlagsLowReserve", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum LiquidityPoolDepositResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       LIQUIDITY_POOL_DEPOSIT_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       LIQUIDITY_POOL_DEPOSIT_MALFORMED = -1,      // bad input
-//       LIQUIDITY_POOL_DEPOSIT_NO_TRUST = -2,       // no trust line for one of the
-//                                                   // assets
-//       LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED = -3, // not authorized for one of the
-//                                                   // assets
-//       LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED = -4,    // not enough balance for one of
-//                                                   // the assets
-//       LIQUIDITY_POOL_DEPOSIT_LINE_FULL = -5,      // pool share trust line doesn't
-//                                                   // have sufficient limit
-//       LIQUIDITY_POOL_DEPOSIT_BAD_PRICE = -6,      // deposit price outside bounds
-//       LIQUIDITY_POOL_DEPOSIT_POOL_FULL = -7       // pool reserves are full
-//   };
-//
-// ===========================================================================
-xdr.enum("LiquidityPoolDepositResultCode", {
-  liquidityPoolDepositSuccess: 0,
-  liquidityPoolDepositMalformed: -1,
-  liquidityPoolDepositNoTrust: -2,
-  liquidityPoolDepositNotAuthorized: -3,
-  liquidityPoolDepositUnderfunded: -4,
-  liquidityPoolDepositLineFull: -5,
-  liquidityPoolDepositBadPrice: -6,
-  liquidityPoolDepositPoolFull: -7,
-});
-
-// === xdr source ============================================================
-//
-//   union LiquidityPoolDepositResult switch (LiquidityPoolDepositResultCode code)
-//   {
-//   case LIQUIDITY_POOL_DEPOSIT_SUCCESS:
-//       void;
-//   case LIQUIDITY_POOL_DEPOSIT_MALFORMED:
-//   case LIQUIDITY_POOL_DEPOSIT_NO_TRUST:
-//   case LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED:
-//   case LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED:
-//   case LIQUIDITY_POOL_DEPOSIT_LINE_FULL:
-//   case LIQUIDITY_POOL_DEPOSIT_BAD_PRICE:
-//   case LIQUIDITY_POOL_DEPOSIT_POOL_FULL:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("LiquidityPoolDepositResult", {
-  switchOn: xdr.lookup("LiquidityPoolDepositResultCode"),
-  switchName: "code",
-  switches: [
-    ["liquidityPoolDepositSuccess", xdr.void()],
-    ["liquidityPoolDepositMalformed", xdr.void()],
-    ["liquidityPoolDepositNoTrust", xdr.void()],
-    ["liquidityPoolDepositNotAuthorized", xdr.void()],
-    ["liquidityPoolDepositUnderfunded", xdr.void()],
-    ["liquidityPoolDepositLineFull", xdr.void()],
-    ["liquidityPoolDepositBadPrice", xdr.void()],
-    ["liquidityPoolDepositPoolFull", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum LiquidityPoolWithdrawResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       LIQUIDITY_POOL_WITHDRAW_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       LIQUIDITY_POOL_WITHDRAW_MALFORMED = -1,    // bad input
-//       LIQUIDITY_POOL_WITHDRAW_NO_TRUST = -2,     // no trust line for one of the
-//                                                  // assets
-//       LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED = -3,  // not enough balance of the
-//                                                  // pool share
-//       LIQUIDITY_POOL_WITHDRAW_LINE_FULL = -4,    // would go above limit for one
-//                                                  // of the assets
-//       LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM = -5 // didn't withdraw enough
-//   };
-//
-// ===========================================================================
-xdr.enum("LiquidityPoolWithdrawResultCode", {
-  liquidityPoolWithdrawSuccess: 0,
-  liquidityPoolWithdrawMalformed: -1,
-  liquidityPoolWithdrawNoTrust: -2,
-  liquidityPoolWithdrawUnderfunded: -3,
-  liquidityPoolWithdrawLineFull: -4,
-  liquidityPoolWithdrawUnderMinimum: -5,
-});
-
-// === xdr source ============================================================
-//
-//   union LiquidityPoolWithdrawResult switch (LiquidityPoolWithdrawResultCode code)
-//   {
-//   case LIQUIDITY_POOL_WITHDRAW_SUCCESS:
-//       void;
-//   case LIQUIDITY_POOL_WITHDRAW_MALFORMED:
-//   case LIQUIDITY_POOL_WITHDRAW_NO_TRUST:
-//   case LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED:
-//   case LIQUIDITY_POOL_WITHDRAW_LINE_FULL:
-//   case LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("LiquidityPoolWithdrawResult", {
-  switchOn: xdr.lookup("LiquidityPoolWithdrawResultCode"),
-  switchName: "code",
-  switches: [
-    ["liquidityPoolWithdrawSuccess", xdr.void()],
-    ["liquidityPoolWithdrawMalformed", xdr.void()],
-    ["liquidityPoolWithdrawNoTrust", xdr.void()],
-    ["liquidityPoolWithdrawUnderfunded", xdr.void()],
-    ["liquidityPoolWithdrawLineFull", xdr.void()],
-    ["liquidityPoolWithdrawUnderMinimum", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum OperationResultCode
-//   {
-//       opINNER = 0, // inner object result is valid
-//   
-//       opBAD_AUTH = -1,            // too few valid signatures / wrong network
-//       opNO_ACCOUNT = -2,          // source account was not found
-//       opNOT_SUPPORTED = -3,       // operation not supported at this time
-//       opTOO_MANY_SUBENTRIES = -4, // max number of subentries already reached
-//       opEXCEEDED_WORK_LIMIT = -5, // operation did too much work
-//       opTOO_MANY_SPONSORING = -6  // account is sponsoring too many entries
-//   };
-//
-// ===========================================================================
-xdr.enum("OperationResultCode", {
-  opInner: 0,
-  opBadAuth: -1,
-  opNoAccount: -2,
-  opNotSupported: -3,
-  opTooManySubentries: -4,
-  opExceededWorkLimit: -5,
-  opTooManySponsoring: -6,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (OperationType type)
-//       {
-//       case CREATE_ACCOUNT:
-//           CreateAccountResult createAccountResult;
-//       case PAYMENT:
-//           PaymentResult paymentResult;
-//       case PATH_PAYMENT_STRICT_RECEIVE:
-//           PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
-//       case MANAGE_SELL_OFFER:
-//           ManageSellOfferResult manageSellOfferResult;
-//       case CREATE_PASSIVE_SELL_OFFER:
-//           ManageSellOfferResult createPassiveSellOfferResult;
-//       case SET_OPTIONS:
-//           SetOptionsResult setOptionsResult;
-//       case CHANGE_TRUST:
-//           ChangeTrustResult changeTrustResult;
-//       case ALLOW_TRUST:
-//           AllowTrustResult allowTrustResult;
-//       case ACCOUNT_MERGE:
-//           AccountMergeResult accountMergeResult;
-//       case INFLATION:
-//           InflationResult inflationResult;
-//       case MANAGE_DATA:
-//           ManageDataResult manageDataResult;
-//       case BUMP_SEQUENCE:
-//           BumpSequenceResult bumpSeqResult;
-//       case MANAGE_BUY_OFFER:
-//           ManageBuyOfferResult manageBuyOfferResult;
-//       case PATH_PAYMENT_STRICT_SEND:
-//           PathPaymentStrictSendResult pathPaymentStrictSendResult;
-//       case CREATE_CLAIMABLE_BALANCE:
-//           CreateClaimableBalanceResult createClaimableBalanceResult;
-//       case CLAIM_CLAIMABLE_BALANCE:
-//           ClaimClaimableBalanceResult claimClaimableBalanceResult;
-//       case BEGIN_SPONSORING_FUTURE_RESERVES:
-//           BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
-//       case END_SPONSORING_FUTURE_RESERVES:
-//           EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
-//       case REVOKE_SPONSORSHIP:
-//           RevokeSponsorshipResult revokeSponsorshipResult;
-//       case CLAWBACK:
-//           ClawbackResult clawbackResult;
-//       case CLAWBACK_CLAIMABLE_BALANCE:
-//           ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
-//       case SET_TRUST_LINE_FLAGS:
-//           SetTrustLineFlagsResult setTrustLineFlagsResult;
-//       case LIQUIDITY_POOL_DEPOSIT:
-//           LiquidityPoolDepositResult liquidityPoolDepositResult;
-//       case LIQUIDITY_POOL_WITHDRAW:
-//           LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
-//       }
-//
-// ===========================================================================
-xdr.union("OperationResultTr", {
-  switchOn: xdr.lookup("OperationType"),
-  switchName: "type",
-  switches: [
-    ["createAccount", "createAccountResult"],
-    ["payment", "paymentResult"],
-    ["pathPaymentStrictReceive", "pathPaymentStrictReceiveResult"],
-    ["manageSellOffer", "manageSellOfferResult"],
-    ["createPassiveSellOffer", "createPassiveSellOfferResult"],
-    ["setOptions", "setOptionsResult"],
-    ["changeTrust", "changeTrustResult"],
-    ["allowTrust", "allowTrustResult"],
-    ["accountMerge", "accountMergeResult"],
-    ["inflation", "inflationResult"],
-    ["manageData", "manageDataResult"],
-    ["bumpSequence", "bumpSeqResult"],
-    ["manageBuyOffer", "manageBuyOfferResult"],
-    ["pathPaymentStrictSend", "pathPaymentStrictSendResult"],
-    ["createClaimableBalance", "createClaimableBalanceResult"],
-    ["claimClaimableBalance", "claimClaimableBalanceResult"],
-    ["beginSponsoringFutureReserves", "beginSponsoringFutureReservesResult"],
-    ["endSponsoringFutureReserves", "endSponsoringFutureReservesResult"],
-    ["revokeSponsorship", "revokeSponsorshipResult"],
-    ["clawback", "clawbackResult"],
-    ["clawbackClaimableBalance", "clawbackClaimableBalanceResult"],
-    ["setTrustLineFlags", "setTrustLineFlagsResult"],
-    ["liquidityPoolDeposit", "liquidityPoolDepositResult"],
-    ["liquidityPoolWithdraw", "liquidityPoolWithdrawResult"],
-  ],
-  arms: {
-    createAccountResult: xdr.lookup("CreateAccountResult"),
-    paymentResult: xdr.lookup("PaymentResult"),
-    pathPaymentStrictReceiveResult: xdr.lookup("PathPaymentStrictReceiveResult"),
-    manageSellOfferResult: xdr.lookup("ManageSellOfferResult"),
-    createPassiveSellOfferResult: xdr.lookup("ManageSellOfferResult"),
-    setOptionsResult: xdr.lookup("SetOptionsResult"),
-    changeTrustResult: xdr.lookup("ChangeTrustResult"),
-    allowTrustResult: xdr.lookup("AllowTrustResult"),
-    accountMergeResult: xdr.lookup("AccountMergeResult"),
-    inflationResult: xdr.lookup("InflationResult"),
-    manageDataResult: xdr.lookup("ManageDataResult"),
-    bumpSeqResult: xdr.lookup("BumpSequenceResult"),
-    manageBuyOfferResult: xdr.lookup("ManageBuyOfferResult"),
-    pathPaymentStrictSendResult: xdr.lookup("PathPaymentStrictSendResult"),
-    createClaimableBalanceResult: xdr.lookup("CreateClaimableBalanceResult"),
-    claimClaimableBalanceResult: xdr.lookup("ClaimClaimableBalanceResult"),
-    beginSponsoringFutureReservesResult: xdr.lookup("BeginSponsoringFutureReservesResult"),
-    endSponsoringFutureReservesResult: xdr.lookup("EndSponsoringFutureReservesResult"),
-    revokeSponsorshipResult: xdr.lookup("RevokeSponsorshipResult"),
-    clawbackResult: xdr.lookup("ClawbackResult"),
-    clawbackClaimableBalanceResult: xdr.lookup("ClawbackClaimableBalanceResult"),
-    setTrustLineFlagsResult: xdr.lookup("SetTrustLineFlagsResult"),
-    liquidityPoolDepositResult: xdr.lookup("LiquidityPoolDepositResult"),
-    liquidityPoolWithdrawResult: xdr.lookup("LiquidityPoolWithdrawResult"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union OperationResult switch (OperationResultCode code)
-//   {
-//   case opINNER:
-//       union switch (OperationType type)
-//       {
-//       case CREATE_ACCOUNT:
-//           CreateAccountResult createAccountResult;
-//       case PAYMENT:
-//           PaymentResult paymentResult;
-//       case PATH_PAYMENT_STRICT_RECEIVE:
-//           PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
-//       case MANAGE_SELL_OFFER:
-//           ManageSellOfferResult manageSellOfferResult;
-//       case CREATE_PASSIVE_SELL_OFFER:
-//           ManageSellOfferResult createPassiveSellOfferResult;
-//       case SET_OPTIONS:
-//           SetOptionsResult setOptionsResult;
-//       case CHANGE_TRUST:
-//           ChangeTrustResult changeTrustResult;
-//       case ALLOW_TRUST:
-//           AllowTrustResult allowTrustResult;
-//       case ACCOUNT_MERGE:
-//           AccountMergeResult accountMergeResult;
-//       case INFLATION:
-//           InflationResult inflationResult;
-//       case MANAGE_DATA:
-//           ManageDataResult manageDataResult;
-//       case BUMP_SEQUENCE:
-//           BumpSequenceResult bumpSeqResult;
-//       case MANAGE_BUY_OFFER:
-//           ManageBuyOfferResult manageBuyOfferResult;
-//       case PATH_PAYMENT_STRICT_SEND:
-//           PathPaymentStrictSendResult pathPaymentStrictSendResult;
-//       case CREATE_CLAIMABLE_BALANCE:
-//           CreateClaimableBalanceResult createClaimableBalanceResult;
-//       case CLAIM_CLAIMABLE_BALANCE:
-//           ClaimClaimableBalanceResult claimClaimableBalanceResult;
-//       case BEGIN_SPONSORING_FUTURE_RESERVES:
-//           BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
-//       case END_SPONSORING_FUTURE_RESERVES:
-//           EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
-//       case REVOKE_SPONSORSHIP:
-//           RevokeSponsorshipResult revokeSponsorshipResult;
-//       case CLAWBACK:
-//           ClawbackResult clawbackResult;
-//       case CLAWBACK_CLAIMABLE_BALANCE:
-//           ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
-//       case SET_TRUST_LINE_FLAGS:
-//           SetTrustLineFlagsResult setTrustLineFlagsResult;
-//       case LIQUIDITY_POOL_DEPOSIT:
-//           LiquidityPoolDepositResult liquidityPoolDepositResult;
-//       case LIQUIDITY_POOL_WITHDRAW:
-//           LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
-//       }
-//       tr;
-//   case opBAD_AUTH:
-//   case opNO_ACCOUNT:
-//   case opNOT_SUPPORTED:
-//   case opTOO_MANY_SUBENTRIES:
-//   case opEXCEEDED_WORK_LIMIT:
-//   case opTOO_MANY_SPONSORING:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("OperationResult", {
-  switchOn: xdr.lookup("OperationResultCode"),
-  switchName: "code",
-  switches: [
-    ["opInner", "tr"],
-    ["opBadAuth", xdr.void()],
-    ["opNoAccount", xdr.void()],
-    ["opNotSupported", xdr.void()],
-    ["opTooManySubentries", xdr.void()],
-    ["opExceededWorkLimit", xdr.void()],
-    ["opTooManySponsoring", xdr.void()],
-  ],
-  arms: {
-    tr: xdr.lookup("OperationResultTr"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum TransactionResultCode
-//   {
-//       txFEE_BUMP_INNER_SUCCESS = 1, // fee bump inner transaction succeeded
-//       txSUCCESS = 0,                // all operations succeeded
-//   
-//       txFAILED = -1, // one of the operations failed (none were applied)
-//   
-//       txTOO_EARLY = -2,         // ledger closeTime before minTime
-//       txTOO_LATE = -3,          // ledger closeTime after maxTime
-//       txMISSING_OPERATION = -4, // no operation was specified
-//       txBAD_SEQ = -5,           // sequence number does not match source account
-//   
-//       txBAD_AUTH = -6,             // too few valid signatures / wrong network
-//       txINSUFFICIENT_BALANCE = -7, // fee would bring account below reserve
-//       txNO_ACCOUNT = -8,           // source account not found
-//       txINSUFFICIENT_FEE = -9,     // fee is too small
-//       txBAD_AUTH_EXTRA = -10,      // unused signatures attached to transaction
-//       txINTERNAL_ERROR = -11,      // an unknown error occurred
-//   
-//       txNOT_SUPPORTED = -12,         // transaction type not supported
-//       txFEE_BUMP_INNER_FAILED = -13, // fee bump inner transaction failed
-//       txBAD_SPONSORSHIP = -14,       // sponsorship not confirmed
-//       txBAD_MIN_SEQ_AGE_OR_GAP =
-//           -15, // minSeqAge or minSeqLedgerGap conditions not met
-//       txMALFORMED = -16 // precondition is invalid
-//   };
-//
-// ===========================================================================
-xdr.enum("TransactionResultCode", {
-  txFeeBumpInnerSuccess: 1,
-  txSuccess: 0,
-  txFailed: -1,
-  txTooEarly: -2,
-  txTooLate: -3,
-  txMissingOperation: -4,
-  txBadSeq: -5,
-  txBadAuth: -6,
-  txInsufficientBalance: -7,
-  txNoAccount: -8,
-  txInsufficientFee: -9,
-  txBadAuthExtra: -10,
-  txInternalError: -11,
-  txNotSupported: -12,
-  txFeeBumpInnerFailed: -13,
-  txBadSponsorship: -14,
-  txBadMinSeqAgeOrGap: -15,
-  txMalformed: -16,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (TransactionResultCode code)
-//       {
-//       // txFEE_BUMP_INNER_SUCCESS is not included
-//       case txSUCCESS:
-//       case txFAILED:
-//           OperationResult results<>;
-//       case txTOO_EARLY:
-//       case txTOO_LATE:
-//       case txMISSING_OPERATION:
-//       case txBAD_SEQ:
-//       case txBAD_AUTH:
-//       case txINSUFFICIENT_BALANCE:
-//       case txNO_ACCOUNT:
-//       case txINSUFFICIENT_FEE:
-//       case txBAD_AUTH_EXTRA:
-//       case txINTERNAL_ERROR:
-//       case txNOT_SUPPORTED:
-//       // txFEE_BUMP_INNER_FAILED is not included
-//       case txBAD_SPONSORSHIP:
-//       case txBAD_MIN_SEQ_AGE_OR_GAP:
-//       case txMALFORMED:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("InnerTransactionResultResult", {
-  switchOn: xdr.lookup("TransactionResultCode"),
-  switchName: "code",
-  switches: [
-    ["txSuccess", "results"],
-    ["txFailed", "results"],
-    ["txTooEarly", xdr.void()],
-    ["txTooLate", xdr.void()],
-    ["txMissingOperation", xdr.void()],
-    ["txBadSeq", xdr.void()],
-    ["txBadAuth", xdr.void()],
-    ["txInsufficientBalance", xdr.void()],
-    ["txNoAccount", xdr.void()],
-    ["txInsufficientFee", xdr.void()],
-    ["txBadAuthExtra", xdr.void()],
-    ["txInternalError", xdr.void()],
-    ["txNotSupported", xdr.void()],
-    ["txBadSponsorship", xdr.void()],
-    ["txBadMinSeqAgeOrGap", xdr.void()],
-    ["txMalformed", xdr.void()],
-  ],
-  arms: {
-    results: xdr.varArray(xdr.lookup("OperationResult"), 2147483647),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("InnerTransactionResultExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct InnerTransactionResult
-//   {
-//       // Always 0. Here for binary compatibility.
-//       int64 feeCharged;
-//   
-//       union switch (TransactionResultCode code)
-//       {
-//       // txFEE_BUMP_INNER_SUCCESS is not included
-//       case txSUCCESS:
-//       case txFAILED:
-//           OperationResult results<>;
-//       case txTOO_EARLY:
-//       case txTOO_LATE:
-//       case txMISSING_OPERATION:
-//       case txBAD_SEQ:
-//       case txBAD_AUTH:
-//       case txINSUFFICIENT_BALANCE:
-//       case txNO_ACCOUNT:
-//       case txINSUFFICIENT_FEE:
-//       case txBAD_AUTH_EXTRA:
-//       case txINTERNAL_ERROR:
-//       case txNOT_SUPPORTED:
-//       // txFEE_BUMP_INNER_FAILED is not included
-//       case txBAD_SPONSORSHIP:
-//       case txBAD_MIN_SEQ_AGE_OR_GAP:
-//       case txMALFORMED:
-//           void;
-//       }
-//       result;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("InnerTransactionResult", [
-  ["feeCharged", xdr.lookup("Int64")],
-  ["result", xdr.lookup("InnerTransactionResultResult")],
-  ["ext", xdr.lookup("InnerTransactionResultExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct InnerTransactionResultPair
-//   {
-//       Hash transactionHash;          // hash of the inner transaction
-//       InnerTransactionResult result; // result for the inner transaction
-//   };
-//
-// ===========================================================================
-xdr.struct("InnerTransactionResultPair", [
-  ["transactionHash", xdr.lookup("Hash")],
-  ["result", xdr.lookup("InnerTransactionResult")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (TransactionResultCode code)
-//       {
-//       case txFEE_BUMP_INNER_SUCCESS:
-//       case txFEE_BUMP_INNER_FAILED:
-//           InnerTransactionResultPair innerResultPair;
-//       case txSUCCESS:
-//       case txFAILED:
-//           OperationResult results<>;
-//       case txTOO_EARLY:
-//       case txTOO_LATE:
-//       case txMISSING_OPERATION:
-//       case txBAD_SEQ:
-//       case txBAD_AUTH:
-//       case txINSUFFICIENT_BALANCE:
-//       case txNO_ACCOUNT:
-//       case txINSUFFICIENT_FEE:
-//       case txBAD_AUTH_EXTRA:
-//       case txINTERNAL_ERROR:
-//       case txNOT_SUPPORTED:
-//       // case txFEE_BUMP_INNER_FAILED: handled above
-//       case txBAD_SPONSORSHIP:
-//       case txBAD_MIN_SEQ_AGE_OR_GAP:
-//       case txMALFORMED:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionResultResult", {
-  switchOn: xdr.lookup("TransactionResultCode"),
-  switchName: "code",
-  switches: [
-    ["txFeeBumpInnerSuccess", "innerResultPair"],
-    ["txFeeBumpInnerFailed", "innerResultPair"],
-    ["txSuccess", "results"],
-    ["txFailed", "results"],
-    ["txTooEarly", xdr.void()],
-    ["txTooLate", xdr.void()],
-    ["txMissingOperation", xdr.void()],
-    ["txBadSeq", xdr.void()],
-    ["txBadAuth", xdr.void()],
-    ["txInsufficientBalance", xdr.void()],
-    ["txNoAccount", xdr.void()],
-    ["txInsufficientFee", xdr.void()],
-    ["txBadAuthExtra", xdr.void()],
-    ["txInternalError", xdr.void()],
-    ["txNotSupported", xdr.void()],
-    ["txBadSponsorship", xdr.void()],
-    ["txBadMinSeqAgeOrGap", xdr.void()],
-    ["txMalformed", xdr.void()],
-  ],
-  arms: {
-    innerResultPair: xdr.lookup("InnerTransactionResultPair"),
-    results: xdr.varArray(xdr.lookup("OperationResult"), 2147483647),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionResultExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionResult
-//   {
-//       int64 feeCharged; // actual fee charged for the transaction
-//   
-//       union switch (TransactionResultCode code)
-//       {
-//       case txFEE_BUMP_INNER_SUCCESS:
-//       case txFEE_BUMP_INNER_FAILED:
-//           InnerTransactionResultPair innerResultPair;
-//       case txSUCCESS:
-//       case txFAILED:
-//           OperationResult results<>;
-//       case txTOO_EARLY:
-//       case txTOO_LATE:
-//       case txMISSING_OPERATION:
-//       case txBAD_SEQ:
-//       case txBAD_AUTH:
-//       case txINSUFFICIENT_BALANCE:
-//       case txNO_ACCOUNT:
-//       case txINSUFFICIENT_FEE:
-//       case txBAD_AUTH_EXTRA:
-//       case txINTERNAL_ERROR:
-//       case txNOT_SUPPORTED:
-//       // case txFEE_BUMP_INNER_FAILED: handled above
-//       case txBAD_SPONSORSHIP:
-//       case txBAD_MIN_SEQ_AGE_OR_GAP:
-//       case txMALFORMED:
-//           void;
-//       }
-//       result;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResult", [
-  ["feeCharged", xdr.lookup("Int64")],
-  ["result", xdr.lookup("TransactionResultResult")],
-  ["ext", xdr.lookup("TransactionResultExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   typedef opaque Hash[32];
-//
-// ===========================================================================
-xdr.typedef("Hash", xdr.opaque(32));
-
-// === xdr source ============================================================
-//
-//   typedef opaque uint256[32];
-//
-// ===========================================================================
-xdr.typedef("Uint256", xdr.opaque(32));
-
-// === xdr source ============================================================
-//
-//   typedef unsigned int uint32;
-//
-// ===========================================================================
-xdr.typedef("Uint32", xdr.uint());
-
-// === xdr source ============================================================
-//
-//   typedef int int32;
-//
-// ===========================================================================
-xdr.typedef("Int32", xdr.int());
-
-// === xdr source ============================================================
-//
-//   typedef unsigned hyper uint64;
-//
-// ===========================================================================
-xdr.typedef("Uint64", xdr.uhyper());
-
-// === xdr source ============================================================
-//
-//   typedef hyper int64;
-//
-// ===========================================================================
-xdr.typedef("Int64", xdr.hyper());
-
-// === xdr source ============================================================
-//
-//   union ExtensionPoint switch (int v)
-//   {
-//   case 0:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ExtensionPoint", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum CryptoKeyType
-//   {
-//       KEY_TYPE_ED25519 = 0,
-//       KEY_TYPE_PRE_AUTH_TX = 1,
-//       KEY_TYPE_HASH_X = 2,
-//       KEY_TYPE_ED25519_SIGNED_PAYLOAD = 3,
-//       // MUXED enum values for supported type are derived from the enum values
-//       // above by ORing them with 0x100
-//       KEY_TYPE_MUXED_ED25519 = 0x100
-//   };
-//
-// ===========================================================================
-xdr.enum("CryptoKeyType", {
-  keyTypeEd25519: 0,
-  keyTypePreAuthTx: 1,
-  keyTypeHashX: 2,
-  keyTypeEd25519SignedPayload: 3,
-  keyTypeMuxedEd25519: 256,
-});
-
-// === xdr source ============================================================
-//
-//   enum PublicKeyType
-//   {
-//       PUBLIC_KEY_TYPE_ED25519 = KEY_TYPE_ED25519
-//   };
-//
-// ===========================================================================
-xdr.enum("PublicKeyType", {
-  publicKeyTypeEd25519: 0,
-});
-
-// === xdr source ============================================================
-//
-//   enum SignerKeyType
-//   {
-//       SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
-//       SIGNER_KEY_TYPE_PRE_AUTH_TX = KEY_TYPE_PRE_AUTH_TX,
-//       SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X,
-//       SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD = KEY_TYPE_ED25519_SIGNED_PAYLOAD
-//   };
-//
-// ===========================================================================
-xdr.enum("SignerKeyType", {
-  signerKeyTypeEd25519: 0,
-  signerKeyTypePreAuthTx: 1,
-  signerKeyTypeHashX: 2,
-  signerKeyTypeEd25519SignedPayload: 3,
-});
-
-// === xdr source ============================================================
-//
-//   union PublicKey switch (PublicKeyType type)
-//   {
-//   case PUBLIC_KEY_TYPE_ED25519:
-//       uint256 ed25519;
-//   };
-//
-// ===========================================================================
-xdr.union("PublicKey", {
-  switchOn: xdr.lookup("PublicKeyType"),
-  switchName: "type",
-  switches: [
-    ["publicKeyTypeEd25519", "ed25519"],
-  ],
-  arms: {
-    ed25519: xdr.lookup("Uint256"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           /* Public key that must sign the payload. */
-//           uint256 ed25519;
-//           /* Payload to be raw signed by ed25519. */
-//           opaque payload<64>;
-//       }
-//
-// ===========================================================================
-xdr.struct("SignerKeyEd25519SignedPayload", [
-  ["ed25519", xdr.lookup("Uint256")],
-  ["payload", xdr.varOpaque(64)],
-]);
-
-// === xdr source ============================================================
-//
-//   union SignerKey switch (SignerKeyType type)
-//   {
-//   case SIGNER_KEY_TYPE_ED25519:
-//       uint256 ed25519;
-//   case SIGNER_KEY_TYPE_PRE_AUTH_TX:
-//       /* SHA-256 Hash of TransactionSignaturePayload structure */
-//       uint256 preAuthTx;
-//   case SIGNER_KEY_TYPE_HASH_X:
-//       /* Hash of random 256 bit preimage X */
-//       uint256 hashX;
-//   case SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD:
-//       struct
-//       {
-//           /* Public key that must sign the payload. */
-//           uint256 ed25519;
-//           /* Payload to be raw signed by ed25519. */
-//           opaque payload<64>;
-//       } ed25519SignedPayload;
-//   };
-//
-// ===========================================================================
-xdr.union("SignerKey", {
-  switchOn: xdr.lookup("SignerKeyType"),
-  switchName: "type",
-  switches: [
-    ["signerKeyTypeEd25519", "ed25519"],
-    ["signerKeyTypePreAuthTx", "preAuthTx"],
-    ["signerKeyTypeHashX", "hashX"],
-    ["signerKeyTypeEd25519SignedPayload", "ed25519SignedPayload"],
-  ],
-  arms: {
-    ed25519: xdr.lookup("Uint256"),
-    preAuthTx: xdr.lookup("Uint256"),
-    hashX: xdr.lookup("Uint256"),
-    ed25519SignedPayload: xdr.lookup("SignerKeyEd25519SignedPayload"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   typedef opaque Signature<64>;
-//
-// ===========================================================================
-xdr.typedef("Signature", xdr.varOpaque(64));
-
-// === xdr source ============================================================
-//
-//   typedef opaque SignatureHint[4];
-//
-// ===========================================================================
-xdr.typedef("SignatureHint", xdr.opaque(4));
-
-// === xdr source ============================================================
-//
-//   typedef PublicKey NodeID;
-//
-// ===========================================================================
-xdr.typedef("NodeId", xdr.lookup("PublicKey"));
-
-// === xdr source ============================================================
-//
-//   struct Curve25519Secret
-//   {
-//       opaque key[32];
-//   };
-//
-// ===========================================================================
-xdr.struct("Curve25519Secret", [
-  ["key", xdr.opaque(32)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct Curve25519Public
-//   {
-//       opaque key[32];
-//   };
-//
-// ===========================================================================
-xdr.struct("Curve25519Public", [
-  ["key", xdr.opaque(32)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct HmacSha256Key
-//   {
-//       opaque key[32];
-//   };
-//
-// ===========================================================================
-xdr.struct("HmacSha256Key", [
-  ["key", xdr.opaque(32)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct HmacSha256Mac
-//   {
-//       opaque mac[32];
-//   };
-//
-// ===========================================================================
-xdr.struct("HmacSha256Mac", [
-  ["mac", xdr.opaque(32)],
-]);
-
+import * as XDR from "js-xdr";
+
+var types = XDR.config((xdr) => {
+  // === xdr source ============================================================
+  //
+  //   typedef opaque Value<>;
+  //
+  // ===========================================================================
+  xdr.typedef("Value", xdr.varOpaque());
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPBallot
+  //   {
+  //       uint32 counter; // n
+  //       Value value;    // x
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpBallot", [
+    ["counter", xdr.lookup("Uint32")],
+    ["value", xdr.lookup("Value")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum SCPStatementType
+  //   {
+  //       SCP_ST_PREPARE = 0,
+  //       SCP_ST_CONFIRM = 1,
+  //       SCP_ST_EXTERNALIZE = 2,
+  //       SCP_ST_NOMINATE = 3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScpStatementType", {
+    scpStPrepare: 0,
+    scpStConfirm: 1,
+    scpStExternalize: 2,
+    scpStNominate: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPNomination
+  //   {
+  //       Hash quorumSetHash; // D
+  //       Value votes<>;      // X
+  //       Value accepted<>;   // Y
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpNomination", [
+    ["quorumSetHash", xdr.lookup("Hash")],
+    ["votes", xdr.varArray(xdr.lookup("Value"), 2147483647)],
+    ["accepted", xdr.varArray(xdr.lookup("Value"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               Hash quorumSetHash;       // D
+  //               SCPBallot ballot;         // b
+  //               SCPBallot* prepared;      // p
+  //               SCPBallot* preparedPrime; // p'
+  //               uint32 nC;                // c.n
+  //               uint32 nH;                // h.n
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("ScpStatementPrepare", [
+    ["quorumSetHash", xdr.lookup("Hash")],
+    ["ballot", xdr.lookup("ScpBallot")],
+    ["prepared", xdr.option(xdr.lookup("ScpBallot"))],
+    ["preparedPrime", xdr.option(xdr.lookup("ScpBallot"))],
+    ["nC", xdr.lookup("Uint32")],
+    ["nH", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               SCPBallot ballot;   // b
+  //               uint32 nPrepared;   // p.n
+  //               uint32 nCommit;     // c.n
+  //               uint32 nH;          // h.n
+  //               Hash quorumSetHash; // D
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("ScpStatementConfirm", [
+    ["ballot", xdr.lookup("ScpBallot")],
+    ["nPrepared", xdr.lookup("Uint32")],
+    ["nCommit", xdr.lookup("Uint32")],
+    ["nH", xdr.lookup("Uint32")],
+    ["quorumSetHash", xdr.lookup("Hash")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               SCPBallot commit;         // c
+  //               uint32 nH;                // h.n
+  //               Hash commitQuorumSetHash; // D used before EXTERNALIZE
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("ScpStatementExternalize", [
+    ["commit", xdr.lookup("ScpBallot")],
+    ["nH", xdr.lookup("Uint32")],
+    ["commitQuorumSetHash", xdr.lookup("Hash")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (SCPStatementType type)
+  //       {
+  //       case SCP_ST_PREPARE:
+  //           struct
+  //           {
+  //               Hash quorumSetHash;       // D
+  //               SCPBallot ballot;         // b
+  //               SCPBallot* prepared;      // p
+  //               SCPBallot* preparedPrime; // p'
+  //               uint32 nC;                // c.n
+  //               uint32 nH;                // h.n
+  //           } prepare;
+  //       case SCP_ST_CONFIRM:
+  //           struct
+  //           {
+  //               SCPBallot ballot;   // b
+  //               uint32 nPrepared;   // p.n
+  //               uint32 nCommit;     // c.n
+  //               uint32 nH;          // h.n
+  //               Hash quorumSetHash; // D
+  //           } confirm;
+  //       case SCP_ST_EXTERNALIZE:
+  //           struct
+  //           {
+  //               SCPBallot commit;         // c
+  //               uint32 nH;                // h.n
+  //               Hash commitQuorumSetHash; // D used before EXTERNALIZE
+  //           } externalize;
+  //       case SCP_ST_NOMINATE:
+  //           SCPNomination nominate;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("ScpStatementPledges", {
+    switchOn: xdr.lookup("ScpStatementType"),
+    switchName: "type",
+    switches: [
+      ["scpStPrepare", "prepare"],
+      ["scpStConfirm", "confirm"],
+      ["scpStExternalize", "externalize"],
+      ["scpStNominate", "nominate"],
+    ],
+    arms: {
+      prepare: xdr.lookup("ScpStatementPrepare"),
+      confirm: xdr.lookup("ScpStatementConfirm"),
+      externalize: xdr.lookup("ScpStatementExternalize"),
+      nominate: xdr.lookup("ScpNomination"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPStatement
+  //   {
+  //       NodeID nodeID;    // v
+  //       uint64 slotIndex; // i
+  //
+  //       union switch (SCPStatementType type)
+  //       {
+  //       case SCP_ST_PREPARE:
+  //           struct
+  //           {
+  //               Hash quorumSetHash;       // D
+  //               SCPBallot ballot;         // b
+  //               SCPBallot* prepared;      // p
+  //               SCPBallot* preparedPrime; // p'
+  //               uint32 nC;                // c.n
+  //               uint32 nH;                // h.n
+  //           } prepare;
+  //       case SCP_ST_CONFIRM:
+  //           struct
+  //           {
+  //               SCPBallot ballot;   // b
+  //               uint32 nPrepared;   // p.n
+  //               uint32 nCommit;     // c.n
+  //               uint32 nH;          // h.n
+  //               Hash quorumSetHash; // D
+  //           } confirm;
+  //       case SCP_ST_EXTERNALIZE:
+  //           struct
+  //           {
+  //               SCPBallot commit;         // c
+  //               uint32 nH;                // h.n
+  //               Hash commitQuorumSetHash; // D used before EXTERNALIZE
+  //           } externalize;
+  //       case SCP_ST_NOMINATE:
+  //           SCPNomination nominate;
+  //       }
+  //       pledges;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpStatement", [
+    ["nodeId", xdr.lookup("NodeId")],
+    ["slotIndex", xdr.lookup("Uint64")],
+    ["pledges", xdr.lookup("ScpStatementPledges")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPEnvelope
+  //   {
+  //       SCPStatement statement;
+  //       Signature signature;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpEnvelope", [
+    ["statement", xdr.lookup("ScpStatement")],
+    ["signature", xdr.lookup("Signature")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPQuorumSet
+  //   {
+  //       uint32 threshold;
+  //       NodeID validators<>;
+  //       SCPQuorumSet innerSets<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpQuorumSet", [
+    ["threshold", xdr.lookup("Uint32")],
+    ["validators", xdr.varArray(xdr.lookup("NodeId"), 2147483647)],
+    ["innerSets", xdr.varArray(xdr.lookup("ScpQuorumSet"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   typedef PublicKey AccountID;
+  //
+  // ===========================================================================
+  xdr.typedef("AccountId", xdr.lookup("PublicKey"));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque Thresholds[4];
+  //
+  // ===========================================================================
+  xdr.typedef("Thresholds", xdr.opaque(4));
+
+  // === xdr source ============================================================
+  //
+  //   typedef string string32<32>;
+  //
+  // ===========================================================================
+  xdr.typedef("String32", xdr.string(32));
+
+  // === xdr source ============================================================
+  //
+  //   typedef string string64<64>;
+  //
+  // ===========================================================================
+  xdr.typedef("String64", xdr.string(64));
+
+  // === xdr source ============================================================
+  //
+  //   typedef int64 SequenceNumber;
+  //
+  // ===========================================================================
+  xdr.typedef("SequenceNumber", xdr.lookup("Int64"));
+
+  // === xdr source ============================================================
+  //
+  //   typedef uint64 TimePoint;
+  //
+  // ===========================================================================
+  xdr.typedef("TimePoint", xdr.lookup("Uint64"));
+
+  // === xdr source ============================================================
+  //
+  //   typedef uint64 Duration;
+  //
+  // ===========================================================================
+  xdr.typedef("Duration", xdr.lookup("Uint64"));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque DataValue<64>;
+  //
+  // ===========================================================================
+  xdr.typedef("DataValue", xdr.varOpaque(64));
+
+  // === xdr source ============================================================
+  //
+  //   typedef Hash PoolID;
+  //
+  // ===========================================================================
+  xdr.typedef("PoolId", xdr.lookup("Hash"));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque AssetCode4[4];
+  //
+  // ===========================================================================
+  xdr.typedef("AssetCode4", xdr.opaque(4));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque AssetCode12[12];
+  //
+  // ===========================================================================
+  xdr.typedef("AssetCode12", xdr.opaque(12));
+
+  // === xdr source ============================================================
+  //
+  //   enum AssetType
+  //   {
+  //       ASSET_TYPE_NATIVE = 0,
+  //       ASSET_TYPE_CREDIT_ALPHANUM4 = 1,
+  //       ASSET_TYPE_CREDIT_ALPHANUM12 = 2,
+  //       ASSET_TYPE_POOL_SHARE = 3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("AssetType", {
+    assetTypeNative: 0,
+    assetTypeCreditAlphanum4: 1,
+    assetTypeCreditAlphanum12: 2,
+    assetTypePoolShare: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union AssetCode switch (AssetType type)
+  //   {
+  //   case ASSET_TYPE_CREDIT_ALPHANUM4:
+  //       AssetCode4 assetCode4;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM12:
+  //       AssetCode12 assetCode12;
+  //
+  //       // add other asset types here in the future
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("AssetCode", {
+    switchOn: xdr.lookup("AssetType"),
+    switchName: "type",
+    switches: [
+      ["assetTypeCreditAlphanum4", "assetCode4"],
+      ["assetTypeCreditAlphanum12", "assetCode12"],
+    ],
+    arms: {
+      assetCode4: xdr.lookup("AssetCode4"),
+      assetCode12: xdr.lookup("AssetCode12"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct AlphaNum4
+  //   {
+  //       AssetCode4 assetCode;
+  //       AccountID issuer;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AlphaNum4", [
+    ["assetCode", xdr.lookup("AssetCode4")],
+    ["issuer", xdr.lookup("AccountId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct AlphaNum12
+  //   {
+  //       AssetCode12 assetCode;
+  //       AccountID issuer;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AlphaNum12", [
+    ["assetCode", xdr.lookup("AssetCode12")],
+    ["issuer", xdr.lookup("AccountId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union Asset switch (AssetType type)
+  //   {
+  //   case ASSET_TYPE_NATIVE: // Not credit
+  //       void;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM4:
+  //       AlphaNum4 alphaNum4;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM12:
+  //       AlphaNum12 alphaNum12;
+  //
+  //       // add other asset types here in the future
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("Asset", {
+    switchOn: xdr.lookup("AssetType"),
+    switchName: "type",
+    switches: [
+      ["assetTypeNative", xdr.void()],
+      ["assetTypeCreditAlphanum4", "alphaNum4"],
+      ["assetTypeCreditAlphanum12", "alphaNum12"],
+    ],
+    arms: {
+      alphaNum4: xdr.lookup("AlphaNum4"),
+      alphaNum12: xdr.lookup("AlphaNum12"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct Price
+  //   {
+  //       int32 n; // numerator
+  //       int32 d; // denominator
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Price", [
+    ["n", xdr.lookup("Int32")],
+    ["d", xdr.lookup("Int32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct Liabilities
+  //   {
+  //       int64 buying;
+  //       int64 selling;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Liabilities", [
+    ["buying", xdr.lookup("Int64")],
+    ["selling", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum ThresholdIndexes
+  //   {
+  //       THRESHOLD_MASTER_WEIGHT = 0,
+  //       THRESHOLD_LOW = 1,
+  //       THRESHOLD_MED = 2,
+  //       THRESHOLD_HIGH = 3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ThresholdIndices", {
+    thresholdMasterWeight: 0,
+    thresholdLow: 1,
+    thresholdMed: 2,
+    thresholdHigh: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum LedgerEntryType
+  //   {
+  //       ACCOUNT = 0,
+  //       TRUSTLINE = 1,
+  //       OFFER = 2,
+  //       DATA = 3,
+  //       CLAIMABLE_BALANCE = 4,
+  //       LIQUIDITY_POOL = 5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LedgerEntryType", {
+    account: 0,
+    trustline: 1,
+    offer: 2,
+    data: 3,
+    claimableBalance: 4,
+    liquidityPool: 5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct Signer
+  //   {
+  //       SignerKey key;
+  //       uint32 weight; // really only need 1 byte
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Signer", [
+    ["key", xdr.lookup("SignerKey")],
+    ["weight", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum AccountFlags
+  //   { // masks for each flag
+  //
+  //       // Flags set on issuer accounts
+  //       // TrustLines are created with authorized set to "false" requiring
+  //       // the issuer to set it for each TrustLine
+  //       AUTH_REQUIRED_FLAG = 0x1,
+  //       // If set, the authorized flag in TrustLines can be cleared
+  //       // otherwise, authorization cannot be revoked
+  //       AUTH_REVOCABLE_FLAG = 0x2,
+  //       // Once set, causes all AUTH_* flags to be read-only
+  //       AUTH_IMMUTABLE_FLAG = 0x4,
+  //       // Trustlines are created with clawback enabled set to "true",
+  //       // and claimable balances created from those trustlines are created
+  //       // with clawback enabled set to "true"
+  //       AUTH_CLAWBACK_ENABLED_FLAG = 0x8
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("AccountFlags", {
+    authRequiredFlag: 1,
+    authRevocableFlag: 2,
+    authImmutableFlag: 4,
+    authClawbackEnabledFlag: 8,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_ACCOUNT_FLAGS = 0x7;
+  //
+  // ===========================================================================
+  xdr.const("MASK_ACCOUNT_FLAGS", 0x7);
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_ACCOUNT_FLAGS_V17 = 0xF;
+  //
+  // ===========================================================================
+  xdr.const("MASK_ACCOUNT_FLAGS_V17", 0xf);
+
+  // === xdr source ============================================================
+  //
+  //   const MAX_SIGNERS = 20;
+  //
+  // ===========================================================================
+  xdr.const("MAX_SIGNERS", 20);
+
+  // === xdr source ============================================================
+  //
+  //   typedef AccountID* SponsorshipDescriptor;
+  //
+  // ===========================================================================
+  xdr.typedef("SponsorshipDescriptor", xdr.option(xdr.lookup("AccountId")));
+
+  // === xdr source ============================================================
+  //
+  //   struct AccountEntryExtensionV3
+  //   {
+  //       // We can use this to add more fields, or because it is first, to
+  //       // change AccountEntryExtensionV3 into a union.
+  //       ExtensionPoint ext;
+  //
+  //       // Ledger number at which `seqNum` took on its present value.
+  //       uint32 seqLedger;
+  //
+  //       // Time at which `seqNum` took on its present value.
+  //       TimePoint seqTime;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AccountEntryExtensionV3", [
+    ["ext", xdr.lookup("ExtensionPoint")],
+    ["seqLedger", xdr.lookup("Uint32")],
+    ["seqTime", xdr.lookup("TimePoint")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 3:
+  //           AccountEntryExtensionV3 v3;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("AccountEntryExtensionV2Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [3, "v3"],
+    ],
+    arms: {
+      v3: xdr.lookup("AccountEntryExtensionV3"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct AccountEntryExtensionV2
+  //   {
+  //       uint32 numSponsored;
+  //       uint32 numSponsoring;
+  //       SponsorshipDescriptor signerSponsoringIDs<MAX_SIGNERS>;
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 3:
+  //           AccountEntryExtensionV3 v3;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AccountEntryExtensionV2", [
+    ["numSponsored", xdr.lookup("Uint32")],
+    ["numSponsoring", xdr.lookup("Uint32")],
+    [
+      "signerSponsoringIDs",
+      xdr.varArray(
+        xdr.lookup("SponsorshipDescriptor"),
+        xdr.lookup("MAX_SIGNERS")
+      ),
+    ],
+    ["ext", xdr.lookup("AccountEntryExtensionV2Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 2:
+  //           AccountEntryExtensionV2 v2;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("AccountEntryExtensionV1Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [2, "v2"],
+    ],
+    arms: {
+      v2: xdr.lookup("AccountEntryExtensionV2"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct AccountEntryExtensionV1
+  //   {
+  //       Liabilities liabilities;
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 2:
+  //           AccountEntryExtensionV2 v2;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AccountEntryExtensionV1", [
+    ["liabilities", xdr.lookup("Liabilities")],
+    ["ext", xdr.lookup("AccountEntryExtensionV1Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           AccountEntryExtensionV1 v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("AccountEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "v1"],
+    ],
+    arms: {
+      v1: xdr.lookup("AccountEntryExtensionV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct AccountEntry
+  //   {
+  //       AccountID accountID;      // master public key for this account
+  //       int64 balance;            // in stroops
+  //       SequenceNumber seqNum;    // last sequence number used for this account
+  //       uint32 numSubEntries;     // number of sub-entries this account has
+  //                                 // drives the reserve
+  //       AccountID* inflationDest; // Account to vote for during inflation
+  //       uint32 flags;             // see AccountFlags
+  //
+  //       string32 homeDomain; // can be used for reverse federation and memo lookup
+  //
+  //       // fields used for signatures
+  //       // thresholds stores unsigned bytes: [weight of master|low|medium|high]
+  //       Thresholds thresholds;
+  //
+  //       Signer signers<MAX_SIGNERS>; // possible signers for this account
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           AccountEntryExtensionV1 v1;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AccountEntry", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["balance", xdr.lookup("Int64")],
+    ["seqNum", xdr.lookup("SequenceNumber")],
+    ["numSubEntries", xdr.lookup("Uint32")],
+    ["inflationDest", xdr.option(xdr.lookup("AccountId"))],
+    ["flags", xdr.lookup("Uint32")],
+    ["homeDomain", xdr.lookup("String32")],
+    ["thresholds", xdr.lookup("Thresholds")],
+    ["signers", xdr.varArray(xdr.lookup("Signer"), xdr.lookup("MAX_SIGNERS"))],
+    ["ext", xdr.lookup("AccountEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum TrustLineFlags
+  //   {
+  //       // issuer has authorized account to perform transactions with its credit
+  //       AUTHORIZED_FLAG = 1,
+  //       // issuer has authorized account to maintain and reduce liabilities for its
+  //       // credit
+  //       AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
+  //       // issuer has specified that it may clawback its credit, and that claimable
+  //       // balances created with its credit may also be clawed back
+  //       TRUSTLINE_CLAWBACK_ENABLED_FLAG = 4
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("TrustLineFlags", {
+    authorizedFlag: 1,
+    authorizedToMaintainLiabilitiesFlag: 2,
+    trustlineClawbackEnabledFlag: 4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_TRUSTLINE_FLAGS = 1;
+  //
+  // ===========================================================================
+  xdr.const("MASK_TRUSTLINE_FLAGS", 1);
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_TRUSTLINE_FLAGS_V13 = 3;
+  //
+  // ===========================================================================
+  xdr.const("MASK_TRUSTLINE_FLAGS_V13", 3);
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_TRUSTLINE_FLAGS_V17 = 7;
+  //
+  // ===========================================================================
+  xdr.const("MASK_TRUSTLINE_FLAGS_V17", 7);
+
+  // === xdr source ============================================================
+  //
+  //   enum LiquidityPoolType
+  //   {
+  //       LIQUIDITY_POOL_CONSTANT_PRODUCT = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LiquidityPoolType", {
+    liquidityPoolConstantProduct: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union TrustLineAsset switch (AssetType type)
+  //   {
+  //   case ASSET_TYPE_NATIVE: // Not credit
+  //       void;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM4:
+  //       AlphaNum4 alphaNum4;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM12:
+  //       AlphaNum12 alphaNum12;
+  //
+  //   case ASSET_TYPE_POOL_SHARE:
+  //       PoolID liquidityPoolID;
+  //
+  //       // add other asset types here in the future
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("TrustLineAsset", {
+    switchOn: xdr.lookup("AssetType"),
+    switchName: "type",
+    switches: [
+      ["assetTypeNative", xdr.void()],
+      ["assetTypeCreditAlphanum4", "alphaNum4"],
+      ["assetTypeCreditAlphanum12", "alphaNum12"],
+      ["assetTypePoolShare", "liquidityPoolId"],
+    ],
+    arms: {
+      alphaNum4: xdr.lookup("AlphaNum4"),
+      alphaNum12: xdr.lookup("AlphaNum12"),
+      liquidityPoolId: xdr.lookup("PoolId"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TrustLineEntryExtensionV2Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TrustLineEntryExtensionV2
+  //   {
+  //       int32 liquidityPoolUseCount;
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TrustLineEntryExtensionV2", [
+    ["liquidityPoolUseCount", xdr.lookup("Int32")],
+    ["ext", xdr.lookup("TrustLineEntryExtensionV2Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //               {
+  //               case 0:
+  //                   void;
+  //               case 2:
+  //                   TrustLineEntryExtensionV2 v2;
+  //               }
+  //
+  // ===========================================================================
+  xdr.union("TrustLineEntryV1Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [2, "v2"],
+    ],
+    arms: {
+      v2: xdr.lookup("TrustLineEntryExtensionV2"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               Liabilities liabilities;
+  //
+  //               union switch (int v)
+  //               {
+  //               case 0:
+  //                   void;
+  //               case 2:
+  //                   TrustLineEntryExtensionV2 v2;
+  //               }
+  //               ext;
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("TrustLineEntryV1", [
+    ["liabilities", xdr.lookup("Liabilities")],
+    ["ext", xdr.lookup("TrustLineEntryV1Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           struct
+  //           {
+  //               Liabilities liabilities;
+  //
+  //               union switch (int v)
+  //               {
+  //               case 0:
+  //                   void;
+  //               case 2:
+  //                   TrustLineEntryExtensionV2 v2;
+  //               }
+  //               ext;
+  //           } v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TrustLineEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "v1"],
+    ],
+    arms: {
+      v1: xdr.lookup("TrustLineEntryV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TrustLineEntry
+  //   {
+  //       AccountID accountID;  // account this trustline belongs to
+  //       TrustLineAsset asset; // type of asset (with issuer)
+  //       int64 balance;        // how much of this asset the user has.
+  //                             // Asset defines the unit for this;
+  //
+  //       int64 limit;  // balance cannot be above this
+  //       uint32 flags; // see TrustLineFlags
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           struct
+  //           {
+  //               Liabilities liabilities;
+  //
+  //               union switch (int v)
+  //               {
+  //               case 0:
+  //                   void;
+  //               case 2:
+  //                   TrustLineEntryExtensionV2 v2;
+  //               }
+  //               ext;
+  //           } v1;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TrustLineEntry", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["asset", xdr.lookup("TrustLineAsset")],
+    ["balance", xdr.lookup("Int64")],
+    ["limit", xdr.lookup("Int64")],
+    ["flags", xdr.lookup("Uint32")],
+    ["ext", xdr.lookup("TrustLineEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum OfferEntryFlags
+  //   {
+  //       // an offer with this flag will not act on and take a reverse offer of equal
+  //       // price
+  //       PASSIVE_FLAG = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("OfferEntryFlags", {
+    passiveFlag: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_OFFERENTRY_FLAGS = 1;
+  //
+  // ===========================================================================
+  xdr.const("MASK_OFFERENTRY_FLAGS", 1);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("OfferEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct OfferEntry
+  //   {
+  //       AccountID sellerID;
+  //       int64 offerID;
+  //       Asset selling; // A
+  //       Asset buying;  // B
+  //       int64 amount;  // amount of A
+  //
+  //       /* price for this offer:
+  //           price of A in terms of B
+  //           price=AmountB/AmountA=priceNumerator/priceDenominator
+  //           price is after fees
+  //       */
+  //       Price price;
+  //       uint32 flags; // see OfferEntryFlags
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("OfferEntry", [
+    ["sellerId", xdr.lookup("AccountId")],
+    ["offerId", xdr.lookup("Int64")],
+    ["selling", xdr.lookup("Asset")],
+    ["buying", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+    ["price", xdr.lookup("Price")],
+    ["flags", xdr.lookup("Uint32")],
+    ["ext", xdr.lookup("OfferEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("DataEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct DataEntry
+  //   {
+  //       AccountID accountID; // account this data belongs to
+  //       string64 dataName;
+  //       DataValue dataValue;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("DataEntry", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["dataName", xdr.lookup("String64")],
+    ["dataValue", xdr.lookup("DataValue")],
+    ["ext", xdr.lookup("DataEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimPredicateType
+  //   {
+  //       CLAIM_PREDICATE_UNCONDITIONAL = 0,
+  //       CLAIM_PREDICATE_AND = 1,
+  //       CLAIM_PREDICATE_OR = 2,
+  //       CLAIM_PREDICATE_NOT = 3,
+  //       CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
+  //       CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimPredicateType", {
+    claimPredicateUnconditional: 0,
+    claimPredicateAnd: 1,
+    claimPredicateOr: 2,
+    claimPredicateNot: 3,
+    claimPredicateBeforeAbsoluteTime: 4,
+    claimPredicateBeforeRelativeTime: 5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ClaimPredicate switch (ClaimPredicateType type)
+  //   {
+  //   case CLAIM_PREDICATE_UNCONDITIONAL:
+  //       void;
+  //   case CLAIM_PREDICATE_AND:
+  //       ClaimPredicate andPredicates<2>;
+  //   case CLAIM_PREDICATE_OR:
+  //       ClaimPredicate orPredicates<2>;
+  //   case CLAIM_PREDICATE_NOT:
+  //       ClaimPredicate* notPredicate;
+  //   case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
+  //       int64 absBefore; // Predicate will be true if closeTime < absBefore
+  //   case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
+  //       int64 relBefore; // Seconds since closeTime of the ledger in which the
+  //                        // ClaimableBalanceEntry was created
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClaimPredicate", {
+    switchOn: xdr.lookup("ClaimPredicateType"),
+    switchName: "type",
+    switches: [
+      ["claimPredicateUnconditional", xdr.void()],
+      ["claimPredicateAnd", "andPredicates"],
+      ["claimPredicateOr", "orPredicates"],
+      ["claimPredicateNot", "notPredicate"],
+      ["claimPredicateBeforeAbsoluteTime", "absBefore"],
+      ["claimPredicateBeforeRelativeTime", "relBefore"],
+    ],
+    arms: {
+      andPredicates: xdr.varArray(xdr.lookup("ClaimPredicate"), 2),
+      orPredicates: xdr.varArray(xdr.lookup("ClaimPredicate"), 2),
+      notPredicate: xdr.option(xdr.lookup("ClaimPredicate")),
+      absBefore: xdr.lookup("Int64"),
+      relBefore: xdr.lookup("Int64"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimantType
+  //   {
+  //       CLAIMANT_TYPE_V0 = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimantType", {
+    claimantTypeV0: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID destination;    // The account that can use this condition
+  //           ClaimPredicate predicate; // Claimable if predicate is true
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("ClaimantV0", [
+    ["destination", xdr.lookup("AccountId")],
+    ["predicate", xdr.lookup("ClaimPredicate")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union Claimant switch (ClaimantType type)
+  //   {
+  //   case CLAIMANT_TYPE_V0:
+  //       struct
+  //       {
+  //           AccountID destination;    // The account that can use this condition
+  //           ClaimPredicate predicate; // Claimable if predicate is true
+  //       } v0;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("Claimant", {
+    switchOn: xdr.lookup("ClaimantType"),
+    switchName: "type",
+    switches: [["claimantTypeV0", "v0"]],
+    arms: {
+      v0: xdr.lookup("ClaimantV0"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimableBalanceIDType
+  //   {
+  //       CLAIMABLE_BALANCE_ID_TYPE_V0 = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimableBalanceIdType", {
+    claimableBalanceIdTypeV0: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ClaimableBalanceID switch (ClaimableBalanceIDType type)
+  //   {
+  //   case CLAIMABLE_BALANCE_ID_TYPE_V0:
+  //       Hash v0;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClaimableBalanceId", {
+    switchOn: xdr.lookup("ClaimableBalanceIdType"),
+    switchName: "type",
+    switches: [["claimableBalanceIdTypeV0", "v0"]],
+    arms: {
+      v0: xdr.lookup("Hash"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimableBalanceFlags
+  //   {
+  //       // If set, the issuer account of the asset held by the claimable balance may
+  //       // clawback the claimable balance
+  //       CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG = 0x1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimableBalanceFlags", {
+    claimableBalanceClawbackEnabledFlag: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1;
+  //
+  // ===========================================================================
+  xdr.const("MASK_CLAIMABLE_BALANCE_FLAGS", 0x1);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("ClaimableBalanceEntryExtensionV1Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimableBalanceEntryExtensionV1
+  //   {
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //
+  //       uint32 flags; // see ClaimableBalanceFlags
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimableBalanceEntryExtensionV1", [
+    ["ext", xdr.lookup("ClaimableBalanceEntryExtensionV1Ext")],
+    ["flags", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           ClaimableBalanceEntryExtensionV1 v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("ClaimableBalanceEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "v1"],
+    ],
+    arms: {
+      v1: xdr.lookup("ClaimableBalanceEntryExtensionV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimableBalanceEntry
+  //   {
+  //       // Unique identifier for this ClaimableBalanceEntry
+  //       ClaimableBalanceID balanceID;
+  //
+  //       // List of claimants with associated predicate
+  //       Claimant claimants<10>;
+  //
+  //       // Any asset including native
+  //       Asset asset;
+  //
+  //       // Amount of asset
+  //       int64 amount;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           ClaimableBalanceEntryExtensionV1 v1;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimableBalanceEntry", [
+    ["balanceId", xdr.lookup("ClaimableBalanceId")],
+    ["claimants", xdr.varArray(xdr.lookup("Claimant"), 10)],
+    ["asset", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+    ["ext", xdr.lookup("ClaimableBalanceEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LiquidityPoolConstantProductParameters
+  //   {
+  //       Asset assetA; // assetA < assetB
+  //       Asset assetB;
+  //       int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LiquidityPoolConstantProductParameters", [
+    ["assetA", xdr.lookup("Asset")],
+    ["assetB", xdr.lookup("Asset")],
+    ["fee", xdr.lookup("Int32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               LiquidityPoolConstantProductParameters params;
+  //
+  //               int64 reserveA;        // amount of A in the pool
+  //               int64 reserveB;        // amount of B in the pool
+  //               int64 totalPoolShares; // total number of pool shares issued
+  //               int64 poolSharesTrustLineCount; // number of trust lines for the
+  //                                               // associated pool shares
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("LiquidityPoolEntryConstantProduct", [
+    ["params", xdr.lookup("LiquidityPoolConstantProductParameters")],
+    ["reserveA", xdr.lookup("Int64")],
+    ["reserveB", xdr.lookup("Int64")],
+    ["totalPoolShares", xdr.lookup("Int64")],
+    ["poolSharesTrustLineCount", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (LiquidityPoolType type)
+  //       {
+  //       case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+  //           struct
+  //           {
+  //               LiquidityPoolConstantProductParameters params;
+  //
+  //               int64 reserveA;        // amount of A in the pool
+  //               int64 reserveB;        // amount of B in the pool
+  //               int64 totalPoolShares; // total number of pool shares issued
+  //               int64 poolSharesTrustLineCount; // number of trust lines for the
+  //                                               // associated pool shares
+  //           } constantProduct;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LiquidityPoolEntryBody", {
+    switchOn: xdr.lookup("LiquidityPoolType"),
+    switchName: "type",
+    switches: [["liquidityPoolConstantProduct", "constantProduct"]],
+    arms: {
+      constantProduct: xdr.lookup("LiquidityPoolEntryConstantProduct"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LiquidityPoolEntry
+  //   {
+  //       PoolID liquidityPoolID;
+  //
+  //       union switch (LiquidityPoolType type)
+  //       {
+  //       case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+  //           struct
+  //           {
+  //               LiquidityPoolConstantProductParameters params;
+  //
+  //               int64 reserveA;        // amount of A in the pool
+  //               int64 reserveB;        // amount of B in the pool
+  //               int64 totalPoolShares; // total number of pool shares issued
+  //               int64 poolSharesTrustLineCount; // number of trust lines for the
+  //                                               // associated pool shares
+  //           } constantProduct;
+  //       }
+  //       body;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LiquidityPoolEntry", [
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+    ["body", xdr.lookup("LiquidityPoolEntryBody")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerEntryExtensionV1Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerEntryExtensionV1
+  //   {
+  //       SponsorshipDescriptor sponsoringID;
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerEntryExtensionV1", [
+    ["sponsoringId", xdr.lookup("SponsorshipDescriptor")],
+    ["ext", xdr.lookup("LedgerEntryExtensionV1Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (LedgerEntryType type)
+  //       {
+  //       case ACCOUNT:
+  //           AccountEntry account;
+  //       case TRUSTLINE:
+  //           TrustLineEntry trustLine;
+  //       case OFFER:
+  //           OfferEntry offer;
+  //       case DATA:
+  //           DataEntry data;
+  //       case CLAIMABLE_BALANCE:
+  //           ClaimableBalanceEntry claimableBalance;
+  //       case LIQUIDITY_POOL:
+  //           LiquidityPoolEntry liquidityPool;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerEntryData", {
+    switchOn: xdr.lookup("LedgerEntryType"),
+    switchName: "type",
+    switches: [
+      ["account", "account"],
+      ["trustline", "trustLine"],
+      ["offer", "offer"],
+      ["data", "data"],
+      ["claimableBalance", "claimableBalance"],
+      ["liquidityPool", "liquidityPool"],
+    ],
+    arms: {
+      account: xdr.lookup("AccountEntry"),
+      trustLine: xdr.lookup("TrustLineEntry"),
+      offer: xdr.lookup("OfferEntry"),
+      data: xdr.lookup("DataEntry"),
+      claimableBalance: xdr.lookup("ClaimableBalanceEntry"),
+      liquidityPool: xdr.lookup("LiquidityPoolEntry"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           LedgerEntryExtensionV1 v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "v1"],
+    ],
+    arms: {
+      v1: xdr.lookup("LedgerEntryExtensionV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerEntry
+  //   {
+  //       uint32 lastModifiedLedgerSeq; // ledger the LedgerEntry was last changed
+  //
+  //       union switch (LedgerEntryType type)
+  //       {
+  //       case ACCOUNT:
+  //           AccountEntry account;
+  //       case TRUSTLINE:
+  //           TrustLineEntry trustLine;
+  //       case OFFER:
+  //           OfferEntry offer;
+  //       case DATA:
+  //           DataEntry data;
+  //       case CLAIMABLE_BALANCE:
+  //           ClaimableBalanceEntry claimableBalance;
+  //       case LIQUIDITY_POOL:
+  //           LiquidityPoolEntry liquidityPool;
+  //       }
+  //       data;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           LedgerEntryExtensionV1 v1;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerEntry", [
+    ["lastModifiedLedgerSeq", xdr.lookup("Uint32")],
+    ["data", xdr.lookup("LedgerEntryData")],
+    ["ext", xdr.lookup("LedgerEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID accountID;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyAccount", [["accountId", xdr.lookup("AccountId")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID accountID;
+  //           TrustLineAsset asset;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyTrustLine", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["asset", xdr.lookup("TrustLineAsset")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID sellerID;
+  //           int64 offerID;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyOffer", [
+    ["sellerId", xdr.lookup("AccountId")],
+    ["offerId", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID accountID;
+  //           string64 dataName;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyData", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["dataName", xdr.lookup("String64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           ClaimableBalanceID balanceID;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyClaimableBalance", [
+    ["balanceId", xdr.lookup("ClaimableBalanceId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           PoolID liquidityPoolID;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyLiquidityPool", [
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union LedgerKey switch (LedgerEntryType type)
+  //   {
+  //   case ACCOUNT:
+  //       struct
+  //       {
+  //           AccountID accountID;
+  //       } account;
+  //
+  //   case TRUSTLINE:
+  //       struct
+  //       {
+  //           AccountID accountID;
+  //           TrustLineAsset asset;
+  //       } trustLine;
+  //
+  //   case OFFER:
+  //       struct
+  //       {
+  //           AccountID sellerID;
+  //           int64 offerID;
+  //       } offer;
+  //
+  //   case DATA:
+  //       struct
+  //       {
+  //           AccountID accountID;
+  //           string64 dataName;
+  //       } data;
+  //
+  //   case CLAIMABLE_BALANCE:
+  //       struct
+  //       {
+  //           ClaimableBalanceID balanceID;
+  //       } claimableBalance;
+  //
+  //   case LIQUIDITY_POOL:
+  //       struct
+  //       {
+  //           PoolID liquidityPoolID;
+  //       } liquidityPool;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LedgerKey", {
+    switchOn: xdr.lookup("LedgerEntryType"),
+    switchName: "type",
+    switches: [
+      ["account", "account"],
+      ["trustline", "trustLine"],
+      ["offer", "offer"],
+      ["data", "data"],
+      ["claimableBalance", "claimableBalance"],
+      ["liquidityPool", "liquidityPool"],
+    ],
+    arms: {
+      account: xdr.lookup("LedgerKeyAccount"),
+      trustLine: xdr.lookup("LedgerKeyTrustLine"),
+      offer: xdr.lookup("LedgerKeyOffer"),
+      data: xdr.lookup("LedgerKeyData"),
+      claimableBalance: xdr.lookup("LedgerKeyClaimableBalance"),
+      liquidityPool: xdr.lookup("LedgerKeyLiquidityPool"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum EnvelopeType
+  //   {
+  //       ENVELOPE_TYPE_TX_V0 = 0,
+  //       ENVELOPE_TYPE_SCP = 1,
+  //       ENVELOPE_TYPE_TX = 2,
+  //       ENVELOPE_TYPE_AUTH = 3,
+  //       ENVELOPE_TYPE_SCPVALUE = 4,
+  //       ENVELOPE_TYPE_TX_FEE_BUMP = 5,
+  //       ENVELOPE_TYPE_OP_ID = 6,
+  //       ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("EnvelopeType", {
+    envelopeTypeTxV0: 0,
+    envelopeTypeScp: 1,
+    envelopeTypeTx: 2,
+    envelopeTypeAuth: 3,
+    envelopeTypeScpvalue: 4,
+    envelopeTypeTxFeeBump: 5,
+    envelopeTypeOpId: 6,
+    envelopeTypePoolRevokeOpId: 7,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque UpgradeType<128>;
+  //
+  // ===========================================================================
+  xdr.typedef("UpgradeType", xdr.varOpaque(128));
+
+  // === xdr source ============================================================
+  //
+  //   enum StellarValueType
+  //   {
+  //       STELLAR_VALUE_BASIC = 0,
+  //       STELLAR_VALUE_SIGNED = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("StellarValueType", {
+    stellarValueBasic: 0,
+    stellarValueSigned: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerCloseValueSignature
+  //   {
+  //       NodeID nodeID;       // which node introduced the value
+  //       Signature signature; // nodeID's signature
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerCloseValueSignature", [
+    ["nodeId", xdr.lookup("NodeId")],
+    ["signature", xdr.lookup("Signature")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (StellarValueType v)
+  //       {
+  //       case STELLAR_VALUE_BASIC:
+  //           void;
+  //       case STELLAR_VALUE_SIGNED:
+  //           LedgerCloseValueSignature lcValueSignature;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("StellarValueExt", {
+    switchOn: xdr.lookup("StellarValueType"),
+    switchName: "v",
+    switches: [
+      ["stellarValueBasic", xdr.void()],
+      ["stellarValueSigned", "lcValueSignature"],
+    ],
+    arms: {
+      lcValueSignature: xdr.lookup("LedgerCloseValueSignature"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct StellarValue
+  //   {
+  //       Hash txSetHash;      // transaction set to apply to previous ledger
+  //       TimePoint closeTime; // network close time
+  //
+  //       // upgrades to apply to the previous ledger (usually empty)
+  //       // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
+  //       // unknown steps during consensus if needed.
+  //       // see notes below on 'LedgerUpgrade' for more detail
+  //       // max size is dictated by number of upgrade types (+ room for future)
+  //       UpgradeType upgrades<6>;
+  //
+  //       // reserved for future use
+  //       union switch (StellarValueType v)
+  //       {
+  //       case STELLAR_VALUE_BASIC:
+  //           void;
+  //       case STELLAR_VALUE_SIGNED:
+  //           LedgerCloseValueSignature lcValueSignature;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("StellarValue", [
+    ["txSetHash", xdr.lookup("Hash")],
+    ["closeTime", xdr.lookup("TimePoint")],
+    ["upgrades", xdr.varArray(xdr.lookup("UpgradeType"), 6)],
+    ["ext", xdr.lookup("StellarValueExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_LEDGER_HEADER_FLAGS = 0x7;
+  //
+  // ===========================================================================
+  xdr.const("MASK_LEDGER_HEADER_FLAGS", 0x7);
+
+  // === xdr source ============================================================
+  //
+  //   enum LedgerHeaderFlags
+  //   {
+  //       DISABLE_LIQUIDITY_POOL_TRADING_FLAG = 0x1,
+  //       DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG = 0x2,
+  //       DISABLE_LIQUIDITY_POOL_WITHDRAWAL_FLAG = 0x4
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LedgerHeaderFlags", {
+    disableLiquidityPoolTradingFlag: 1,
+    disableLiquidityPoolDepositFlag: 2,
+    disableLiquidityPoolWithdrawalFlag: 4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerHeaderExtensionV1Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerHeaderExtensionV1
+  //   {
+  //       uint32 flags; // LedgerHeaderFlags
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerHeaderExtensionV1", [
+    ["flags", xdr.lookup("Uint32")],
+    ["ext", xdr.lookup("LedgerHeaderExtensionV1Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           LedgerHeaderExtensionV1 v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerHeaderExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "v1"],
+    ],
+    arms: {
+      v1: xdr.lookup("LedgerHeaderExtensionV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerHeader
+  //   {
+  //       uint32 ledgerVersion;    // the protocol version of the ledger
+  //       Hash previousLedgerHash; // hash of the previous ledger header
+  //       StellarValue scpValue;   // what consensus agreed to
+  //       Hash txSetResultHash;    // the TransactionResultSet that led to this ledger
+  //       Hash bucketListHash;     // hash of the ledger state
+  //
+  //       uint32 ledgerSeq; // sequence number of this ledger
+  //
+  //       int64 totalCoins; // total number of stroops in existence.
+  //                         // 10,000,000 stroops in 1 XLM
+  //
+  //       int64 feePool;       // fees burned since last inflation run
+  //       uint32 inflationSeq; // inflation sequence number
+  //
+  //       uint64 idPool; // last used global ID, used for generating objects
+  //
+  //       uint32 baseFee;     // base fee per operation in stroops
+  //       uint32 baseReserve; // account base reserve in stroops
+  //
+  //       uint32 maxTxSetSize; // maximum size a transaction set can be
+  //
+  //       Hash skipList[4]; // hashes of ledgers in the past. allows you to jump back
+  //                         // in time without walking the chain back ledger by ledger
+  //                         // each slot contains the oldest ledger that is mod of
+  //                         // either 50  5000  50000 or 500000 depending on index
+  //                         // skipList[0] mod(50), skipList[1] mod(5000), etc
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           LedgerHeaderExtensionV1 v1;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerHeader", [
+    ["ledgerVersion", xdr.lookup("Uint32")],
+    ["previousLedgerHash", xdr.lookup("Hash")],
+    ["scpValue", xdr.lookup("StellarValue")],
+    ["txSetResultHash", xdr.lookup("Hash")],
+    ["bucketListHash", xdr.lookup("Hash")],
+    ["ledgerSeq", xdr.lookup("Uint32")],
+    ["totalCoins", xdr.lookup("Int64")],
+    ["feePool", xdr.lookup("Int64")],
+    ["inflationSeq", xdr.lookup("Uint32")],
+    ["idPool", xdr.lookup("Uint64")],
+    ["baseFee", xdr.lookup("Uint32")],
+    ["baseReserve", xdr.lookup("Uint32")],
+    ["maxTxSetSize", xdr.lookup("Uint32")],
+    ["skipList", xdr.array(xdr.lookup("Hash"), 4)],
+    ["ext", xdr.lookup("LedgerHeaderExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum LedgerUpgradeType
+  //   {
+  //       LEDGER_UPGRADE_VERSION = 1,
+  //       LEDGER_UPGRADE_BASE_FEE = 2,
+  //       LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3,
+  //       LEDGER_UPGRADE_BASE_RESERVE = 4,
+  //       LEDGER_UPGRADE_FLAGS = 5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LedgerUpgradeType", {
+    ledgerUpgradeVersion: 1,
+    ledgerUpgradeBaseFee: 2,
+    ledgerUpgradeMaxTxSetSize: 3,
+    ledgerUpgradeBaseReserve: 4,
+    ledgerUpgradeFlags: 5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union LedgerUpgrade switch (LedgerUpgradeType type)
+  //   {
+  //   case LEDGER_UPGRADE_VERSION:
+  //       uint32 newLedgerVersion; // update ledgerVersion
+  //   case LEDGER_UPGRADE_BASE_FEE:
+  //       uint32 newBaseFee; // update baseFee
+  //   case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
+  //       uint32 newMaxTxSetSize; // update maxTxSetSize
+  //   case LEDGER_UPGRADE_BASE_RESERVE:
+  //       uint32 newBaseReserve; // update baseReserve
+  //   case LEDGER_UPGRADE_FLAGS:
+  //       uint32 newFlags; // update flags
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LedgerUpgrade", {
+    switchOn: xdr.lookup("LedgerUpgradeType"),
+    switchName: "type",
+    switches: [
+      ["ledgerUpgradeVersion", "newLedgerVersion"],
+      ["ledgerUpgradeBaseFee", "newBaseFee"],
+      ["ledgerUpgradeMaxTxSetSize", "newMaxTxSetSize"],
+      ["ledgerUpgradeBaseReserve", "newBaseReserve"],
+      ["ledgerUpgradeFlags", "newFlags"],
+    ],
+    arms: {
+      newLedgerVersion: xdr.lookup("Uint32"),
+      newBaseFee: xdr.lookup("Uint32"),
+      newMaxTxSetSize: xdr.lookup("Uint32"),
+      newBaseReserve: xdr.lookup("Uint32"),
+      newFlags: xdr.lookup("Uint32"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum BucketEntryType
+  //   {
+  //       METAENTRY =
+  //           -1, // At-and-after protocol 11: bucket metadata, should come first.
+  //       LIVEENTRY = 0, // Before protocol 11: created-or-updated;
+  //                      // At-and-after protocol 11: only updated.
+  //       DEADENTRY = 1,
+  //       INITENTRY = 2 // At-and-after protocol 11: only created.
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("BucketEntryType", {
+    metaentry: -1,
+    liveentry: 0,
+    deadentry: 1,
+    initentry: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("BucketMetadataExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct BucketMetadata
+  //   {
+  //       // Indicates the protocol version used to create / merge this bucket.
+  //       uint32 ledgerVersion;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("BucketMetadata", [
+    ["ledgerVersion", xdr.lookup("Uint32")],
+    ["ext", xdr.lookup("BucketMetadataExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union BucketEntry switch (BucketEntryType type)
+  //   {
+  //   case LIVEENTRY:
+  //   case INITENTRY:
+  //       LedgerEntry liveEntry;
+  //
+  //   case DEADENTRY:
+  //       LedgerKey deadEntry;
+  //   case METAENTRY:
+  //       BucketMetadata metaEntry;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("BucketEntry", {
+    switchOn: xdr.lookup("BucketEntryType"),
+    switchName: "type",
+    switches: [
+      ["liveentry", "liveEntry"],
+      ["initentry", "liveEntry"],
+      ["deadentry", "deadEntry"],
+      ["metaentry", "metaEntry"],
+    ],
+    arms: {
+      liveEntry: xdr.lookup("LedgerEntry"),
+      deadEntry: xdr.lookup("LedgerKey"),
+      metaEntry: xdr.lookup("BucketMetadata"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum TxSetComponentType
+  //   {
+  //     // txs with effective fee <= bid derived from a base fee (if any).
+  //     // If base fee is not specified, no discount is applied.
+  //     TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("TxSetComponentType", {
+    txsetCompTxsMaybeDiscountedFee: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //     {
+  //       int64* baseFee;
+  //       TransactionEnvelope txs<>;
+  //     }
+  //
+  // ===========================================================================
+  xdr.struct("TxSetComponentTxsMaybeDiscountedFee", [
+    ["baseFee", xdr.option(xdr.lookup("Int64"))],
+    ["txes", xdr.varArray(xdr.lookup("TransactionEnvelope"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union TxSetComponent switch (TxSetComponentType type)
+  //   {
+  //   case TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE:
+  //     struct
+  //     {
+  //       int64* baseFee;
+  //       TransactionEnvelope txs<>;
+  //     } txsMaybeDiscountedFee;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("TxSetComponent", {
+    switchOn: xdr.lookup("TxSetComponentType"),
+    switchName: "type",
+    switches: [["txsetCompTxsMaybeDiscountedFee", "txsMaybeDiscountedFee"]],
+    arms: {
+      txsMaybeDiscountedFee: xdr.lookup("TxSetComponentTxsMaybeDiscountedFee"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union TransactionPhase switch (int v)
+  //   {
+  //   case 0:
+  //       TxSetComponent v0Components<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("TransactionPhase", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, "v0Components"]],
+    arms: {
+      v0Components: xdr.varArray(xdr.lookup("TxSetComponent"), 2147483647),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionSet
+  //   {
+  //       Hash previousLedgerHash;
+  //       TransactionEnvelope txs<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionSet", [
+    ["previousLedgerHash", xdr.lookup("Hash")],
+    ["txes", xdr.varArray(xdr.lookup("TransactionEnvelope"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionSetV1
+  //   {
+  //       Hash previousLedgerHash;
+  //       TransactionPhase phases<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionSetV1", [
+    ["previousLedgerHash", xdr.lookup("Hash")],
+    ["phases", xdr.varArray(xdr.lookup("TransactionPhase"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union GeneralizedTransactionSet switch (int v)
+  //   {
+  //   // We consider the legacy TransactionSet to be v0.
+  //   case 1:
+  //       TransactionSetV1 v1TxSet;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("GeneralizedTransactionSet", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[1, "v1TxSet"]],
+    arms: {
+      v1TxSet: xdr.lookup("TransactionSetV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResultPair
+  //   {
+  //       Hash transactionHash;
+  //       TransactionResult result; // result for the transaction
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResultPair", [
+    ["transactionHash", xdr.lookup("Hash")],
+    ["result", xdr.lookup("TransactionResult")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResultSet
+  //   {
+  //       TransactionResultPair results<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResultSet", [
+    ["results", xdr.varArray(xdr.lookup("TransactionResultPair"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           GeneralizedTransactionSet generalizedTxSet;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionHistoryEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "generalizedTxSet"],
+    ],
+    arms: {
+      generalizedTxSet: xdr.lookup("GeneralizedTransactionSet"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionHistoryEntry
+  //   {
+  //       uint32 ledgerSeq;
+  //       TransactionSet txSet;
+  //
+  //       // when v != 0, txSet must be empty
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           GeneralizedTransactionSet generalizedTxSet;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionHistoryEntry", [
+    ["ledgerSeq", xdr.lookup("Uint32")],
+    ["txSet", xdr.lookup("TransactionSet")],
+    ["ext", xdr.lookup("TransactionHistoryEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionHistoryResultEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionHistoryResultEntry
+  //   {
+  //       uint32 ledgerSeq;
+  //       TransactionResultSet txResultSet;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionHistoryResultEntry", [
+    ["ledgerSeq", xdr.lookup("Uint32")],
+    ["txResultSet", xdr.lookup("TransactionResultSet")],
+    ["ext", xdr.lookup("TransactionHistoryResultEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerHeaderHistoryEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerHeaderHistoryEntry
+  //   {
+  //       Hash hash;
+  //       LedgerHeader header;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerHeaderHistoryEntry", [
+    ["hash", xdr.lookup("Hash")],
+    ["header", xdr.lookup("LedgerHeader")],
+    ["ext", xdr.lookup("LedgerHeaderHistoryEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerSCPMessages
+  //   {
+  //       uint32 ledgerSeq;
+  //       SCPEnvelope messages<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerScpMessages", [
+    ["ledgerSeq", xdr.lookup("Uint32")],
+    ["messages", xdr.varArray(xdr.lookup("ScpEnvelope"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPHistoryEntryV0
+  //   {
+  //       SCPQuorumSet quorumSets<>; // additional quorum sets used by ledgerMessages
+  //       LedgerSCPMessages ledgerMessages;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpHistoryEntryV0", [
+    ["quorumSets", xdr.varArray(xdr.lookup("ScpQuorumSet"), 2147483647)],
+    ["ledgerMessages", xdr.lookup("LedgerScpMessages")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union SCPHistoryEntry switch (int v)
+  //   {
+  //   case 0:
+  //       SCPHistoryEntryV0 v0;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ScpHistoryEntry", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, "v0"]],
+    arms: {
+      v0: xdr.lookup("ScpHistoryEntryV0"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum LedgerEntryChangeType
+  //   {
+  //       LEDGER_ENTRY_CREATED = 0, // entry was added to the ledger
+  //       LEDGER_ENTRY_UPDATED = 1, // entry was modified in the ledger
+  //       LEDGER_ENTRY_REMOVED = 2, // entry was removed from the ledger
+  //       LEDGER_ENTRY_STATE = 3    // value of the entry
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LedgerEntryChangeType", {
+    ledgerEntryCreated: 0,
+    ledgerEntryUpdated: 1,
+    ledgerEntryRemoved: 2,
+    ledgerEntryState: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union LedgerEntryChange switch (LedgerEntryChangeType type)
+  //   {
+  //   case LEDGER_ENTRY_CREATED:
+  //       LedgerEntry created;
+  //   case LEDGER_ENTRY_UPDATED:
+  //       LedgerEntry updated;
+  //   case LEDGER_ENTRY_REMOVED:
+  //       LedgerKey removed;
+  //   case LEDGER_ENTRY_STATE:
+  //       LedgerEntry state;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LedgerEntryChange", {
+    switchOn: xdr.lookup("LedgerEntryChangeType"),
+    switchName: "type",
+    switches: [
+      ["ledgerEntryCreated", "created"],
+      ["ledgerEntryUpdated", "updated"],
+      ["ledgerEntryRemoved", "removed"],
+      ["ledgerEntryState", "state"],
+    ],
+    arms: {
+      created: xdr.lookup("LedgerEntry"),
+      updated: xdr.lookup("LedgerEntry"),
+      removed: xdr.lookup("LedgerKey"),
+      state: xdr.lookup("LedgerEntry"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   typedef LedgerEntryChange LedgerEntryChanges<>;
+  //
+  // ===========================================================================
+  xdr.typedef(
+    "LedgerEntryChanges",
+    xdr.varArray(xdr.lookup("LedgerEntryChange"), 2147483647)
+  );
+
+  // === xdr source ============================================================
+  //
+  //   struct OperationMeta
+  //   {
+  //       LedgerEntryChanges changes;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("OperationMeta", [["changes", xdr.lookup("LedgerEntryChanges")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionMetaV1
+  //   {
+  //       LedgerEntryChanges txChanges; // tx level changes if any
+  //       OperationMeta operations<>;   // meta for each operation
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionMetaV1", [
+    ["txChanges", xdr.lookup("LedgerEntryChanges")],
+    ["operations", xdr.varArray(xdr.lookup("OperationMeta"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionMetaV2
+  //   {
+  //       LedgerEntryChanges txChangesBefore; // tx level changes before operations
+  //                                           // are applied if any
+  //       OperationMeta operations<>;         // meta for each operation
+  //       LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
+  //                                           // applied if any
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionMetaV2", [
+    ["txChangesBefore", xdr.lookup("LedgerEntryChanges")],
+    ["operations", xdr.varArray(xdr.lookup("OperationMeta"), 2147483647)],
+    ["txChangesAfter", xdr.lookup("LedgerEntryChanges")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union TransactionMeta switch (int v)
+  //   {
+  //   case 0:
+  //       OperationMeta operations<>;
+  //   case 1:
+  //       TransactionMetaV1 v1;
+  //   case 2:
+  //       TransactionMetaV2 v2;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("TransactionMeta", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, "operations"],
+      [1, "v1"],
+      [2, "v2"],
+    ],
+    arms: {
+      operations: xdr.varArray(xdr.lookup("OperationMeta"), 2147483647),
+      v1: xdr.lookup("TransactionMetaV1"),
+      v2: xdr.lookup("TransactionMetaV2"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResultMeta
+  //   {
+  //       TransactionResultPair result;
+  //       LedgerEntryChanges feeProcessing;
+  //       TransactionMeta txApplyProcessing;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResultMeta", [
+    ["result", xdr.lookup("TransactionResultPair")],
+    ["feeProcessing", xdr.lookup("LedgerEntryChanges")],
+    ["txApplyProcessing", xdr.lookup("TransactionMeta")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct UpgradeEntryMeta
+  //   {
+  //       LedgerUpgrade upgrade;
+  //       LedgerEntryChanges changes;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("UpgradeEntryMeta", [
+    ["upgrade", xdr.lookup("LedgerUpgrade")],
+    ["changes", xdr.lookup("LedgerEntryChanges")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerCloseMetaV0
+  //   {
+  //       LedgerHeaderHistoryEntry ledgerHeader;
+  //       // NB: txSet is sorted in "Hash order"
+  //       TransactionSet txSet;
+  //
+  //       // NB: transactions are sorted in apply order here
+  //       // fees for all transactions are processed first
+  //       // followed by applying transactions
+  //       TransactionResultMeta txProcessing<>;
+  //
+  //       // upgrades are applied last
+  //       UpgradeEntryMeta upgradesProcessing<>;
+  //
+  //       // other misc information attached to the ledger close
+  //       SCPHistoryEntry scpInfo<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerCloseMetaV0", [
+    ["ledgerHeader", xdr.lookup("LedgerHeaderHistoryEntry")],
+    ["txSet", xdr.lookup("TransactionSet")],
+    [
+      "txProcessing",
+      xdr.varArray(xdr.lookup("TransactionResultMeta"), 2147483647),
+    ],
+    [
+      "upgradesProcessing",
+      xdr.varArray(xdr.lookup("UpgradeEntryMeta"), 2147483647),
+    ],
+    ["scpInfo", xdr.varArray(xdr.lookup("ScpHistoryEntry"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerCloseMetaV1
+  //   {
+  //       LedgerHeaderHistoryEntry ledgerHeader;
+  //
+  //       GeneralizedTransactionSet txSet;
+  //
+  //       // NB: transactions are sorted in apply order here
+  //       // fees for all transactions are processed first
+  //       // followed by applying transactions
+  //       TransactionResultMeta txProcessing<>;
+  //
+  //       // upgrades are applied last
+  //       UpgradeEntryMeta upgradesProcessing<>;
+  //
+  //       // other misc information attached to the ledger close
+  //       SCPHistoryEntry scpInfo<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerCloseMetaV1", [
+    ["ledgerHeader", xdr.lookup("LedgerHeaderHistoryEntry")],
+    ["txSet", xdr.lookup("GeneralizedTransactionSet")],
+    [
+      "txProcessing",
+      xdr.varArray(xdr.lookup("TransactionResultMeta"), 2147483647),
+    ],
+    [
+      "upgradesProcessing",
+      xdr.varArray(xdr.lookup("UpgradeEntryMeta"), 2147483647),
+    ],
+    ["scpInfo", xdr.varArray(xdr.lookup("ScpHistoryEntry"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union LedgerCloseMeta switch (int v)
+  //   {
+  //   case 0:
+  //       LedgerCloseMetaV0 v0;
+  //   case 1:
+  //       LedgerCloseMetaV1 v1;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LedgerCloseMeta", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, "v0"],
+      [1, "v1"],
+    ],
+    arms: {
+      v0: xdr.lookup("LedgerCloseMetaV0"),
+      v1: xdr.lookup("LedgerCloseMetaV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ErrorCode
+  //   {
+  //       ERR_MISC = 0, // Unspecific error
+  //       ERR_DATA = 1, // Malformed data
+  //       ERR_CONF = 2, // Misconfiguration error
+  //       ERR_AUTH = 3, // Authentication failure
+  //       ERR_LOAD = 4  // System overloaded
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ErrorCode", {
+    errMisc: 0,
+    errData: 1,
+    errConf: 2,
+    errAuth: 3,
+    errLoad: 4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct Error
+  //   {
+  //       ErrorCode code;
+  //       string msg<100>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Error", [
+    ["code", xdr.lookup("ErrorCode")],
+    ["msg", xdr.string(100)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SendMore
+  //   {
+  //       uint32 numMessages;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SendMore", [["numMessages", xdr.lookup("Uint32")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct AuthCert
+  //   {
+  //       Curve25519Public pubkey;
+  //       uint64 expiration;
+  //       Signature sig;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AuthCert", [
+    ["pubkey", xdr.lookup("Curve25519Public")],
+    ["expiration", xdr.lookup("Uint64")],
+    ["sig", xdr.lookup("Signature")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct Hello
+  //   {
+  //       uint32 ledgerVersion;
+  //       uint32 overlayVersion;
+  //       uint32 overlayMinVersion;
+  //       Hash networkID;
+  //       string versionStr<100>;
+  //       int listeningPort;
+  //       NodeID peerID;
+  //       AuthCert cert;
+  //       uint256 nonce;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Hello", [
+    ["ledgerVersion", xdr.lookup("Uint32")],
+    ["overlayVersion", xdr.lookup("Uint32")],
+    ["overlayMinVersion", xdr.lookup("Uint32")],
+    ["networkId", xdr.lookup("Hash")],
+    ["versionStr", xdr.string(100)],
+    ["listeningPort", xdr.int()],
+    ["peerId", xdr.lookup("NodeId")],
+    ["cert", xdr.lookup("AuthCert")],
+    ["nonce", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   const AUTH_MSG_FLAG_PULL_MODE_REQUESTED = 100;
+  //
+  // ===========================================================================
+  xdr.const("AUTH_MSG_FLAG_PULL_MODE_REQUESTED", 100);
+
+  // === xdr source ============================================================
+  //
+  //   struct Auth
+  //   {
+  //       int flags;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Auth", [["flags", xdr.int()]]);
+
+  // === xdr source ============================================================
+  //
+  //   enum IPAddrType
+  //   {
+  //       IPv4 = 0,
+  //       IPv6 = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("IpAddrType", {
+    iPv4: 0,
+    iPv6: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (IPAddrType type)
+  //       {
+  //       case IPv4:
+  //           opaque ipv4[4];
+  //       case IPv6:
+  //           opaque ipv6[16];
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("PeerAddressIp", {
+    switchOn: xdr.lookup("IpAddrType"),
+    switchName: "type",
+    switches: [
+      ["iPv4", "ipv4"],
+      ["iPv6", "ipv6"],
+    ],
+    arms: {
+      ipv4: xdr.opaque(4),
+      ipv6: xdr.opaque(16),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct PeerAddress
+  //   {
+  //       union switch (IPAddrType type)
+  //       {
+  //       case IPv4:
+  //           opaque ipv4[4];
+  //       case IPv6:
+  //           opaque ipv6[16];
+  //       }
+  //       ip;
+  //       uint32 port;
+  //       uint32 numFailures;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PeerAddress", [
+    ["ip", xdr.lookup("PeerAddressIp")],
+    ["port", xdr.lookup("Uint32")],
+    ["numFailures", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum MessageType
+  //   {
+  //       ERROR_MSG = 0,
+  //       AUTH = 2,
+  //       DONT_HAVE = 3,
+  //
+  //       GET_PEERS = 4, // gets a list of peers this guy knows about
+  //       PEERS = 5,
+  //
+  //       GET_TX_SET = 6, // gets a particular txset by hash
+  //       TX_SET = 7,
+  //       GENERALIZED_TX_SET = 17,
+  //
+  //       TRANSACTION = 8, // pass on a tx you have heard about
+  //
+  //       // SCP
+  //       GET_SCP_QUORUMSET = 9,
+  //       SCP_QUORUMSET = 10,
+  //       SCP_MESSAGE = 11,
+  //       GET_SCP_STATE = 12,
+  //
+  //       // new messages
+  //       HELLO = 13,
+  //
+  //       SURVEY_REQUEST = 14,
+  //       SURVEY_RESPONSE = 15,
+  //
+  //       SEND_MORE = 16,
+  //       FLOOD_ADVERT = 18,
+  //       FLOOD_DEMAND = 19
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("MessageType", {
+    errorMsg: 0,
+    auth: 2,
+    dontHave: 3,
+    getPeers: 4,
+    peers: 5,
+    getTxSet: 6,
+    txSet: 7,
+    generalizedTxSet: 17,
+    transaction: 8,
+    getScpQuorumset: 9,
+    scpQuorumset: 10,
+    scpMessage: 11,
+    getScpState: 12,
+    hello: 13,
+    surveyRequest: 14,
+    surveyResponse: 15,
+    sendMore: 16,
+    floodAdvert: 18,
+    floodDemand: 19,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct DontHave
+  //   {
+  //       MessageType type;
+  //       uint256 reqHash;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("DontHave", [
+    ["type", xdr.lookup("MessageType")],
+    ["reqHash", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum SurveyMessageCommandType
+  //   {
+  //       SURVEY_TOPOLOGY = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("SurveyMessageCommandType", {
+    surveyTopology: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SurveyRequestMessage
+  //   {
+  //       NodeID surveyorPeerID;
+  //       NodeID surveyedPeerID;
+  //       uint32 ledgerNum;
+  //       Curve25519Public encryptionKey;
+  //       SurveyMessageCommandType commandType;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SurveyRequestMessage", [
+    ["surveyorPeerId", xdr.lookup("NodeId")],
+    ["surveyedPeerId", xdr.lookup("NodeId")],
+    ["ledgerNum", xdr.lookup("Uint32")],
+    ["encryptionKey", xdr.lookup("Curve25519Public")],
+    ["commandType", xdr.lookup("SurveyMessageCommandType")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SignedSurveyRequestMessage
+  //   {
+  //       Signature requestSignature;
+  //       SurveyRequestMessage request;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SignedSurveyRequestMessage", [
+    ["requestSignature", xdr.lookup("Signature")],
+    ["request", xdr.lookup("SurveyRequestMessage")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque EncryptedBody<64000>;
+  //
+  // ===========================================================================
+  xdr.typedef("EncryptedBody", xdr.varOpaque(64000));
+
+  // === xdr source ============================================================
+  //
+  //   struct SurveyResponseMessage
+  //   {
+  //       NodeID surveyorPeerID;
+  //       NodeID surveyedPeerID;
+  //       uint32 ledgerNum;
+  //       SurveyMessageCommandType commandType;
+  //       EncryptedBody encryptedBody;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SurveyResponseMessage", [
+    ["surveyorPeerId", xdr.lookup("NodeId")],
+    ["surveyedPeerId", xdr.lookup("NodeId")],
+    ["ledgerNum", xdr.lookup("Uint32")],
+    ["commandType", xdr.lookup("SurveyMessageCommandType")],
+    ["encryptedBody", xdr.lookup("EncryptedBody")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SignedSurveyResponseMessage
+  //   {
+  //       Signature responseSignature;
+  //       SurveyResponseMessage response;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SignedSurveyResponseMessage", [
+    ["responseSignature", xdr.lookup("Signature")],
+    ["response", xdr.lookup("SurveyResponseMessage")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct PeerStats
+  //   {
+  //       NodeID id;
+  //       string versionStr<100>;
+  //       uint64 messagesRead;
+  //       uint64 messagesWritten;
+  //       uint64 bytesRead;
+  //       uint64 bytesWritten;
+  //       uint64 secondsConnected;
+  //
+  //       uint64 uniqueFloodBytesRecv;
+  //       uint64 duplicateFloodBytesRecv;
+  //       uint64 uniqueFetchBytesRecv;
+  //       uint64 duplicateFetchBytesRecv;
+  //
+  //       uint64 uniqueFloodMessageRecv;
+  //       uint64 duplicateFloodMessageRecv;
+  //       uint64 uniqueFetchMessageRecv;
+  //       uint64 duplicateFetchMessageRecv;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PeerStats", [
+    ["id", xdr.lookup("NodeId")],
+    ["versionStr", xdr.string(100)],
+    ["messagesRead", xdr.lookup("Uint64")],
+    ["messagesWritten", xdr.lookup("Uint64")],
+    ["bytesRead", xdr.lookup("Uint64")],
+    ["bytesWritten", xdr.lookup("Uint64")],
+    ["secondsConnected", xdr.lookup("Uint64")],
+    ["uniqueFloodBytesRecv", xdr.lookup("Uint64")],
+    ["duplicateFloodBytesRecv", xdr.lookup("Uint64")],
+    ["uniqueFetchBytesRecv", xdr.lookup("Uint64")],
+    ["duplicateFetchBytesRecv", xdr.lookup("Uint64")],
+    ["uniqueFloodMessageRecv", xdr.lookup("Uint64")],
+    ["duplicateFloodMessageRecv", xdr.lookup("Uint64")],
+    ["uniqueFetchMessageRecv", xdr.lookup("Uint64")],
+    ["duplicateFetchMessageRecv", xdr.lookup("Uint64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   typedef PeerStats PeerStatList<25>;
+  //
+  // ===========================================================================
+  xdr.typedef("PeerStatList", xdr.varArray(xdr.lookup("PeerStats"), 25));
+
+  // === xdr source ============================================================
+  //
+  //   struct TopologyResponseBody
+  //   {
+  //       PeerStatList inboundPeers;
+  //       PeerStatList outboundPeers;
+  //
+  //       uint32 totalInboundPeerCount;
+  //       uint32 totalOutboundPeerCount;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TopologyResponseBody", [
+    ["inboundPeers", xdr.lookup("PeerStatList")],
+    ["outboundPeers", xdr.lookup("PeerStatList")],
+    ["totalInboundPeerCount", xdr.lookup("Uint32")],
+    ["totalOutboundPeerCount", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union SurveyResponseBody switch (SurveyMessageCommandType type)
+  //   {
+  //   case SURVEY_TOPOLOGY:
+  //       TopologyResponseBody topologyResponseBody;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("SurveyResponseBody", {
+    switchOn: xdr.lookup("SurveyMessageCommandType"),
+    switchName: "type",
+    switches: [["surveyTopology", "topologyResponseBody"]],
+    arms: {
+      topologyResponseBody: xdr.lookup("TopologyResponseBody"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
+  //
+  // ===========================================================================
+  xdr.const("TX_ADVERT_VECTOR_MAX_SIZE", 1000);
+
+  // === xdr source ============================================================
+  //
+  //   typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
+  //
+  // ===========================================================================
+  xdr.typedef(
+    "TxAdvertVector",
+    xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_ADVERT_VECTOR_MAX_SIZE"))
+  );
+
+  // === xdr source ============================================================
+  //
+  //   struct FloodAdvert
+  //   {
+  //       TxAdvertVector txHashes;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("FloodAdvert", [["txHashes", xdr.lookup("TxAdvertVector")]]);
+
+  // === xdr source ============================================================
+  //
+  //   const TX_DEMAND_VECTOR_MAX_SIZE = 1000;
+  //
+  // ===========================================================================
+  xdr.const("TX_DEMAND_VECTOR_MAX_SIZE", 1000);
+
+  // === xdr source ============================================================
+  //
+  //   typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
+  //
+  // ===========================================================================
+  xdr.typedef(
+    "TxDemandVector",
+    xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_DEMAND_VECTOR_MAX_SIZE"))
+  );
+
+  // === xdr source ============================================================
+  //
+  //   struct FloodDemand
+  //   {
+  //       TxDemandVector txHashes;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("FloodDemand", [["txHashes", xdr.lookup("TxDemandVector")]]);
+
+  // === xdr source ============================================================
+  //
+  //   union StellarMessage switch (MessageType type)
+  //   {
+  //   case ERROR_MSG:
+  //       Error error;
+  //   case HELLO:
+  //       Hello hello;
+  //   case AUTH:
+  //       Auth auth;
+  //   case DONT_HAVE:
+  //       DontHave dontHave;
+  //   case GET_PEERS:
+  //       void;
+  //   case PEERS:
+  //       PeerAddress peers<100>;
+  //
+  //   case GET_TX_SET:
+  //       uint256 txSetHash;
+  //   case TX_SET:
+  //       TransactionSet txSet;
+  //   case GENERALIZED_TX_SET:
+  //       GeneralizedTransactionSet generalizedTxSet;
+  //
+  //   case TRANSACTION:
+  //       TransactionEnvelope transaction;
+  //
+  //   case SURVEY_REQUEST:
+  //       SignedSurveyRequestMessage signedSurveyRequestMessage;
+  //
+  //   case SURVEY_RESPONSE:
+  //       SignedSurveyResponseMessage signedSurveyResponseMessage;
+  //
+  //   // SCP
+  //   case GET_SCP_QUORUMSET:
+  //       uint256 qSetHash;
+  //   case SCP_QUORUMSET:
+  //       SCPQuorumSet qSet;
+  //   case SCP_MESSAGE:
+  //       SCPEnvelope envelope;
+  //   case GET_SCP_STATE:
+  //       uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
+  //   case SEND_MORE:
+  //       SendMore sendMoreMessage;
+  //
+  //   // Pull mode
+  //   case FLOOD_ADVERT:
+  //        FloodAdvert floodAdvert;
+  //   case FLOOD_DEMAND:
+  //        FloodDemand floodDemand;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("StellarMessage", {
+    switchOn: xdr.lookup("MessageType"),
+    switchName: "type",
+    switches: [
+      ["errorMsg", "error"],
+      ["hello", "hello"],
+      ["auth", "auth"],
+      ["dontHave", "dontHave"],
+      ["getPeers", xdr.void()],
+      ["peers", "peers"],
+      ["getTxSet", "txSetHash"],
+      ["txSet", "txSet"],
+      ["generalizedTxSet", "generalizedTxSet"],
+      ["transaction", "transaction"],
+      ["surveyRequest", "signedSurveyRequestMessage"],
+      ["surveyResponse", "signedSurveyResponseMessage"],
+      ["getScpQuorumset", "qSetHash"],
+      ["scpQuorumset", "qSet"],
+      ["scpMessage", "envelope"],
+      ["getScpState", "getScpLedgerSeq"],
+      ["sendMore", "sendMoreMessage"],
+      ["floodAdvert", "floodAdvert"],
+      ["floodDemand", "floodDemand"],
+    ],
+    arms: {
+      error: xdr.lookup("Error"),
+      hello: xdr.lookup("Hello"),
+      auth: xdr.lookup("Auth"),
+      dontHave: xdr.lookup("DontHave"),
+      peers: xdr.varArray(xdr.lookup("PeerAddress"), 100),
+      txSetHash: xdr.lookup("Uint256"),
+      txSet: xdr.lookup("TransactionSet"),
+      generalizedTxSet: xdr.lookup("GeneralizedTransactionSet"),
+      transaction: xdr.lookup("TransactionEnvelope"),
+      signedSurveyRequestMessage: xdr.lookup("SignedSurveyRequestMessage"),
+      signedSurveyResponseMessage: xdr.lookup("SignedSurveyResponseMessage"),
+      qSetHash: xdr.lookup("Uint256"),
+      qSet: xdr.lookup("ScpQuorumSet"),
+      envelope: xdr.lookup("ScpEnvelope"),
+      getScpLedgerSeq: xdr.lookup("Uint32"),
+      sendMoreMessage: xdr.lookup("SendMore"),
+      floodAdvert: xdr.lookup("FloodAdvert"),
+      floodDemand: xdr.lookup("FloodDemand"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           uint64 sequence;
+  //           StellarMessage message;
+  //           HmacSha256Mac mac;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("AuthenticatedMessageV0", [
+    ["sequence", xdr.lookup("Uint64")],
+    ["message", xdr.lookup("StellarMessage")],
+    ["mac", xdr.lookup("HmacSha256Mac")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union AuthenticatedMessage switch (uint32 v)
+  //   {
+  //   case 0:
+  //       struct
+  //       {
+  //           uint64 sequence;
+  //           StellarMessage message;
+  //           HmacSha256Mac mac;
+  //       } v0;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("AuthenticatedMessage", {
+    switchOn: xdr.lookup("Uint32"),
+    switchName: "v",
+    switches: [[0, "v0"]],
+    arms: {
+      v0: xdr.lookup("AuthenticatedMessageV0"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union LiquidityPoolParameters switch (LiquidityPoolType type)
+  //   {
+  //   case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+  //       LiquidityPoolConstantProductParameters constantProduct;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LiquidityPoolParameters", {
+    switchOn: xdr.lookup("LiquidityPoolType"),
+    switchName: "type",
+    switches: [["liquidityPoolConstantProduct", "constantProduct"]],
+    arms: {
+      constantProduct: xdr.lookup("LiquidityPoolConstantProductParameters"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           uint64 id;
+  //           uint256 ed25519;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("MuxedAccountMed25519", [
+    ["id", xdr.lookup("Uint64")],
+    ["ed25519", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union MuxedAccount switch (CryptoKeyType type)
+  //   {
+  //   case KEY_TYPE_ED25519:
+  //       uint256 ed25519;
+  //   case KEY_TYPE_MUXED_ED25519:
+  //       struct
+  //       {
+  //           uint64 id;
+  //           uint256 ed25519;
+  //       } med25519;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("MuxedAccount", {
+    switchOn: xdr.lookup("CryptoKeyType"),
+    switchName: "type",
+    switches: [
+      ["keyTypeEd25519", "ed25519"],
+      ["keyTypeMuxedEd25519", "med25519"],
+    ],
+    arms: {
+      ed25519: xdr.lookup("Uint256"),
+      med25519: xdr.lookup("MuxedAccountMed25519"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct DecoratedSignature
+  //   {
+  //       SignatureHint hint;  // last 4 bytes of the public key, used as a hint
+  //       Signature signature; // actual signature
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("DecoratedSignature", [
+    ["hint", xdr.lookup("SignatureHint")],
+    ["signature", xdr.lookup("Signature")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum OperationType
+  //   {
+  //       CREATE_ACCOUNT = 0,
+  //       PAYMENT = 1,
+  //       PATH_PAYMENT_STRICT_RECEIVE = 2,
+  //       MANAGE_SELL_OFFER = 3,
+  //       CREATE_PASSIVE_SELL_OFFER = 4,
+  //       SET_OPTIONS = 5,
+  //       CHANGE_TRUST = 6,
+  //       ALLOW_TRUST = 7,
+  //       ACCOUNT_MERGE = 8,
+  //       INFLATION = 9,
+  //       MANAGE_DATA = 10,
+  //       BUMP_SEQUENCE = 11,
+  //       MANAGE_BUY_OFFER = 12,
+  //       PATH_PAYMENT_STRICT_SEND = 13,
+  //       CREATE_CLAIMABLE_BALANCE = 14,
+  //       CLAIM_CLAIMABLE_BALANCE = 15,
+  //       BEGIN_SPONSORING_FUTURE_RESERVES = 16,
+  //       END_SPONSORING_FUTURE_RESERVES = 17,
+  //       REVOKE_SPONSORSHIP = 18,
+  //       CLAWBACK = 19,
+  //       CLAWBACK_CLAIMABLE_BALANCE = 20,
+  //       SET_TRUST_LINE_FLAGS = 21,
+  //       LIQUIDITY_POOL_DEPOSIT = 22,
+  //       LIQUIDITY_POOL_WITHDRAW = 23
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("OperationType", {
+    createAccount: 0,
+    payment: 1,
+    pathPaymentStrictReceive: 2,
+    manageSellOffer: 3,
+    createPassiveSellOffer: 4,
+    setOptions: 5,
+    changeTrust: 6,
+    allowTrust: 7,
+    accountMerge: 8,
+    inflation: 9,
+    manageData: 10,
+    bumpSequence: 11,
+    manageBuyOffer: 12,
+    pathPaymentStrictSend: 13,
+    createClaimableBalance: 14,
+    claimClaimableBalance: 15,
+    beginSponsoringFutureReserves: 16,
+    endSponsoringFutureReserves: 17,
+    revokeSponsorship: 18,
+    clawback: 19,
+    clawbackClaimableBalance: 20,
+    setTrustLineFlags: 21,
+    liquidityPoolDeposit: 22,
+    liquidityPoolWithdraw: 23,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct CreateAccountOp
+  //   {
+  //       AccountID destination; // account to create
+  //       int64 startingBalance; // amount they end up with
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("CreateAccountOp", [
+    ["destination", xdr.lookup("AccountId")],
+    ["startingBalance", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct PaymentOp
+  //   {
+  //       MuxedAccount destination; // recipient of the payment
+  //       Asset asset;              // what they end up with
+  //       int64 amount;             // amount they end up with
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PaymentOp", [
+    ["destination", xdr.lookup("MuxedAccount")],
+    ["asset", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct PathPaymentStrictReceiveOp
+  //   {
+  //       Asset sendAsset; // asset we pay with
+  //       int64 sendMax;   // the maximum amount of sendAsset to
+  //                        // send (excluding fees).
+  //                        // The operation will fail if can't be met
+  //
+  //       MuxedAccount destination; // recipient of the payment
+  //       Asset destAsset;          // what they end up with
+  //       int64 destAmount;         // amount they end up with
+  //
+  //       Asset path<5>; // additional hops it must go through to get there
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PathPaymentStrictReceiveOp", [
+    ["sendAsset", xdr.lookup("Asset")],
+    ["sendMax", xdr.lookup("Int64")],
+    ["destination", xdr.lookup("MuxedAccount")],
+    ["destAsset", xdr.lookup("Asset")],
+    ["destAmount", xdr.lookup("Int64")],
+    ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct PathPaymentStrictSendOp
+  //   {
+  //       Asset sendAsset;  // asset we pay with
+  //       int64 sendAmount; // amount of sendAsset to send (excluding fees)
+  //
+  //       MuxedAccount destination; // recipient of the payment
+  //       Asset destAsset;          // what they end up with
+  //       int64 destMin;            // the minimum amount of dest asset to
+  //                                 // be received
+  //                                 // The operation will fail if it can't be met
+  //
+  //       Asset path<5>; // additional hops it must go through to get there
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PathPaymentStrictSendOp", [
+    ["sendAsset", xdr.lookup("Asset")],
+    ["sendAmount", xdr.lookup("Int64")],
+    ["destination", xdr.lookup("MuxedAccount")],
+    ["destAsset", xdr.lookup("Asset")],
+    ["destMin", xdr.lookup("Int64")],
+    ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ManageSellOfferOp
+  //   {
+  //       Asset selling;
+  //       Asset buying;
+  //       int64 amount; // amount being sold. if set to 0, delete the offer
+  //       Price price;  // price of thing being sold in terms of what you are buying
+  //
+  //       // 0=create a new offer, otherwise edit an existing offer
+  //       int64 offerID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ManageSellOfferOp", [
+    ["selling", xdr.lookup("Asset")],
+    ["buying", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+    ["price", xdr.lookup("Price")],
+    ["offerId", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ManageBuyOfferOp
+  //   {
+  //       Asset selling;
+  //       Asset buying;
+  //       int64 buyAmount; // amount being bought. if set to 0, delete the offer
+  //       Price price;     // price of thing being bought in terms of what you are
+  //                        // selling
+  //
+  //       // 0=create a new offer, otherwise edit an existing offer
+  //       int64 offerID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ManageBuyOfferOp", [
+    ["selling", xdr.lookup("Asset")],
+    ["buying", xdr.lookup("Asset")],
+    ["buyAmount", xdr.lookup("Int64")],
+    ["price", xdr.lookup("Price")],
+    ["offerId", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct CreatePassiveSellOfferOp
+  //   {
+  //       Asset selling; // A
+  //       Asset buying;  // B
+  //       int64 amount;  // amount taker gets
+  //       Price price;   // cost of A in terms of B
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("CreatePassiveSellOfferOp", [
+    ["selling", xdr.lookup("Asset")],
+    ["buying", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+    ["price", xdr.lookup("Price")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SetOptionsOp
+  //   {
+  //       AccountID* inflationDest; // sets the inflation destination
+  //
+  //       uint32* clearFlags; // which flags to clear
+  //       uint32* setFlags;   // which flags to set
+  //
+  //       // account threshold manipulation
+  //       uint32* masterWeight; // weight of the master account
+  //       uint32* lowThreshold;
+  //       uint32* medThreshold;
+  //       uint32* highThreshold;
+  //
+  //       string32* homeDomain; // sets the home domain
+  //
+  //       // Add, update or remove a signer for the account
+  //       // signer is deleted if the weight is 0
+  //       Signer* signer;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SetOptionsOp", [
+    ["inflationDest", xdr.option(xdr.lookup("AccountId"))],
+    ["clearFlags", xdr.option(xdr.lookup("Uint32"))],
+    ["setFlags", xdr.option(xdr.lookup("Uint32"))],
+    ["masterWeight", xdr.option(xdr.lookup("Uint32"))],
+    ["lowThreshold", xdr.option(xdr.lookup("Uint32"))],
+    ["medThreshold", xdr.option(xdr.lookup("Uint32"))],
+    ["highThreshold", xdr.option(xdr.lookup("Uint32"))],
+    ["homeDomain", xdr.option(xdr.lookup("String32"))],
+    ["signer", xdr.option(xdr.lookup("Signer"))],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union ChangeTrustAsset switch (AssetType type)
+  //   {
+  //   case ASSET_TYPE_NATIVE: // Not credit
+  //       void;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM4:
+  //       AlphaNum4 alphaNum4;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM12:
+  //       AlphaNum12 alphaNum12;
+  //
+  //   case ASSET_TYPE_POOL_SHARE:
+  //       LiquidityPoolParameters liquidityPool;
+  //
+  //       // add other asset types here in the future
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ChangeTrustAsset", {
+    switchOn: xdr.lookup("AssetType"),
+    switchName: "type",
+    switches: [
+      ["assetTypeNative", xdr.void()],
+      ["assetTypeCreditAlphanum4", "alphaNum4"],
+      ["assetTypeCreditAlphanum12", "alphaNum12"],
+      ["assetTypePoolShare", "liquidityPool"],
+    ],
+    arms: {
+      alphaNum4: xdr.lookup("AlphaNum4"),
+      alphaNum12: xdr.lookup("AlphaNum12"),
+      liquidityPool: xdr.lookup("LiquidityPoolParameters"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ChangeTrustOp
+  //   {
+  //       ChangeTrustAsset line;
+  //
+  //       // if limit is set to 0, deletes the trust line
+  //       int64 limit;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ChangeTrustOp", [
+    ["line", xdr.lookup("ChangeTrustAsset")],
+    ["limit", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct AllowTrustOp
+  //   {
+  //       AccountID trustor;
+  //       AssetCode asset;
+  //
+  //       // One of 0, AUTHORIZED_FLAG, or AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG
+  //       uint32 authorize;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AllowTrustOp", [
+    ["trustor", xdr.lookup("AccountId")],
+    ["asset", xdr.lookup("AssetCode")],
+    ["authorize", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ManageDataOp
+  //   {
+  //       string64 dataName;
+  //       DataValue* dataValue; // set to null to clear
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ManageDataOp", [
+    ["dataName", xdr.lookup("String64")],
+    ["dataValue", xdr.option(xdr.lookup("DataValue"))],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct BumpSequenceOp
+  //   {
+  //       SequenceNumber bumpTo;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("BumpSequenceOp", [["bumpTo", xdr.lookup("SequenceNumber")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct CreateClaimableBalanceOp
+  //   {
+  //       Asset asset;
+  //       int64 amount;
+  //       Claimant claimants<10>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("CreateClaimableBalanceOp", [
+    ["asset", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+    ["claimants", xdr.varArray(xdr.lookup("Claimant"), 10)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimClaimableBalanceOp
+  //   {
+  //       ClaimableBalanceID balanceID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimClaimableBalanceOp", [
+    ["balanceId", xdr.lookup("ClaimableBalanceId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct BeginSponsoringFutureReservesOp
+  //   {
+  //       AccountID sponsoredID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("BeginSponsoringFutureReservesOp", [
+    ["sponsoredId", xdr.lookup("AccountId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum RevokeSponsorshipType
+  //   {
+  //       REVOKE_SPONSORSHIP_LEDGER_ENTRY = 0,
+  //       REVOKE_SPONSORSHIP_SIGNER = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("RevokeSponsorshipType", {
+    revokeSponsorshipLedgerEntry: 0,
+    revokeSponsorshipSigner: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID accountID;
+  //           SignerKey signerKey;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("RevokeSponsorshipOpSigner", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["signerKey", xdr.lookup("SignerKey")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union RevokeSponsorshipOp switch (RevokeSponsorshipType type)
+  //   {
+  //   case REVOKE_SPONSORSHIP_LEDGER_ENTRY:
+  //       LedgerKey ledgerKey;
+  //   case REVOKE_SPONSORSHIP_SIGNER:
+  //       struct
+  //       {
+  //           AccountID accountID;
+  //           SignerKey signerKey;
+  //       } signer;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("RevokeSponsorshipOp", {
+    switchOn: xdr.lookup("RevokeSponsorshipType"),
+    switchName: "type",
+    switches: [
+      ["revokeSponsorshipLedgerEntry", "ledgerKey"],
+      ["revokeSponsorshipSigner", "signer"],
+    ],
+    arms: {
+      ledgerKey: xdr.lookup("LedgerKey"),
+      signer: xdr.lookup("RevokeSponsorshipOpSigner"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ClawbackOp
+  //   {
+  //       Asset asset;
+  //       MuxedAccount from;
+  //       int64 amount;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClawbackOp", [
+    ["asset", xdr.lookup("Asset")],
+    ["from", xdr.lookup("MuxedAccount")],
+    ["amount", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ClawbackClaimableBalanceOp
+  //   {
+  //       ClaimableBalanceID balanceID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClawbackClaimableBalanceOp", [
+    ["balanceId", xdr.lookup("ClaimableBalanceId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SetTrustLineFlagsOp
+  //   {
+  //       AccountID trustor;
+  //       Asset asset;
+  //
+  //       uint32 clearFlags; // which flags to clear
+  //       uint32 setFlags;   // which flags to set
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SetTrustLineFlagsOp", [
+    ["trustor", xdr.lookup("AccountId")],
+    ["asset", xdr.lookup("Asset")],
+    ["clearFlags", xdr.lookup("Uint32")],
+    ["setFlags", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   const LIQUIDITY_POOL_FEE_V18 = 30;
+  //
+  // ===========================================================================
+  xdr.const("LIQUIDITY_POOL_FEE_V18", 30);
+
+  // === xdr source ============================================================
+  //
+  //   struct LiquidityPoolDepositOp
+  //   {
+  //       PoolID liquidityPoolID;
+  //       int64 maxAmountA; // maximum amount of first asset to deposit
+  //       int64 maxAmountB; // maximum amount of second asset to deposit
+  //       Price minPrice;   // minimum depositA/depositB
+  //       Price maxPrice;   // maximum depositA/depositB
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LiquidityPoolDepositOp", [
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+    ["maxAmountA", xdr.lookup("Int64")],
+    ["maxAmountB", xdr.lookup("Int64")],
+    ["minPrice", xdr.lookup("Price")],
+    ["maxPrice", xdr.lookup("Price")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LiquidityPoolWithdrawOp
+  //   {
+  //       PoolID liquidityPoolID;
+  //       int64 amount;     // amount of pool shares to withdraw
+  //       int64 minAmountA; // minimum amount of first asset to withdraw
+  //       int64 minAmountB; // minimum amount of second asset to withdraw
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LiquidityPoolWithdrawOp", [
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+    ["amount", xdr.lookup("Int64")],
+    ["minAmountA", xdr.lookup("Int64")],
+    ["minAmountB", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (OperationType type)
+  //       {
+  //       case CREATE_ACCOUNT:
+  //           CreateAccountOp createAccountOp;
+  //       case PAYMENT:
+  //           PaymentOp paymentOp;
+  //       case PATH_PAYMENT_STRICT_RECEIVE:
+  //           PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
+  //       case MANAGE_SELL_OFFER:
+  //           ManageSellOfferOp manageSellOfferOp;
+  //       case CREATE_PASSIVE_SELL_OFFER:
+  //           CreatePassiveSellOfferOp createPassiveSellOfferOp;
+  //       case SET_OPTIONS:
+  //           SetOptionsOp setOptionsOp;
+  //       case CHANGE_TRUST:
+  //           ChangeTrustOp changeTrustOp;
+  //       case ALLOW_TRUST:
+  //           AllowTrustOp allowTrustOp;
+  //       case ACCOUNT_MERGE:
+  //           MuxedAccount destination;
+  //       case INFLATION:
+  //           void;
+  //       case MANAGE_DATA:
+  //           ManageDataOp manageDataOp;
+  //       case BUMP_SEQUENCE:
+  //           BumpSequenceOp bumpSequenceOp;
+  //       case MANAGE_BUY_OFFER:
+  //           ManageBuyOfferOp manageBuyOfferOp;
+  //       case PATH_PAYMENT_STRICT_SEND:
+  //           PathPaymentStrictSendOp pathPaymentStrictSendOp;
+  //       case CREATE_CLAIMABLE_BALANCE:
+  //           CreateClaimableBalanceOp createClaimableBalanceOp;
+  //       case CLAIM_CLAIMABLE_BALANCE:
+  //           ClaimClaimableBalanceOp claimClaimableBalanceOp;
+  //       case BEGIN_SPONSORING_FUTURE_RESERVES:
+  //           BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
+  //       case END_SPONSORING_FUTURE_RESERVES:
+  //           void;
+  //       case REVOKE_SPONSORSHIP:
+  //           RevokeSponsorshipOp revokeSponsorshipOp;
+  //       case CLAWBACK:
+  //           ClawbackOp clawbackOp;
+  //       case CLAWBACK_CLAIMABLE_BALANCE:
+  //           ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
+  //       case SET_TRUST_LINE_FLAGS:
+  //           SetTrustLineFlagsOp setTrustLineFlagsOp;
+  //       case LIQUIDITY_POOL_DEPOSIT:
+  //           LiquidityPoolDepositOp liquidityPoolDepositOp;
+  //       case LIQUIDITY_POOL_WITHDRAW:
+  //           LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("OperationBody", {
+    switchOn: xdr.lookup("OperationType"),
+    switchName: "type",
+    switches: [
+      ["createAccount", "createAccountOp"],
+      ["payment", "paymentOp"],
+      ["pathPaymentStrictReceive", "pathPaymentStrictReceiveOp"],
+      ["manageSellOffer", "manageSellOfferOp"],
+      ["createPassiveSellOffer", "createPassiveSellOfferOp"],
+      ["setOptions", "setOptionsOp"],
+      ["changeTrust", "changeTrustOp"],
+      ["allowTrust", "allowTrustOp"],
+      ["accountMerge", "destination"],
+      ["inflation", xdr.void()],
+      ["manageData", "manageDataOp"],
+      ["bumpSequence", "bumpSequenceOp"],
+      ["manageBuyOffer", "manageBuyOfferOp"],
+      ["pathPaymentStrictSend", "pathPaymentStrictSendOp"],
+      ["createClaimableBalance", "createClaimableBalanceOp"],
+      ["claimClaimableBalance", "claimClaimableBalanceOp"],
+      ["beginSponsoringFutureReserves", "beginSponsoringFutureReservesOp"],
+      ["endSponsoringFutureReserves", xdr.void()],
+      ["revokeSponsorship", "revokeSponsorshipOp"],
+      ["clawback", "clawbackOp"],
+      ["clawbackClaimableBalance", "clawbackClaimableBalanceOp"],
+      ["setTrustLineFlags", "setTrustLineFlagsOp"],
+      ["liquidityPoolDeposit", "liquidityPoolDepositOp"],
+      ["liquidityPoolWithdraw", "liquidityPoolWithdrawOp"],
+    ],
+    arms: {
+      createAccountOp: xdr.lookup("CreateAccountOp"),
+      paymentOp: xdr.lookup("PaymentOp"),
+      pathPaymentStrictReceiveOp: xdr.lookup("PathPaymentStrictReceiveOp"),
+      manageSellOfferOp: xdr.lookup("ManageSellOfferOp"),
+      createPassiveSellOfferOp: xdr.lookup("CreatePassiveSellOfferOp"),
+      setOptionsOp: xdr.lookup("SetOptionsOp"),
+      changeTrustOp: xdr.lookup("ChangeTrustOp"),
+      allowTrustOp: xdr.lookup("AllowTrustOp"),
+      destination: xdr.lookup("MuxedAccount"),
+      manageDataOp: xdr.lookup("ManageDataOp"),
+      bumpSequenceOp: xdr.lookup("BumpSequenceOp"),
+      manageBuyOfferOp: xdr.lookup("ManageBuyOfferOp"),
+      pathPaymentStrictSendOp: xdr.lookup("PathPaymentStrictSendOp"),
+      createClaimableBalanceOp: xdr.lookup("CreateClaimableBalanceOp"),
+      claimClaimableBalanceOp: xdr.lookup("ClaimClaimableBalanceOp"),
+      beginSponsoringFutureReservesOp: xdr.lookup(
+        "BeginSponsoringFutureReservesOp"
+      ),
+      revokeSponsorshipOp: xdr.lookup("RevokeSponsorshipOp"),
+      clawbackOp: xdr.lookup("ClawbackOp"),
+      clawbackClaimableBalanceOp: xdr.lookup("ClawbackClaimableBalanceOp"),
+      setTrustLineFlagsOp: xdr.lookup("SetTrustLineFlagsOp"),
+      liquidityPoolDepositOp: xdr.lookup("LiquidityPoolDepositOp"),
+      liquidityPoolWithdrawOp: xdr.lookup("LiquidityPoolWithdrawOp"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct Operation
+  //   {
+  //       // sourceAccount is the account used to run the operation
+  //       // if not set, the runtime defaults to "sourceAccount" specified at
+  //       // the transaction level
+  //       MuxedAccount* sourceAccount;
+  //
+  //       union switch (OperationType type)
+  //       {
+  //       case CREATE_ACCOUNT:
+  //           CreateAccountOp createAccountOp;
+  //       case PAYMENT:
+  //           PaymentOp paymentOp;
+  //       case PATH_PAYMENT_STRICT_RECEIVE:
+  //           PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
+  //       case MANAGE_SELL_OFFER:
+  //           ManageSellOfferOp manageSellOfferOp;
+  //       case CREATE_PASSIVE_SELL_OFFER:
+  //           CreatePassiveSellOfferOp createPassiveSellOfferOp;
+  //       case SET_OPTIONS:
+  //           SetOptionsOp setOptionsOp;
+  //       case CHANGE_TRUST:
+  //           ChangeTrustOp changeTrustOp;
+  //       case ALLOW_TRUST:
+  //           AllowTrustOp allowTrustOp;
+  //       case ACCOUNT_MERGE:
+  //           MuxedAccount destination;
+  //       case INFLATION:
+  //           void;
+  //       case MANAGE_DATA:
+  //           ManageDataOp manageDataOp;
+  //       case BUMP_SEQUENCE:
+  //           BumpSequenceOp bumpSequenceOp;
+  //       case MANAGE_BUY_OFFER:
+  //           ManageBuyOfferOp manageBuyOfferOp;
+  //       case PATH_PAYMENT_STRICT_SEND:
+  //           PathPaymentStrictSendOp pathPaymentStrictSendOp;
+  //       case CREATE_CLAIMABLE_BALANCE:
+  //           CreateClaimableBalanceOp createClaimableBalanceOp;
+  //       case CLAIM_CLAIMABLE_BALANCE:
+  //           ClaimClaimableBalanceOp claimClaimableBalanceOp;
+  //       case BEGIN_SPONSORING_FUTURE_RESERVES:
+  //           BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
+  //       case END_SPONSORING_FUTURE_RESERVES:
+  //           void;
+  //       case REVOKE_SPONSORSHIP:
+  //           RevokeSponsorshipOp revokeSponsorshipOp;
+  //       case CLAWBACK:
+  //           ClawbackOp clawbackOp;
+  //       case CLAWBACK_CLAIMABLE_BALANCE:
+  //           ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
+  //       case SET_TRUST_LINE_FLAGS:
+  //           SetTrustLineFlagsOp setTrustLineFlagsOp;
+  //       case LIQUIDITY_POOL_DEPOSIT:
+  //           LiquidityPoolDepositOp liquidityPoolDepositOp;
+  //       case LIQUIDITY_POOL_WITHDRAW:
+  //           LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
+  //       }
+  //       body;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Operation", [
+    ["sourceAccount", xdr.option(xdr.lookup("MuxedAccount"))],
+    ["body", xdr.lookup("OperationBody")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID sourceAccount;
+  //           SequenceNumber seqNum;
+  //           uint32 opNum;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("HashIdPreimageOperationId", [
+    ["sourceAccount", xdr.lookup("AccountId")],
+    ["seqNum", xdr.lookup("SequenceNumber")],
+    ["opNum", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID sourceAccount;
+  //           SequenceNumber seqNum;
+  //           uint32 opNum;
+  //           PoolID liquidityPoolID;
+  //           Asset asset;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("HashIdPreimageRevokeId", [
+    ["sourceAccount", xdr.lookup("AccountId")],
+    ["seqNum", xdr.lookup("SequenceNumber")],
+    ["opNum", xdr.lookup("Uint32")],
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+    ["asset", xdr.lookup("Asset")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union HashIDPreimage switch (EnvelopeType type)
+  //   {
+  //   case ENVELOPE_TYPE_OP_ID:
+  //       struct
+  //       {
+  //           AccountID sourceAccount;
+  //           SequenceNumber seqNum;
+  //           uint32 opNum;
+  //       } operationID;
+  //   case ENVELOPE_TYPE_POOL_REVOKE_OP_ID:
+  //       struct
+  //       {
+  //           AccountID sourceAccount;
+  //           SequenceNumber seqNum;
+  //           uint32 opNum;
+  //           PoolID liquidityPoolID;
+  //           Asset asset;
+  //       } revokeID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("HashIdPreimage", {
+    switchOn: xdr.lookup("EnvelopeType"),
+    switchName: "type",
+    switches: [
+      ["envelopeTypeOpId", "operationId"],
+      ["envelopeTypePoolRevokeOpId", "revokeId"],
+    ],
+    arms: {
+      operationId: xdr.lookup("HashIdPreimageOperationId"),
+      revokeId: xdr.lookup("HashIdPreimageRevokeId"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum MemoType
+  //   {
+  //       MEMO_NONE = 0,
+  //       MEMO_TEXT = 1,
+  //       MEMO_ID = 2,
+  //       MEMO_HASH = 3,
+  //       MEMO_RETURN = 4
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("MemoType", {
+    memoNone: 0,
+    memoText: 1,
+    memoId: 2,
+    memoHash: 3,
+    memoReturn: 4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union Memo switch (MemoType type)
+  //   {
+  //   case MEMO_NONE:
+  //       void;
+  //   case MEMO_TEXT:
+  //       string text<28>;
+  //   case MEMO_ID:
+  //       uint64 id;
+  //   case MEMO_HASH:
+  //       Hash hash; // the hash of what to pull from the content server
+  //   case MEMO_RETURN:
+  //       Hash retHash; // the hash of the tx you are rejecting
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("Memo", {
+    switchOn: xdr.lookup("MemoType"),
+    switchName: "type",
+    switches: [
+      ["memoNone", xdr.void()],
+      ["memoText", "text"],
+      ["memoId", "id"],
+      ["memoHash", "hash"],
+      ["memoReturn", "retHash"],
+    ],
+    arms: {
+      text: xdr.string(28),
+      id: xdr.lookup("Uint64"),
+      hash: xdr.lookup("Hash"),
+      retHash: xdr.lookup("Hash"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TimeBounds
+  //   {
+  //       TimePoint minTime;
+  //       TimePoint maxTime; // 0 here means no maxTime
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TimeBounds", [
+    ["minTime", xdr.lookup("TimePoint")],
+    ["maxTime", xdr.lookup("TimePoint")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerBounds
+  //   {
+  //       uint32 minLedger;
+  //       uint32 maxLedger; // 0 here means no maxLedger
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerBounds", [
+    ["minLedger", xdr.lookup("Uint32")],
+    ["maxLedger", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct PreconditionsV2
+  //   {
+  //       TimeBounds* timeBounds;
+  //
+  //       // Transaction only valid for ledger numbers n such that
+  //       // minLedger <= n < maxLedger (if maxLedger == 0, then
+  //       // only minLedger is checked)
+  //       LedgerBounds* ledgerBounds;
+  //
+  //       // If NULL, only valid when sourceAccount's sequence number
+  //       // is seqNum - 1.  Otherwise, valid when sourceAccount's
+  //       // sequence number n satisfies minSeqNum <= n < tx.seqNum.
+  //       // Note that after execution the account's sequence number
+  //       // is always raised to tx.seqNum, and a transaction is not
+  //       // valid if tx.seqNum is too high to ensure replay protection.
+  //       SequenceNumber* minSeqNum;
+  //
+  //       // For the transaction to be valid, the current ledger time must
+  //       // be at least minSeqAge greater than sourceAccount's seqTime.
+  //       Duration minSeqAge;
+  //
+  //       // For the transaction to be valid, the current ledger number
+  //       // must be at least minSeqLedgerGap greater than sourceAccount's
+  //       // seqLedger.
+  //       uint32 minSeqLedgerGap;
+  //
+  //       // For the transaction to be valid, there must be a signature
+  //       // corresponding to every Signer in this array, even if the
+  //       // signature is not otherwise required by the sourceAccount or
+  //       // operations.
+  //       SignerKey extraSigners<2>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PreconditionsV2", [
+    ["timeBounds", xdr.option(xdr.lookup("TimeBounds"))],
+    ["ledgerBounds", xdr.option(xdr.lookup("LedgerBounds"))],
+    ["minSeqNum", xdr.option(xdr.lookup("SequenceNumber"))],
+    ["minSeqAge", xdr.lookup("Duration")],
+    ["minSeqLedgerGap", xdr.lookup("Uint32")],
+    ["extraSigners", xdr.varArray(xdr.lookup("SignerKey"), 2)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum PreconditionType
+  //   {
+  //       PRECOND_NONE = 0,
+  //       PRECOND_TIME = 1,
+  //       PRECOND_V2 = 2
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("PreconditionType", {
+    precondNone: 0,
+    precondTime: 1,
+    precondV2: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union Preconditions switch (PreconditionType type)
+  //   {
+  //   case PRECOND_NONE:
+  //       void;
+  //   case PRECOND_TIME:
+  //       TimeBounds timeBounds;
+  //   case PRECOND_V2:
+  //       PreconditionsV2 v2;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("Preconditions", {
+    switchOn: xdr.lookup("PreconditionType"),
+    switchName: "type",
+    switches: [
+      ["precondNone", xdr.void()],
+      ["precondTime", "timeBounds"],
+      ["precondV2", "v2"],
+    ],
+    arms: {
+      timeBounds: xdr.lookup("TimeBounds"),
+      v2: xdr.lookup("PreconditionsV2"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const MAX_OPS_PER_TX = 100;
+  //
+  // ===========================================================================
+  xdr.const("MAX_OPS_PER_TX", 100);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionV0Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionV0
+  //   {
+  //       uint256 sourceAccountEd25519;
+  //       uint32 fee;
+  //       SequenceNumber seqNum;
+  //       TimeBounds* timeBounds;
+  //       Memo memo;
+  //       Operation operations<MAX_OPS_PER_TX>;
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionV0", [
+    ["sourceAccountEd25519", xdr.lookup("Uint256")],
+    ["fee", xdr.lookup("Uint32")],
+    ["seqNum", xdr.lookup("SequenceNumber")],
+    ["timeBounds", xdr.option(xdr.lookup("TimeBounds"))],
+    ["memo", xdr.lookup("Memo")],
+    [
+      "operations",
+      xdr.varArray(xdr.lookup("Operation"), xdr.lookup("MAX_OPS_PER_TX")),
+    ],
+    ["ext", xdr.lookup("TransactionV0Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionV0Envelope
+  //   {
+  //       TransactionV0 tx;
+  //       /* Each decorated signature is a signature over the SHA256 hash of
+  //        * a TransactionSignaturePayload */
+  //       DecoratedSignature signatures<20>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionV0Envelope", [
+    ["tx", xdr.lookup("TransactionV0")],
+    ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct Transaction
+  //   {
+  //       // account used to run the transaction
+  //       MuxedAccount sourceAccount;
+  //
+  //       // the fee the sourceAccount will pay
+  //       uint32 fee;
+  //
+  //       // sequence number to consume in the account
+  //       SequenceNumber seqNum;
+  //
+  //       // validity conditions
+  //       Preconditions cond;
+  //
+  //       Memo memo;
+  //
+  //       Operation operations<MAX_OPS_PER_TX>;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Transaction", [
+    ["sourceAccount", xdr.lookup("MuxedAccount")],
+    ["fee", xdr.lookup("Uint32")],
+    ["seqNum", xdr.lookup("SequenceNumber")],
+    ["cond", xdr.lookup("Preconditions")],
+    ["memo", xdr.lookup("Memo")],
+    [
+      "operations",
+      xdr.varArray(xdr.lookup("Operation"), xdr.lookup("MAX_OPS_PER_TX")),
+    ],
+    ["ext", xdr.lookup("TransactionExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionV1Envelope
+  //   {
+  //       Transaction tx;
+  //       /* Each decorated signature is a signature over the SHA256 hash of
+  //        * a TransactionSignaturePayload */
+  //       DecoratedSignature signatures<20>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionV1Envelope", [
+    ["tx", xdr.lookup("Transaction")],
+    ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (EnvelopeType type)
+  //       {
+  //       case ENVELOPE_TYPE_TX:
+  //           TransactionV1Envelope v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("FeeBumpTransactionInnerTx", {
+    switchOn: xdr.lookup("EnvelopeType"),
+    switchName: "type",
+    switches: [["envelopeTypeTx", "v1"]],
+    arms: {
+      v1: xdr.lookup("TransactionV1Envelope"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("FeeBumpTransactionExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct FeeBumpTransaction
+  //   {
+  //       MuxedAccount feeSource;
+  //       int64 fee;
+  //       union switch (EnvelopeType type)
+  //       {
+  //       case ENVELOPE_TYPE_TX:
+  //           TransactionV1Envelope v1;
+  //       }
+  //       innerTx;
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("FeeBumpTransaction", [
+    ["feeSource", xdr.lookup("MuxedAccount")],
+    ["fee", xdr.lookup("Int64")],
+    ["innerTx", xdr.lookup("FeeBumpTransactionInnerTx")],
+    ["ext", xdr.lookup("FeeBumpTransactionExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct FeeBumpTransactionEnvelope
+  //   {
+  //       FeeBumpTransaction tx;
+  //       /* Each decorated signature is a signature over the SHA256 hash of
+  //        * a TransactionSignaturePayload */
+  //       DecoratedSignature signatures<20>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("FeeBumpTransactionEnvelope", [
+    ["tx", xdr.lookup("FeeBumpTransaction")],
+    ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union TransactionEnvelope switch (EnvelopeType type)
+  //   {
+  //   case ENVELOPE_TYPE_TX_V0:
+  //       TransactionV0Envelope v0;
+  //   case ENVELOPE_TYPE_TX:
+  //       TransactionV1Envelope v1;
+  //   case ENVELOPE_TYPE_TX_FEE_BUMP:
+  //       FeeBumpTransactionEnvelope feeBump;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("TransactionEnvelope", {
+    switchOn: xdr.lookup("EnvelopeType"),
+    switchName: "type",
+    switches: [
+      ["envelopeTypeTxV0", "v0"],
+      ["envelopeTypeTx", "v1"],
+      ["envelopeTypeTxFeeBump", "feeBump"],
+    ],
+    arms: {
+      v0: xdr.lookup("TransactionV0Envelope"),
+      v1: xdr.lookup("TransactionV1Envelope"),
+      feeBump: xdr.lookup("FeeBumpTransactionEnvelope"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (EnvelopeType type)
+  //       {
+  //       // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
+  //       case ENVELOPE_TYPE_TX:
+  //           Transaction tx;
+  //       case ENVELOPE_TYPE_TX_FEE_BUMP:
+  //           FeeBumpTransaction feeBump;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionSignaturePayloadTaggedTransaction", {
+    switchOn: xdr.lookup("EnvelopeType"),
+    switchName: "type",
+    switches: [
+      ["envelopeTypeTx", "tx"],
+      ["envelopeTypeTxFeeBump", "feeBump"],
+    ],
+    arms: {
+      tx: xdr.lookup("Transaction"),
+      feeBump: xdr.lookup("FeeBumpTransaction"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionSignaturePayload
+  //   {
+  //       Hash networkId;
+  //       union switch (EnvelopeType type)
+  //       {
+  //       // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
+  //       case ENVELOPE_TYPE_TX:
+  //           Transaction tx;
+  //       case ENVELOPE_TYPE_TX_FEE_BUMP:
+  //           FeeBumpTransaction feeBump;
+  //       }
+  //       taggedTransaction;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionSignaturePayload", [
+    ["networkId", xdr.lookup("Hash")],
+    [
+      "taggedTransaction",
+      xdr.lookup("TransactionSignaturePayloadTaggedTransaction"),
+    ],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimAtomType
+  //   {
+  //       CLAIM_ATOM_TYPE_V0 = 0,
+  //       CLAIM_ATOM_TYPE_ORDER_BOOK = 1,
+  //       CLAIM_ATOM_TYPE_LIQUIDITY_POOL = 2
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimAtomType", {
+    claimAtomTypeV0: 0,
+    claimAtomTypeOrderBook: 1,
+    claimAtomTypeLiquidityPool: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimOfferAtomV0
+  //   {
+  //       // emitted to identify the offer
+  //       uint256 sellerEd25519; // Account that owns the offer
+  //       int64 offerID;
+  //
+  //       // amount and asset taken from the owner
+  //       Asset assetSold;
+  //       int64 amountSold;
+  //
+  //       // amount and asset sent to the owner
+  //       Asset assetBought;
+  //       int64 amountBought;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimOfferAtomV0", [
+    ["sellerEd25519", xdr.lookup("Uint256")],
+    ["offerId", xdr.lookup("Int64")],
+    ["assetSold", xdr.lookup("Asset")],
+    ["amountSold", xdr.lookup("Int64")],
+    ["assetBought", xdr.lookup("Asset")],
+    ["amountBought", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimOfferAtom
+  //   {
+  //       // emitted to identify the offer
+  //       AccountID sellerID; // Account that owns the offer
+  //       int64 offerID;
+  //
+  //       // amount and asset taken from the owner
+  //       Asset assetSold;
+  //       int64 amountSold;
+  //
+  //       // amount and asset sent to the owner
+  //       Asset assetBought;
+  //       int64 amountBought;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimOfferAtom", [
+    ["sellerId", xdr.lookup("AccountId")],
+    ["offerId", xdr.lookup("Int64")],
+    ["assetSold", xdr.lookup("Asset")],
+    ["amountSold", xdr.lookup("Int64")],
+    ["assetBought", xdr.lookup("Asset")],
+    ["amountBought", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimLiquidityAtom
+  //   {
+  //       PoolID liquidityPoolID;
+  //
+  //       // amount and asset taken from the pool
+  //       Asset assetSold;
+  //       int64 amountSold;
+  //
+  //       // amount and asset sent to the pool
+  //       Asset assetBought;
+  //       int64 amountBought;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimLiquidityAtom", [
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+    ["assetSold", xdr.lookup("Asset")],
+    ["amountSold", xdr.lookup("Int64")],
+    ["assetBought", xdr.lookup("Asset")],
+    ["amountBought", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union ClaimAtom switch (ClaimAtomType type)
+  //   {
+  //   case CLAIM_ATOM_TYPE_V0:
+  //       ClaimOfferAtomV0 v0;
+  //   case CLAIM_ATOM_TYPE_ORDER_BOOK:
+  //       ClaimOfferAtom orderBook;
+  //   case CLAIM_ATOM_TYPE_LIQUIDITY_POOL:
+  //       ClaimLiquidityAtom liquidityPool;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClaimAtom", {
+    switchOn: xdr.lookup("ClaimAtomType"),
+    switchName: "type",
+    switches: [
+      ["claimAtomTypeV0", "v0"],
+      ["claimAtomTypeOrderBook", "orderBook"],
+      ["claimAtomTypeLiquidityPool", "liquidityPool"],
+    ],
+    arms: {
+      v0: xdr.lookup("ClaimOfferAtomV0"),
+      orderBook: xdr.lookup("ClaimOfferAtom"),
+      liquidityPool: xdr.lookup("ClaimLiquidityAtom"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum CreateAccountResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       CREATE_ACCOUNT_SUCCESS = 0, // account was created
+  //
+  //       // codes considered as "failure" for the operation
+  //       CREATE_ACCOUNT_MALFORMED = -1,   // invalid destination
+  //       CREATE_ACCOUNT_UNDERFUNDED = -2, // not enough funds in source account
+  //       CREATE_ACCOUNT_LOW_RESERVE =
+  //           -3, // would create an account below the min reserve
+  //       CREATE_ACCOUNT_ALREADY_EXIST = -4 // account already exists
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("CreateAccountResultCode", {
+    createAccountSuccess: 0,
+    createAccountMalformed: -1,
+    createAccountUnderfunded: -2,
+    createAccountLowReserve: -3,
+    createAccountAlreadyExist: -4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union CreateAccountResult switch (CreateAccountResultCode code)
+  //   {
+  //   case CREATE_ACCOUNT_SUCCESS:
+  //       void;
+  //   case CREATE_ACCOUNT_MALFORMED:
+  //   case CREATE_ACCOUNT_UNDERFUNDED:
+  //   case CREATE_ACCOUNT_LOW_RESERVE:
+  //   case CREATE_ACCOUNT_ALREADY_EXIST:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("CreateAccountResult", {
+    switchOn: xdr.lookup("CreateAccountResultCode"),
+    switchName: "code",
+    switches: [
+      ["createAccountSuccess", xdr.void()],
+      ["createAccountMalformed", xdr.void()],
+      ["createAccountUnderfunded", xdr.void()],
+      ["createAccountLowReserve", xdr.void()],
+      ["createAccountAlreadyExist", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum PaymentResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       PAYMENT_SUCCESS = 0, // payment successfully completed
+  //
+  //       // codes considered as "failure" for the operation
+  //       PAYMENT_MALFORMED = -1,          // bad input
+  //       PAYMENT_UNDERFUNDED = -2,        // not enough funds in source account
+  //       PAYMENT_SRC_NO_TRUST = -3,       // no trust line on source account
+  //       PAYMENT_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+  //       PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
+  //       PAYMENT_NO_TRUST = -6,       // destination missing a trust line for asset
+  //       PAYMENT_NOT_AUTHORIZED = -7, // destination not authorized to hold asset
+  //       PAYMENT_LINE_FULL = -8,      // destination would go above their limit
+  //       PAYMENT_NO_ISSUER = -9       // missing issuer on asset
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("PaymentResultCode", {
+    paymentSuccess: 0,
+    paymentMalformed: -1,
+    paymentUnderfunded: -2,
+    paymentSrcNoTrust: -3,
+    paymentSrcNotAuthorized: -4,
+    paymentNoDestination: -5,
+    paymentNoTrust: -6,
+    paymentNotAuthorized: -7,
+    paymentLineFull: -8,
+    paymentNoIssuer: -9,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union PaymentResult switch (PaymentResultCode code)
+  //   {
+  //   case PAYMENT_SUCCESS:
+  //       void;
+  //   case PAYMENT_MALFORMED:
+  //   case PAYMENT_UNDERFUNDED:
+  //   case PAYMENT_SRC_NO_TRUST:
+  //   case PAYMENT_SRC_NOT_AUTHORIZED:
+  //   case PAYMENT_NO_DESTINATION:
+  //   case PAYMENT_NO_TRUST:
+  //   case PAYMENT_NOT_AUTHORIZED:
+  //   case PAYMENT_LINE_FULL:
+  //   case PAYMENT_NO_ISSUER:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("PaymentResult", {
+    switchOn: xdr.lookup("PaymentResultCode"),
+    switchName: "code",
+    switches: [
+      ["paymentSuccess", xdr.void()],
+      ["paymentMalformed", xdr.void()],
+      ["paymentUnderfunded", xdr.void()],
+      ["paymentSrcNoTrust", xdr.void()],
+      ["paymentSrcNotAuthorized", xdr.void()],
+      ["paymentNoDestination", xdr.void()],
+      ["paymentNoTrust", xdr.void()],
+      ["paymentNotAuthorized", xdr.void()],
+      ["paymentLineFull", xdr.void()],
+      ["paymentNoIssuer", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum PathPaymentStrictReceiveResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
+  //
+  //       // codes considered as "failure" for the operation
+  //       PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1, // bad input
+  //       PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED =
+  //           -2, // not enough funds in source account
+  //       PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST =
+  //           -3, // no trust line on source account
+  //       PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED =
+  //           -4, // source not authorized to transfer
+  //       PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION =
+  //           -5, // destination account does not exist
+  //       PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST =
+  //           -6, // dest missing a trust line for asset
+  //       PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED =
+  //           -7, // dest not authorized to hold asset
+  //       PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL =
+  //           -8, // dest would go above their limit
+  //       PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9, // missing issuer on one asset
+  //       PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS =
+  //           -10, // not enough offers to satisfy path
+  //       PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF =
+  //           -11, // would cross one of its own offers
+  //       PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12 // could not satisfy sendmax
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("PathPaymentStrictReceiveResultCode", {
+    pathPaymentStrictReceiveSuccess: 0,
+    pathPaymentStrictReceiveMalformed: -1,
+    pathPaymentStrictReceiveUnderfunded: -2,
+    pathPaymentStrictReceiveSrcNoTrust: -3,
+    pathPaymentStrictReceiveSrcNotAuthorized: -4,
+    pathPaymentStrictReceiveNoDestination: -5,
+    pathPaymentStrictReceiveNoTrust: -6,
+    pathPaymentStrictReceiveNotAuthorized: -7,
+    pathPaymentStrictReceiveLineFull: -8,
+    pathPaymentStrictReceiveNoIssuer: -9,
+    pathPaymentStrictReceiveTooFewOffers: -10,
+    pathPaymentStrictReceiveOfferCrossSelf: -11,
+    pathPaymentStrictReceiveOverSendmax: -12,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SimplePaymentResult
+  //   {
+  //       AccountID destination;
+  //       Asset asset;
+  //       int64 amount;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SimplePaymentResult", [
+    ["destination", xdr.lookup("AccountId")],
+    ["asset", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           ClaimAtom offers<>;
+  //           SimplePaymentResult last;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("PathPaymentStrictReceiveResultSuccess", [
+    ["offers", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
+    ["last", xdr.lookup("SimplePaymentResult")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union PathPaymentStrictReceiveResult switch (
+  //       PathPaymentStrictReceiveResultCode code)
+  //   {
+  //   case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
+  //       struct
+  //       {
+  //           ClaimAtom offers<>;
+  //           SimplePaymentResult last;
+  //       } success;
+  //   case PATH_PAYMENT_STRICT_RECEIVE_MALFORMED:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL:
+  //       void;
+  //   case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
+  //       Asset noIssuer; // the asset that caused the error
+  //   case PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("PathPaymentStrictReceiveResult", {
+    switchOn: xdr.lookup("PathPaymentStrictReceiveResultCode"),
+    switchName: "code",
+    switches: [
+      ["pathPaymentStrictReceiveSuccess", "success"],
+      ["pathPaymentStrictReceiveMalformed", xdr.void()],
+      ["pathPaymentStrictReceiveUnderfunded", xdr.void()],
+      ["pathPaymentStrictReceiveSrcNoTrust", xdr.void()],
+      ["pathPaymentStrictReceiveSrcNotAuthorized", xdr.void()],
+      ["pathPaymentStrictReceiveNoDestination", xdr.void()],
+      ["pathPaymentStrictReceiveNoTrust", xdr.void()],
+      ["pathPaymentStrictReceiveNotAuthorized", xdr.void()],
+      ["pathPaymentStrictReceiveLineFull", xdr.void()],
+      ["pathPaymentStrictReceiveNoIssuer", "noIssuer"],
+      ["pathPaymentStrictReceiveTooFewOffers", xdr.void()],
+      ["pathPaymentStrictReceiveOfferCrossSelf", xdr.void()],
+      ["pathPaymentStrictReceiveOverSendmax", xdr.void()],
+    ],
+    arms: {
+      success: xdr.lookup("PathPaymentStrictReceiveResultSuccess"),
+      noIssuer: xdr.lookup("Asset"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum PathPaymentStrictSendResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
+  //
+  //       // codes considered as "failure" for the operation
+  //       PATH_PAYMENT_STRICT_SEND_MALFORMED = -1, // bad input
+  //       PATH_PAYMENT_STRICT_SEND_UNDERFUNDED =
+  //           -2, // not enough funds in source account
+  //       PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST =
+  //           -3, // no trust line on source account
+  //       PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED =
+  //           -4, // source not authorized to transfer
+  //       PATH_PAYMENT_STRICT_SEND_NO_DESTINATION =
+  //           -5, // destination account does not exist
+  //       PATH_PAYMENT_STRICT_SEND_NO_TRUST =
+  //           -6, // dest missing a trust line for asset
+  //       PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED =
+  //           -7, // dest not authorized to hold asset
+  //       PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8, // dest would go above their limit
+  //       PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9, // missing issuer on one asset
+  //       PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS =
+  //           -10, // not enough offers to satisfy path
+  //       PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF =
+  //           -11, // would cross one of its own offers
+  //       PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12 // could not satisfy destMin
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("PathPaymentStrictSendResultCode", {
+    pathPaymentStrictSendSuccess: 0,
+    pathPaymentStrictSendMalformed: -1,
+    pathPaymentStrictSendUnderfunded: -2,
+    pathPaymentStrictSendSrcNoTrust: -3,
+    pathPaymentStrictSendSrcNotAuthorized: -4,
+    pathPaymentStrictSendNoDestination: -5,
+    pathPaymentStrictSendNoTrust: -6,
+    pathPaymentStrictSendNotAuthorized: -7,
+    pathPaymentStrictSendLineFull: -8,
+    pathPaymentStrictSendNoIssuer: -9,
+    pathPaymentStrictSendTooFewOffers: -10,
+    pathPaymentStrictSendOfferCrossSelf: -11,
+    pathPaymentStrictSendUnderDestmin: -12,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           ClaimAtom offers<>;
+  //           SimplePaymentResult last;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("PathPaymentStrictSendResultSuccess", [
+    ["offers", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
+    ["last", xdr.lookup("SimplePaymentResult")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
+  //   {
+  //   case PATH_PAYMENT_STRICT_SEND_SUCCESS:
+  //       struct
+  //       {
+  //           ClaimAtom offers<>;
+  //           SimplePaymentResult last;
+  //       } success;
+  //   case PATH_PAYMENT_STRICT_SEND_MALFORMED:
+  //   case PATH_PAYMENT_STRICT_SEND_UNDERFUNDED:
+  //   case PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST:
+  //   case PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED:
+  //   case PATH_PAYMENT_STRICT_SEND_NO_DESTINATION:
+  //   case PATH_PAYMENT_STRICT_SEND_NO_TRUST:
+  //   case PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED:
+  //   case PATH_PAYMENT_STRICT_SEND_LINE_FULL:
+  //       void;
+  //   case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
+  //       Asset noIssuer; // the asset that caused the error
+  //   case PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS:
+  //   case PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF:
+  //   case PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("PathPaymentStrictSendResult", {
+    switchOn: xdr.lookup("PathPaymentStrictSendResultCode"),
+    switchName: "code",
+    switches: [
+      ["pathPaymentStrictSendSuccess", "success"],
+      ["pathPaymentStrictSendMalformed", xdr.void()],
+      ["pathPaymentStrictSendUnderfunded", xdr.void()],
+      ["pathPaymentStrictSendSrcNoTrust", xdr.void()],
+      ["pathPaymentStrictSendSrcNotAuthorized", xdr.void()],
+      ["pathPaymentStrictSendNoDestination", xdr.void()],
+      ["pathPaymentStrictSendNoTrust", xdr.void()],
+      ["pathPaymentStrictSendNotAuthorized", xdr.void()],
+      ["pathPaymentStrictSendLineFull", xdr.void()],
+      ["pathPaymentStrictSendNoIssuer", "noIssuer"],
+      ["pathPaymentStrictSendTooFewOffers", xdr.void()],
+      ["pathPaymentStrictSendOfferCrossSelf", xdr.void()],
+      ["pathPaymentStrictSendUnderDestmin", xdr.void()],
+    ],
+    arms: {
+      success: xdr.lookup("PathPaymentStrictSendResultSuccess"),
+      noIssuer: xdr.lookup("Asset"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ManageSellOfferResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       MANAGE_SELL_OFFER_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       MANAGE_SELL_OFFER_MALFORMED = -1, // generated offer would be invalid
+  //       MANAGE_SELL_OFFER_SELL_NO_TRUST =
+  //           -2,                              // no trust line for what we're selling
+  //       MANAGE_SELL_OFFER_BUY_NO_TRUST = -3, // no trust line for what we're buying
+  //       MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
+  //       MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
+  //       MANAGE_SELL_OFFER_LINE_FULL = -6, // can't receive more of what it's buying
+  //       MANAGE_SELL_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
+  //       MANAGE_SELL_OFFER_CROSS_SELF =
+  //           -8, // would cross an offer from the same user
+  //       MANAGE_SELL_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
+  //       MANAGE_SELL_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
+  //
+  //       // update errors
+  //       MANAGE_SELL_OFFER_NOT_FOUND =
+  //           -11, // offerID does not match an existing offer
+  //
+  //       MANAGE_SELL_OFFER_LOW_RESERVE =
+  //           -12 // not enough funds to create a new Offer
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ManageSellOfferResultCode", {
+    manageSellOfferSuccess: 0,
+    manageSellOfferMalformed: -1,
+    manageSellOfferSellNoTrust: -2,
+    manageSellOfferBuyNoTrust: -3,
+    manageSellOfferSellNotAuthorized: -4,
+    manageSellOfferBuyNotAuthorized: -5,
+    manageSellOfferLineFull: -6,
+    manageSellOfferUnderfunded: -7,
+    manageSellOfferCrossSelf: -8,
+    manageSellOfferSellNoIssuer: -9,
+    manageSellOfferBuyNoIssuer: -10,
+    manageSellOfferNotFound: -11,
+    manageSellOfferLowReserve: -12,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ManageOfferEffect
+  //   {
+  //       MANAGE_OFFER_CREATED = 0,
+  //       MANAGE_OFFER_UPDATED = 1,
+  //       MANAGE_OFFER_DELETED = 2
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ManageOfferEffect", {
+    manageOfferCreated: 0,
+    manageOfferUpdated: 1,
+    manageOfferDeleted: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (ManageOfferEffect effect)
+  //       {
+  //       case MANAGE_OFFER_CREATED:
+  //       case MANAGE_OFFER_UPDATED:
+  //           OfferEntry offer;
+  //       case MANAGE_OFFER_DELETED:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("ManageOfferSuccessResultOffer", {
+    switchOn: xdr.lookup("ManageOfferEffect"),
+    switchName: "effect",
+    switches: [
+      ["manageOfferCreated", "offer"],
+      ["manageOfferUpdated", "offer"],
+      ["manageOfferDeleted", xdr.void()],
+    ],
+    arms: {
+      offer: xdr.lookup("OfferEntry"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ManageOfferSuccessResult
+  //   {
+  //       // offers that got claimed while creating this offer
+  //       ClaimAtom offersClaimed<>;
+  //
+  //       union switch (ManageOfferEffect effect)
+  //       {
+  //       case MANAGE_OFFER_CREATED:
+  //       case MANAGE_OFFER_UPDATED:
+  //           OfferEntry offer;
+  //       case MANAGE_OFFER_DELETED:
+  //           void;
+  //       }
+  //       offer;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ManageOfferSuccessResult", [
+    ["offersClaimed", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
+    ["offer", xdr.lookup("ManageOfferSuccessResultOffer")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union ManageSellOfferResult switch (ManageSellOfferResultCode code)
+  //   {
+  //   case MANAGE_SELL_OFFER_SUCCESS:
+  //       ManageOfferSuccessResult success;
+  //   case MANAGE_SELL_OFFER_MALFORMED:
+  //   case MANAGE_SELL_OFFER_SELL_NO_TRUST:
+  //   case MANAGE_SELL_OFFER_BUY_NO_TRUST:
+  //   case MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED:
+  //   case MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED:
+  //   case MANAGE_SELL_OFFER_LINE_FULL:
+  //   case MANAGE_SELL_OFFER_UNDERFUNDED:
+  //   case MANAGE_SELL_OFFER_CROSS_SELF:
+  //   case MANAGE_SELL_OFFER_SELL_NO_ISSUER:
+  //   case MANAGE_SELL_OFFER_BUY_NO_ISSUER:
+  //   case MANAGE_SELL_OFFER_NOT_FOUND:
+  //   case MANAGE_SELL_OFFER_LOW_RESERVE:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ManageSellOfferResult", {
+    switchOn: xdr.lookup("ManageSellOfferResultCode"),
+    switchName: "code",
+    switches: [
+      ["manageSellOfferSuccess", "success"],
+      ["manageSellOfferMalformed", xdr.void()],
+      ["manageSellOfferSellNoTrust", xdr.void()],
+      ["manageSellOfferBuyNoTrust", xdr.void()],
+      ["manageSellOfferSellNotAuthorized", xdr.void()],
+      ["manageSellOfferBuyNotAuthorized", xdr.void()],
+      ["manageSellOfferLineFull", xdr.void()],
+      ["manageSellOfferUnderfunded", xdr.void()],
+      ["manageSellOfferCrossSelf", xdr.void()],
+      ["manageSellOfferSellNoIssuer", xdr.void()],
+      ["manageSellOfferBuyNoIssuer", xdr.void()],
+      ["manageSellOfferNotFound", xdr.void()],
+      ["manageSellOfferLowReserve", xdr.void()],
+    ],
+    arms: {
+      success: xdr.lookup("ManageOfferSuccessResult"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ManageBuyOfferResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       MANAGE_BUY_OFFER_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       MANAGE_BUY_OFFER_MALFORMED = -1,     // generated offer would be invalid
+  //       MANAGE_BUY_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
+  //       MANAGE_BUY_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
+  //       MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
+  //       MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
+  //       MANAGE_BUY_OFFER_LINE_FULL = -6,   // can't receive more of what it's buying
+  //       MANAGE_BUY_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
+  //       MANAGE_BUY_OFFER_CROSS_SELF = -8, // would cross an offer from the same user
+  //       MANAGE_BUY_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
+  //       MANAGE_BUY_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
+  //
+  //       // update errors
+  //       MANAGE_BUY_OFFER_NOT_FOUND =
+  //           -11, // offerID does not match an existing offer
+  //
+  //       MANAGE_BUY_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ManageBuyOfferResultCode", {
+    manageBuyOfferSuccess: 0,
+    manageBuyOfferMalformed: -1,
+    manageBuyOfferSellNoTrust: -2,
+    manageBuyOfferBuyNoTrust: -3,
+    manageBuyOfferSellNotAuthorized: -4,
+    manageBuyOfferBuyNotAuthorized: -5,
+    manageBuyOfferLineFull: -6,
+    manageBuyOfferUnderfunded: -7,
+    manageBuyOfferCrossSelf: -8,
+    manageBuyOfferSellNoIssuer: -9,
+    manageBuyOfferBuyNoIssuer: -10,
+    manageBuyOfferNotFound: -11,
+    manageBuyOfferLowReserve: -12,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ManageBuyOfferResult switch (ManageBuyOfferResultCode code)
+  //   {
+  //   case MANAGE_BUY_OFFER_SUCCESS:
+  //       ManageOfferSuccessResult success;
+  //   case MANAGE_BUY_OFFER_MALFORMED:
+  //   case MANAGE_BUY_OFFER_SELL_NO_TRUST:
+  //   case MANAGE_BUY_OFFER_BUY_NO_TRUST:
+  //   case MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED:
+  //   case MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED:
+  //   case MANAGE_BUY_OFFER_LINE_FULL:
+  //   case MANAGE_BUY_OFFER_UNDERFUNDED:
+  //   case MANAGE_BUY_OFFER_CROSS_SELF:
+  //   case MANAGE_BUY_OFFER_SELL_NO_ISSUER:
+  //   case MANAGE_BUY_OFFER_BUY_NO_ISSUER:
+  //   case MANAGE_BUY_OFFER_NOT_FOUND:
+  //   case MANAGE_BUY_OFFER_LOW_RESERVE:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ManageBuyOfferResult", {
+    switchOn: xdr.lookup("ManageBuyOfferResultCode"),
+    switchName: "code",
+    switches: [
+      ["manageBuyOfferSuccess", "success"],
+      ["manageBuyOfferMalformed", xdr.void()],
+      ["manageBuyOfferSellNoTrust", xdr.void()],
+      ["manageBuyOfferBuyNoTrust", xdr.void()],
+      ["manageBuyOfferSellNotAuthorized", xdr.void()],
+      ["manageBuyOfferBuyNotAuthorized", xdr.void()],
+      ["manageBuyOfferLineFull", xdr.void()],
+      ["manageBuyOfferUnderfunded", xdr.void()],
+      ["manageBuyOfferCrossSelf", xdr.void()],
+      ["manageBuyOfferSellNoIssuer", xdr.void()],
+      ["manageBuyOfferBuyNoIssuer", xdr.void()],
+      ["manageBuyOfferNotFound", xdr.void()],
+      ["manageBuyOfferLowReserve", xdr.void()],
+    ],
+    arms: {
+      success: xdr.lookup("ManageOfferSuccessResult"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SetOptionsResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       SET_OPTIONS_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       SET_OPTIONS_LOW_RESERVE = -1,      // not enough funds to add a signer
+  //       SET_OPTIONS_TOO_MANY_SIGNERS = -2, // max number of signers already reached
+  //       SET_OPTIONS_BAD_FLAGS = -3,        // invalid combination of clear/set flags
+  //       SET_OPTIONS_INVALID_INFLATION = -4,      // inflation account does not exist
+  //       SET_OPTIONS_CANT_CHANGE = -5,            // can no longer change this option
+  //       SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
+  //       SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
+  //       SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
+  //       SET_OPTIONS_INVALID_HOME_DOMAIN = -9,    // malformed home domain
+  //       SET_OPTIONS_AUTH_REVOCABLE_REQUIRED =
+  //           -10 // auth revocable is required for clawback
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("SetOptionsResultCode", {
+    setOptionsSuccess: 0,
+    setOptionsLowReserve: -1,
+    setOptionsTooManySigners: -2,
+    setOptionsBadFlags: -3,
+    setOptionsInvalidInflation: -4,
+    setOptionsCantChange: -5,
+    setOptionsUnknownFlag: -6,
+    setOptionsThresholdOutOfRange: -7,
+    setOptionsBadSigner: -8,
+    setOptionsInvalidHomeDomain: -9,
+    setOptionsAuthRevocableRequired: -10,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union SetOptionsResult switch (SetOptionsResultCode code)
+  //   {
+  //   case SET_OPTIONS_SUCCESS:
+  //       void;
+  //   case SET_OPTIONS_LOW_RESERVE:
+  //   case SET_OPTIONS_TOO_MANY_SIGNERS:
+  //   case SET_OPTIONS_BAD_FLAGS:
+  //   case SET_OPTIONS_INVALID_INFLATION:
+  //   case SET_OPTIONS_CANT_CHANGE:
+  //   case SET_OPTIONS_UNKNOWN_FLAG:
+  //   case SET_OPTIONS_THRESHOLD_OUT_OF_RANGE:
+  //   case SET_OPTIONS_BAD_SIGNER:
+  //   case SET_OPTIONS_INVALID_HOME_DOMAIN:
+  //   case SET_OPTIONS_AUTH_REVOCABLE_REQUIRED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("SetOptionsResult", {
+    switchOn: xdr.lookup("SetOptionsResultCode"),
+    switchName: "code",
+    switches: [
+      ["setOptionsSuccess", xdr.void()],
+      ["setOptionsLowReserve", xdr.void()],
+      ["setOptionsTooManySigners", xdr.void()],
+      ["setOptionsBadFlags", xdr.void()],
+      ["setOptionsInvalidInflation", xdr.void()],
+      ["setOptionsCantChange", xdr.void()],
+      ["setOptionsUnknownFlag", xdr.void()],
+      ["setOptionsThresholdOutOfRange", xdr.void()],
+      ["setOptionsBadSigner", xdr.void()],
+      ["setOptionsInvalidHomeDomain", xdr.void()],
+      ["setOptionsAuthRevocableRequired", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ChangeTrustResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       CHANGE_TRUST_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       CHANGE_TRUST_MALFORMED = -1,     // bad input
+  //       CHANGE_TRUST_NO_ISSUER = -2,     // could not find issuer
+  //       CHANGE_TRUST_INVALID_LIMIT = -3, // cannot drop limit below balance
+  //                                        // cannot create with a limit of 0
+  //       CHANGE_TRUST_LOW_RESERVE =
+  //           -4, // not enough funds to create a new trust line,
+  //       CHANGE_TRUST_SELF_NOT_ALLOWED = -5,   // trusting self is not allowed
+  //       CHANGE_TRUST_TRUST_LINE_MISSING = -6, // Asset trustline is missing for pool
+  //       CHANGE_TRUST_CANNOT_DELETE =
+  //           -7, // Asset trustline is still referenced in a pool
+  //       CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES =
+  //           -8 // Asset trustline is deauthorized
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ChangeTrustResultCode", {
+    changeTrustSuccess: 0,
+    changeTrustMalformed: -1,
+    changeTrustNoIssuer: -2,
+    changeTrustInvalidLimit: -3,
+    changeTrustLowReserve: -4,
+    changeTrustSelfNotAllowed: -5,
+    changeTrustTrustLineMissing: -6,
+    changeTrustCannotDelete: -7,
+    changeTrustNotAuthMaintainLiabilities: -8,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ChangeTrustResult switch (ChangeTrustResultCode code)
+  //   {
+  //   case CHANGE_TRUST_SUCCESS:
+  //       void;
+  //   case CHANGE_TRUST_MALFORMED:
+  //   case CHANGE_TRUST_NO_ISSUER:
+  //   case CHANGE_TRUST_INVALID_LIMIT:
+  //   case CHANGE_TRUST_LOW_RESERVE:
+  //   case CHANGE_TRUST_SELF_NOT_ALLOWED:
+  //   case CHANGE_TRUST_TRUST_LINE_MISSING:
+  //   case CHANGE_TRUST_CANNOT_DELETE:
+  //   case CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ChangeTrustResult", {
+    switchOn: xdr.lookup("ChangeTrustResultCode"),
+    switchName: "code",
+    switches: [
+      ["changeTrustSuccess", xdr.void()],
+      ["changeTrustMalformed", xdr.void()],
+      ["changeTrustNoIssuer", xdr.void()],
+      ["changeTrustInvalidLimit", xdr.void()],
+      ["changeTrustLowReserve", xdr.void()],
+      ["changeTrustSelfNotAllowed", xdr.void()],
+      ["changeTrustTrustLineMissing", xdr.void()],
+      ["changeTrustCannotDelete", xdr.void()],
+      ["changeTrustNotAuthMaintainLiabilities", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum AllowTrustResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       ALLOW_TRUST_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       ALLOW_TRUST_MALFORMED = -1,     // asset is not ASSET_TYPE_ALPHANUM
+  //       ALLOW_TRUST_NO_TRUST_LINE = -2, // trustor does not have a trustline
+  //                                       // source account does not require trust
+  //       ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
+  //       ALLOW_TRUST_CANT_REVOKE = -4,      // source account can't revoke trust,
+  //       ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
+  //       ALLOW_TRUST_LOW_RESERVE = -6       // claimable balances can't be created
+  //                                          // on revoke due to low reserves
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("AllowTrustResultCode", {
+    allowTrustSuccess: 0,
+    allowTrustMalformed: -1,
+    allowTrustNoTrustLine: -2,
+    allowTrustTrustNotRequired: -3,
+    allowTrustCantRevoke: -4,
+    allowTrustSelfNotAllowed: -5,
+    allowTrustLowReserve: -6,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union AllowTrustResult switch (AllowTrustResultCode code)
+  //   {
+  //   case ALLOW_TRUST_SUCCESS:
+  //       void;
+  //   case ALLOW_TRUST_MALFORMED:
+  //   case ALLOW_TRUST_NO_TRUST_LINE:
+  //   case ALLOW_TRUST_TRUST_NOT_REQUIRED:
+  //   case ALLOW_TRUST_CANT_REVOKE:
+  //   case ALLOW_TRUST_SELF_NOT_ALLOWED:
+  //   case ALLOW_TRUST_LOW_RESERVE:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("AllowTrustResult", {
+    switchOn: xdr.lookup("AllowTrustResultCode"),
+    switchName: "code",
+    switches: [
+      ["allowTrustSuccess", xdr.void()],
+      ["allowTrustMalformed", xdr.void()],
+      ["allowTrustNoTrustLine", xdr.void()],
+      ["allowTrustTrustNotRequired", xdr.void()],
+      ["allowTrustCantRevoke", xdr.void()],
+      ["allowTrustSelfNotAllowed", xdr.void()],
+      ["allowTrustLowReserve", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum AccountMergeResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       ACCOUNT_MERGE_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       ACCOUNT_MERGE_MALFORMED = -1,       // can't merge onto itself
+  //       ACCOUNT_MERGE_NO_ACCOUNT = -2,      // destination does not exist
+  //       ACCOUNT_MERGE_IMMUTABLE_SET = -3,   // source account has AUTH_IMMUTABLE set
+  //       ACCOUNT_MERGE_HAS_SUB_ENTRIES = -4, // account has trust lines/offers
+  //       ACCOUNT_MERGE_SEQNUM_TOO_FAR = -5,  // sequence number is over max allowed
+  //       ACCOUNT_MERGE_DEST_FULL = -6,       // can't add source balance to
+  //                                           // destination balance
+  //       ACCOUNT_MERGE_IS_SPONSOR = -7       // can't merge account that is a sponsor
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("AccountMergeResultCode", {
+    accountMergeSuccess: 0,
+    accountMergeMalformed: -1,
+    accountMergeNoAccount: -2,
+    accountMergeImmutableSet: -3,
+    accountMergeHasSubEntries: -4,
+    accountMergeSeqnumTooFar: -5,
+    accountMergeDestFull: -6,
+    accountMergeIsSponsor: -7,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union AccountMergeResult switch (AccountMergeResultCode code)
+  //   {
+  //   case ACCOUNT_MERGE_SUCCESS:
+  //       int64 sourceAccountBalance; // how much got transferred from source account
+  //   case ACCOUNT_MERGE_MALFORMED:
+  //   case ACCOUNT_MERGE_NO_ACCOUNT:
+  //   case ACCOUNT_MERGE_IMMUTABLE_SET:
+  //   case ACCOUNT_MERGE_HAS_SUB_ENTRIES:
+  //   case ACCOUNT_MERGE_SEQNUM_TOO_FAR:
+  //   case ACCOUNT_MERGE_DEST_FULL:
+  //   case ACCOUNT_MERGE_IS_SPONSOR:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("AccountMergeResult", {
+    switchOn: xdr.lookup("AccountMergeResultCode"),
+    switchName: "code",
+    switches: [
+      ["accountMergeSuccess", "sourceAccountBalance"],
+      ["accountMergeMalformed", xdr.void()],
+      ["accountMergeNoAccount", xdr.void()],
+      ["accountMergeImmutableSet", xdr.void()],
+      ["accountMergeHasSubEntries", xdr.void()],
+      ["accountMergeSeqnumTooFar", xdr.void()],
+      ["accountMergeDestFull", xdr.void()],
+      ["accountMergeIsSponsor", xdr.void()],
+    ],
+    arms: {
+      sourceAccountBalance: xdr.lookup("Int64"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum InflationResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       INFLATION_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       INFLATION_NOT_TIME = -1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("InflationResultCode", {
+    inflationSuccess: 0,
+    inflationNotTime: -1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct InflationPayout // or use PaymentResultAtom to limit types?
+  //   {
+  //       AccountID destination;
+  //       int64 amount;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("InflationPayout", [
+    ["destination", xdr.lookup("AccountId")],
+    ["amount", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union InflationResult switch (InflationResultCode code)
+  //   {
+  //   case INFLATION_SUCCESS:
+  //       InflationPayout payouts<>;
+  //   case INFLATION_NOT_TIME:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("InflationResult", {
+    switchOn: xdr.lookup("InflationResultCode"),
+    switchName: "code",
+    switches: [
+      ["inflationSuccess", "payouts"],
+      ["inflationNotTime", xdr.void()],
+    ],
+    arms: {
+      payouts: xdr.varArray(xdr.lookup("InflationPayout"), 2147483647),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ManageDataResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       MANAGE_DATA_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       MANAGE_DATA_NOT_SUPPORTED_YET =
+  //           -1, // The network hasn't moved to this protocol change yet
+  //       MANAGE_DATA_NAME_NOT_FOUND =
+  //           -2, // Trying to remove a Data Entry that isn't there
+  //       MANAGE_DATA_LOW_RESERVE = -3, // not enough funds to create a new Data Entry
+  //       MANAGE_DATA_INVALID_NAME = -4 // Name not a valid string
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ManageDataResultCode", {
+    manageDataSuccess: 0,
+    manageDataNotSupportedYet: -1,
+    manageDataNameNotFound: -2,
+    manageDataLowReserve: -3,
+    manageDataInvalidName: -4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ManageDataResult switch (ManageDataResultCode code)
+  //   {
+  //   case MANAGE_DATA_SUCCESS:
+  //       void;
+  //   case MANAGE_DATA_NOT_SUPPORTED_YET:
+  //   case MANAGE_DATA_NAME_NOT_FOUND:
+  //   case MANAGE_DATA_LOW_RESERVE:
+  //   case MANAGE_DATA_INVALID_NAME:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ManageDataResult", {
+    switchOn: xdr.lookup("ManageDataResultCode"),
+    switchName: "code",
+    switches: [
+      ["manageDataSuccess", xdr.void()],
+      ["manageDataNotSupportedYet", xdr.void()],
+      ["manageDataNameNotFound", xdr.void()],
+      ["manageDataLowReserve", xdr.void()],
+      ["manageDataInvalidName", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum BumpSequenceResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       BUMP_SEQUENCE_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       BUMP_SEQUENCE_BAD_SEQ = -1 // `bumpTo` is not within bounds
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("BumpSequenceResultCode", {
+    bumpSequenceSuccess: 0,
+    bumpSequenceBadSeq: -1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union BumpSequenceResult switch (BumpSequenceResultCode code)
+  //   {
+  //   case BUMP_SEQUENCE_SUCCESS:
+  //       void;
+  //   case BUMP_SEQUENCE_BAD_SEQ:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("BumpSequenceResult", {
+    switchOn: xdr.lookup("BumpSequenceResultCode"),
+    switchName: "code",
+    switches: [
+      ["bumpSequenceSuccess", xdr.void()],
+      ["bumpSequenceBadSeq", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum CreateClaimableBalanceResultCode
+  //   {
+  //       CREATE_CLAIMABLE_BALANCE_SUCCESS = 0,
+  //       CREATE_CLAIMABLE_BALANCE_MALFORMED = -1,
+  //       CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
+  //       CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
+  //       CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
+  //       CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("CreateClaimableBalanceResultCode", {
+    createClaimableBalanceSuccess: 0,
+    createClaimableBalanceMalformed: -1,
+    createClaimableBalanceLowReserve: -2,
+    createClaimableBalanceNoTrust: -3,
+    createClaimableBalanceNotAuthorized: -4,
+    createClaimableBalanceUnderfunded: -5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union CreateClaimableBalanceResult switch (
+  //       CreateClaimableBalanceResultCode code)
+  //   {
+  //   case CREATE_CLAIMABLE_BALANCE_SUCCESS:
+  //       ClaimableBalanceID balanceID;
+  //   case CREATE_CLAIMABLE_BALANCE_MALFORMED:
+  //   case CREATE_CLAIMABLE_BALANCE_LOW_RESERVE:
+  //   case CREATE_CLAIMABLE_BALANCE_NO_TRUST:
+  //   case CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
+  //   case CREATE_CLAIMABLE_BALANCE_UNDERFUNDED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("CreateClaimableBalanceResult", {
+    switchOn: xdr.lookup("CreateClaimableBalanceResultCode"),
+    switchName: "code",
+    switches: [
+      ["createClaimableBalanceSuccess", "balanceId"],
+      ["createClaimableBalanceMalformed", xdr.void()],
+      ["createClaimableBalanceLowReserve", xdr.void()],
+      ["createClaimableBalanceNoTrust", xdr.void()],
+      ["createClaimableBalanceNotAuthorized", xdr.void()],
+      ["createClaimableBalanceUnderfunded", xdr.void()],
+    ],
+    arms: {
+      balanceId: xdr.lookup("ClaimableBalanceId"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimClaimableBalanceResultCode
+  //   {
+  //       CLAIM_CLAIMABLE_BALANCE_SUCCESS = 0,
+  //       CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
+  //       CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM = -2,
+  //       CLAIM_CLAIMABLE_BALANCE_LINE_FULL = -3,
+  //       CLAIM_CLAIMABLE_BALANCE_NO_TRUST = -4,
+  //       CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimClaimableBalanceResultCode", {
+    claimClaimableBalanceSuccess: 0,
+    claimClaimableBalanceDoesNotExist: -1,
+    claimClaimableBalanceCannotClaim: -2,
+    claimClaimableBalanceLineFull: -3,
+    claimClaimableBalanceNoTrust: -4,
+    claimClaimableBalanceNotAuthorized: -5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ClaimClaimableBalanceResult switch (ClaimClaimableBalanceResultCode code)
+  //   {
+  //   case CLAIM_CLAIMABLE_BALANCE_SUCCESS:
+  //       void;
+  //   case CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
+  //   case CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM:
+  //   case CLAIM_CLAIMABLE_BALANCE_LINE_FULL:
+  //   case CLAIM_CLAIMABLE_BALANCE_NO_TRUST:
+  //   case CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClaimClaimableBalanceResult", {
+    switchOn: xdr.lookup("ClaimClaimableBalanceResultCode"),
+    switchName: "code",
+    switches: [
+      ["claimClaimableBalanceSuccess", xdr.void()],
+      ["claimClaimableBalanceDoesNotExist", xdr.void()],
+      ["claimClaimableBalanceCannotClaim", xdr.void()],
+      ["claimClaimableBalanceLineFull", xdr.void()],
+      ["claimClaimableBalanceNoTrust", xdr.void()],
+      ["claimClaimableBalanceNotAuthorized", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum BeginSponsoringFutureReservesResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED = -1,
+  //       BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED = -2,
+  //       BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE = -3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("BeginSponsoringFutureReservesResultCode", {
+    beginSponsoringFutureReservesSuccess: 0,
+    beginSponsoringFutureReservesMalformed: -1,
+    beginSponsoringFutureReservesAlreadySponsored: -2,
+    beginSponsoringFutureReservesRecursive: -3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union BeginSponsoringFutureReservesResult switch (
+  //       BeginSponsoringFutureReservesResultCode code)
+  //   {
+  //   case BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS:
+  //       void;
+  //   case BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED:
+  //   case BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED:
+  //   case BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("BeginSponsoringFutureReservesResult", {
+    switchOn: xdr.lookup("BeginSponsoringFutureReservesResultCode"),
+    switchName: "code",
+    switches: [
+      ["beginSponsoringFutureReservesSuccess", xdr.void()],
+      ["beginSponsoringFutureReservesMalformed", xdr.void()],
+      ["beginSponsoringFutureReservesAlreadySponsored", xdr.void()],
+      ["beginSponsoringFutureReservesRecursive", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum EndSponsoringFutureReservesResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       END_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED = -1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("EndSponsoringFutureReservesResultCode", {
+    endSponsoringFutureReservesSuccess: 0,
+    endSponsoringFutureReservesNotSponsored: -1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union EndSponsoringFutureReservesResult switch (
+  //       EndSponsoringFutureReservesResultCode code)
+  //   {
+  //   case END_SPONSORING_FUTURE_RESERVES_SUCCESS:
+  //       void;
+  //   case END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("EndSponsoringFutureReservesResult", {
+    switchOn: xdr.lookup("EndSponsoringFutureReservesResultCode"),
+    switchName: "code",
+    switches: [
+      ["endSponsoringFutureReservesSuccess", xdr.void()],
+      ["endSponsoringFutureReservesNotSponsored", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum RevokeSponsorshipResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       REVOKE_SPONSORSHIP_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       REVOKE_SPONSORSHIP_DOES_NOT_EXIST = -1,
+  //       REVOKE_SPONSORSHIP_NOT_SPONSOR = -2,
+  //       REVOKE_SPONSORSHIP_LOW_RESERVE = -3,
+  //       REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE = -4,
+  //       REVOKE_SPONSORSHIP_MALFORMED = -5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("RevokeSponsorshipResultCode", {
+    revokeSponsorshipSuccess: 0,
+    revokeSponsorshipDoesNotExist: -1,
+    revokeSponsorshipNotSponsor: -2,
+    revokeSponsorshipLowReserve: -3,
+    revokeSponsorshipOnlyTransferable: -4,
+    revokeSponsorshipMalformed: -5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union RevokeSponsorshipResult switch (RevokeSponsorshipResultCode code)
+  //   {
+  //   case REVOKE_SPONSORSHIP_SUCCESS:
+  //       void;
+  //   case REVOKE_SPONSORSHIP_DOES_NOT_EXIST:
+  //   case REVOKE_SPONSORSHIP_NOT_SPONSOR:
+  //   case REVOKE_SPONSORSHIP_LOW_RESERVE:
+  //   case REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE:
+  //   case REVOKE_SPONSORSHIP_MALFORMED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("RevokeSponsorshipResult", {
+    switchOn: xdr.lookup("RevokeSponsorshipResultCode"),
+    switchName: "code",
+    switches: [
+      ["revokeSponsorshipSuccess", xdr.void()],
+      ["revokeSponsorshipDoesNotExist", xdr.void()],
+      ["revokeSponsorshipNotSponsor", xdr.void()],
+      ["revokeSponsorshipLowReserve", xdr.void()],
+      ["revokeSponsorshipOnlyTransferable", xdr.void()],
+      ["revokeSponsorshipMalformed", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClawbackResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       CLAWBACK_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       CLAWBACK_MALFORMED = -1,
+  //       CLAWBACK_NOT_CLAWBACK_ENABLED = -2,
+  //       CLAWBACK_NO_TRUST = -3,
+  //       CLAWBACK_UNDERFUNDED = -4
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClawbackResultCode", {
+    clawbackSuccess: 0,
+    clawbackMalformed: -1,
+    clawbackNotClawbackEnabled: -2,
+    clawbackNoTrust: -3,
+    clawbackUnderfunded: -4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ClawbackResult switch (ClawbackResultCode code)
+  //   {
+  //   case CLAWBACK_SUCCESS:
+  //       void;
+  //   case CLAWBACK_MALFORMED:
+  //   case CLAWBACK_NOT_CLAWBACK_ENABLED:
+  //   case CLAWBACK_NO_TRUST:
+  //   case CLAWBACK_UNDERFUNDED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClawbackResult", {
+    switchOn: xdr.lookup("ClawbackResultCode"),
+    switchName: "code",
+    switches: [
+      ["clawbackSuccess", xdr.void()],
+      ["clawbackMalformed", xdr.void()],
+      ["clawbackNotClawbackEnabled", xdr.void()],
+      ["clawbackNoTrust", xdr.void()],
+      ["clawbackUnderfunded", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClawbackClaimableBalanceResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       CLAWBACK_CLAIMABLE_BALANCE_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
+  //       CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER = -2,
+  //       CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED = -3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClawbackClaimableBalanceResultCode", {
+    clawbackClaimableBalanceSuccess: 0,
+    clawbackClaimableBalanceDoesNotExist: -1,
+    clawbackClaimableBalanceNotIssuer: -2,
+    clawbackClaimableBalanceNotClawbackEnabled: -3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ClawbackClaimableBalanceResult switch (
+  //       ClawbackClaimableBalanceResultCode code)
+  //   {
+  //   case CLAWBACK_CLAIMABLE_BALANCE_SUCCESS:
+  //       void;
+  //   case CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
+  //   case CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER:
+  //   case CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClawbackClaimableBalanceResult", {
+    switchOn: xdr.lookup("ClawbackClaimableBalanceResultCode"),
+    switchName: "code",
+    switches: [
+      ["clawbackClaimableBalanceSuccess", xdr.void()],
+      ["clawbackClaimableBalanceDoesNotExist", xdr.void()],
+      ["clawbackClaimableBalanceNotIssuer", xdr.void()],
+      ["clawbackClaimableBalanceNotClawbackEnabled", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SetTrustLineFlagsResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       SET_TRUST_LINE_FLAGS_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       SET_TRUST_LINE_FLAGS_MALFORMED = -1,
+  //       SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
+  //       SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
+  //       SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
+  //       SET_TRUST_LINE_FLAGS_LOW_RESERVE = -5 // claimable balances can't be created
+  //                                             // on revoke due to low reserves
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("SetTrustLineFlagsResultCode", {
+    setTrustLineFlagsSuccess: 0,
+    setTrustLineFlagsMalformed: -1,
+    setTrustLineFlagsNoTrustLine: -2,
+    setTrustLineFlagsCantRevoke: -3,
+    setTrustLineFlagsInvalidState: -4,
+    setTrustLineFlagsLowReserve: -5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
+  //   {
+  //   case SET_TRUST_LINE_FLAGS_SUCCESS:
+  //       void;
+  //   case SET_TRUST_LINE_FLAGS_MALFORMED:
+  //   case SET_TRUST_LINE_FLAGS_NO_TRUST_LINE:
+  //   case SET_TRUST_LINE_FLAGS_CANT_REVOKE:
+  //   case SET_TRUST_LINE_FLAGS_INVALID_STATE:
+  //   case SET_TRUST_LINE_FLAGS_LOW_RESERVE:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("SetTrustLineFlagsResult", {
+    switchOn: xdr.lookup("SetTrustLineFlagsResultCode"),
+    switchName: "code",
+    switches: [
+      ["setTrustLineFlagsSuccess", xdr.void()],
+      ["setTrustLineFlagsMalformed", xdr.void()],
+      ["setTrustLineFlagsNoTrustLine", xdr.void()],
+      ["setTrustLineFlagsCantRevoke", xdr.void()],
+      ["setTrustLineFlagsInvalidState", xdr.void()],
+      ["setTrustLineFlagsLowReserve", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum LiquidityPoolDepositResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       LIQUIDITY_POOL_DEPOSIT_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       LIQUIDITY_POOL_DEPOSIT_MALFORMED = -1,      // bad input
+  //       LIQUIDITY_POOL_DEPOSIT_NO_TRUST = -2,       // no trust line for one of the
+  //                                                   // assets
+  //       LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED = -3, // not authorized for one of the
+  //                                                   // assets
+  //       LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED = -4,    // not enough balance for one of
+  //                                                   // the assets
+  //       LIQUIDITY_POOL_DEPOSIT_LINE_FULL = -5,      // pool share trust line doesn't
+  //                                                   // have sufficient limit
+  //       LIQUIDITY_POOL_DEPOSIT_BAD_PRICE = -6,      // deposit price outside bounds
+  //       LIQUIDITY_POOL_DEPOSIT_POOL_FULL = -7       // pool reserves are full
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LiquidityPoolDepositResultCode", {
+    liquidityPoolDepositSuccess: 0,
+    liquidityPoolDepositMalformed: -1,
+    liquidityPoolDepositNoTrust: -2,
+    liquidityPoolDepositNotAuthorized: -3,
+    liquidityPoolDepositUnderfunded: -4,
+    liquidityPoolDepositLineFull: -5,
+    liquidityPoolDepositBadPrice: -6,
+    liquidityPoolDepositPoolFull: -7,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union LiquidityPoolDepositResult switch (LiquidityPoolDepositResultCode code)
+  //   {
+  //   case LIQUIDITY_POOL_DEPOSIT_SUCCESS:
+  //       void;
+  //   case LIQUIDITY_POOL_DEPOSIT_MALFORMED:
+  //   case LIQUIDITY_POOL_DEPOSIT_NO_TRUST:
+  //   case LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED:
+  //   case LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED:
+  //   case LIQUIDITY_POOL_DEPOSIT_LINE_FULL:
+  //   case LIQUIDITY_POOL_DEPOSIT_BAD_PRICE:
+  //   case LIQUIDITY_POOL_DEPOSIT_POOL_FULL:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LiquidityPoolDepositResult", {
+    switchOn: xdr.lookup("LiquidityPoolDepositResultCode"),
+    switchName: "code",
+    switches: [
+      ["liquidityPoolDepositSuccess", xdr.void()],
+      ["liquidityPoolDepositMalformed", xdr.void()],
+      ["liquidityPoolDepositNoTrust", xdr.void()],
+      ["liquidityPoolDepositNotAuthorized", xdr.void()],
+      ["liquidityPoolDepositUnderfunded", xdr.void()],
+      ["liquidityPoolDepositLineFull", xdr.void()],
+      ["liquidityPoolDepositBadPrice", xdr.void()],
+      ["liquidityPoolDepositPoolFull", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum LiquidityPoolWithdrawResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       LIQUIDITY_POOL_WITHDRAW_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       LIQUIDITY_POOL_WITHDRAW_MALFORMED = -1,    // bad input
+  //       LIQUIDITY_POOL_WITHDRAW_NO_TRUST = -2,     // no trust line for one of the
+  //                                                  // assets
+  //       LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED = -3,  // not enough balance of the
+  //                                                  // pool share
+  //       LIQUIDITY_POOL_WITHDRAW_LINE_FULL = -4,    // would go above limit for one
+  //                                                  // of the assets
+  //       LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM = -5 // didn't withdraw enough
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LiquidityPoolWithdrawResultCode", {
+    liquidityPoolWithdrawSuccess: 0,
+    liquidityPoolWithdrawMalformed: -1,
+    liquidityPoolWithdrawNoTrust: -2,
+    liquidityPoolWithdrawUnderfunded: -3,
+    liquidityPoolWithdrawLineFull: -4,
+    liquidityPoolWithdrawUnderMinimum: -5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union LiquidityPoolWithdrawResult switch (LiquidityPoolWithdrawResultCode code)
+  //   {
+  //   case LIQUIDITY_POOL_WITHDRAW_SUCCESS:
+  //       void;
+  //   case LIQUIDITY_POOL_WITHDRAW_MALFORMED:
+  //   case LIQUIDITY_POOL_WITHDRAW_NO_TRUST:
+  //   case LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED:
+  //   case LIQUIDITY_POOL_WITHDRAW_LINE_FULL:
+  //   case LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LiquidityPoolWithdrawResult", {
+    switchOn: xdr.lookup("LiquidityPoolWithdrawResultCode"),
+    switchName: "code",
+    switches: [
+      ["liquidityPoolWithdrawSuccess", xdr.void()],
+      ["liquidityPoolWithdrawMalformed", xdr.void()],
+      ["liquidityPoolWithdrawNoTrust", xdr.void()],
+      ["liquidityPoolWithdrawUnderfunded", xdr.void()],
+      ["liquidityPoolWithdrawLineFull", xdr.void()],
+      ["liquidityPoolWithdrawUnderMinimum", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum OperationResultCode
+  //   {
+  //       opINNER = 0, // inner object result is valid
+  //
+  //       opBAD_AUTH = -1,            // too few valid signatures / wrong network
+  //       opNO_ACCOUNT = -2,          // source account was not found
+  //       opNOT_SUPPORTED = -3,       // operation not supported at this time
+  //       opTOO_MANY_SUBENTRIES = -4, // max number of subentries already reached
+  //       opEXCEEDED_WORK_LIMIT = -5, // operation did too much work
+  //       opTOO_MANY_SPONSORING = -6  // account is sponsoring too many entries
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("OperationResultCode", {
+    opInner: 0,
+    opBadAuth: -1,
+    opNoAccount: -2,
+    opNotSupported: -3,
+    opTooManySubentries: -4,
+    opExceededWorkLimit: -5,
+    opTooManySponsoring: -6,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (OperationType type)
+  //       {
+  //       case CREATE_ACCOUNT:
+  //           CreateAccountResult createAccountResult;
+  //       case PAYMENT:
+  //           PaymentResult paymentResult;
+  //       case PATH_PAYMENT_STRICT_RECEIVE:
+  //           PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
+  //       case MANAGE_SELL_OFFER:
+  //           ManageSellOfferResult manageSellOfferResult;
+  //       case CREATE_PASSIVE_SELL_OFFER:
+  //           ManageSellOfferResult createPassiveSellOfferResult;
+  //       case SET_OPTIONS:
+  //           SetOptionsResult setOptionsResult;
+  //       case CHANGE_TRUST:
+  //           ChangeTrustResult changeTrustResult;
+  //       case ALLOW_TRUST:
+  //           AllowTrustResult allowTrustResult;
+  //       case ACCOUNT_MERGE:
+  //           AccountMergeResult accountMergeResult;
+  //       case INFLATION:
+  //           InflationResult inflationResult;
+  //       case MANAGE_DATA:
+  //           ManageDataResult manageDataResult;
+  //       case BUMP_SEQUENCE:
+  //           BumpSequenceResult bumpSeqResult;
+  //       case MANAGE_BUY_OFFER:
+  //           ManageBuyOfferResult manageBuyOfferResult;
+  //       case PATH_PAYMENT_STRICT_SEND:
+  //           PathPaymentStrictSendResult pathPaymentStrictSendResult;
+  //       case CREATE_CLAIMABLE_BALANCE:
+  //           CreateClaimableBalanceResult createClaimableBalanceResult;
+  //       case CLAIM_CLAIMABLE_BALANCE:
+  //           ClaimClaimableBalanceResult claimClaimableBalanceResult;
+  //       case BEGIN_SPONSORING_FUTURE_RESERVES:
+  //           BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
+  //       case END_SPONSORING_FUTURE_RESERVES:
+  //           EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
+  //       case REVOKE_SPONSORSHIP:
+  //           RevokeSponsorshipResult revokeSponsorshipResult;
+  //       case CLAWBACK:
+  //           ClawbackResult clawbackResult;
+  //       case CLAWBACK_CLAIMABLE_BALANCE:
+  //           ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
+  //       case SET_TRUST_LINE_FLAGS:
+  //           SetTrustLineFlagsResult setTrustLineFlagsResult;
+  //       case LIQUIDITY_POOL_DEPOSIT:
+  //           LiquidityPoolDepositResult liquidityPoolDepositResult;
+  //       case LIQUIDITY_POOL_WITHDRAW:
+  //           LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("OperationResultTr", {
+    switchOn: xdr.lookup("OperationType"),
+    switchName: "type",
+    switches: [
+      ["createAccount", "createAccountResult"],
+      ["payment", "paymentResult"],
+      ["pathPaymentStrictReceive", "pathPaymentStrictReceiveResult"],
+      ["manageSellOffer", "manageSellOfferResult"],
+      ["createPassiveSellOffer", "createPassiveSellOfferResult"],
+      ["setOptions", "setOptionsResult"],
+      ["changeTrust", "changeTrustResult"],
+      ["allowTrust", "allowTrustResult"],
+      ["accountMerge", "accountMergeResult"],
+      ["inflation", "inflationResult"],
+      ["manageData", "manageDataResult"],
+      ["bumpSequence", "bumpSeqResult"],
+      ["manageBuyOffer", "manageBuyOfferResult"],
+      ["pathPaymentStrictSend", "pathPaymentStrictSendResult"],
+      ["createClaimableBalance", "createClaimableBalanceResult"],
+      ["claimClaimableBalance", "claimClaimableBalanceResult"],
+      ["beginSponsoringFutureReserves", "beginSponsoringFutureReservesResult"],
+      ["endSponsoringFutureReserves", "endSponsoringFutureReservesResult"],
+      ["revokeSponsorship", "revokeSponsorshipResult"],
+      ["clawback", "clawbackResult"],
+      ["clawbackClaimableBalance", "clawbackClaimableBalanceResult"],
+      ["setTrustLineFlags", "setTrustLineFlagsResult"],
+      ["liquidityPoolDeposit", "liquidityPoolDepositResult"],
+      ["liquidityPoolWithdraw", "liquidityPoolWithdrawResult"],
+    ],
+    arms: {
+      createAccountResult: xdr.lookup("CreateAccountResult"),
+      paymentResult: xdr.lookup("PaymentResult"),
+      pathPaymentStrictReceiveResult: xdr.lookup(
+        "PathPaymentStrictReceiveResult"
+      ),
+      manageSellOfferResult: xdr.lookup("ManageSellOfferResult"),
+      createPassiveSellOfferResult: xdr.lookup("ManageSellOfferResult"),
+      setOptionsResult: xdr.lookup("SetOptionsResult"),
+      changeTrustResult: xdr.lookup("ChangeTrustResult"),
+      allowTrustResult: xdr.lookup("AllowTrustResult"),
+      accountMergeResult: xdr.lookup("AccountMergeResult"),
+      inflationResult: xdr.lookup("InflationResult"),
+      manageDataResult: xdr.lookup("ManageDataResult"),
+      bumpSeqResult: xdr.lookup("BumpSequenceResult"),
+      manageBuyOfferResult: xdr.lookup("ManageBuyOfferResult"),
+      pathPaymentStrictSendResult: xdr.lookup("PathPaymentStrictSendResult"),
+      createClaimableBalanceResult: xdr.lookup("CreateClaimableBalanceResult"),
+      claimClaimableBalanceResult: xdr.lookup("ClaimClaimableBalanceResult"),
+      beginSponsoringFutureReservesResult: xdr.lookup(
+        "BeginSponsoringFutureReservesResult"
+      ),
+      endSponsoringFutureReservesResult: xdr.lookup(
+        "EndSponsoringFutureReservesResult"
+      ),
+      revokeSponsorshipResult: xdr.lookup("RevokeSponsorshipResult"),
+      clawbackResult: xdr.lookup("ClawbackResult"),
+      clawbackClaimableBalanceResult: xdr.lookup(
+        "ClawbackClaimableBalanceResult"
+      ),
+      setTrustLineFlagsResult: xdr.lookup("SetTrustLineFlagsResult"),
+      liquidityPoolDepositResult: xdr.lookup("LiquidityPoolDepositResult"),
+      liquidityPoolWithdrawResult: xdr.lookup("LiquidityPoolWithdrawResult"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union OperationResult switch (OperationResultCode code)
+  //   {
+  //   case opINNER:
+  //       union switch (OperationType type)
+  //       {
+  //       case CREATE_ACCOUNT:
+  //           CreateAccountResult createAccountResult;
+  //       case PAYMENT:
+  //           PaymentResult paymentResult;
+  //       case PATH_PAYMENT_STRICT_RECEIVE:
+  //           PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
+  //       case MANAGE_SELL_OFFER:
+  //           ManageSellOfferResult manageSellOfferResult;
+  //       case CREATE_PASSIVE_SELL_OFFER:
+  //           ManageSellOfferResult createPassiveSellOfferResult;
+  //       case SET_OPTIONS:
+  //           SetOptionsResult setOptionsResult;
+  //       case CHANGE_TRUST:
+  //           ChangeTrustResult changeTrustResult;
+  //       case ALLOW_TRUST:
+  //           AllowTrustResult allowTrustResult;
+  //       case ACCOUNT_MERGE:
+  //           AccountMergeResult accountMergeResult;
+  //       case INFLATION:
+  //           InflationResult inflationResult;
+  //       case MANAGE_DATA:
+  //           ManageDataResult manageDataResult;
+  //       case BUMP_SEQUENCE:
+  //           BumpSequenceResult bumpSeqResult;
+  //       case MANAGE_BUY_OFFER:
+  //           ManageBuyOfferResult manageBuyOfferResult;
+  //       case PATH_PAYMENT_STRICT_SEND:
+  //           PathPaymentStrictSendResult pathPaymentStrictSendResult;
+  //       case CREATE_CLAIMABLE_BALANCE:
+  //           CreateClaimableBalanceResult createClaimableBalanceResult;
+  //       case CLAIM_CLAIMABLE_BALANCE:
+  //           ClaimClaimableBalanceResult claimClaimableBalanceResult;
+  //       case BEGIN_SPONSORING_FUTURE_RESERVES:
+  //           BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
+  //       case END_SPONSORING_FUTURE_RESERVES:
+  //           EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
+  //       case REVOKE_SPONSORSHIP:
+  //           RevokeSponsorshipResult revokeSponsorshipResult;
+  //       case CLAWBACK:
+  //           ClawbackResult clawbackResult;
+  //       case CLAWBACK_CLAIMABLE_BALANCE:
+  //           ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
+  //       case SET_TRUST_LINE_FLAGS:
+  //           SetTrustLineFlagsResult setTrustLineFlagsResult;
+  //       case LIQUIDITY_POOL_DEPOSIT:
+  //           LiquidityPoolDepositResult liquidityPoolDepositResult;
+  //       case LIQUIDITY_POOL_WITHDRAW:
+  //           LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
+  //       }
+  //       tr;
+  //   case opBAD_AUTH:
+  //   case opNO_ACCOUNT:
+  //   case opNOT_SUPPORTED:
+  //   case opTOO_MANY_SUBENTRIES:
+  //   case opEXCEEDED_WORK_LIMIT:
+  //   case opTOO_MANY_SPONSORING:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("OperationResult", {
+    switchOn: xdr.lookup("OperationResultCode"),
+    switchName: "code",
+    switches: [
+      ["opInner", "tr"],
+      ["opBadAuth", xdr.void()],
+      ["opNoAccount", xdr.void()],
+      ["opNotSupported", xdr.void()],
+      ["opTooManySubentries", xdr.void()],
+      ["opExceededWorkLimit", xdr.void()],
+      ["opTooManySponsoring", xdr.void()],
+    ],
+    arms: {
+      tr: xdr.lookup("OperationResultTr"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum TransactionResultCode
+  //   {
+  //       txFEE_BUMP_INNER_SUCCESS = 1, // fee bump inner transaction succeeded
+  //       txSUCCESS = 0,                // all operations succeeded
+  //
+  //       txFAILED = -1, // one of the operations failed (none were applied)
+  //
+  //       txTOO_EARLY = -2,         // ledger closeTime before minTime
+  //       txTOO_LATE = -3,          // ledger closeTime after maxTime
+  //       txMISSING_OPERATION = -4, // no operation was specified
+  //       txBAD_SEQ = -5,           // sequence number does not match source account
+  //
+  //       txBAD_AUTH = -6,             // too few valid signatures / wrong network
+  //       txINSUFFICIENT_BALANCE = -7, // fee would bring account below reserve
+  //       txNO_ACCOUNT = -8,           // source account not found
+  //       txINSUFFICIENT_FEE = -9,     // fee is too small
+  //       txBAD_AUTH_EXTRA = -10,      // unused signatures attached to transaction
+  //       txINTERNAL_ERROR = -11,      // an unknown error occurred
+  //
+  //       txNOT_SUPPORTED = -12,         // transaction type not supported
+  //       txFEE_BUMP_INNER_FAILED = -13, // fee bump inner transaction failed
+  //       txBAD_SPONSORSHIP = -14,       // sponsorship not confirmed
+  //       txBAD_MIN_SEQ_AGE_OR_GAP =
+  //           -15, // minSeqAge or minSeqLedgerGap conditions not met
+  //       txMALFORMED = -16 // precondition is invalid
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("TransactionResultCode", {
+    txFeeBumpInnerSuccess: 1,
+    txSuccess: 0,
+    txFailed: -1,
+    txTooEarly: -2,
+    txTooLate: -3,
+    txMissingOperation: -4,
+    txBadSeq: -5,
+    txBadAuth: -6,
+    txInsufficientBalance: -7,
+    txNoAccount: -8,
+    txInsufficientFee: -9,
+    txBadAuthExtra: -10,
+    txInternalError: -11,
+    txNotSupported: -12,
+    txFeeBumpInnerFailed: -13,
+    txBadSponsorship: -14,
+    txBadMinSeqAgeOrGap: -15,
+    txMalformed: -16,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (TransactionResultCode code)
+  //       {
+  //       // txFEE_BUMP_INNER_SUCCESS is not included
+  //       case txSUCCESS:
+  //       case txFAILED:
+  //           OperationResult results<>;
+  //       case txTOO_EARLY:
+  //       case txTOO_LATE:
+  //       case txMISSING_OPERATION:
+  //       case txBAD_SEQ:
+  //       case txBAD_AUTH:
+  //       case txINSUFFICIENT_BALANCE:
+  //       case txNO_ACCOUNT:
+  //       case txINSUFFICIENT_FEE:
+  //       case txBAD_AUTH_EXTRA:
+  //       case txINTERNAL_ERROR:
+  //       case txNOT_SUPPORTED:
+  //       // txFEE_BUMP_INNER_FAILED is not included
+  //       case txBAD_SPONSORSHIP:
+  //       case txBAD_MIN_SEQ_AGE_OR_GAP:
+  //       case txMALFORMED:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("InnerTransactionResultResult", {
+    switchOn: xdr.lookup("TransactionResultCode"),
+    switchName: "code",
+    switches: [
+      ["txSuccess", "results"],
+      ["txFailed", "results"],
+      ["txTooEarly", xdr.void()],
+      ["txTooLate", xdr.void()],
+      ["txMissingOperation", xdr.void()],
+      ["txBadSeq", xdr.void()],
+      ["txBadAuth", xdr.void()],
+      ["txInsufficientBalance", xdr.void()],
+      ["txNoAccount", xdr.void()],
+      ["txInsufficientFee", xdr.void()],
+      ["txBadAuthExtra", xdr.void()],
+      ["txInternalError", xdr.void()],
+      ["txNotSupported", xdr.void()],
+      ["txBadSponsorship", xdr.void()],
+      ["txBadMinSeqAgeOrGap", xdr.void()],
+      ["txMalformed", xdr.void()],
+    ],
+    arms: {
+      results: xdr.varArray(xdr.lookup("OperationResult"), 2147483647),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("InnerTransactionResultExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct InnerTransactionResult
+  //   {
+  //       // Always 0. Here for binary compatibility.
+  //       int64 feeCharged;
+  //
+  //       union switch (TransactionResultCode code)
+  //       {
+  //       // txFEE_BUMP_INNER_SUCCESS is not included
+  //       case txSUCCESS:
+  //       case txFAILED:
+  //           OperationResult results<>;
+  //       case txTOO_EARLY:
+  //       case txTOO_LATE:
+  //       case txMISSING_OPERATION:
+  //       case txBAD_SEQ:
+  //       case txBAD_AUTH:
+  //       case txINSUFFICIENT_BALANCE:
+  //       case txNO_ACCOUNT:
+  //       case txINSUFFICIENT_FEE:
+  //       case txBAD_AUTH_EXTRA:
+  //       case txINTERNAL_ERROR:
+  //       case txNOT_SUPPORTED:
+  //       // txFEE_BUMP_INNER_FAILED is not included
+  //       case txBAD_SPONSORSHIP:
+  //       case txBAD_MIN_SEQ_AGE_OR_GAP:
+  //       case txMALFORMED:
+  //           void;
+  //       }
+  //       result;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("InnerTransactionResult", [
+    ["feeCharged", xdr.lookup("Int64")],
+    ["result", xdr.lookup("InnerTransactionResultResult")],
+    ["ext", xdr.lookup("InnerTransactionResultExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct InnerTransactionResultPair
+  //   {
+  //       Hash transactionHash;          // hash of the inner transaction
+  //       InnerTransactionResult result; // result for the inner transaction
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("InnerTransactionResultPair", [
+    ["transactionHash", xdr.lookup("Hash")],
+    ["result", xdr.lookup("InnerTransactionResult")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (TransactionResultCode code)
+  //       {
+  //       case txFEE_BUMP_INNER_SUCCESS:
+  //       case txFEE_BUMP_INNER_FAILED:
+  //           InnerTransactionResultPair innerResultPair;
+  //       case txSUCCESS:
+  //       case txFAILED:
+  //           OperationResult results<>;
+  //       case txTOO_EARLY:
+  //       case txTOO_LATE:
+  //       case txMISSING_OPERATION:
+  //       case txBAD_SEQ:
+  //       case txBAD_AUTH:
+  //       case txINSUFFICIENT_BALANCE:
+  //       case txNO_ACCOUNT:
+  //       case txINSUFFICIENT_FEE:
+  //       case txBAD_AUTH_EXTRA:
+  //       case txINTERNAL_ERROR:
+  //       case txNOT_SUPPORTED:
+  //       // case txFEE_BUMP_INNER_FAILED: handled above
+  //       case txBAD_SPONSORSHIP:
+  //       case txBAD_MIN_SEQ_AGE_OR_GAP:
+  //       case txMALFORMED:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionResultResult", {
+    switchOn: xdr.lookup("TransactionResultCode"),
+    switchName: "code",
+    switches: [
+      ["txFeeBumpInnerSuccess", "innerResultPair"],
+      ["txFeeBumpInnerFailed", "innerResultPair"],
+      ["txSuccess", "results"],
+      ["txFailed", "results"],
+      ["txTooEarly", xdr.void()],
+      ["txTooLate", xdr.void()],
+      ["txMissingOperation", xdr.void()],
+      ["txBadSeq", xdr.void()],
+      ["txBadAuth", xdr.void()],
+      ["txInsufficientBalance", xdr.void()],
+      ["txNoAccount", xdr.void()],
+      ["txInsufficientFee", xdr.void()],
+      ["txBadAuthExtra", xdr.void()],
+      ["txInternalError", xdr.void()],
+      ["txNotSupported", xdr.void()],
+      ["txBadSponsorship", xdr.void()],
+      ["txBadMinSeqAgeOrGap", xdr.void()],
+      ["txMalformed", xdr.void()],
+    ],
+    arms: {
+      innerResultPair: xdr.lookup("InnerTransactionResultPair"),
+      results: xdr.varArray(xdr.lookup("OperationResult"), 2147483647),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionResultExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResult
+  //   {
+  //       int64 feeCharged; // actual fee charged for the transaction
+  //
+  //       union switch (TransactionResultCode code)
+  //       {
+  //       case txFEE_BUMP_INNER_SUCCESS:
+  //       case txFEE_BUMP_INNER_FAILED:
+  //           InnerTransactionResultPair innerResultPair;
+  //       case txSUCCESS:
+  //       case txFAILED:
+  //           OperationResult results<>;
+  //       case txTOO_EARLY:
+  //       case txTOO_LATE:
+  //       case txMISSING_OPERATION:
+  //       case txBAD_SEQ:
+  //       case txBAD_AUTH:
+  //       case txINSUFFICIENT_BALANCE:
+  //       case txNO_ACCOUNT:
+  //       case txINSUFFICIENT_FEE:
+  //       case txBAD_AUTH_EXTRA:
+  //       case txINTERNAL_ERROR:
+  //       case txNOT_SUPPORTED:
+  //       // case txFEE_BUMP_INNER_FAILED: handled above
+  //       case txBAD_SPONSORSHIP:
+  //       case txBAD_MIN_SEQ_AGE_OR_GAP:
+  //       case txMALFORMED:
+  //           void;
+  //       }
+  //       result;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResult", [
+    ["feeCharged", xdr.lookup("Int64")],
+    ["result", xdr.lookup("TransactionResultResult")],
+    ["ext", xdr.lookup("TransactionResultExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque Hash[32];
+  //
+  // ===========================================================================
+  xdr.typedef("Hash", xdr.opaque(32));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque uint256[32];
+  //
+  // ===========================================================================
+  xdr.typedef("Uint256", xdr.opaque(32));
+
+  // === xdr source ============================================================
+  //
+  //   typedef unsigned int uint32;
+  //
+  // ===========================================================================
+  xdr.typedef("Uint32", xdr.uint());
+
+  // === xdr source ============================================================
+  //
+  //   typedef int int32;
+  //
+  // ===========================================================================
+  xdr.typedef("Int32", xdr.int());
+
+  // === xdr source ============================================================
+  //
+  //   typedef unsigned hyper uint64;
+  //
+  // ===========================================================================
+  xdr.typedef("Uint64", xdr.uhyper());
+
+  // === xdr source ============================================================
+  //
+  //   typedef hyper int64;
+  //
+  // ===========================================================================
+  xdr.typedef("Int64", xdr.hyper());
+
+  // === xdr source ============================================================
+  //
+  //   union ExtensionPoint switch (int v)
+  //   {
+  //   case 0:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ExtensionPoint", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum CryptoKeyType
+  //   {
+  //       KEY_TYPE_ED25519 = 0,
+  //       KEY_TYPE_PRE_AUTH_TX = 1,
+  //       KEY_TYPE_HASH_X = 2,
+  //       KEY_TYPE_ED25519_SIGNED_PAYLOAD = 3,
+  //       // MUXED enum values for supported type are derived from the enum values
+  //       // above by ORing them with 0x100
+  //       KEY_TYPE_MUXED_ED25519 = 0x100
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("CryptoKeyType", {
+    keyTypeEd25519: 0,
+    keyTypePreAuthTx: 1,
+    keyTypeHashX: 2,
+    keyTypeEd25519SignedPayload: 3,
+    keyTypeMuxedEd25519: 256,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum PublicKeyType
+  //   {
+  //       PUBLIC_KEY_TYPE_ED25519 = KEY_TYPE_ED25519
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("PublicKeyType", {
+    publicKeyTypeEd25519: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SignerKeyType
+  //   {
+  //       SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
+  //       SIGNER_KEY_TYPE_PRE_AUTH_TX = KEY_TYPE_PRE_AUTH_TX,
+  //       SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X,
+  //       SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD = KEY_TYPE_ED25519_SIGNED_PAYLOAD
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("SignerKeyType", {
+    signerKeyTypeEd25519: 0,
+    signerKeyTypePreAuthTx: 1,
+    signerKeyTypeHashX: 2,
+    signerKeyTypeEd25519SignedPayload: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union PublicKey switch (PublicKeyType type)
+  //   {
+  //   case PUBLIC_KEY_TYPE_ED25519:
+  //       uint256 ed25519;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("PublicKey", {
+    switchOn: xdr.lookup("PublicKeyType"),
+    switchName: "type",
+    switches: [["publicKeyTypeEd25519", "ed25519"]],
+    arms: {
+      ed25519: xdr.lookup("Uint256"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           /* Public key that must sign the payload. */
+  //           uint256 ed25519;
+  //           /* Payload to be raw signed by ed25519. */
+  //           opaque payload<64>;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("SignerKeyEd25519SignedPayload", [
+    ["ed25519", xdr.lookup("Uint256")],
+    ["payload", xdr.varOpaque(64)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union SignerKey switch (SignerKeyType type)
+  //   {
+  //   case SIGNER_KEY_TYPE_ED25519:
+  //       uint256 ed25519;
+  //   case SIGNER_KEY_TYPE_PRE_AUTH_TX:
+  //       /* SHA-256 Hash of TransactionSignaturePayload structure */
+  //       uint256 preAuthTx;
+  //   case SIGNER_KEY_TYPE_HASH_X:
+  //       /* Hash of random 256 bit preimage X */
+  //       uint256 hashX;
+  //   case SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD:
+  //       struct
+  //       {
+  //           /* Public key that must sign the payload. */
+  //           uint256 ed25519;
+  //           /* Payload to be raw signed by ed25519. */
+  //           opaque payload<64>;
+  //       } ed25519SignedPayload;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("SignerKey", {
+    switchOn: xdr.lookup("SignerKeyType"),
+    switchName: "type",
+    switches: [
+      ["signerKeyTypeEd25519", "ed25519"],
+      ["signerKeyTypePreAuthTx", "preAuthTx"],
+      ["signerKeyTypeHashX", "hashX"],
+      ["signerKeyTypeEd25519SignedPayload", "ed25519SignedPayload"],
+    ],
+    arms: {
+      ed25519: xdr.lookup("Uint256"),
+      preAuthTx: xdr.lookup("Uint256"),
+      hashX: xdr.lookup("Uint256"),
+      ed25519SignedPayload: xdr.lookup("SignerKeyEd25519SignedPayload"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque Signature<64>;
+  //
+  // ===========================================================================
+  xdr.typedef("Signature", xdr.varOpaque(64));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque SignatureHint[4];
+  //
+  // ===========================================================================
+  xdr.typedef("SignatureHint", xdr.opaque(4));
+
+  // === xdr source ============================================================
+  //
+  //   typedef PublicKey NodeID;
+  //
+  // ===========================================================================
+  xdr.typedef("NodeId", xdr.lookup("PublicKey"));
+
+  // === xdr source ============================================================
+  //
+  //   struct Curve25519Secret
+  //   {
+  //       opaque key[32];
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Curve25519Secret", [["key", xdr.opaque(32)]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct Curve25519Public
+  //   {
+  //       opaque key[32];
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Curve25519Public", [["key", xdr.opaque(32)]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct HmacSha256Key
+  //   {
+  //       opaque key[32];
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("HmacSha256Key", [["key", xdr.opaque(32)]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct HmacSha256Mac
+  //   {
+  //       opaque mac[32];
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("HmacSha256Mac", [["mac", xdr.opaque(32)]]);
 });
 export default types;

--- a/src/generated/curr_generated.js
+++ b/src/generated/curr_generated.js
@@ -2849,16 +2849,21 @@ xdr.struct("Hello", [
 
 // === xdr source ============================================================
 //
+//   const AUTH_MSG_FLAG_PULL_MODE_REQUESTED = 100;
+//
+// ===========================================================================
+xdr.const("AUTH_MSG_FLAG_PULL_MODE_REQUESTED", 100);
+
+// === xdr source ============================================================
+//
 //   struct Auth
 //   {
-//       // Empty message, just to confirm
-//       // establishment of MAC keys.
-//       int unused;
+//       int flags;
 //   };
 //
 // ===========================================================================
 xdr.struct("Auth", [
-  ["unused", xdr.int()],
+  ["flags", xdr.int()],
 ]);
 
 // === xdr source ============================================================
@@ -2951,7 +2956,9 @@ xdr.struct("PeerAddress", [
 //       SURVEY_REQUEST = 14,
 //       SURVEY_RESPONSE = 15,
 //   
-//       SEND_MORE = 16
+//       SEND_MORE = 16,
+//       FLOOD_ADVERT = 18,
+//       FLOOD_DEMAND = 19
 //   };
 //
 // ===========================================================================
@@ -2973,6 +2980,8 @@ xdr.enum("MessageType", {
   surveyRequest: 14,
   surveyResponse: 15,
   sendMore: 16,
+  floodAdvert: 18,
+  floodDemand: 19,
 });
 
 // === xdr source ============================================================
@@ -3166,6 +3175,58 @@ xdr.union("SurveyResponseBody", {
 
 // === xdr source ============================================================
 //
+//   const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
+//
+// ===========================================================================
+xdr.const("TX_ADVERT_VECTOR_MAX_SIZE", 1000);
+
+// === xdr source ============================================================
+//
+//   typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
+//
+// ===========================================================================
+xdr.typedef("TxAdvertVector", xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_ADVERT_VECTOR_MAX_SIZE")));
+
+// === xdr source ============================================================
+//
+//   struct FloodAdvert
+//   {
+//       TxAdvertVector txHashes;
+//   };
+//
+// ===========================================================================
+xdr.struct("FloodAdvert", [
+  ["txHashes", xdr.lookup("TxAdvertVector")],
+]);
+
+// === xdr source ============================================================
+//
+//   const TX_DEMAND_VECTOR_MAX_SIZE = 1000;
+//
+// ===========================================================================
+xdr.const("TX_DEMAND_VECTOR_MAX_SIZE", 1000);
+
+// === xdr source ============================================================
+//
+//   typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
+//
+// ===========================================================================
+xdr.typedef("TxDemandVector", xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_DEMAND_VECTOR_MAX_SIZE")));
+
+// === xdr source ============================================================
+//
+//   struct FloodDemand
+//   {
+//       TxDemandVector txHashes;
+//   };
+//
+// ===========================================================================
+xdr.struct("FloodDemand", [
+  ["txHashes", xdr.lookup("TxDemandVector")],
+]);
+
+// === xdr source ============================================================
+//
 //   union StellarMessage switch (MessageType type)
 //   {
 //   case ERROR_MSG:
@@ -3208,6 +3269,12 @@ xdr.union("SurveyResponseBody", {
 //       uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
 //   case SEND_MORE:
 //       SendMore sendMoreMessage;
+//   
+//   // Pull mode
+//   case FLOOD_ADVERT:
+//        FloodAdvert floodAdvert;
+//   case FLOOD_DEMAND:
+//        FloodDemand floodDemand;
 //   };
 //
 // ===========================================================================
@@ -3232,6 +3299,8 @@ xdr.union("StellarMessage", {
     ["scpMessage", "envelope"],
     ["getScpState", "getScpLedgerSeq"],
     ["sendMore", "sendMoreMessage"],
+    ["floodAdvert", "floodAdvert"],
+    ["floodDemand", "floodDemand"],
   ],
   arms: {
     error: xdr.lookup("Error"),
@@ -3250,6 +3319,8 @@ xdr.union("StellarMessage", {
     envelope: xdr.lookup("ScpEnvelope"),
     getScpLedgerSeq: xdr.lookup("Uint32"),
     sendMoreMessage: xdr.lookup("SendMore"),
+    floodAdvert: xdr.lookup("FloodAdvert"),
+    floodDemand: xdr.lookup("FloodDemand"),
   },
 });
 

--- a/src/generated/next_generated.js
+++ b/src/generated/next_generated.js
@@ -4,9532 +4,9477 @@
 /* jshint maxstatements:2147483647  */
 /* jshint esnext:true  */
 
-import * as XDR from 'js-xdr';
-
-
-var types = XDR.config(xdr => {
-
-// === xdr source ============================================================
-//
-//   typedef opaque Value<>;
-//
-// ===========================================================================
-xdr.typedef("Value", xdr.varOpaque());
-
-// === xdr source ============================================================
-//
-//   struct SCPBallot
-//   {
-//       uint32 counter; // n
-//       Value value;    // x
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpBallot", [
-  ["counter", xdr.lookup("Uint32")],
-  ["value", xdr.lookup("Value")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum SCPStatementType
-//   {
-//       SCP_ST_PREPARE = 0,
-//       SCP_ST_CONFIRM = 1,
-//       SCP_ST_EXTERNALIZE = 2,
-//       SCP_ST_NOMINATE = 3
-//   };
-//
-// ===========================================================================
-xdr.enum("ScpStatementType", {
-  scpStPrepare: 0,
-  scpStConfirm: 1,
-  scpStExternalize: 2,
-  scpStNominate: 3,
-});
-
-// === xdr source ============================================================
-//
-//   struct SCPNomination
-//   {
-//       Hash quorumSetHash; // D
-//       Value votes<>;      // X
-//       Value accepted<>;   // Y
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpNomination", [
-  ["quorumSetHash", xdr.lookup("Hash")],
-  ["votes", xdr.varArray(xdr.lookup("Value"), 2147483647)],
-  ["accepted", xdr.varArray(xdr.lookup("Value"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               Hash quorumSetHash;       // D
-//               SCPBallot ballot;         // b
-//               SCPBallot* prepared;      // p
-//               SCPBallot* preparedPrime; // p'
-//               uint32 nC;                // c.n
-//               uint32 nH;                // h.n
-//           }
-//
-// ===========================================================================
-xdr.struct("ScpStatementPrepare", [
-  ["quorumSetHash", xdr.lookup("Hash")],
-  ["ballot", xdr.lookup("ScpBallot")],
-  ["prepared", xdr.option(xdr.lookup("ScpBallot"))],
-  ["preparedPrime", xdr.option(xdr.lookup("ScpBallot"))],
-  ["nC", xdr.lookup("Uint32")],
-  ["nH", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               SCPBallot ballot;   // b
-//               uint32 nPrepared;   // p.n
-//               uint32 nCommit;     // c.n
-//               uint32 nH;          // h.n
-//               Hash quorumSetHash; // D
-//           }
-//
-// ===========================================================================
-xdr.struct("ScpStatementConfirm", [
-  ["ballot", xdr.lookup("ScpBallot")],
-  ["nPrepared", xdr.lookup("Uint32")],
-  ["nCommit", xdr.lookup("Uint32")],
-  ["nH", xdr.lookup("Uint32")],
-  ["quorumSetHash", xdr.lookup("Hash")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               SCPBallot commit;         // c
-//               uint32 nH;                // h.n
-//               Hash commitQuorumSetHash; // D used before EXTERNALIZE
-//           }
-//
-// ===========================================================================
-xdr.struct("ScpStatementExternalize", [
-  ["commit", xdr.lookup("ScpBallot")],
-  ["nH", xdr.lookup("Uint32")],
-  ["commitQuorumSetHash", xdr.lookup("Hash")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (SCPStatementType type)
-//       {
-//       case SCP_ST_PREPARE:
-//           struct
-//           {
-//               Hash quorumSetHash;       // D
-//               SCPBallot ballot;         // b
-//               SCPBallot* prepared;      // p
-//               SCPBallot* preparedPrime; // p'
-//               uint32 nC;                // c.n
-//               uint32 nH;                // h.n
-//           } prepare;
-//       case SCP_ST_CONFIRM:
-//           struct
-//           {
-//               SCPBallot ballot;   // b
-//               uint32 nPrepared;   // p.n
-//               uint32 nCommit;     // c.n
-//               uint32 nH;          // h.n
-//               Hash quorumSetHash; // D
-//           } confirm;
-//       case SCP_ST_EXTERNALIZE:
-//           struct
-//           {
-//               SCPBallot commit;         // c
-//               uint32 nH;                // h.n
-//               Hash commitQuorumSetHash; // D used before EXTERNALIZE
-//           } externalize;
-//       case SCP_ST_NOMINATE:
-//           SCPNomination nominate;
-//       }
-//
-// ===========================================================================
-xdr.union("ScpStatementPledges", {
-  switchOn: xdr.lookup("ScpStatementType"),
-  switchName: "type",
-  switches: [
-    ["scpStPrepare", "prepare"],
-    ["scpStConfirm", "confirm"],
-    ["scpStExternalize", "externalize"],
-    ["scpStNominate", "nominate"],
-  ],
-  arms: {
-    prepare: xdr.lookup("ScpStatementPrepare"),
-    confirm: xdr.lookup("ScpStatementConfirm"),
-    externalize: xdr.lookup("ScpStatementExternalize"),
-    nominate: xdr.lookup("ScpNomination"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct SCPStatement
-//   {
-//       NodeID nodeID;    // v
-//       uint64 slotIndex; // i
-//   
-//       union switch (SCPStatementType type)
-//       {
-//       case SCP_ST_PREPARE:
-//           struct
-//           {
-//               Hash quorumSetHash;       // D
-//               SCPBallot ballot;         // b
-//               SCPBallot* prepared;      // p
-//               SCPBallot* preparedPrime; // p'
-//               uint32 nC;                // c.n
-//               uint32 nH;                // h.n
-//           } prepare;
-//       case SCP_ST_CONFIRM:
-//           struct
-//           {
-//               SCPBallot ballot;   // b
-//               uint32 nPrepared;   // p.n
-//               uint32 nCommit;     // c.n
-//               uint32 nH;          // h.n
-//               Hash quorumSetHash; // D
-//           } confirm;
-//       case SCP_ST_EXTERNALIZE:
-//           struct
-//           {
-//               SCPBallot commit;         // c
-//               uint32 nH;                // h.n
-//               Hash commitQuorumSetHash; // D used before EXTERNALIZE
-//           } externalize;
-//       case SCP_ST_NOMINATE:
-//           SCPNomination nominate;
-//       }
-//       pledges;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpStatement", [
-  ["nodeId", xdr.lookup("NodeId")],
-  ["slotIndex", xdr.lookup("Uint64")],
-  ["pledges", xdr.lookup("ScpStatementPledges")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCPEnvelope
-//   {
-//       SCPStatement statement;
-//       Signature signature;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpEnvelope", [
-  ["statement", xdr.lookup("ScpStatement")],
-  ["signature", xdr.lookup("Signature")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCPQuorumSet
-//   {
-//       uint32 threshold;
-//       NodeID validators<>;
-//       SCPQuorumSet innerSets<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpQuorumSet", [
-  ["threshold", xdr.lookup("Uint32")],
-  ["validators", xdr.varArray(xdr.lookup("NodeId"), 2147483647)],
-  ["innerSets", xdr.varArray(xdr.lookup("ScpQuorumSet"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   typedef opaque Thresholds[4];
-//
-// ===========================================================================
-xdr.typedef("Thresholds", xdr.opaque(4));
-
-// === xdr source ============================================================
-//
-//   typedef string string32<32>;
-//
-// ===========================================================================
-xdr.typedef("String32", xdr.string(32));
-
-// === xdr source ============================================================
-//
-//   typedef string string64<64>;
-//
-// ===========================================================================
-xdr.typedef("String64", xdr.string(64));
-
-// === xdr source ============================================================
-//
-//   typedef int64 SequenceNumber;
-//
-// ===========================================================================
-xdr.typedef("SequenceNumber", xdr.lookup("Int64"));
-
-// === xdr source ============================================================
-//
-//   typedef opaque DataValue<64>;
-//
-// ===========================================================================
-xdr.typedef("DataValue", xdr.varOpaque(64));
-
-// === xdr source ============================================================
-//
-//   typedef Hash PoolID;
-//
-// ===========================================================================
-xdr.typedef("PoolId", xdr.lookup("Hash"));
-
-// === xdr source ============================================================
-//
-//   typedef opaque AssetCode4[4];
-//
-// ===========================================================================
-xdr.typedef("AssetCode4", xdr.opaque(4));
-
-// === xdr source ============================================================
-//
-//   typedef opaque AssetCode12[12];
-//
-// ===========================================================================
-xdr.typedef("AssetCode12", xdr.opaque(12));
-
-// === xdr source ============================================================
-//
-//   enum AssetType
-//   {
-//       ASSET_TYPE_NATIVE = 0,
-//       ASSET_TYPE_CREDIT_ALPHANUM4 = 1,
-//       ASSET_TYPE_CREDIT_ALPHANUM12 = 2,
-//       ASSET_TYPE_POOL_SHARE = 3
-//   };
-//
-// ===========================================================================
-xdr.enum("AssetType", {
-  assetTypeNative: 0,
-  assetTypeCreditAlphanum4: 1,
-  assetTypeCreditAlphanum12: 2,
-  assetTypePoolShare: 3,
-});
-
-// === xdr source ============================================================
-//
-//   union AssetCode switch (AssetType type)
-//   {
-//   case ASSET_TYPE_CREDIT_ALPHANUM4:
-//       AssetCode4 assetCode4;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM12:
-//       AssetCode12 assetCode12;
-//   
-//       // add other asset types here in the future
-//   };
-//
-// ===========================================================================
-xdr.union("AssetCode", {
-  switchOn: xdr.lookup("AssetType"),
-  switchName: "type",
-  switches: [
-    ["assetTypeCreditAlphanum4", "assetCode4"],
-    ["assetTypeCreditAlphanum12", "assetCode12"],
-  ],
-  arms: {
-    assetCode4: xdr.lookup("AssetCode4"),
-    assetCode12: xdr.lookup("AssetCode12"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct AlphaNum4
-//   {
-//       AssetCode4 assetCode;
-//       AccountID issuer;
-//   };
-//
-// ===========================================================================
-xdr.struct("AlphaNum4", [
-  ["assetCode", xdr.lookup("AssetCode4")],
-  ["issuer", xdr.lookup("AccountId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct AlphaNum12
-//   {
-//       AssetCode12 assetCode;
-//       AccountID issuer;
-//   };
-//
-// ===========================================================================
-xdr.struct("AlphaNum12", [
-  ["assetCode", xdr.lookup("AssetCode12")],
-  ["issuer", xdr.lookup("AccountId")],
-]);
-
-// === xdr source ============================================================
-//
-//   union Asset switch (AssetType type)
-//   {
-//   case ASSET_TYPE_NATIVE: // Not credit
-//       void;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM4:
-//       AlphaNum4 alphaNum4;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM12:
-//       AlphaNum12 alphaNum12;
-//   
-//       // add other asset types here in the future
-//   };
-//
-// ===========================================================================
-xdr.union("Asset", {
-  switchOn: xdr.lookup("AssetType"),
-  switchName: "type",
-  switches: [
-    ["assetTypeNative", xdr.void()],
-    ["assetTypeCreditAlphanum4", "alphaNum4"],
-    ["assetTypeCreditAlphanum12", "alphaNum12"],
-  ],
-  arms: {
-    alphaNum4: xdr.lookup("AlphaNum4"),
-    alphaNum12: xdr.lookup("AlphaNum12"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct Price
-//   {
-//       int32 n; // numerator
-//       int32 d; // denominator
-//   };
-//
-// ===========================================================================
-xdr.struct("Price", [
-  ["n", xdr.lookup("Int32")],
-  ["d", xdr.lookup("Int32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct Liabilities
-//   {
-//       int64 buying;
-//       int64 selling;
-//   };
-//
-// ===========================================================================
-xdr.struct("Liabilities", [
-  ["buying", xdr.lookup("Int64")],
-  ["selling", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum ThresholdIndexes
-//   {
-//       THRESHOLD_MASTER_WEIGHT = 0,
-//       THRESHOLD_LOW = 1,
-//       THRESHOLD_MED = 2,
-//       THRESHOLD_HIGH = 3
-//   };
-//
-// ===========================================================================
-xdr.enum("ThresholdIndices", {
-  thresholdMasterWeight: 0,
-  thresholdLow: 1,
-  thresholdMed: 2,
-  thresholdHigh: 3,
-});
-
-// === xdr source ============================================================
-//
-//   enum LedgerEntryType
-//   {
-//       ACCOUNT = 0,
-//       TRUSTLINE = 1,
-//       OFFER = 2,
-//       DATA = 3,
-//       CLAIMABLE_BALANCE = 4,
-//       LIQUIDITY_POOL = 5,
-//       CONTRACT_DATA = 6,
-//       CONTRACT_CODE = 7,
-//       CONFIG_SETTING = 8
-//   };
-//
-// ===========================================================================
-xdr.enum("LedgerEntryType", {
-  account: 0,
-  trustline: 1,
-  offer: 2,
-  data: 3,
-  claimableBalance: 4,
-  liquidityPool: 5,
-  contractData: 6,
-  contractCode: 7,
-  configSetting: 8,
-});
-
-// === xdr source ============================================================
-//
-//   struct Signer
-//   {
-//       SignerKey key;
-//       uint32 weight; // really only need 1 byte
-//   };
-//
-// ===========================================================================
-xdr.struct("Signer", [
-  ["key", xdr.lookup("SignerKey")],
-  ["weight", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum AccountFlags
-//   { // masks for each flag
-//   
-//       // Flags set on issuer accounts
-//       // TrustLines are created with authorized set to "false" requiring
-//       // the issuer to set it for each TrustLine
-//       AUTH_REQUIRED_FLAG = 0x1,
-//       // If set, the authorized flag in TrustLines can be cleared
-//       // otherwise, authorization cannot be revoked
-//       AUTH_REVOCABLE_FLAG = 0x2,
-//       // Once set, causes all AUTH_* flags to be read-only
-//       AUTH_IMMUTABLE_FLAG = 0x4,
-//       // Trustlines are created with clawback enabled set to "true",
-//       // and claimable balances created from those trustlines are created
-//       // with clawback enabled set to "true"
-//       AUTH_CLAWBACK_ENABLED_FLAG = 0x8
-//   };
-//
-// ===========================================================================
-xdr.enum("AccountFlags", {
-  authRequiredFlag: 1,
-  authRevocableFlag: 2,
-  authImmutableFlag: 4,
-  authClawbackEnabledFlag: 8,
-});
-
-// === xdr source ============================================================
-//
-//   const MASK_ACCOUNT_FLAGS = 0x7;
-//
-// ===========================================================================
-xdr.const("MASK_ACCOUNT_FLAGS", 0x7);
-
-// === xdr source ============================================================
-//
-//   const MASK_ACCOUNT_FLAGS_V17 = 0xF;
-//
-// ===========================================================================
-xdr.const("MASK_ACCOUNT_FLAGS_V17", 0xF);
-
-// === xdr source ============================================================
-//
-//   const MAX_SIGNERS = 20;
-//
-// ===========================================================================
-xdr.const("MAX_SIGNERS", 20);
-
-// === xdr source ============================================================
-//
-//   typedef AccountID* SponsorshipDescriptor;
-//
-// ===========================================================================
-xdr.typedef("SponsorshipDescriptor", xdr.option(xdr.lookup("AccountId")));
-
-// === xdr source ============================================================
-//
-//   struct AccountEntryExtensionV3
-//   {
-//       // We can use this to add more fields, or because it is first, to
-//       // change AccountEntryExtensionV3 into a union.
-//       ExtensionPoint ext;
-//   
-//       // Ledger number at which `seqNum` took on its present value.
-//       uint32 seqLedger;
-//   
-//       // Time at which `seqNum` took on its present value.
-//       TimePoint seqTime;
-//   };
-//
-// ===========================================================================
-xdr.struct("AccountEntryExtensionV3", [
-  ["ext", xdr.lookup("ExtensionPoint")],
-  ["seqLedger", xdr.lookup("Uint32")],
-  ["seqTime", xdr.lookup("TimePoint")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 3:
-//           AccountEntryExtensionV3 v3;
-//       }
-//
-// ===========================================================================
-xdr.union("AccountEntryExtensionV2Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [3, "v3"],
-  ],
-  arms: {
-    v3: xdr.lookup("AccountEntryExtensionV3"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct AccountEntryExtensionV2
-//   {
-//       uint32 numSponsored;
-//       uint32 numSponsoring;
-//       SponsorshipDescriptor signerSponsoringIDs<MAX_SIGNERS>;
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 3:
-//           AccountEntryExtensionV3 v3;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("AccountEntryExtensionV2", [
-  ["numSponsored", xdr.lookup("Uint32")],
-  ["numSponsoring", xdr.lookup("Uint32")],
-  ["signerSponsoringIDs", xdr.varArray(xdr.lookup("SponsorshipDescriptor"), xdr.lookup("MAX_SIGNERS"))],
-  ["ext", xdr.lookup("AccountEntryExtensionV2Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 2:
-//           AccountEntryExtensionV2 v2;
-//       }
-//
-// ===========================================================================
-xdr.union("AccountEntryExtensionV1Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [2, "v2"],
-  ],
-  arms: {
-    v2: xdr.lookup("AccountEntryExtensionV2"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct AccountEntryExtensionV1
-//   {
-//       Liabilities liabilities;
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 2:
-//           AccountEntryExtensionV2 v2;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("AccountEntryExtensionV1", [
-  ["liabilities", xdr.lookup("Liabilities")],
-  ["ext", xdr.lookup("AccountEntryExtensionV1Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           AccountEntryExtensionV1 v1;
-//       }
-//
-// ===========================================================================
-xdr.union("AccountEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("AccountEntryExtensionV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct AccountEntry
-//   {
-//       AccountID accountID;      // master public key for this account
-//       int64 balance;            // in stroops
-//       SequenceNumber seqNum;    // last sequence number used for this account
-//       uint32 numSubEntries;     // number of sub-entries this account has
-//                                 // drives the reserve
-//       AccountID* inflationDest; // Account to vote for during inflation
-//       uint32 flags;             // see AccountFlags
-//   
-//       string32 homeDomain; // can be used for reverse federation and memo lookup
-//   
-//       // fields used for signatures
-//       // thresholds stores unsigned bytes: [weight of master|low|medium|high]
-//       Thresholds thresholds;
-//   
-//       Signer signers<MAX_SIGNERS>; // possible signers for this account
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           AccountEntryExtensionV1 v1;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("AccountEntry", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["balance", xdr.lookup("Int64")],
-  ["seqNum", xdr.lookup("SequenceNumber")],
-  ["numSubEntries", xdr.lookup("Uint32")],
-  ["inflationDest", xdr.option(xdr.lookup("AccountId"))],
-  ["flags", xdr.lookup("Uint32")],
-  ["homeDomain", xdr.lookup("String32")],
-  ["thresholds", xdr.lookup("Thresholds")],
-  ["signers", xdr.varArray(xdr.lookup("Signer"), xdr.lookup("MAX_SIGNERS"))],
-  ["ext", xdr.lookup("AccountEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum TrustLineFlags
-//   {
-//       // issuer has authorized account to perform transactions with its credit
-//       AUTHORIZED_FLAG = 1,
-//       // issuer has authorized account to maintain and reduce liabilities for its
-//       // credit
-//       AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
-//       // issuer has specified that it may clawback its credit, and that claimable
-//       // balances created with its credit may also be clawed back
-//       TRUSTLINE_CLAWBACK_ENABLED_FLAG = 4
-//   };
-//
-// ===========================================================================
-xdr.enum("TrustLineFlags", {
-  authorizedFlag: 1,
-  authorizedToMaintainLiabilitiesFlag: 2,
-  trustlineClawbackEnabledFlag: 4,
-});
-
-// === xdr source ============================================================
-//
-//   const MASK_TRUSTLINE_FLAGS = 1;
-//
-// ===========================================================================
-xdr.const("MASK_TRUSTLINE_FLAGS", 1);
-
-// === xdr source ============================================================
-//
-//   const MASK_TRUSTLINE_FLAGS_V13 = 3;
-//
-// ===========================================================================
-xdr.const("MASK_TRUSTLINE_FLAGS_V13", 3);
-
-// === xdr source ============================================================
-//
-//   const MASK_TRUSTLINE_FLAGS_V17 = 7;
-//
-// ===========================================================================
-xdr.const("MASK_TRUSTLINE_FLAGS_V17", 7);
-
-// === xdr source ============================================================
-//
-//   enum LiquidityPoolType
-//   {
-//       LIQUIDITY_POOL_CONSTANT_PRODUCT = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("LiquidityPoolType", {
-  liquidityPoolConstantProduct: 0,
-});
-
-// === xdr source ============================================================
-//
-//   union TrustLineAsset switch (AssetType type)
-//   {
-//   case ASSET_TYPE_NATIVE: // Not credit
-//       void;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM4:
-//       AlphaNum4 alphaNum4;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM12:
-//       AlphaNum12 alphaNum12;
-//   
-//   case ASSET_TYPE_POOL_SHARE:
-//       PoolID liquidityPoolID;
-//   
-//       // add other asset types here in the future
-//   };
-//
-// ===========================================================================
-xdr.union("TrustLineAsset", {
-  switchOn: xdr.lookup("AssetType"),
-  switchName: "type",
-  switches: [
-    ["assetTypeNative", xdr.void()],
-    ["assetTypeCreditAlphanum4", "alphaNum4"],
-    ["assetTypeCreditAlphanum12", "alphaNum12"],
-    ["assetTypePoolShare", "liquidityPoolId"],
-  ],
-  arms: {
-    alphaNum4: xdr.lookup("AlphaNum4"),
-    alphaNum12: xdr.lookup("AlphaNum12"),
-    liquidityPoolId: xdr.lookup("PoolId"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TrustLineEntryExtensionV2Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TrustLineEntryExtensionV2
-//   {
-//       int32 liquidityPoolUseCount;
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TrustLineEntryExtensionV2", [
-  ["liquidityPoolUseCount", xdr.lookup("Int32")],
-  ["ext", xdr.lookup("TrustLineEntryExtensionV2Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//               {
-//               case 0:
-//                   void;
-//               case 2:
-//                   TrustLineEntryExtensionV2 v2;
-//               }
-//
-// ===========================================================================
-xdr.union("TrustLineEntryV1Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [2, "v2"],
-  ],
-  arms: {
-    v2: xdr.lookup("TrustLineEntryExtensionV2"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               Liabilities liabilities;
-//   
-//               union switch (int v)
-//               {
-//               case 0:
-//                   void;
-//               case 2:
-//                   TrustLineEntryExtensionV2 v2;
-//               }
-//               ext;
-//           }
-//
-// ===========================================================================
-xdr.struct("TrustLineEntryV1", [
-  ["liabilities", xdr.lookup("Liabilities")],
-  ["ext", xdr.lookup("TrustLineEntryV1Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           struct
-//           {
-//               Liabilities liabilities;
-//   
-//               union switch (int v)
-//               {
-//               case 0:
-//                   void;
-//               case 2:
-//                   TrustLineEntryExtensionV2 v2;
-//               }
-//               ext;
-//           } v1;
-//       }
-//
-// ===========================================================================
-xdr.union("TrustLineEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("TrustLineEntryV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TrustLineEntry
-//   {
-//       AccountID accountID;  // account this trustline belongs to
-//       TrustLineAsset asset; // type of asset (with issuer)
-//       int64 balance;        // how much of this asset the user has.
-//                             // Asset defines the unit for this;
-//   
-//       int64 limit;  // balance cannot be above this
-//       uint32 flags; // see TrustLineFlags
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           struct
-//           {
-//               Liabilities liabilities;
-//   
-//               union switch (int v)
-//               {
-//               case 0:
-//                   void;
-//               case 2:
-//                   TrustLineEntryExtensionV2 v2;
-//               }
-//               ext;
-//           } v1;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TrustLineEntry", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["asset", xdr.lookup("TrustLineAsset")],
-  ["balance", xdr.lookup("Int64")],
-  ["limit", xdr.lookup("Int64")],
-  ["flags", xdr.lookup("Uint32")],
-  ["ext", xdr.lookup("TrustLineEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum OfferEntryFlags
-//   {
-//       // an offer with this flag will not act on and take a reverse offer of equal
-//       // price
-//       PASSIVE_FLAG = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("OfferEntryFlags", {
-  passiveFlag: 1,
-});
-
-// === xdr source ============================================================
-//
-//   const MASK_OFFERENTRY_FLAGS = 1;
-//
-// ===========================================================================
-xdr.const("MASK_OFFERENTRY_FLAGS", 1);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("OfferEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct OfferEntry
-//   {
-//       AccountID sellerID;
-//       int64 offerID;
-//       Asset selling; // A
-//       Asset buying;  // B
-//       int64 amount;  // amount of A
-//   
-//       /* price for this offer:
-//           price of A in terms of B
-//           price=AmountB/AmountA=priceNumerator/priceDenominator
-//           price is after fees
-//       */
-//       Price price;
-//       uint32 flags; // see OfferEntryFlags
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("OfferEntry", [
-  ["sellerId", xdr.lookup("AccountId")],
-  ["offerId", xdr.lookup("Int64")],
-  ["selling", xdr.lookup("Asset")],
-  ["buying", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-  ["price", xdr.lookup("Price")],
-  ["flags", xdr.lookup("Uint32")],
-  ["ext", xdr.lookup("OfferEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("DataEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct DataEntry
-//   {
-//       AccountID accountID; // account this data belongs to
-//       string64 dataName;
-//       DataValue dataValue;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("DataEntry", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["dataName", xdr.lookup("String64")],
-  ["dataValue", xdr.lookup("DataValue")],
-  ["ext", xdr.lookup("DataEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum ClaimPredicateType
-//   {
-//       CLAIM_PREDICATE_UNCONDITIONAL = 0,
-//       CLAIM_PREDICATE_AND = 1,
-//       CLAIM_PREDICATE_OR = 2,
-//       CLAIM_PREDICATE_NOT = 3,
-//       CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
-//       CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimPredicateType", {
-  claimPredicateUnconditional: 0,
-  claimPredicateAnd: 1,
-  claimPredicateOr: 2,
-  claimPredicateNot: 3,
-  claimPredicateBeforeAbsoluteTime: 4,
-  claimPredicateBeforeRelativeTime: 5,
-});
-
-// === xdr source ============================================================
-//
-//   union ClaimPredicate switch (ClaimPredicateType type)
-//   {
-//   case CLAIM_PREDICATE_UNCONDITIONAL:
-//       void;
-//   case CLAIM_PREDICATE_AND:
-//       ClaimPredicate andPredicates<2>;
-//   case CLAIM_PREDICATE_OR:
-//       ClaimPredicate orPredicates<2>;
-//   case CLAIM_PREDICATE_NOT:
-//       ClaimPredicate* notPredicate;
-//   case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
-//       int64 absBefore; // Predicate will be true if closeTime < absBefore
-//   case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
-//       int64 relBefore; // Seconds since closeTime of the ledger in which the
-//                        // ClaimableBalanceEntry was created
-//   };
-//
-// ===========================================================================
-xdr.union("ClaimPredicate", {
-  switchOn: xdr.lookup("ClaimPredicateType"),
-  switchName: "type",
-  switches: [
-    ["claimPredicateUnconditional", xdr.void()],
-    ["claimPredicateAnd", "andPredicates"],
-    ["claimPredicateOr", "orPredicates"],
-    ["claimPredicateNot", "notPredicate"],
-    ["claimPredicateBeforeAbsoluteTime", "absBefore"],
-    ["claimPredicateBeforeRelativeTime", "relBefore"],
-  ],
-  arms: {
-    andPredicates: xdr.varArray(xdr.lookup("ClaimPredicate"), 2),
-    orPredicates: xdr.varArray(xdr.lookup("ClaimPredicate"), 2),
-    notPredicate: xdr.option(xdr.lookup("ClaimPredicate")),
-    absBefore: xdr.lookup("Int64"),
-    relBefore: xdr.lookup("Int64"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClaimantType
-//   {
-//       CLAIMANT_TYPE_V0 = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimantType", {
-  claimantTypeV0: 0,
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID destination;    // The account that can use this condition
-//           ClaimPredicate predicate; // Claimable if predicate is true
-//       }
-//
-// ===========================================================================
-xdr.struct("ClaimantV0", [
-  ["destination", xdr.lookup("AccountId")],
-  ["predicate", xdr.lookup("ClaimPredicate")],
-]);
-
-// === xdr source ============================================================
-//
-//   union Claimant switch (ClaimantType type)
-//   {
-//   case CLAIMANT_TYPE_V0:
-//       struct
-//       {
-//           AccountID destination;    // The account that can use this condition
-//           ClaimPredicate predicate; // Claimable if predicate is true
-//       } v0;
-//   };
-//
-// ===========================================================================
-xdr.union("Claimant", {
-  switchOn: xdr.lookup("ClaimantType"),
-  switchName: "type",
-  switches: [
-    ["claimantTypeV0", "v0"],
-  ],
-  arms: {
-    v0: xdr.lookup("ClaimantV0"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClaimableBalanceIDType
-//   {
-//       CLAIMABLE_BALANCE_ID_TYPE_V0 = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimableBalanceIdType", {
-  claimableBalanceIdTypeV0: 0,
-});
-
-// === xdr source ============================================================
-//
-//   union ClaimableBalanceID switch (ClaimableBalanceIDType type)
-//   {
-//   case CLAIMABLE_BALANCE_ID_TYPE_V0:
-//       Hash v0;
-//   };
-//
-// ===========================================================================
-xdr.union("ClaimableBalanceId", {
-  switchOn: xdr.lookup("ClaimableBalanceIdType"),
-  switchName: "type",
-  switches: [
-    ["claimableBalanceIdTypeV0", "v0"],
-  ],
-  arms: {
-    v0: xdr.lookup("Hash"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClaimableBalanceFlags
-//   {
-//       // If set, the issuer account of the asset held by the claimable balance may
-//       // clawback the claimable balance
-//       CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG = 0x1
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimableBalanceFlags", {
-  claimableBalanceClawbackEnabledFlag: 1,
-});
-
-// === xdr source ============================================================
-//
-//   const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1;
-//
-// ===========================================================================
-xdr.const("MASK_CLAIMABLE_BALANCE_FLAGS", 0x1);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("ClaimableBalanceEntryExtensionV1Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ClaimableBalanceEntryExtensionV1
-//   {
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   
-//       uint32 flags; // see ClaimableBalanceFlags
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimableBalanceEntryExtensionV1", [
-  ["ext", xdr.lookup("ClaimableBalanceEntryExtensionV1Ext")],
-  ["flags", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           ClaimableBalanceEntryExtensionV1 v1;
-//       }
-//
-// ===========================================================================
-xdr.union("ClaimableBalanceEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("ClaimableBalanceEntryExtensionV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ClaimableBalanceEntry
-//   {
-//       // Unique identifier for this ClaimableBalanceEntry
-//       ClaimableBalanceID balanceID;
-//   
-//       // List of claimants with associated predicate
-//       Claimant claimants<10>;
-//   
-//       // Any asset including native
-//       Asset asset;
-//   
-//       // Amount of asset
-//       int64 amount;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           ClaimableBalanceEntryExtensionV1 v1;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimableBalanceEntry", [
-  ["balanceId", xdr.lookup("ClaimableBalanceId")],
-  ["claimants", xdr.varArray(xdr.lookup("Claimant"), 10)],
-  ["asset", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-  ["ext", xdr.lookup("ClaimableBalanceEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LiquidityPoolConstantProductParameters
-//   {
-//       Asset assetA; // assetA < assetB
-//       Asset assetB;
-//       int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
-//   };
-//
-// ===========================================================================
-xdr.struct("LiquidityPoolConstantProductParameters", [
-  ["assetA", xdr.lookup("Asset")],
-  ["assetB", xdr.lookup("Asset")],
-  ["fee", xdr.lookup("Int32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               LiquidityPoolConstantProductParameters params;
-//   
-//               int64 reserveA;        // amount of A in the pool
-//               int64 reserveB;        // amount of B in the pool
-//               int64 totalPoolShares; // total number of pool shares issued
-//               int64 poolSharesTrustLineCount; // number of trust lines for the
-//                                               // associated pool shares
-//           }
-//
-// ===========================================================================
-xdr.struct("LiquidityPoolEntryConstantProduct", [
-  ["params", xdr.lookup("LiquidityPoolConstantProductParameters")],
-  ["reserveA", xdr.lookup("Int64")],
-  ["reserveB", xdr.lookup("Int64")],
-  ["totalPoolShares", xdr.lookup("Int64")],
-  ["poolSharesTrustLineCount", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (LiquidityPoolType type)
-//       {
-//       case LIQUIDITY_POOL_CONSTANT_PRODUCT:
-//           struct
-//           {
-//               LiquidityPoolConstantProductParameters params;
-//   
-//               int64 reserveA;        // amount of A in the pool
-//               int64 reserveB;        // amount of B in the pool
-//               int64 totalPoolShares; // total number of pool shares issued
-//               int64 poolSharesTrustLineCount; // number of trust lines for the
-//                                               // associated pool shares
-//           } constantProduct;
-//       }
-//
-// ===========================================================================
-xdr.union("LiquidityPoolEntryBody", {
-  switchOn: xdr.lookup("LiquidityPoolType"),
-  switchName: "type",
-  switches: [
-    ["liquidityPoolConstantProduct", "constantProduct"],
-  ],
-  arms: {
-    constantProduct: xdr.lookup("LiquidityPoolEntryConstantProduct"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LiquidityPoolEntry
-//   {
-//       PoolID liquidityPoolID;
-//   
-//       union switch (LiquidityPoolType type)
-//       {
-//       case LIQUIDITY_POOL_CONSTANT_PRODUCT:
-//           struct
-//           {
-//               LiquidityPoolConstantProductParameters params;
-//   
-//               int64 reserveA;        // amount of A in the pool
-//               int64 reserveB;        // amount of B in the pool
-//               int64 totalPoolShares; // total number of pool shares issued
-//               int64 poolSharesTrustLineCount; // number of trust lines for the
-//                                               // associated pool shares
-//           } constantProduct;
-//       }
-//       body;
-//   };
-//
-// ===========================================================================
-xdr.struct("LiquidityPoolEntry", [
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-  ["body", xdr.lookup("LiquidityPoolEntryBody")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ContractDataEntry {
-//       Hash contractID;
-//       SCVal key;
-//       SCVal val;
-//   };
-//
-// ===========================================================================
-xdr.struct("ContractDataEntry", [
-  ["contractId", xdr.lookup("Hash")],
-  ["key", xdr.lookup("ScVal")],
-  ["val", xdr.lookup("ScVal")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ContractCodeEntry {
-//       ExtensionPoint ext;
-//   
-//       Hash hash;
-//       opaque code<SCVAL_LIMIT>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ContractCodeEntry", [
-  ["ext", xdr.lookup("ExtensionPoint")],
-  ["hash", xdr.lookup("Hash")],
-  ["code", xdr.varOpaque(SCVAL_LIMIT)],
-]);
-
-// === xdr source ============================================================
-//
-//   enum ConfigSettingID
-//   {
-//       CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES = 0,
-//       CONFIG_SETTING_CONTRACT_COMPUTE_V0 = 1,
-//       CONFIG_SETTING_CONTRACT_LEDGER_COST_V0 = 2,
-//       CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0 = 3,
-//       CONFIG_SETTING_CONTRACT_META_DATA_V0 = 4,
-//       CONFIG_SETTING_CONTRACT_BANDWIDTH_V0 = 5,
-//       CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION = 6
-//   };
-//
-// ===========================================================================
-xdr.enum("ConfigSettingId", {
-  configSettingContractMaxSizeBytes: 0,
-  configSettingContractComputeV0: 1,
-  configSettingContractLedgerCostV0: 2,
-  configSettingContractHistoricalDataV0: 3,
-  configSettingContractMetaDataV0: 4,
-  configSettingContractBandwidthV0: 5,
-  configSettingContractHostLogicVersion: 6,
-});
-
-// === xdr source ============================================================
-//
-//   struct ConfigSettingContractComputeV0
-//   {
-//       // Maximum instructions per ledger
-//       int64 ledgerMaxInstructions;
-//       // Maximum instructions per transaction
-//       int64 txMaxInstructions;
-//       // Cost of 10000 instructions
-//       int64 feeRatePerInstructionsIncrement;
-//   
-//       // Memory limit per contract/host function invocation. Unlike 
-//       // instructions, there is no fee for memory and it's not
-//       // accumulated between operations - the same limit is applied 
-//       // to every operation.
-//       uint32 memoryLimit;
-//   };
-//
-// ===========================================================================
-xdr.struct("ConfigSettingContractComputeV0", [
-  ["ledgerMaxInstructions", xdr.lookup("Int64")],
-  ["txMaxInstructions", xdr.lookup("Int64")],
-  ["feeRatePerInstructionsIncrement", xdr.lookup("Int64")],
-  ["memoryLimit", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ConfigSettingContractLedgerCostV0
-//   {
-//       // Maximum number of ledger entry read operations per ledger
-//       uint32 ledgerMaxReadLedgerEntries;
-//       // Maximum number of bytes that can be read per ledger
-//       uint32 ledgerMaxReadBytes;
-//       // Maximum number of ledger entry write operations per ledger
-//       uint32 ledgerMaxWriteLedgerEntries;
-//       // Maximum number of bytes that can be written per ledger
-//       uint32 ledgerMaxWriteBytes;
-//   
-//       // Maximum number of ledger entry read operations per transaction
-//       uint32 txMaxReadLedgerEntries;
-//       // Maximum number of bytes that can be read per transaction
-//       uint32 txMaxReadBytes;
-//       // Maximum number of ledger entry write operations per transaction
-//       uint32 txMaxWriteLedgerEntries;
-//       // Maximum number of bytes that can be written per transaction
-//       uint32 txMaxWriteBytes;
-//   
-//       int64 feeReadLedgerEntry;  // Fee per ledger entry read
-//       int64 feeWriteLedgerEntry; // Fee per ledger entry write
-//   
-//       int64 feeRead1KB;  // Fee for reading 1KB    
-//       int64 feeWrite1KB; // Fee for writing 1KB
-//   
-//       // Bucket list fees grow slowly up to that size
-//       int64 bucketListSizeBytes;
-//       // Fee rate in stroops when the bucket list is empty
-//       int64 bucketListFeeRateLow;
-//       // Fee rate in stroops when the bucket list reached bucketListSizeBytes
-//       int64 bucketListFeeRateHigh;
-//       // Rate multiplier for any additional data past the first bucketListSizeBytes
-//       uint32 bucketListGrowthFactor;
-//   };
-//
-// ===========================================================================
-xdr.struct("ConfigSettingContractLedgerCostV0", [
-  ["ledgerMaxReadLedgerEntries", xdr.lookup("Uint32")],
-  ["ledgerMaxReadBytes", xdr.lookup("Uint32")],
-  ["ledgerMaxWriteLedgerEntries", xdr.lookup("Uint32")],
-  ["ledgerMaxWriteBytes", xdr.lookup("Uint32")],
-  ["txMaxReadLedgerEntries", xdr.lookup("Uint32")],
-  ["txMaxReadBytes", xdr.lookup("Uint32")],
-  ["txMaxWriteLedgerEntries", xdr.lookup("Uint32")],
-  ["txMaxWriteBytes", xdr.lookup("Uint32")],
-  ["feeReadLedgerEntry", xdr.lookup("Int64")],
-  ["feeWriteLedgerEntry", xdr.lookup("Int64")],
-  ["feeRead1Kb", xdr.lookup("Int64")],
-  ["feeWrite1Kb", xdr.lookup("Int64")],
-  ["bucketListSizeBytes", xdr.lookup("Int64")],
-  ["bucketListFeeRateLow", xdr.lookup("Int64")],
-  ["bucketListFeeRateHigh", xdr.lookup("Int64")],
-  ["bucketListGrowthFactor", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ConfigSettingContractHistoricalDataV0
-//   {
-//       int64 feeHistorical1KB; // Fee for storing 1KB in archives
-//   };
-//
-// ===========================================================================
-xdr.struct("ConfigSettingContractHistoricalDataV0", [
-  ["feeHistorical1Kb", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ConfigSettingContractMetaDataV0
-//   {
-//       // Maximum size of extended meta data produced by a transaction
-//       uint32 txMaxExtendedMetaDataSizeBytes;
-//       // Fee for generating 1KB of extended meta data
-//       int64 feeExtendedMetaData1KB;
-//   };
-//
-// ===========================================================================
-xdr.struct("ConfigSettingContractMetaDataV0", [
-  ["txMaxExtendedMetaDataSizeBytes", xdr.lookup("Uint32")],
-  ["feeExtendedMetaData1Kb", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ConfigSettingContractBandwidthV0
-//   {
-//       // Maximum size in bytes to propagate per ledger
-//       uint32 ledgerMaxPropagateSizeBytes;
-//       // Maximum size in bytes for a transaction
-//       uint32 txMaxSizeBytes;
-//   
-//       // Fee for propagating 1KB of data
-//       int64 feePropagateData1KB;
-//   };
-//
-// ===========================================================================
-xdr.struct("ConfigSettingContractBandwidthV0", [
-  ["ledgerMaxPropagateSizeBytes", xdr.lookup("Uint32")],
-  ["txMaxSizeBytes", xdr.lookup("Uint32")],
-  ["feePropagateData1Kb", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   union ConfigSettingEntry switch (ConfigSettingID configSettingID)
-//   {
-//   case CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES:
-//       uint32 contractMaxSizeBytes;
-//   case CONFIG_SETTING_CONTRACT_COMPUTE_V0:
-//       ConfigSettingContractComputeV0 contractCompute;
-//   case CONFIG_SETTING_CONTRACT_LEDGER_COST_V0:
-//       ConfigSettingContractLedgerCostV0 contractLedgerCost;
-//   case CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0:
-//       ConfigSettingContractHistoricalDataV0 contractHistoricalData;
-//   case CONFIG_SETTING_CONTRACT_META_DATA_V0:
-//       ConfigSettingContractMetaDataV0 contractMetaData;
-//   case CONFIG_SETTING_CONTRACT_BANDWIDTH_V0:
-//       ConfigSettingContractBandwidthV0 contractBandwidth;
-//   case CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION:
-//       uint32 contractHostLogicVersion;
-//   };
-//
-// ===========================================================================
-xdr.union("ConfigSettingEntry", {
-  switchOn: xdr.lookup("ConfigSettingId"),
-  switchName: "configSettingId",
-  switches: [
-    ["configSettingContractMaxSizeBytes", "contractMaxSizeBytes"],
-    ["configSettingContractComputeV0", "contractCompute"],
-    ["configSettingContractLedgerCostV0", "contractLedgerCost"],
-    ["configSettingContractHistoricalDataV0", "contractHistoricalData"],
-    ["configSettingContractMetaDataV0", "contractMetaData"],
-    ["configSettingContractBandwidthV0", "contractBandwidth"],
-    ["configSettingContractHostLogicVersion", "contractHostLogicVersion"],
-  ],
-  arms: {
-    contractMaxSizeBytes: xdr.lookup("Uint32"),
-    contractCompute: xdr.lookup("ConfigSettingContractComputeV0"),
-    contractLedgerCost: xdr.lookup("ConfigSettingContractLedgerCostV0"),
-    contractHistoricalData: xdr.lookup("ConfigSettingContractHistoricalDataV0"),
-    contractMetaData: xdr.lookup("ConfigSettingContractMetaDataV0"),
-    contractBandwidth: xdr.lookup("ConfigSettingContractBandwidthV0"),
-    contractHostLogicVersion: xdr.lookup("Uint32"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerEntryExtensionV1Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerEntryExtensionV1
-//   {
-//       SponsorshipDescriptor sponsoringID;
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerEntryExtensionV1", [
-  ["sponsoringId", xdr.lookup("SponsorshipDescriptor")],
-  ["ext", xdr.lookup("LedgerEntryExtensionV1Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (LedgerEntryType type)
-//       {
-//       case ACCOUNT:
-//           AccountEntry account;
-//       case TRUSTLINE:
-//           TrustLineEntry trustLine;
-//       case OFFER:
-//           OfferEntry offer;
-//       case DATA:
-//           DataEntry data;
-//       case CLAIMABLE_BALANCE:
-//           ClaimableBalanceEntry claimableBalance;
-//       case LIQUIDITY_POOL:
-//           LiquidityPoolEntry liquidityPool;
-//       case CONTRACT_DATA:
-//           ContractDataEntry contractData;
-//       case CONTRACT_CODE:
-//           ContractCodeEntry contractCode;
-//       case CONFIG_SETTING:
-//           ConfigSettingEntry configSetting;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerEntryData", {
-  switchOn: xdr.lookup("LedgerEntryType"),
-  switchName: "type",
-  switches: [
-    ["account", "account"],
-    ["trustline", "trustLine"],
-    ["offer", "offer"],
-    ["data", "data"],
-    ["claimableBalance", "claimableBalance"],
-    ["liquidityPool", "liquidityPool"],
-    ["contractData", "contractData"],
-    ["contractCode", "contractCode"],
-    ["configSetting", "configSetting"],
-  ],
-  arms: {
-    account: xdr.lookup("AccountEntry"),
-    trustLine: xdr.lookup("TrustLineEntry"),
-    offer: xdr.lookup("OfferEntry"),
-    data: xdr.lookup("DataEntry"),
-    claimableBalance: xdr.lookup("ClaimableBalanceEntry"),
-    liquidityPool: xdr.lookup("LiquidityPoolEntry"),
-    contractData: xdr.lookup("ContractDataEntry"),
-    contractCode: xdr.lookup("ContractCodeEntry"),
-    configSetting: xdr.lookup("ConfigSettingEntry"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           LedgerEntryExtensionV1 v1;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("LedgerEntryExtensionV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerEntry
-//   {
-//       uint32 lastModifiedLedgerSeq; // ledger the LedgerEntry was last changed
-//   
-//       union switch (LedgerEntryType type)
-//       {
-//       case ACCOUNT:
-//           AccountEntry account;
-//       case TRUSTLINE:
-//           TrustLineEntry trustLine;
-//       case OFFER:
-//           OfferEntry offer;
-//       case DATA:
-//           DataEntry data;
-//       case CLAIMABLE_BALANCE:
-//           ClaimableBalanceEntry claimableBalance;
-//       case LIQUIDITY_POOL:
-//           LiquidityPoolEntry liquidityPool;
-//       case CONTRACT_DATA:
-//           ContractDataEntry contractData;
-//       case CONTRACT_CODE:
-//           ContractCodeEntry contractCode;
-//       case CONFIG_SETTING:
-//           ConfigSettingEntry configSetting;
-//       }
-//       data;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           LedgerEntryExtensionV1 v1;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerEntry", [
-  ["lastModifiedLedgerSeq", xdr.lookup("Uint32")],
-  ["data", xdr.lookup("LedgerEntryData")],
-  ["ext", xdr.lookup("LedgerEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID accountID;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyAccount", [
-  ["accountId", xdr.lookup("AccountId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID accountID;
-//           TrustLineAsset asset;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyTrustLine", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["asset", xdr.lookup("TrustLineAsset")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID sellerID;
-//           int64 offerID;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyOffer", [
-  ["sellerId", xdr.lookup("AccountId")],
-  ["offerId", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID accountID;
-//           string64 dataName;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyData", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["dataName", xdr.lookup("String64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           ClaimableBalanceID balanceID;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyClaimableBalance", [
-  ["balanceId", xdr.lookup("ClaimableBalanceId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           PoolID liquidityPoolID;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyLiquidityPool", [
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           Hash contractID;
-//           SCVal key;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyContractData", [
-  ["contractId", xdr.lookup("Hash")],
-  ["key", xdr.lookup("ScVal")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           Hash hash;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyContractCode", [
-  ["hash", xdr.lookup("Hash")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           ConfigSettingID configSettingID;
-//       }
-//
-// ===========================================================================
-xdr.struct("LedgerKeyConfigSetting", [
-  ["configSettingId", xdr.lookup("ConfigSettingId")],
-]);
-
-// === xdr source ============================================================
-//
-//   union LedgerKey switch (LedgerEntryType type)
-//   {
-//   case ACCOUNT:
-//       struct
-//       {
-//           AccountID accountID;
-//       } account;
-//   
-//   case TRUSTLINE:
-//       struct
-//       {
-//           AccountID accountID;
-//           TrustLineAsset asset;
-//       } trustLine;
-//   
-//   case OFFER:
-//       struct
-//       {
-//           AccountID sellerID;
-//           int64 offerID;
-//       } offer;
-//   
-//   case DATA:
-//       struct
-//       {
-//           AccountID accountID;
-//           string64 dataName;
-//       } data;
-//   
-//   case CLAIMABLE_BALANCE:
-//       struct
-//       {
-//           ClaimableBalanceID balanceID;
-//       } claimableBalance;
-//   
-//   case LIQUIDITY_POOL:
-//       struct
-//       {
-//           PoolID liquidityPoolID;
-//       } liquidityPool;
-//   case CONTRACT_DATA:
-//       struct
-//       {
-//           Hash contractID;
-//           SCVal key;
-//       } contractData;
-//   case CONTRACT_CODE:
-//       struct
-//       {
-//           Hash hash;
-//       } contractCode;
-//   case CONFIG_SETTING:
-//       struct
-//       {
-//           ConfigSettingID configSettingID;
-//       } configSetting;
-//   };
-//
-// ===========================================================================
-xdr.union("LedgerKey", {
-  switchOn: xdr.lookup("LedgerEntryType"),
-  switchName: "type",
-  switches: [
-    ["account", "account"],
-    ["trustline", "trustLine"],
-    ["offer", "offer"],
-    ["data", "data"],
-    ["claimableBalance", "claimableBalance"],
-    ["liquidityPool", "liquidityPool"],
-    ["contractData", "contractData"],
-    ["contractCode", "contractCode"],
-    ["configSetting", "configSetting"],
-  ],
-  arms: {
-    account: xdr.lookup("LedgerKeyAccount"),
-    trustLine: xdr.lookup("LedgerKeyTrustLine"),
-    offer: xdr.lookup("LedgerKeyOffer"),
-    data: xdr.lookup("LedgerKeyData"),
-    claimableBalance: xdr.lookup("LedgerKeyClaimableBalance"),
-    liquidityPool: xdr.lookup("LedgerKeyLiquidityPool"),
-    contractData: xdr.lookup("LedgerKeyContractData"),
-    contractCode: xdr.lookup("LedgerKeyContractCode"),
-    configSetting: xdr.lookup("LedgerKeyConfigSetting"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum EnvelopeType
-//   {
-//       ENVELOPE_TYPE_TX_V0 = 0,
-//       ENVELOPE_TYPE_SCP = 1,
-//       ENVELOPE_TYPE_TX = 2,
-//       ENVELOPE_TYPE_AUTH = 3,
-//       ENVELOPE_TYPE_SCPVALUE = 4,
-//       ENVELOPE_TYPE_TX_FEE_BUMP = 5,
-//       ENVELOPE_TYPE_OP_ID = 6,
-//       ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7,
-//       ENVELOPE_TYPE_CONTRACT_ID_FROM_ED25519 = 8,
-//       ENVELOPE_TYPE_CONTRACT_ID_FROM_CONTRACT = 9,
-//       ENVELOPE_TYPE_CONTRACT_ID_FROM_ASSET = 10,
-//       ENVELOPE_TYPE_CONTRACT_ID_FROM_SOURCE_ACCOUNT = 11,
-//       ENVELOPE_TYPE_CREATE_CONTRACT_ARGS = 12,
-//       ENVELOPE_TYPE_CONTRACT_AUTH = 13
-//   };
-//
-// ===========================================================================
-xdr.enum("EnvelopeType", {
-  envelopeTypeTxV0: 0,
-  envelopeTypeScp: 1,
-  envelopeTypeTx: 2,
-  envelopeTypeAuth: 3,
-  envelopeTypeScpvalue: 4,
-  envelopeTypeTxFeeBump: 5,
-  envelopeTypeOpId: 6,
-  envelopeTypePoolRevokeOpId: 7,
-  envelopeTypeContractIdFromEd25519: 8,
-  envelopeTypeContractIdFromContract: 9,
-  envelopeTypeContractIdFromAsset: 10,
-  envelopeTypeContractIdFromSourceAccount: 11,
-  envelopeTypeCreateContractArgs: 12,
-  envelopeTypeContractAuth: 13,
-});
-
-// === xdr source ============================================================
-//
-//   typedef opaque UpgradeType<128>;
-//
-// ===========================================================================
-xdr.typedef("UpgradeType", xdr.varOpaque(128));
-
-// === xdr source ============================================================
-//
-//   enum StellarValueType
-//   {
-//       STELLAR_VALUE_BASIC = 0,
-//       STELLAR_VALUE_SIGNED = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("StellarValueType", {
-  stellarValueBasic: 0,
-  stellarValueSigned: 1,
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerCloseValueSignature
-//   {
-//       NodeID nodeID;       // which node introduced the value
-//       Signature signature; // nodeID's signature
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerCloseValueSignature", [
-  ["nodeId", xdr.lookup("NodeId")],
-  ["signature", xdr.lookup("Signature")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (StellarValueType v)
-//       {
-//       case STELLAR_VALUE_BASIC:
-//           void;
-//       case STELLAR_VALUE_SIGNED:
-//           LedgerCloseValueSignature lcValueSignature;
-//       }
-//
-// ===========================================================================
-xdr.union("StellarValueExt", {
-  switchOn: xdr.lookup("StellarValueType"),
-  switchName: "v",
-  switches: [
-    ["stellarValueBasic", xdr.void()],
-    ["stellarValueSigned", "lcValueSignature"],
-  ],
-  arms: {
-    lcValueSignature: xdr.lookup("LedgerCloseValueSignature"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct StellarValue
-//   {
-//       Hash txSetHash;      // transaction set to apply to previous ledger
-//       TimePoint closeTime; // network close time
-//   
-//       // upgrades to apply to the previous ledger (usually empty)
-//       // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
-//       // unknown steps during consensus if needed.
-//       // see notes below on 'LedgerUpgrade' for more detail
-//       // max size is dictated by number of upgrade types (+ room for future)
-//       UpgradeType upgrades<6>;
-//   
-//       // reserved for future use
-//       union switch (StellarValueType v)
-//       {
-//       case STELLAR_VALUE_BASIC:
-//           void;
-//       case STELLAR_VALUE_SIGNED:
-//           LedgerCloseValueSignature lcValueSignature;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("StellarValue", [
-  ["txSetHash", xdr.lookup("Hash")],
-  ["closeTime", xdr.lookup("TimePoint")],
-  ["upgrades", xdr.varArray(xdr.lookup("UpgradeType"), 6)],
-  ["ext", xdr.lookup("StellarValueExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   const MASK_LEDGER_HEADER_FLAGS = 0x7F;
-//
-// ===========================================================================
-xdr.const("MASK_LEDGER_HEADER_FLAGS", 0x7F);
-
-// === xdr source ============================================================
-//
-//   enum LedgerHeaderFlags
-//   {
-//       DISABLE_LIQUIDITY_POOL_TRADING_FLAG = 0x1,
-//       DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG = 0x2,
-//       DISABLE_LIQUIDITY_POOL_WITHDRAWAL_FLAG = 0x4,
-//       DISABLE_CONTRACT_CREATE = 0x8,
-//       DISABLE_CONTRACT_UPDATE = 0x10,
-//       DISABLE_CONTRACT_REMOVE = 0x20,
-//       DISABLE_CONTRACT_INVOKE = 0x40
-//   };
-//
-// ===========================================================================
-xdr.enum("LedgerHeaderFlags", {
-  disableLiquidityPoolTradingFlag: 1,
-  disableLiquidityPoolDepositFlag: 2,
-  disableLiquidityPoolWithdrawalFlag: 4,
-  disableContractCreate: 8,
-  disableContractUpdate: 16,
-  disableContractRemove: 32,
-  disableContractInvoke: 64,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerHeaderExtensionV1Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerHeaderExtensionV1
-//   {
-//       uint32 flags; // LedgerHeaderFlags
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerHeaderExtensionV1", [
-  ["flags", xdr.lookup("Uint32")],
-  ["ext", xdr.lookup("LedgerHeaderExtensionV1Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           LedgerHeaderExtensionV1 v1;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerHeaderExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("LedgerHeaderExtensionV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerHeader
-//   {
-//       uint32 ledgerVersion;    // the protocol version of the ledger
-//       Hash previousLedgerHash; // hash of the previous ledger header
-//       StellarValue scpValue;   // what consensus agreed to
-//       Hash txSetResultHash;    // the TransactionResultSet that led to this ledger
-//       Hash bucketListHash;     // hash of the ledger state
-//   
-//       uint32 ledgerSeq; // sequence number of this ledger
-//   
-//       int64 totalCoins; // total number of stroops in existence.
-//                         // 10,000,000 stroops in 1 XLM
-//   
-//       int64 feePool;       // fees burned since last inflation run
-//       uint32 inflationSeq; // inflation sequence number
-//   
-//       uint64 idPool; // last used global ID, used for generating objects
-//   
-//       uint32 baseFee;     // base fee per operation in stroops
-//       uint32 baseReserve; // account base reserve in stroops
-//   
-//       uint32 maxTxSetSize; // maximum size a transaction set can be
-//   
-//       Hash skipList[4]; // hashes of ledgers in the past. allows you to jump back
-//                         // in time without walking the chain back ledger by ledger
-//                         // each slot contains the oldest ledger that is mod of
-//                         // either 50  5000  50000 or 500000 depending on index
-//                         // skipList[0] mod(50), skipList[1] mod(5000), etc
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           LedgerHeaderExtensionV1 v1;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerHeader", [
-  ["ledgerVersion", xdr.lookup("Uint32")],
-  ["previousLedgerHash", xdr.lookup("Hash")],
-  ["scpValue", xdr.lookup("StellarValue")],
-  ["txSetResultHash", xdr.lookup("Hash")],
-  ["bucketListHash", xdr.lookup("Hash")],
-  ["ledgerSeq", xdr.lookup("Uint32")],
-  ["totalCoins", xdr.lookup("Int64")],
-  ["feePool", xdr.lookup("Int64")],
-  ["inflationSeq", xdr.lookup("Uint32")],
-  ["idPool", xdr.lookup("Uint64")],
-  ["baseFee", xdr.lookup("Uint32")],
-  ["baseReserve", xdr.lookup("Uint32")],
-  ["maxTxSetSize", xdr.lookup("Uint32")],
-  ["skipList", xdr.array(xdr.lookup("Hash"), 4)],
-  ["ext", xdr.lookup("LedgerHeaderExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum LedgerUpgradeType
-//   {
-//       LEDGER_UPGRADE_VERSION = 1,
-//       LEDGER_UPGRADE_BASE_FEE = 2,
-//       LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3,
-//       LEDGER_UPGRADE_BASE_RESERVE = 4,
-//       LEDGER_UPGRADE_FLAGS = 5,
-//       LEDGER_UPGRADE_CONFIG = 6
-//   };
-//
-// ===========================================================================
-xdr.enum("LedgerUpgradeType", {
-  ledgerUpgradeVersion: 1,
-  ledgerUpgradeBaseFee: 2,
-  ledgerUpgradeMaxTxSetSize: 3,
-  ledgerUpgradeBaseReserve: 4,
-  ledgerUpgradeFlags: 5,
-  ledgerUpgradeConfig: 6,
-});
-
-// === xdr source ============================================================
-//
-//   struct ConfigUpgradeSetKey {
-//       Hash contractID;
-//       Hash contentHash;
-//   };
-//
-// ===========================================================================
-xdr.struct("ConfigUpgradeSetKey", [
-  ["contractId", xdr.lookup("Hash")],
-  ["contentHash", xdr.lookup("Hash")],
-]);
-
-// === xdr source ============================================================
-//
-//   union LedgerUpgrade switch (LedgerUpgradeType type)
-//   {
-//   case LEDGER_UPGRADE_VERSION:
-//       uint32 newLedgerVersion; // update ledgerVersion
-//   case LEDGER_UPGRADE_BASE_FEE:
-//       uint32 newBaseFee; // update baseFee
-//   case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
-//       uint32 newMaxTxSetSize; // update maxTxSetSize
-//   case LEDGER_UPGRADE_BASE_RESERVE:
-//       uint32 newBaseReserve; // update baseReserve
-//   case LEDGER_UPGRADE_FLAGS:
-//       uint32 newFlags; // update flags
-//   case LEDGER_UPGRADE_CONFIG:
-//       ConfigUpgradeSetKey newConfig;
-//   };
-//
-// ===========================================================================
-xdr.union("LedgerUpgrade", {
-  switchOn: xdr.lookup("LedgerUpgradeType"),
-  switchName: "type",
-  switches: [
-    ["ledgerUpgradeVersion", "newLedgerVersion"],
-    ["ledgerUpgradeBaseFee", "newBaseFee"],
-    ["ledgerUpgradeMaxTxSetSize", "newMaxTxSetSize"],
-    ["ledgerUpgradeBaseReserve", "newBaseReserve"],
-    ["ledgerUpgradeFlags", "newFlags"],
-    ["ledgerUpgradeConfig", "newConfig"],
-  ],
-  arms: {
-    newLedgerVersion: xdr.lookup("Uint32"),
-    newBaseFee: xdr.lookup("Uint32"),
-    newMaxTxSetSize: xdr.lookup("Uint32"),
-    newBaseReserve: xdr.lookup("Uint32"),
-    newFlags: xdr.lookup("Uint32"),
-    newConfig: xdr.lookup("ConfigUpgradeSetKey"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ConfigUpgradeSet {
-//       ConfigSettingEntry updatedEntry<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ConfigUpgradeSet", [
-  ["updatedEntry", xdr.varArray(xdr.lookup("ConfigSettingEntry"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   enum BucketEntryType
-//   {
-//       METAENTRY =
-//           -1, // At-and-after protocol 11: bucket metadata, should come first.
-//       LIVEENTRY = 0, // Before protocol 11: created-or-updated;
-//                      // At-and-after protocol 11: only updated.
-//       DEADENTRY = 1,
-//       INITENTRY = 2 // At-and-after protocol 11: only created.
-//   };
-//
-// ===========================================================================
-xdr.enum("BucketEntryType", {
-  metaentry: -1,
-  liveentry: 0,
-  deadentry: 1,
-  initentry: 2,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("BucketMetadataExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct BucketMetadata
-//   {
-//       // Indicates the protocol version used to create / merge this bucket.
-//       uint32 ledgerVersion;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("BucketMetadata", [
-  ["ledgerVersion", xdr.lookup("Uint32")],
-  ["ext", xdr.lookup("BucketMetadataExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   union BucketEntry switch (BucketEntryType type)
-//   {
-//   case LIVEENTRY:
-//   case INITENTRY:
-//       LedgerEntry liveEntry;
-//   
-//   case DEADENTRY:
-//       LedgerKey deadEntry;
-//   case METAENTRY:
-//       BucketMetadata metaEntry;
-//   };
-//
-// ===========================================================================
-xdr.union("BucketEntry", {
-  switchOn: xdr.lookup("BucketEntryType"),
-  switchName: "type",
-  switches: [
-    ["liveentry", "liveEntry"],
-    ["initentry", "liveEntry"],
-    ["deadentry", "deadEntry"],
-    ["metaentry", "metaEntry"],
-  ],
-  arms: {
-    liveEntry: xdr.lookup("LedgerEntry"),
-    deadEntry: xdr.lookup("LedgerKey"),
-    metaEntry: xdr.lookup("BucketMetadata"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum TxSetComponentType
-//   {
-//     // txs with effective fee <= bid derived from a base fee (if any).
-//     // If base fee is not specified, no discount is applied.
-//     TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("TxSetComponentType", {
-  txsetCompTxsMaybeDiscountedFee: 0,
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//     {
-//       int64* baseFee;
-//       TransactionEnvelope txs<>;
-//     }
-//
-// ===========================================================================
-xdr.struct("TxSetComponentTxsMaybeDiscountedFee", [
-  ["baseFee", xdr.option(xdr.lookup("Int64"))],
-  ["txes", xdr.varArray(xdr.lookup("TransactionEnvelope"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union TxSetComponent switch (TxSetComponentType type)
-//   {
-//   case TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE:
-//     struct
-//     {
-//       int64* baseFee;
-//       TransactionEnvelope txs<>;
-//     } txsMaybeDiscountedFee;
-//   };
-//
-// ===========================================================================
-xdr.union("TxSetComponent", {
-  switchOn: xdr.lookup("TxSetComponentType"),
-  switchName: "type",
-  switches: [
-    ["txsetCompTxsMaybeDiscountedFee", "txsMaybeDiscountedFee"],
-  ],
-  arms: {
-    txsMaybeDiscountedFee: xdr.lookup("TxSetComponentTxsMaybeDiscountedFee"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union TransactionPhase switch (int v)
-//   {
-//   case 0:
-//       TxSetComponent v0Components<>;
-//   };
-//
-// ===========================================================================
-xdr.union("TransactionPhase", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, "v0Components"],
-  ],
-  arms: {
-    v0Components: xdr.varArray(xdr.lookup("TxSetComponent"), 2147483647),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionSet
-//   {
-//       Hash previousLedgerHash;
-//       TransactionEnvelope txs<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionSet", [
-  ["previousLedgerHash", xdr.lookup("Hash")],
-  ["txes", xdr.varArray(xdr.lookup("TransactionEnvelope"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionSetV1
-//   {
-//       Hash previousLedgerHash;
-//       TransactionPhase phases<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionSetV1", [
-  ["previousLedgerHash", xdr.lookup("Hash")],
-  ["phases", xdr.varArray(xdr.lookup("TransactionPhase"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union GeneralizedTransactionSet switch (int v)
-//   {
-//   // We consider the legacy TransactionSet to be v0.
-//   case 1:
-//       TransactionSetV1 v1TxSet;
-//   };
-//
-// ===========================================================================
-xdr.union("GeneralizedTransactionSet", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [1, "v1TxSet"],
-  ],
-  arms: {
-    v1TxSet: xdr.lookup("TransactionSetV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionResultPair
-//   {
-//       Hash transactionHash;
-//       TransactionResult result; // result for the transaction
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResultPair", [
-  ["transactionHash", xdr.lookup("Hash")],
-  ["result", xdr.lookup("TransactionResult")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionResultSet
-//   {
-//       TransactionResultPair results<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResultSet", [
-  ["results", xdr.varArray(xdr.lookup("TransactionResultPair"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           GeneralizedTransactionSet generalizedTxSet;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionHistoryEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-    [1, "generalizedTxSet"],
-  ],
-  arms: {
-    generalizedTxSet: xdr.lookup("GeneralizedTransactionSet"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionHistoryEntry
-//   {
-//       uint32 ledgerSeq;
-//       TransactionSet txSet;
-//   
-//       // when v != 0, txSet must be empty
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       case 1:
-//           GeneralizedTransactionSet generalizedTxSet;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionHistoryEntry", [
-  ["ledgerSeq", xdr.lookup("Uint32")],
-  ["txSet", xdr.lookup("TransactionSet")],
-  ["ext", xdr.lookup("TransactionHistoryEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionHistoryResultEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionHistoryResultEntry
-//   {
-//       uint32 ledgerSeq;
-//       TransactionResultSet txResultSet;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionHistoryResultEntry", [
-  ["ledgerSeq", xdr.lookup("Uint32")],
-  ["txResultSet", xdr.lookup("TransactionResultSet")],
-  ["ext", xdr.lookup("TransactionHistoryResultEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionResultPairV2
-//   {
-//       Hash transactionHash;
-//       Hash hashOfMetaHashes; // hash of hashes in TransactionMetaV3
-//                              // TransactionResult is in the meta
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResultPairV2", [
-  ["transactionHash", xdr.lookup("Hash")],
-  ["hashOfMetaHashes", xdr.lookup("Hash")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionResultSetV2
-//   {
-//       TransactionResultPairV2 results<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResultSetV2", [
-  ["results", xdr.varArray(xdr.lookup("TransactionResultPairV2"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionHistoryResultEntryV2Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionHistoryResultEntryV2
-//   {
-//       uint32 ledgerSeq;
-//       TransactionResultSetV2 txResultSet;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionHistoryResultEntryV2", [
-  ["ledgerSeq", xdr.lookup("Uint32")],
-  ["txResultSet", xdr.lookup("TransactionResultSetV2")],
-  ["ext", xdr.lookup("TransactionHistoryResultEntryV2Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("LedgerHeaderHistoryEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct LedgerHeaderHistoryEntry
-//   {
-//       Hash hash;
-//       LedgerHeader header;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerHeaderHistoryEntry", [
-  ["hash", xdr.lookup("Hash")],
-  ["header", xdr.lookup("LedgerHeader")],
-  ["ext", xdr.lookup("LedgerHeaderHistoryEntryExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LedgerSCPMessages
-//   {
-//       uint32 ledgerSeq;
-//       SCPEnvelope messages<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerScpMessages", [
-  ["ledgerSeq", xdr.lookup("Uint32")],
-  ["messages", xdr.varArray(xdr.lookup("ScpEnvelope"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCPHistoryEntryV0
-//   {
-//       SCPQuorumSet quorumSets<>; // additional quorum sets used by ledgerMessages
-//       LedgerSCPMessages ledgerMessages;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScpHistoryEntryV0", [
-  ["quorumSets", xdr.varArray(xdr.lookup("ScpQuorumSet"), 2147483647)],
-  ["ledgerMessages", xdr.lookup("LedgerScpMessages")],
-]);
-
-// === xdr source ============================================================
-//
-//   union SCPHistoryEntry switch (int v)
-//   {
-//   case 0:
-//       SCPHistoryEntryV0 v0;
-//   };
-//
-// ===========================================================================
-xdr.union("ScpHistoryEntry", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, "v0"],
-  ],
-  arms: {
-    v0: xdr.lookup("ScpHistoryEntryV0"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum LedgerEntryChangeType
-//   {
-//       LEDGER_ENTRY_CREATED = 0, // entry was added to the ledger
-//       LEDGER_ENTRY_UPDATED = 1, // entry was modified in the ledger
-//       LEDGER_ENTRY_REMOVED = 2, // entry was removed from the ledger
-//       LEDGER_ENTRY_STATE = 3    // value of the entry
-//   };
-//
-// ===========================================================================
-xdr.enum("LedgerEntryChangeType", {
-  ledgerEntryCreated: 0,
-  ledgerEntryUpdated: 1,
-  ledgerEntryRemoved: 2,
-  ledgerEntryState: 3,
-});
-
-// === xdr source ============================================================
-//
-//   union LedgerEntryChange switch (LedgerEntryChangeType type)
-//   {
-//   case LEDGER_ENTRY_CREATED:
-//       LedgerEntry created;
-//   case LEDGER_ENTRY_UPDATED:
-//       LedgerEntry updated;
-//   case LEDGER_ENTRY_REMOVED:
-//       LedgerKey removed;
-//   case LEDGER_ENTRY_STATE:
-//       LedgerEntry state;
-//   };
-//
-// ===========================================================================
-xdr.union("LedgerEntryChange", {
-  switchOn: xdr.lookup("LedgerEntryChangeType"),
-  switchName: "type",
-  switches: [
-    ["ledgerEntryCreated", "created"],
-    ["ledgerEntryUpdated", "updated"],
-    ["ledgerEntryRemoved", "removed"],
-    ["ledgerEntryState", "state"],
-  ],
-  arms: {
-    created: xdr.lookup("LedgerEntry"),
-    updated: xdr.lookup("LedgerEntry"),
-    removed: xdr.lookup("LedgerKey"),
-    state: xdr.lookup("LedgerEntry"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   typedef LedgerEntryChange LedgerEntryChanges<>;
-//
-// ===========================================================================
-xdr.typedef("LedgerEntryChanges", xdr.varArray(xdr.lookup("LedgerEntryChange"), 2147483647));
-
-// === xdr source ============================================================
-//
-//   struct OperationMeta
-//   {
-//       LedgerEntryChanges changes;
-//   };
-//
-// ===========================================================================
-xdr.struct("OperationMeta", [
-  ["changes", xdr.lookup("LedgerEntryChanges")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionMetaV1
-//   {
-//       LedgerEntryChanges txChanges; // tx level changes if any
-//       OperationMeta operations<>;   // meta for each operation
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionMetaV1", [
-  ["txChanges", xdr.lookup("LedgerEntryChanges")],
-  ["operations", xdr.varArray(xdr.lookup("OperationMeta"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionMetaV2
-//   {
-//       LedgerEntryChanges txChangesBefore; // tx level changes before operations
-//                                           // are applied if any
-//       OperationMeta operations<>;         // meta for each operation
-//       LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
-//                                           // applied if any
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionMetaV2", [
-  ["txChangesBefore", xdr.lookup("LedgerEntryChanges")],
-  ["operations", xdr.varArray(xdr.lookup("OperationMeta"), 2147483647)],
-  ["txChangesAfter", xdr.lookup("LedgerEntryChanges")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum ContractEventType
-//   {
-//       SYSTEM = 0,
-//       CONTRACT = 1,
-//       DIAGNOSTIC = 2
-//   };
-//
-// ===========================================================================
-xdr.enum("ContractEventType", {
-  system: 0,
-  contract: 1,
-  diagnostic: 2,
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//           {
-//               SCVec topics;
-//               SCVal data;
-//           }
-//
-// ===========================================================================
-xdr.struct("ContractEventV0", [
-  ["topics", xdr.lookup("ScVec")],
-  ["data", xdr.lookup("ScVal")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           struct
-//           {
-//               SCVec topics;
-//               SCVal data;
-//           } v0;
-//       }
-//
-// ===========================================================================
-xdr.union("ContractEventBody", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, "v0"],
-  ],
-  arms: {
-    v0: xdr.lookup("ContractEventV0"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ContractEvent
-//   {
-//       // We can use this to add more fields, or because it
-//       // is first, to change ContractEvent into a union.
-//       ExtensionPoint ext;
-//   
-//       Hash* contractID;
-//       ContractEventType type;
-//   
-//       union switch (int v)
-//       {
-//       case 0:
-//           struct
-//           {
-//               SCVec topics;
-//               SCVal data;
-//           } v0;
-//       }
-//       body;
-//   };
-//
-// ===========================================================================
-xdr.struct("ContractEvent", [
-  ["ext", xdr.lookup("ExtensionPoint")],
-  ["contractId", xdr.option(xdr.lookup("Hash"))],
-  ["type", xdr.lookup("ContractEventType")],
-  ["body", xdr.lookup("ContractEventBody")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct DiagnosticEvent
-//   {
-//       bool inSuccessfulContractCall;
-//       ContractEvent event;
-//   };
-//
-// ===========================================================================
-xdr.struct("DiagnosticEvent", [
-  ["inSuccessfulContractCall", xdr.bool()],
-  ["event", xdr.lookup("ContractEvent")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct OperationDiagnosticEvents
-//   {
-//       DiagnosticEvent events<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("OperationDiagnosticEvents", [
-  ["events", xdr.varArray(xdr.lookup("DiagnosticEvent"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct OperationEvents
-//   {
-//       ContractEvent events<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("OperationEvents", [
-  ["events", xdr.varArray(xdr.lookup("ContractEvent"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionMetaV3
-//   {
-//       LedgerEntryChanges txChangesBefore; // tx level changes before operations
-//                                           // are applied if any
-//       OperationMeta operations<>;         // meta for each operation
-//       LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
-//                                           // applied if any
-//       OperationEvents events<>;           // custom events populated by the
-//                                           // contracts themselves. One list per operation.
-//       TransactionResult txResult;
-//   
-//       Hash hashes[3];                     // stores sha256(txChangesBefore, operations, txChangesAfter),
-//                                           // sha256(events), and sha256(txResult)
-//   
-//       // Diagnostics events that are not hashed. One list per operation.
-//       // This will contain all contract and diagnostic events. Even ones
-//       // that were emitted in a failed contract call.
-//       OperationDiagnosticEvents diagnosticEvents<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionMetaV3", [
-  ["txChangesBefore", xdr.lookup("LedgerEntryChanges")],
-  ["operations", xdr.varArray(xdr.lookup("OperationMeta"), 2147483647)],
-  ["txChangesAfter", xdr.lookup("LedgerEntryChanges")],
-  ["events", xdr.varArray(xdr.lookup("OperationEvents"), 2147483647)],
-  ["txResult", xdr.lookup("TransactionResult")],
-  ["hashes", xdr.array(xdr.lookup("Hash"), 3)],
-  ["diagnosticEvents", xdr.varArray(xdr.lookup("OperationDiagnosticEvents"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union TransactionMeta switch (int v)
-//   {
-//   case 0:
-//       OperationMeta operations<>;
-//   case 1:
-//       TransactionMetaV1 v1;
-//   case 2:
-//       TransactionMetaV2 v2;
-//   case 3:
-//       TransactionMetaV3 v3;
-//   };
-//
-// ===========================================================================
-xdr.union("TransactionMeta", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, "operations"],
-    [1, "v1"],
-    [2, "v2"],
-    [3, "v3"],
-  ],
-  arms: {
-    operations: xdr.varArray(xdr.lookup("OperationMeta"), 2147483647),
-    v1: xdr.lookup("TransactionMetaV1"),
-    v2: xdr.lookup("TransactionMetaV2"),
-    v3: xdr.lookup("TransactionMetaV3"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionResultMeta
-//   {
-//       TransactionResultPair result;
-//       LedgerEntryChanges feeProcessing;
-//       TransactionMeta txApplyProcessing;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResultMeta", [
-  ["result", xdr.lookup("TransactionResultPair")],
-  ["feeProcessing", xdr.lookup("LedgerEntryChanges")],
-  ["txApplyProcessing", xdr.lookup("TransactionMeta")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionResultMetaV2
-//   {
-//       TransactionResultPairV2 result;
-//       LedgerEntryChanges feeProcessing;
-//       TransactionMeta txApplyProcessing;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResultMetaV2", [
-  ["result", xdr.lookup("TransactionResultPairV2")],
-  ["feeProcessing", xdr.lookup("LedgerEntryChanges")],
-  ["txApplyProcessing", xdr.lookup("TransactionMeta")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct UpgradeEntryMeta
-//   {
-//       LedgerUpgrade upgrade;
-//       LedgerEntryChanges changes;
-//   };
-//
-// ===========================================================================
-xdr.struct("UpgradeEntryMeta", [
-  ["upgrade", xdr.lookup("LedgerUpgrade")],
-  ["changes", xdr.lookup("LedgerEntryChanges")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LedgerCloseMetaV0
-//   {
-//       LedgerHeaderHistoryEntry ledgerHeader;
-//       // NB: txSet is sorted in "Hash order"
-//       TransactionSet txSet;
-//   
-//       // NB: transactions are sorted in apply order here
-//       // fees for all transactions are processed first
-//       // followed by applying transactions
-//       TransactionResultMeta txProcessing<>;
-//   
-//       // upgrades are applied last
-//       UpgradeEntryMeta upgradesProcessing<>;
-//   
-//       // other misc information attached to the ledger close
-//       SCPHistoryEntry scpInfo<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerCloseMetaV0", [
-  ["ledgerHeader", xdr.lookup("LedgerHeaderHistoryEntry")],
-  ["txSet", xdr.lookup("TransactionSet")],
-  ["txProcessing", xdr.varArray(xdr.lookup("TransactionResultMeta"), 2147483647)],
-  ["upgradesProcessing", xdr.varArray(xdr.lookup("UpgradeEntryMeta"), 2147483647)],
-  ["scpInfo", xdr.varArray(xdr.lookup("ScpHistoryEntry"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LedgerCloseMetaV1
-//   {
-//       LedgerHeaderHistoryEntry ledgerHeader;
-//   
-//       GeneralizedTransactionSet txSet;
-//   
-//       // NB: transactions are sorted in apply order here
-//       // fees for all transactions are processed first
-//       // followed by applying transactions
-//       TransactionResultMeta txProcessing<>;
-//   
-//       // upgrades are applied last
-//       UpgradeEntryMeta upgradesProcessing<>;
-//   
-//       // other misc information attached to the ledger close
-//       SCPHistoryEntry scpInfo<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerCloseMetaV1", [
-  ["ledgerHeader", xdr.lookup("LedgerHeaderHistoryEntry")],
-  ["txSet", xdr.lookup("GeneralizedTransactionSet")],
-  ["txProcessing", xdr.varArray(xdr.lookup("TransactionResultMeta"), 2147483647)],
-  ["upgradesProcessing", xdr.varArray(xdr.lookup("UpgradeEntryMeta"), 2147483647)],
-  ["scpInfo", xdr.varArray(xdr.lookup("ScpHistoryEntry"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LedgerCloseMetaV2
-//   {
-//       LedgerHeaderHistoryEntry ledgerHeader;
-//       
-//       GeneralizedTransactionSet txSet;
-//   
-//       // NB: transactions are sorted in apply order here
-//       // fees for all transactions are processed first
-//       // followed by applying transactions
-//       TransactionResultMetaV2 txProcessing<>;
-//   
-//       // upgrades are applied last
-//       UpgradeEntryMeta upgradesProcessing<>;
-//   
-//       // other misc information attached to the ledger close
-//       SCPHistoryEntry scpInfo<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerCloseMetaV2", [
-  ["ledgerHeader", xdr.lookup("LedgerHeaderHistoryEntry")],
-  ["txSet", xdr.lookup("GeneralizedTransactionSet")],
-  ["txProcessing", xdr.varArray(xdr.lookup("TransactionResultMetaV2"), 2147483647)],
-  ["upgradesProcessing", xdr.varArray(xdr.lookup("UpgradeEntryMeta"), 2147483647)],
-  ["scpInfo", xdr.varArray(xdr.lookup("ScpHistoryEntry"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union LedgerCloseMeta switch (int v)
-//   {
-//   case 0:
-//       LedgerCloseMetaV0 v0;
-//   case 1:
-//       LedgerCloseMetaV1 v1;
-//   case 2:
-//       LedgerCloseMetaV2 v2;
-//   };
-//
-// ===========================================================================
-xdr.union("LedgerCloseMeta", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, "v0"],
-    [1, "v1"],
-    [2, "v2"],
-  ],
-  arms: {
-    v0: xdr.lookup("LedgerCloseMetaV0"),
-    v1: xdr.lookup("LedgerCloseMetaV1"),
-    v2: xdr.lookup("LedgerCloseMetaV2"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ErrorCode
-//   {
-//       ERR_MISC = 0, // Unspecific error
-//       ERR_DATA = 1, // Malformed data
-//       ERR_CONF = 2, // Misconfiguration error
-//       ERR_AUTH = 3, // Authentication failure
-//       ERR_LOAD = 4  // System overloaded
-//   };
-//
-// ===========================================================================
-xdr.enum("ErrorCode", {
-  errMisc: 0,
-  errData: 1,
-  errConf: 2,
-  errAuth: 3,
-  errLoad: 4,
-});
-
-// === xdr source ============================================================
-//
-//   struct Error
-//   {
-//       ErrorCode code;
-//       string msg<100>;
-//   };
-//
-// ===========================================================================
-xdr.struct("Error", [
-  ["code", xdr.lookup("ErrorCode")],
-  ["msg", xdr.string(100)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SendMore
-//   {
-//       uint32 numMessages;
-//   };
-//
-// ===========================================================================
-xdr.struct("SendMore", [
-  ["numMessages", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct AuthCert
-//   {
-//       Curve25519Public pubkey;
-//       uint64 expiration;
-//       Signature sig;
-//   };
-//
-// ===========================================================================
-xdr.struct("AuthCert", [
-  ["pubkey", xdr.lookup("Curve25519Public")],
-  ["expiration", xdr.lookup("Uint64")],
-  ["sig", xdr.lookup("Signature")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct Hello
-//   {
-//       uint32 ledgerVersion;
-//       uint32 overlayVersion;
-//       uint32 overlayMinVersion;
-//       Hash networkID;
-//       string versionStr<100>;
-//       int listeningPort;
-//       NodeID peerID;
-//       AuthCert cert;
-//       uint256 nonce;
-//   };
-//
-// ===========================================================================
-xdr.struct("Hello", [
-  ["ledgerVersion", xdr.lookup("Uint32")],
-  ["overlayVersion", xdr.lookup("Uint32")],
-  ["overlayMinVersion", xdr.lookup("Uint32")],
-  ["networkId", xdr.lookup("Hash")],
-  ["versionStr", xdr.string(100)],
-  ["listeningPort", xdr.int()],
-  ["peerId", xdr.lookup("NodeId")],
-  ["cert", xdr.lookup("AuthCert")],
-  ["nonce", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   const AUTH_MSG_FLAG_PULL_MODE_REQUESTED = 100;
-//
-// ===========================================================================
-xdr.const("AUTH_MSG_FLAG_PULL_MODE_REQUESTED", 100);
-
-// === xdr source ============================================================
-//
-//   struct Auth
-//   {
-//       int flags;
-//   };
-//
-// ===========================================================================
-xdr.struct("Auth", [
-  ["flags", xdr.int()],
-]);
-
-// === xdr source ============================================================
-//
-//   enum IPAddrType
-//   {
-//       IPv4 = 0,
-//       IPv6 = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("IpAddrType", {
-  iPv4: 0,
-  iPv6: 1,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (IPAddrType type)
-//       {
-//       case IPv4:
-//           opaque ipv4[4];
-//       case IPv6:
-//           opaque ipv6[16];
-//       }
-//
-// ===========================================================================
-xdr.union("PeerAddressIp", {
-  switchOn: xdr.lookup("IpAddrType"),
-  switchName: "type",
-  switches: [
-    ["iPv4", "ipv4"],
-    ["iPv6", "ipv6"],
-  ],
-  arms: {
-    ipv4: xdr.opaque(4),
-    ipv6: xdr.opaque(16),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct PeerAddress
-//   {
-//       union switch (IPAddrType type)
-//       {
-//       case IPv4:
-//           opaque ipv4[4];
-//       case IPv6:
-//           opaque ipv6[16];
-//       }
-//       ip;
-//       uint32 port;
-//       uint32 numFailures;
-//   };
-//
-// ===========================================================================
-xdr.struct("PeerAddress", [
-  ["ip", xdr.lookup("PeerAddressIp")],
-  ["port", xdr.lookup("Uint32")],
-  ["numFailures", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum MessageType
-//   {
-//       ERROR_MSG = 0,
-//       AUTH = 2,
-//       DONT_HAVE = 3,
-//   
-//       GET_PEERS = 4, // gets a list of peers this guy knows about
-//       PEERS = 5,
-//   
-//       GET_TX_SET = 6, // gets a particular txset by hash
-//       TX_SET = 7,
-//       GENERALIZED_TX_SET = 17,
-//   
-//       TRANSACTION = 8, // pass on a tx you have heard about
-//   
-//       // SCP
-//       GET_SCP_QUORUMSET = 9,
-//       SCP_QUORUMSET = 10,
-//       SCP_MESSAGE = 11,
-//       GET_SCP_STATE = 12,
-//   
-//       // new messages
-//       HELLO = 13,
-//   
-//       SURVEY_REQUEST = 14,
-//       SURVEY_RESPONSE = 15,
-//   
-//       SEND_MORE = 16,
-//       FLOOD_ADVERT = 18,
-//       FLOOD_DEMAND = 19
-//   };
-//
-// ===========================================================================
-xdr.enum("MessageType", {
-  errorMsg: 0,
-  auth: 2,
-  dontHave: 3,
-  getPeers: 4,
-  peers: 5,
-  getTxSet: 6,
-  txSet: 7,
-  generalizedTxSet: 17,
-  transaction: 8,
-  getScpQuorumset: 9,
-  scpQuorumset: 10,
-  scpMessage: 11,
-  getScpState: 12,
-  hello: 13,
-  surveyRequest: 14,
-  surveyResponse: 15,
-  sendMore: 16,
-  floodAdvert: 18,
-  floodDemand: 19,
-});
-
-// === xdr source ============================================================
-//
-//   struct DontHave
-//   {
-//       MessageType type;
-//       uint256 reqHash;
-//   };
-//
-// ===========================================================================
-xdr.struct("DontHave", [
-  ["type", xdr.lookup("MessageType")],
-  ["reqHash", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum SurveyMessageCommandType
-//   {
-//       SURVEY_TOPOLOGY = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("SurveyMessageCommandType", {
-  surveyTopology: 0,
-});
-
-// === xdr source ============================================================
-//
-//   enum SurveyMessageResponseType
-//   {
-//       SURVEY_TOPOLOGY_RESPONSE_V0 = 0,
-//       SURVEY_TOPOLOGY_RESPONSE_V1 = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("SurveyMessageResponseType", {
-  surveyTopologyResponseV0: 0,
-  surveyTopologyResponseV1: 1,
-});
-
-// === xdr source ============================================================
-//
-//   struct SurveyRequestMessage
-//   {
-//       NodeID surveyorPeerID;
-//       NodeID surveyedPeerID;
-//       uint32 ledgerNum;
-//       Curve25519Public encryptionKey;
-//       SurveyMessageCommandType commandType;
-//   };
-//
-// ===========================================================================
-xdr.struct("SurveyRequestMessage", [
-  ["surveyorPeerId", xdr.lookup("NodeId")],
-  ["surveyedPeerId", xdr.lookup("NodeId")],
-  ["ledgerNum", xdr.lookup("Uint32")],
-  ["encryptionKey", xdr.lookup("Curve25519Public")],
-  ["commandType", xdr.lookup("SurveyMessageCommandType")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SignedSurveyRequestMessage
-//   {
-//       Signature requestSignature;
-//       SurveyRequestMessage request;
-//   };
-//
-// ===========================================================================
-xdr.struct("SignedSurveyRequestMessage", [
-  ["requestSignature", xdr.lookup("Signature")],
-  ["request", xdr.lookup("SurveyRequestMessage")],
-]);
-
-// === xdr source ============================================================
-//
-//   typedef opaque EncryptedBody<64000>;
-//
-// ===========================================================================
-xdr.typedef("EncryptedBody", xdr.varOpaque(64000));
-
-// === xdr source ============================================================
-//
-//   struct SurveyResponseMessage
-//   {
-//       NodeID surveyorPeerID;
-//       NodeID surveyedPeerID;
-//       uint32 ledgerNum;
-//       SurveyMessageCommandType commandType;
-//       EncryptedBody encryptedBody;
-//   };
-//
-// ===========================================================================
-xdr.struct("SurveyResponseMessage", [
-  ["surveyorPeerId", xdr.lookup("NodeId")],
-  ["surveyedPeerId", xdr.lookup("NodeId")],
-  ["ledgerNum", xdr.lookup("Uint32")],
-  ["commandType", xdr.lookup("SurveyMessageCommandType")],
-  ["encryptedBody", xdr.lookup("EncryptedBody")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SignedSurveyResponseMessage
-//   {
-//       Signature responseSignature;
-//       SurveyResponseMessage response;
-//   };
-//
-// ===========================================================================
-xdr.struct("SignedSurveyResponseMessage", [
-  ["responseSignature", xdr.lookup("Signature")],
-  ["response", xdr.lookup("SurveyResponseMessage")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct PeerStats
-//   {
-//       NodeID id;
-//       string versionStr<100>;
-//       uint64 messagesRead;
-//       uint64 messagesWritten;
-//       uint64 bytesRead;
-//       uint64 bytesWritten;
-//       uint64 secondsConnected;
-//   
-//       uint64 uniqueFloodBytesRecv;
-//       uint64 duplicateFloodBytesRecv;
-//       uint64 uniqueFetchBytesRecv;
-//       uint64 duplicateFetchBytesRecv;
-//   
-//       uint64 uniqueFloodMessageRecv;
-//       uint64 duplicateFloodMessageRecv;
-//       uint64 uniqueFetchMessageRecv;
-//       uint64 duplicateFetchMessageRecv;
-//   };
-//
-// ===========================================================================
-xdr.struct("PeerStats", [
-  ["id", xdr.lookup("NodeId")],
-  ["versionStr", xdr.string(100)],
-  ["messagesRead", xdr.lookup("Uint64")],
-  ["messagesWritten", xdr.lookup("Uint64")],
-  ["bytesRead", xdr.lookup("Uint64")],
-  ["bytesWritten", xdr.lookup("Uint64")],
-  ["secondsConnected", xdr.lookup("Uint64")],
-  ["uniqueFloodBytesRecv", xdr.lookup("Uint64")],
-  ["duplicateFloodBytesRecv", xdr.lookup("Uint64")],
-  ["uniqueFetchBytesRecv", xdr.lookup("Uint64")],
-  ["duplicateFetchBytesRecv", xdr.lookup("Uint64")],
-  ["uniqueFloodMessageRecv", xdr.lookup("Uint64")],
-  ["duplicateFloodMessageRecv", xdr.lookup("Uint64")],
-  ["uniqueFetchMessageRecv", xdr.lookup("Uint64")],
-  ["duplicateFetchMessageRecv", xdr.lookup("Uint64")],
-]);
-
-// === xdr source ============================================================
-//
-//   typedef PeerStats PeerStatList<25>;
-//
-// ===========================================================================
-xdr.typedef("PeerStatList", xdr.varArray(xdr.lookup("PeerStats"), 25));
-
-// === xdr source ============================================================
-//
-//   struct TopologyResponseBodyV0
-//   {
-//       PeerStatList inboundPeers;
-//       PeerStatList outboundPeers;
-//   
-//       uint32 totalInboundPeerCount;
-//       uint32 totalOutboundPeerCount;
-//   };
-//
-// ===========================================================================
-xdr.struct("TopologyResponseBodyV0", [
-  ["inboundPeers", xdr.lookup("PeerStatList")],
-  ["outboundPeers", xdr.lookup("PeerStatList")],
-  ["totalInboundPeerCount", xdr.lookup("Uint32")],
-  ["totalOutboundPeerCount", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TopologyResponseBodyV1
-//   {
-//       PeerStatList inboundPeers;
-//       PeerStatList outboundPeers;
-//   
-//       uint32 totalInboundPeerCount;
-//       uint32 totalOutboundPeerCount;
-//   
-//       uint32 maxInboundPeerCount;
-//       uint32 maxOutboundPeerCount;
-//   };
-//
-// ===========================================================================
-xdr.struct("TopologyResponseBodyV1", [
-  ["inboundPeers", xdr.lookup("PeerStatList")],
-  ["outboundPeers", xdr.lookup("PeerStatList")],
-  ["totalInboundPeerCount", xdr.lookup("Uint32")],
-  ["totalOutboundPeerCount", xdr.lookup("Uint32")],
-  ["maxInboundPeerCount", xdr.lookup("Uint32")],
-  ["maxOutboundPeerCount", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   union SurveyResponseBody switch (SurveyMessageResponseType type)
-//   {
-//   case SURVEY_TOPOLOGY_RESPONSE_V0:
-//       TopologyResponseBodyV0 topologyResponseBodyV0;
-//   case SURVEY_TOPOLOGY_RESPONSE_V1:
-//       TopologyResponseBodyV1 topologyResponseBodyV1;
-//   };
-//
-// ===========================================================================
-xdr.union("SurveyResponseBody", {
-  switchOn: xdr.lookup("SurveyMessageResponseType"),
-  switchName: "type",
-  switches: [
-    ["surveyTopologyResponseV0", "topologyResponseBodyV0"],
-    ["surveyTopologyResponseV1", "topologyResponseBodyV1"],
-  ],
-  arms: {
-    topologyResponseBodyV0: xdr.lookup("TopologyResponseBodyV0"),
-    topologyResponseBodyV1: xdr.lookup("TopologyResponseBodyV1"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
-//
-// ===========================================================================
-xdr.const("TX_ADVERT_VECTOR_MAX_SIZE", 1000);
-
-// === xdr source ============================================================
-//
-//   typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
-//
-// ===========================================================================
-xdr.typedef("TxAdvertVector", xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_ADVERT_VECTOR_MAX_SIZE")));
-
-// === xdr source ============================================================
-//
-//   struct FloodAdvert
-//   {
-//       TxAdvertVector txHashes;
-//   };
-//
-// ===========================================================================
-xdr.struct("FloodAdvert", [
-  ["txHashes", xdr.lookup("TxAdvertVector")],
-]);
-
-// === xdr source ============================================================
-//
-//   const TX_DEMAND_VECTOR_MAX_SIZE = 1000;
-//
-// ===========================================================================
-xdr.const("TX_DEMAND_VECTOR_MAX_SIZE", 1000);
-
-// === xdr source ============================================================
-//
-//   typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
-//
-// ===========================================================================
-xdr.typedef("TxDemandVector", xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_DEMAND_VECTOR_MAX_SIZE")));
-
-// === xdr source ============================================================
-//
-//   struct FloodDemand
-//   {
-//       TxDemandVector txHashes;
-//   };
-//
-// ===========================================================================
-xdr.struct("FloodDemand", [
-  ["txHashes", xdr.lookup("TxDemandVector")],
-]);
-
-// === xdr source ============================================================
-//
-//   union StellarMessage switch (MessageType type)
-//   {
-//   case ERROR_MSG:
-//       Error error;
-//   case HELLO:
-//       Hello hello;
-//   case AUTH:
-//       Auth auth;
-//   case DONT_HAVE:
-//       DontHave dontHave;
-//   case GET_PEERS:
-//       void;
-//   case PEERS:
-//       PeerAddress peers<100>;
-//   
-//   case GET_TX_SET:
-//       uint256 txSetHash;
-//   case TX_SET:
-//       TransactionSet txSet;
-//   case GENERALIZED_TX_SET:
-//       GeneralizedTransactionSet generalizedTxSet;
-//   
-//   case TRANSACTION:
-//       TransactionEnvelope transaction;
-//   
-//   case SURVEY_REQUEST:
-//       SignedSurveyRequestMessage signedSurveyRequestMessage;
-//   
-//   case SURVEY_RESPONSE:
-//       SignedSurveyResponseMessage signedSurveyResponseMessage;
-//   
-//   // SCP
-//   case GET_SCP_QUORUMSET:
-//       uint256 qSetHash;
-//   case SCP_QUORUMSET:
-//       SCPQuorumSet qSet;
-//   case SCP_MESSAGE:
-//       SCPEnvelope envelope;
-//   case GET_SCP_STATE:
-//       uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
-//   case SEND_MORE:
-//       SendMore sendMoreMessage;
-//   
-//   // Pull mode
-//   case FLOOD_ADVERT:
-//        FloodAdvert floodAdvert;
-//   case FLOOD_DEMAND:
-//        FloodDemand floodDemand;
-//   };
-//
-// ===========================================================================
-xdr.union("StellarMessage", {
-  switchOn: xdr.lookup("MessageType"),
-  switchName: "type",
-  switches: [
-    ["errorMsg", "error"],
-    ["hello", "hello"],
-    ["auth", "auth"],
-    ["dontHave", "dontHave"],
-    ["getPeers", xdr.void()],
-    ["peers", "peers"],
-    ["getTxSet", "txSetHash"],
-    ["txSet", "txSet"],
-    ["generalizedTxSet", "generalizedTxSet"],
-    ["transaction", "transaction"],
-    ["surveyRequest", "signedSurveyRequestMessage"],
-    ["surveyResponse", "signedSurveyResponseMessage"],
-    ["getScpQuorumset", "qSetHash"],
-    ["scpQuorumset", "qSet"],
-    ["scpMessage", "envelope"],
-    ["getScpState", "getScpLedgerSeq"],
-    ["sendMore", "sendMoreMessage"],
-    ["floodAdvert", "floodAdvert"],
-    ["floodDemand", "floodDemand"],
-  ],
-  arms: {
-    error: xdr.lookup("Error"),
-    hello: xdr.lookup("Hello"),
-    auth: xdr.lookup("Auth"),
-    dontHave: xdr.lookup("DontHave"),
-    peers: xdr.varArray(xdr.lookup("PeerAddress"), 100),
-    txSetHash: xdr.lookup("Uint256"),
-    txSet: xdr.lookup("TransactionSet"),
-    generalizedTxSet: xdr.lookup("GeneralizedTransactionSet"),
-    transaction: xdr.lookup("TransactionEnvelope"),
-    signedSurveyRequestMessage: xdr.lookup("SignedSurveyRequestMessage"),
-    signedSurveyResponseMessage: xdr.lookup("SignedSurveyResponseMessage"),
-    qSetHash: xdr.lookup("Uint256"),
-    qSet: xdr.lookup("ScpQuorumSet"),
-    envelope: xdr.lookup("ScpEnvelope"),
-    getScpLedgerSeq: xdr.lookup("Uint32"),
-    sendMoreMessage: xdr.lookup("SendMore"),
-    floodAdvert: xdr.lookup("FloodAdvert"),
-    floodDemand: xdr.lookup("FloodDemand"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           uint64 sequence;
-//           StellarMessage message;
-//           HmacSha256Mac mac;
-//       }
-//
-// ===========================================================================
-xdr.struct("AuthenticatedMessageV0", [
-  ["sequence", xdr.lookup("Uint64")],
-  ["message", xdr.lookup("StellarMessage")],
-  ["mac", xdr.lookup("HmacSha256Mac")],
-]);
-
-// === xdr source ============================================================
-//
-//   union AuthenticatedMessage switch (uint32 v)
-//   {
-//   case 0:
-//       struct
-//       {
-//           uint64 sequence;
-//           StellarMessage message;
-//           HmacSha256Mac mac;
-//       } v0;
-//   };
-//
-// ===========================================================================
-xdr.union("AuthenticatedMessage", {
-  switchOn: xdr.lookup("Uint32"),
-  switchName: "v",
-  switches: [
-    [0, "v0"],
-  ],
-  arms: {
-    v0: xdr.lookup("AuthenticatedMessageV0"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union LiquidityPoolParameters switch (LiquidityPoolType type)
-//   {
-//   case LIQUIDITY_POOL_CONSTANT_PRODUCT:
-//       LiquidityPoolConstantProductParameters constantProduct;
-//   };
-//
-// ===========================================================================
-xdr.union("LiquidityPoolParameters", {
-  switchOn: xdr.lookup("LiquidityPoolType"),
-  switchName: "type",
-  switches: [
-    ["liquidityPoolConstantProduct", "constantProduct"],
-  ],
-  arms: {
-    constantProduct: xdr.lookup("LiquidityPoolConstantProductParameters"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           uint64 id;
-//           uint256 ed25519;
-//       }
-//
-// ===========================================================================
-xdr.struct("MuxedAccountMed25519", [
-  ["id", xdr.lookup("Uint64")],
-  ["ed25519", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   union MuxedAccount switch (CryptoKeyType type)
-//   {
-//   case KEY_TYPE_ED25519:
-//       uint256 ed25519;
-//   case KEY_TYPE_MUXED_ED25519:
-//       struct
-//       {
-//           uint64 id;
-//           uint256 ed25519;
-//       } med25519;
-//   };
-//
-// ===========================================================================
-xdr.union("MuxedAccount", {
-  switchOn: xdr.lookup("CryptoKeyType"),
-  switchName: "type",
-  switches: [
-    ["keyTypeEd25519", "ed25519"],
-    ["keyTypeMuxedEd25519", "med25519"],
-  ],
-  arms: {
-    ed25519: xdr.lookup("Uint256"),
-    med25519: xdr.lookup("MuxedAccountMed25519"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct DecoratedSignature
-//   {
-//       SignatureHint hint;  // last 4 bytes of the public key, used as a hint
-//       Signature signature; // actual signature
-//   };
-//
-// ===========================================================================
-xdr.struct("DecoratedSignature", [
-  ["hint", xdr.lookup("SignatureHint")],
-  ["signature", xdr.lookup("Signature")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LedgerFootprint
-//   {
-//       LedgerKey readOnly<>;
-//       LedgerKey readWrite<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerFootprint", [
-  ["readOnly", xdr.varArray(xdr.lookup("LedgerKey"), 2147483647)],
-  ["readWrite", xdr.varArray(xdr.lookup("LedgerKey"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   enum OperationType
-//   {
-//       CREATE_ACCOUNT = 0,
-//       PAYMENT = 1,
-//       PATH_PAYMENT_STRICT_RECEIVE = 2,
-//       MANAGE_SELL_OFFER = 3,
-//       CREATE_PASSIVE_SELL_OFFER = 4,
-//       SET_OPTIONS = 5,
-//       CHANGE_TRUST = 6,
-//       ALLOW_TRUST = 7,
-//       ACCOUNT_MERGE = 8,
-//       INFLATION = 9,
-//       MANAGE_DATA = 10,
-//       BUMP_SEQUENCE = 11,
-//       MANAGE_BUY_OFFER = 12,
-//       PATH_PAYMENT_STRICT_SEND = 13,
-//       CREATE_CLAIMABLE_BALANCE = 14,
-//       CLAIM_CLAIMABLE_BALANCE = 15,
-//       BEGIN_SPONSORING_FUTURE_RESERVES = 16,
-//       END_SPONSORING_FUTURE_RESERVES = 17,
-//       REVOKE_SPONSORSHIP = 18,
-//       CLAWBACK = 19,
-//       CLAWBACK_CLAIMABLE_BALANCE = 20,
-//       SET_TRUST_LINE_FLAGS = 21,
-//       LIQUIDITY_POOL_DEPOSIT = 22,
-//       LIQUIDITY_POOL_WITHDRAW = 23,
-//       INVOKE_HOST_FUNCTION = 24
-//   };
-//
-// ===========================================================================
-xdr.enum("OperationType", {
-  createAccount: 0,
-  payment: 1,
-  pathPaymentStrictReceive: 2,
-  manageSellOffer: 3,
-  createPassiveSellOffer: 4,
-  setOptions: 5,
-  changeTrust: 6,
-  allowTrust: 7,
-  accountMerge: 8,
-  inflation: 9,
-  manageData: 10,
-  bumpSequence: 11,
-  manageBuyOffer: 12,
-  pathPaymentStrictSend: 13,
-  createClaimableBalance: 14,
-  claimClaimableBalance: 15,
-  beginSponsoringFutureReserves: 16,
-  endSponsoringFutureReserves: 17,
-  revokeSponsorship: 18,
-  clawback: 19,
-  clawbackClaimableBalance: 20,
-  setTrustLineFlags: 21,
-  liquidityPoolDeposit: 22,
-  liquidityPoolWithdraw: 23,
-  invokeHostFunction: 24,
-});
-
-// === xdr source ============================================================
-//
-//   struct CreateAccountOp
-//   {
-//       AccountID destination; // account to create
-//       int64 startingBalance; // amount they end up with
-//   };
-//
-// ===========================================================================
-xdr.struct("CreateAccountOp", [
-  ["destination", xdr.lookup("AccountId")],
-  ["startingBalance", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct PaymentOp
-//   {
-//       MuxedAccount destination; // recipient of the payment
-//       Asset asset;              // what they end up with
-//       int64 amount;             // amount they end up with
-//   };
-//
-// ===========================================================================
-xdr.struct("PaymentOp", [
-  ["destination", xdr.lookup("MuxedAccount")],
-  ["asset", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct PathPaymentStrictReceiveOp
-//   {
-//       Asset sendAsset; // asset we pay with
-//       int64 sendMax;   // the maximum amount of sendAsset to
-//                        // send (excluding fees).
-//                        // The operation will fail if can't be met
-//   
-//       MuxedAccount destination; // recipient of the payment
-//       Asset destAsset;          // what they end up with
-//       int64 destAmount;         // amount they end up with
-//   
-//       Asset path<5>; // additional hops it must go through to get there
-//   };
-//
-// ===========================================================================
-xdr.struct("PathPaymentStrictReceiveOp", [
-  ["sendAsset", xdr.lookup("Asset")],
-  ["sendMax", xdr.lookup("Int64")],
-  ["destination", xdr.lookup("MuxedAccount")],
-  ["destAsset", xdr.lookup("Asset")],
-  ["destAmount", xdr.lookup("Int64")],
-  ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct PathPaymentStrictSendOp
-//   {
-//       Asset sendAsset;  // asset we pay with
-//       int64 sendAmount; // amount of sendAsset to send (excluding fees)
-//   
-//       MuxedAccount destination; // recipient of the payment
-//       Asset destAsset;          // what they end up with
-//       int64 destMin;            // the minimum amount of dest asset to
-//                                 // be received
-//                                 // The operation will fail if it can't be met
-//   
-//       Asset path<5>; // additional hops it must go through to get there
-//   };
-//
-// ===========================================================================
-xdr.struct("PathPaymentStrictSendOp", [
-  ["sendAsset", xdr.lookup("Asset")],
-  ["sendAmount", xdr.lookup("Int64")],
-  ["destination", xdr.lookup("MuxedAccount")],
-  ["destAsset", xdr.lookup("Asset")],
-  ["destMin", xdr.lookup("Int64")],
-  ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ManageSellOfferOp
-//   {
-//       Asset selling;
-//       Asset buying;
-//       int64 amount; // amount being sold. if set to 0, delete the offer
-//       Price price;  // price of thing being sold in terms of what you are buying
-//   
-//       // 0=create a new offer, otherwise edit an existing offer
-//       int64 offerID;
-//   };
-//
-// ===========================================================================
-xdr.struct("ManageSellOfferOp", [
-  ["selling", xdr.lookup("Asset")],
-  ["buying", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-  ["price", xdr.lookup("Price")],
-  ["offerId", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ManageBuyOfferOp
-//   {
-//       Asset selling;
-//       Asset buying;
-//       int64 buyAmount; // amount being bought. if set to 0, delete the offer
-//       Price price;     // price of thing being bought in terms of what you are
-//                        // selling
-//   
-//       // 0=create a new offer, otherwise edit an existing offer
-//       int64 offerID;
-//   };
-//
-// ===========================================================================
-xdr.struct("ManageBuyOfferOp", [
-  ["selling", xdr.lookup("Asset")],
-  ["buying", xdr.lookup("Asset")],
-  ["buyAmount", xdr.lookup("Int64")],
-  ["price", xdr.lookup("Price")],
-  ["offerId", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct CreatePassiveSellOfferOp
-//   {
-//       Asset selling; // A
-//       Asset buying;  // B
-//       int64 amount;  // amount taker gets
-//       Price price;   // cost of A in terms of B
-//   };
-//
-// ===========================================================================
-xdr.struct("CreatePassiveSellOfferOp", [
-  ["selling", xdr.lookup("Asset")],
-  ["buying", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-  ["price", xdr.lookup("Price")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SetOptionsOp
-//   {
-//       AccountID* inflationDest; // sets the inflation destination
-//   
-//       uint32* clearFlags; // which flags to clear
-//       uint32* setFlags;   // which flags to set
-//   
-//       // account threshold manipulation
-//       uint32* masterWeight; // weight of the master account
-//       uint32* lowThreshold;
-//       uint32* medThreshold;
-//       uint32* highThreshold;
-//   
-//       string32* homeDomain; // sets the home domain
-//   
-//       // Add, update or remove a signer for the account
-//       // signer is deleted if the weight is 0
-//       Signer* signer;
-//   };
-//
-// ===========================================================================
-xdr.struct("SetOptionsOp", [
-  ["inflationDest", xdr.option(xdr.lookup("AccountId"))],
-  ["clearFlags", xdr.option(xdr.lookup("Uint32"))],
-  ["setFlags", xdr.option(xdr.lookup("Uint32"))],
-  ["masterWeight", xdr.option(xdr.lookup("Uint32"))],
-  ["lowThreshold", xdr.option(xdr.lookup("Uint32"))],
-  ["medThreshold", xdr.option(xdr.lookup("Uint32"))],
-  ["highThreshold", xdr.option(xdr.lookup("Uint32"))],
-  ["homeDomain", xdr.option(xdr.lookup("String32"))],
-  ["signer", xdr.option(xdr.lookup("Signer"))],
-]);
-
-// === xdr source ============================================================
-//
-//   union ChangeTrustAsset switch (AssetType type)
-//   {
-//   case ASSET_TYPE_NATIVE: // Not credit
-//       void;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM4:
-//       AlphaNum4 alphaNum4;
-//   
-//   case ASSET_TYPE_CREDIT_ALPHANUM12:
-//       AlphaNum12 alphaNum12;
-//   
-//   case ASSET_TYPE_POOL_SHARE:
-//       LiquidityPoolParameters liquidityPool;
-//   
-//       // add other asset types here in the future
-//   };
-//
-// ===========================================================================
-xdr.union("ChangeTrustAsset", {
-  switchOn: xdr.lookup("AssetType"),
-  switchName: "type",
-  switches: [
-    ["assetTypeNative", xdr.void()],
-    ["assetTypeCreditAlphanum4", "alphaNum4"],
-    ["assetTypeCreditAlphanum12", "alphaNum12"],
-    ["assetTypePoolShare", "liquidityPool"],
-  ],
-  arms: {
-    alphaNum4: xdr.lookup("AlphaNum4"),
-    alphaNum12: xdr.lookup("AlphaNum12"),
-    liquidityPool: xdr.lookup("LiquidityPoolParameters"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ChangeTrustOp
-//   {
-//       ChangeTrustAsset line;
-//   
-//       // if limit is set to 0, deletes the trust line
-//       int64 limit;
-//   };
-//
-// ===========================================================================
-xdr.struct("ChangeTrustOp", [
-  ["line", xdr.lookup("ChangeTrustAsset")],
-  ["limit", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct AllowTrustOp
-//   {
-//       AccountID trustor;
-//       AssetCode asset;
-//   
-//       // One of 0, AUTHORIZED_FLAG, or AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG
-//       uint32 authorize;
-//   };
-//
-// ===========================================================================
-xdr.struct("AllowTrustOp", [
-  ["trustor", xdr.lookup("AccountId")],
-  ["asset", xdr.lookup("AssetCode")],
-  ["authorize", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ManageDataOp
-//   {
-//       string64 dataName;
-//       DataValue* dataValue; // set to null to clear
-//   };
-//
-// ===========================================================================
-xdr.struct("ManageDataOp", [
-  ["dataName", xdr.lookup("String64")],
-  ["dataValue", xdr.option(xdr.lookup("DataValue"))],
-]);
-
-// === xdr source ============================================================
-//
-//   struct BumpSequenceOp
-//   {
-//       SequenceNumber bumpTo;
-//   };
-//
-// ===========================================================================
-xdr.struct("BumpSequenceOp", [
-  ["bumpTo", xdr.lookup("SequenceNumber")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct CreateClaimableBalanceOp
-//   {
-//       Asset asset;
-//       int64 amount;
-//       Claimant claimants<10>;
-//   };
-//
-// ===========================================================================
-xdr.struct("CreateClaimableBalanceOp", [
-  ["asset", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-  ["claimants", xdr.varArray(xdr.lookup("Claimant"), 10)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ClaimClaimableBalanceOp
-//   {
-//       ClaimableBalanceID balanceID;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimClaimableBalanceOp", [
-  ["balanceId", xdr.lookup("ClaimableBalanceId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct BeginSponsoringFutureReservesOp
-//   {
-//       AccountID sponsoredID;
-//   };
-//
-// ===========================================================================
-xdr.struct("BeginSponsoringFutureReservesOp", [
-  ["sponsoredId", xdr.lookup("AccountId")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum RevokeSponsorshipType
-//   {
-//       REVOKE_SPONSORSHIP_LEDGER_ENTRY = 0,
-//       REVOKE_SPONSORSHIP_SIGNER = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("RevokeSponsorshipType", {
-  revokeSponsorshipLedgerEntry: 0,
-  revokeSponsorshipSigner: 1,
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID accountID;
-//           SignerKey signerKey;
-//       }
-//
-// ===========================================================================
-xdr.struct("RevokeSponsorshipOpSigner", [
-  ["accountId", xdr.lookup("AccountId")],
-  ["signerKey", xdr.lookup("SignerKey")],
-]);
-
-// === xdr source ============================================================
-//
-//   union RevokeSponsorshipOp switch (RevokeSponsorshipType type)
-//   {
-//   case REVOKE_SPONSORSHIP_LEDGER_ENTRY:
-//       LedgerKey ledgerKey;
-//   case REVOKE_SPONSORSHIP_SIGNER:
-//       struct
-//       {
-//           AccountID accountID;
-//           SignerKey signerKey;
-//       } signer;
-//   };
-//
-// ===========================================================================
-xdr.union("RevokeSponsorshipOp", {
-  switchOn: xdr.lookup("RevokeSponsorshipType"),
-  switchName: "type",
-  switches: [
-    ["revokeSponsorshipLedgerEntry", "ledgerKey"],
-    ["revokeSponsorshipSigner", "signer"],
-  ],
-  arms: {
-    ledgerKey: xdr.lookup("LedgerKey"),
-    signer: xdr.lookup("RevokeSponsorshipOpSigner"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ClawbackOp
-//   {
-//       Asset asset;
-//       MuxedAccount from;
-//       int64 amount;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClawbackOp", [
-  ["asset", xdr.lookup("Asset")],
-  ["from", xdr.lookup("MuxedAccount")],
-  ["amount", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ClawbackClaimableBalanceOp
-//   {
-//       ClaimableBalanceID balanceID;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClawbackClaimableBalanceOp", [
-  ["balanceId", xdr.lookup("ClaimableBalanceId")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SetTrustLineFlagsOp
-//   {
-//       AccountID trustor;
-//       Asset asset;
-//   
-//       uint32 clearFlags; // which flags to clear
-//       uint32 setFlags;   // which flags to set
-//   };
-//
-// ===========================================================================
-xdr.struct("SetTrustLineFlagsOp", [
-  ["trustor", xdr.lookup("AccountId")],
-  ["asset", xdr.lookup("Asset")],
-  ["clearFlags", xdr.lookup("Uint32")],
-  ["setFlags", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   const LIQUIDITY_POOL_FEE_V18 = 30;
-//
-// ===========================================================================
-xdr.const("LIQUIDITY_POOL_FEE_V18", 30);
-
-// === xdr source ============================================================
-//
-//   struct LiquidityPoolDepositOp
-//   {
-//       PoolID liquidityPoolID;
-//       int64 maxAmountA; // maximum amount of first asset to deposit
-//       int64 maxAmountB; // maximum amount of second asset to deposit
-//       Price minPrice;   // minimum depositA/depositB
-//       Price maxPrice;   // maximum depositA/depositB
-//   };
-//
-// ===========================================================================
-xdr.struct("LiquidityPoolDepositOp", [
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-  ["maxAmountA", xdr.lookup("Int64")],
-  ["maxAmountB", xdr.lookup("Int64")],
-  ["minPrice", xdr.lookup("Price")],
-  ["maxPrice", xdr.lookup("Price")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LiquidityPoolWithdrawOp
-//   {
-//       PoolID liquidityPoolID;
-//       int64 amount;     // amount of pool shares to withdraw
-//       int64 minAmountA; // minimum amount of first asset to withdraw
-//       int64 minAmountB; // minimum amount of second asset to withdraw
-//   };
-//
-// ===========================================================================
-xdr.struct("LiquidityPoolWithdrawOp", [
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-  ["amount", xdr.lookup("Int64")],
-  ["minAmountA", xdr.lookup("Int64")],
-  ["minAmountB", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum HostFunctionType
-//   {
-//       HOST_FUNCTION_TYPE_INVOKE_CONTRACT = 0,
-//       HOST_FUNCTION_TYPE_CREATE_CONTRACT = 1,
-//       HOST_FUNCTION_TYPE_INSTALL_CONTRACT_CODE = 2
-//   };
-//
-// ===========================================================================
-xdr.enum("HostFunctionType", {
-  hostFunctionTypeInvokeContract: 0,
-  hostFunctionTypeCreateContract: 1,
-  hostFunctionTypeInstallContractCode: 2,
-});
-
-// === xdr source ============================================================
-//
-//   enum ContractIDType
-//   {
-//       CONTRACT_ID_FROM_SOURCE_ACCOUNT = 0,
-//       CONTRACT_ID_FROM_ED25519_PUBLIC_KEY = 1,
-//       CONTRACT_ID_FROM_ASSET = 2
-//   };
-//
-// ===========================================================================
-xdr.enum("ContractIdType", {
-  contractIdFromSourceAccount: 0,
-  contractIdFromEd25519PublicKey: 1,
-  contractIdFromAsset: 2,
-});
-
-// === xdr source ============================================================
-//
-//   enum ContractIDPublicKeyType
-//   {
-//       CONTRACT_ID_PUBLIC_KEY_SOURCE_ACCOUNT = 0,
-//       CONTRACT_ID_PUBLIC_KEY_ED25519 = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("ContractIdPublicKeyType", {
-  contractIdPublicKeySourceAccount: 0,
-  contractIdPublicKeyEd25519: 1,
-});
-
-// === xdr source ============================================================
-//
-//   struct InstallContractCodeArgs
-//   {
-//       opaque code<SCVAL_LIMIT>;
-//   };
-//
-// ===========================================================================
-xdr.struct("InstallContractCodeArgs", [
-  ["code", xdr.varOpaque(SCVAL_LIMIT)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct 
-//       {
-//           uint256 key;
-//           Signature signature;
-//           uint256 salt;
-//       }
-//
-// ===========================================================================
-xdr.struct("ContractIdFromEd25519PublicKey", [
-  ["key", xdr.lookup("Uint256")],
-  ["signature", xdr.lookup("Signature")],
-  ["salt", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   union ContractID switch (ContractIDType type)
-//   {
-//   case CONTRACT_ID_FROM_SOURCE_ACCOUNT:
-//       uint256 salt;
-//   case CONTRACT_ID_FROM_ED25519_PUBLIC_KEY:
-//       struct 
-//       {
-//           uint256 key;
-//           Signature signature;
-//           uint256 salt;
-//       } fromEd25519PublicKey;
-//   case CONTRACT_ID_FROM_ASSET:
-//       Asset asset;
-//   };
-//
-// ===========================================================================
-xdr.union("ContractId", {
-  switchOn: xdr.lookup("ContractIdType"),
-  switchName: "type",
-  switches: [
-    ["contractIdFromSourceAccount", "salt"],
-    ["contractIdFromEd25519PublicKey", "fromEd25519PublicKey"],
-    ["contractIdFromAsset", "asset"],
-  ],
-  arms: {
-    salt: xdr.lookup("Uint256"),
-    fromEd25519PublicKey: xdr.lookup("ContractIdFromEd25519PublicKey"),
-    asset: xdr.lookup("Asset"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct CreateContractArgs
-//   {
-//       ContractID contractID;
-//       SCContractExecutable source;
-//   };
-//
-// ===========================================================================
-xdr.struct("CreateContractArgs", [
-  ["contractId", xdr.lookup("ContractId")],
-  ["source", xdr.lookup("ScContractExecutable")],
-]);
-
-// === xdr source ============================================================
-//
-//   union HostFunction switch (HostFunctionType type)
-//   {
-//   case HOST_FUNCTION_TYPE_INVOKE_CONTRACT:
-//       SCVec invokeArgs;
-//   case HOST_FUNCTION_TYPE_CREATE_CONTRACT:
-//       CreateContractArgs createContractArgs;
-//   case HOST_FUNCTION_TYPE_INSTALL_CONTRACT_CODE:
-//       InstallContractCodeArgs installContractCodeArgs;
-//   };
-//
-// ===========================================================================
-xdr.union("HostFunction", {
-  switchOn: xdr.lookup("HostFunctionType"),
-  switchName: "type",
-  switches: [
-    ["hostFunctionTypeInvokeContract", "invokeArgs"],
-    ["hostFunctionTypeCreateContract", "createContractArgs"],
-    ["hostFunctionTypeInstallContractCode", "installContractCodeArgs"],
-  ],
-  arms: {
-    invokeArgs: xdr.lookup("ScVec"),
-    createContractArgs: xdr.lookup("CreateContractArgs"),
-    installContractCodeArgs: xdr.lookup("InstallContractCodeArgs"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct AuthorizedInvocation
-//   {
-//       Hash contractID;
-//       SCSymbol functionName;
-//       SCVec args;
-//       AuthorizedInvocation subInvocations<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("AuthorizedInvocation", [
-  ["contractId", xdr.lookup("Hash")],
-  ["functionName", xdr.lookup("ScSymbol")],
-  ["args", xdr.lookup("ScVec")],
-  ["subInvocations", xdr.varArray(xdr.lookup("AuthorizedInvocation"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct AddressWithNonce
-//   {
-//       SCAddress address;
-//       uint64 nonce;
-//   };
-//
-// ===========================================================================
-xdr.struct("AddressWithNonce", [
-  ["address", xdr.lookup("ScAddress")],
-  ["nonce", xdr.lookup("Uint64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ContractAuth
-//   {
-//       AddressWithNonce* addressWithNonce; // not present for invoker
-//       AuthorizedInvocation rootInvocation;
-//       SCVec signatureArgs;
-//   };
-//
-// ===========================================================================
-xdr.struct("ContractAuth", [
-  ["addressWithNonce", xdr.option(xdr.lookup("AddressWithNonce"))],
-  ["rootInvocation", xdr.lookup("AuthorizedInvocation")],
-  ["signatureArgs", xdr.lookup("ScVec")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct InvokeHostFunctionOp
-//   {
-//       // The host function to invoke
-//       HostFunction function;
-//       // The footprint for this invocation
-//       LedgerFootprint footprint;
-//       // Per-address authorizations for this host fn
-//       // Currently only supported for INVOKE_CONTRACT function
-//       ContractAuth auth<>;
-//   };
-//
-// ===========================================================================
-xdr.struct("InvokeHostFunctionOp", [
-  ["function", xdr.lookup("HostFunction")],
-  ["footprint", xdr.lookup("LedgerFootprint")],
-  ["auth", xdr.varArray(xdr.lookup("ContractAuth"), 2147483647)],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (OperationType type)
-//       {
-//       case CREATE_ACCOUNT:
-//           CreateAccountOp createAccountOp;
-//       case PAYMENT:
-//           PaymentOp paymentOp;
-//       case PATH_PAYMENT_STRICT_RECEIVE:
-//           PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
-//       case MANAGE_SELL_OFFER:
-//           ManageSellOfferOp manageSellOfferOp;
-//       case CREATE_PASSIVE_SELL_OFFER:
-//           CreatePassiveSellOfferOp createPassiveSellOfferOp;
-//       case SET_OPTIONS:
-//           SetOptionsOp setOptionsOp;
-//       case CHANGE_TRUST:
-//           ChangeTrustOp changeTrustOp;
-//       case ALLOW_TRUST:
-//           AllowTrustOp allowTrustOp;
-//       case ACCOUNT_MERGE:
-//           MuxedAccount destination;
-//       case INFLATION:
-//           void;
-//       case MANAGE_DATA:
-//           ManageDataOp manageDataOp;
-//       case BUMP_SEQUENCE:
-//           BumpSequenceOp bumpSequenceOp;
-//       case MANAGE_BUY_OFFER:
-//           ManageBuyOfferOp manageBuyOfferOp;
-//       case PATH_PAYMENT_STRICT_SEND:
-//           PathPaymentStrictSendOp pathPaymentStrictSendOp;
-//       case CREATE_CLAIMABLE_BALANCE:
-//           CreateClaimableBalanceOp createClaimableBalanceOp;
-//       case CLAIM_CLAIMABLE_BALANCE:
-//           ClaimClaimableBalanceOp claimClaimableBalanceOp;
-//       case BEGIN_SPONSORING_FUTURE_RESERVES:
-//           BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
-//       case END_SPONSORING_FUTURE_RESERVES:
-//           void;
-//       case REVOKE_SPONSORSHIP:
-//           RevokeSponsorshipOp revokeSponsorshipOp;
-//       case CLAWBACK:
-//           ClawbackOp clawbackOp;
-//       case CLAWBACK_CLAIMABLE_BALANCE:
-//           ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
-//       case SET_TRUST_LINE_FLAGS:
-//           SetTrustLineFlagsOp setTrustLineFlagsOp;
-//       case LIQUIDITY_POOL_DEPOSIT:
-//           LiquidityPoolDepositOp liquidityPoolDepositOp;
-//       case LIQUIDITY_POOL_WITHDRAW:
-//           LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
-//       case INVOKE_HOST_FUNCTION:
-//           InvokeHostFunctionOp invokeHostFunctionOp;
-//       }
-//
-// ===========================================================================
-xdr.union("OperationBody", {
-  switchOn: xdr.lookup("OperationType"),
-  switchName: "type",
-  switches: [
-    ["createAccount", "createAccountOp"],
-    ["payment", "paymentOp"],
-    ["pathPaymentStrictReceive", "pathPaymentStrictReceiveOp"],
-    ["manageSellOffer", "manageSellOfferOp"],
-    ["createPassiveSellOffer", "createPassiveSellOfferOp"],
-    ["setOptions", "setOptionsOp"],
-    ["changeTrust", "changeTrustOp"],
-    ["allowTrust", "allowTrustOp"],
-    ["accountMerge", "destination"],
-    ["inflation", xdr.void()],
-    ["manageData", "manageDataOp"],
-    ["bumpSequence", "bumpSequenceOp"],
-    ["manageBuyOffer", "manageBuyOfferOp"],
-    ["pathPaymentStrictSend", "pathPaymentStrictSendOp"],
-    ["createClaimableBalance", "createClaimableBalanceOp"],
-    ["claimClaimableBalance", "claimClaimableBalanceOp"],
-    ["beginSponsoringFutureReserves", "beginSponsoringFutureReservesOp"],
-    ["endSponsoringFutureReserves", xdr.void()],
-    ["revokeSponsorship", "revokeSponsorshipOp"],
-    ["clawback", "clawbackOp"],
-    ["clawbackClaimableBalance", "clawbackClaimableBalanceOp"],
-    ["setTrustLineFlags", "setTrustLineFlagsOp"],
-    ["liquidityPoolDeposit", "liquidityPoolDepositOp"],
-    ["liquidityPoolWithdraw", "liquidityPoolWithdrawOp"],
-    ["invokeHostFunction", "invokeHostFunctionOp"],
-  ],
-  arms: {
-    createAccountOp: xdr.lookup("CreateAccountOp"),
-    paymentOp: xdr.lookup("PaymentOp"),
-    pathPaymentStrictReceiveOp: xdr.lookup("PathPaymentStrictReceiveOp"),
-    manageSellOfferOp: xdr.lookup("ManageSellOfferOp"),
-    createPassiveSellOfferOp: xdr.lookup("CreatePassiveSellOfferOp"),
-    setOptionsOp: xdr.lookup("SetOptionsOp"),
-    changeTrustOp: xdr.lookup("ChangeTrustOp"),
-    allowTrustOp: xdr.lookup("AllowTrustOp"),
-    destination: xdr.lookup("MuxedAccount"),
-    manageDataOp: xdr.lookup("ManageDataOp"),
-    bumpSequenceOp: xdr.lookup("BumpSequenceOp"),
-    manageBuyOfferOp: xdr.lookup("ManageBuyOfferOp"),
-    pathPaymentStrictSendOp: xdr.lookup("PathPaymentStrictSendOp"),
-    createClaimableBalanceOp: xdr.lookup("CreateClaimableBalanceOp"),
-    claimClaimableBalanceOp: xdr.lookup("ClaimClaimableBalanceOp"),
-    beginSponsoringFutureReservesOp: xdr.lookup("BeginSponsoringFutureReservesOp"),
-    revokeSponsorshipOp: xdr.lookup("RevokeSponsorshipOp"),
-    clawbackOp: xdr.lookup("ClawbackOp"),
-    clawbackClaimableBalanceOp: xdr.lookup("ClawbackClaimableBalanceOp"),
-    setTrustLineFlagsOp: xdr.lookup("SetTrustLineFlagsOp"),
-    liquidityPoolDepositOp: xdr.lookup("LiquidityPoolDepositOp"),
-    liquidityPoolWithdrawOp: xdr.lookup("LiquidityPoolWithdrawOp"),
-    invokeHostFunctionOp: xdr.lookup("InvokeHostFunctionOp"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct Operation
-//   {
-//       // sourceAccount is the account used to run the operation
-//       // if not set, the runtime defaults to "sourceAccount" specified at
-//       // the transaction level
-//       MuxedAccount* sourceAccount;
-//   
-//       union switch (OperationType type)
-//       {
-//       case CREATE_ACCOUNT:
-//           CreateAccountOp createAccountOp;
-//       case PAYMENT:
-//           PaymentOp paymentOp;
-//       case PATH_PAYMENT_STRICT_RECEIVE:
-//           PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
-//       case MANAGE_SELL_OFFER:
-//           ManageSellOfferOp manageSellOfferOp;
-//       case CREATE_PASSIVE_SELL_OFFER:
-//           CreatePassiveSellOfferOp createPassiveSellOfferOp;
-//       case SET_OPTIONS:
-//           SetOptionsOp setOptionsOp;
-//       case CHANGE_TRUST:
-//           ChangeTrustOp changeTrustOp;
-//       case ALLOW_TRUST:
-//           AllowTrustOp allowTrustOp;
-//       case ACCOUNT_MERGE:
-//           MuxedAccount destination;
-//       case INFLATION:
-//           void;
-//       case MANAGE_DATA:
-//           ManageDataOp manageDataOp;
-//       case BUMP_SEQUENCE:
-//           BumpSequenceOp bumpSequenceOp;
-//       case MANAGE_BUY_OFFER:
-//           ManageBuyOfferOp manageBuyOfferOp;
-//       case PATH_PAYMENT_STRICT_SEND:
-//           PathPaymentStrictSendOp pathPaymentStrictSendOp;
-//       case CREATE_CLAIMABLE_BALANCE:
-//           CreateClaimableBalanceOp createClaimableBalanceOp;
-//       case CLAIM_CLAIMABLE_BALANCE:
-//           ClaimClaimableBalanceOp claimClaimableBalanceOp;
-//       case BEGIN_SPONSORING_FUTURE_RESERVES:
-//           BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
-//       case END_SPONSORING_FUTURE_RESERVES:
-//           void;
-//       case REVOKE_SPONSORSHIP:
-//           RevokeSponsorshipOp revokeSponsorshipOp;
-//       case CLAWBACK:
-//           ClawbackOp clawbackOp;
-//       case CLAWBACK_CLAIMABLE_BALANCE:
-//           ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
-//       case SET_TRUST_LINE_FLAGS:
-//           SetTrustLineFlagsOp setTrustLineFlagsOp;
-//       case LIQUIDITY_POOL_DEPOSIT:
-//           LiquidityPoolDepositOp liquidityPoolDepositOp;
-//       case LIQUIDITY_POOL_WITHDRAW:
-//           LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
-//       case INVOKE_HOST_FUNCTION:
-//           InvokeHostFunctionOp invokeHostFunctionOp;
-//       }
-//       body;
-//   };
-//
-// ===========================================================================
-xdr.struct("Operation", [
-  ["sourceAccount", xdr.option(xdr.lookup("MuxedAccount"))],
-  ["body", xdr.lookup("OperationBody")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID sourceAccount;
-//           SequenceNumber seqNum;
-//           uint32 opNum;
-//       }
-//
-// ===========================================================================
-xdr.struct("HashIdPreimageOperationId", [
-  ["sourceAccount", xdr.lookup("AccountId")],
-  ["seqNum", xdr.lookup("SequenceNumber")],
-  ["opNum", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           AccountID sourceAccount;
-//           SequenceNumber seqNum;
-//           uint32 opNum;
-//           PoolID liquidityPoolID;
-//           Asset asset;
-//       }
-//
-// ===========================================================================
-xdr.struct("HashIdPreimageRevokeId", [
-  ["sourceAccount", xdr.lookup("AccountId")],
-  ["seqNum", xdr.lookup("SequenceNumber")],
-  ["opNum", xdr.lookup("Uint32")],
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-  ["asset", xdr.lookup("Asset")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           Hash networkID;
-//           uint256 ed25519;
-//           uint256 salt;
-//       }
-//
-// ===========================================================================
-xdr.struct("HashIdPreimageEd25519ContractId", [
-  ["networkId", xdr.lookup("Hash")],
-  ["ed25519", xdr.lookup("Uint256")],
-  ["salt", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           Hash networkID;
-//           Hash contractID;
-//           uint256 salt;
-//       }
-//
-// ===========================================================================
-xdr.struct("HashIdPreimageContractId", [
-  ["networkId", xdr.lookup("Hash")],
-  ["contractId", xdr.lookup("Hash")],
-  ["salt", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           Hash networkID;
-//           Asset asset;
-//       }
-//
-// ===========================================================================
-xdr.struct("HashIdPreimageFromAsset", [
-  ["networkId", xdr.lookup("Hash")],
-  ["asset", xdr.lookup("Asset")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           Hash networkID;
-//           AccountID sourceAccount;
-//           uint256 salt;
-//       }
-//
-// ===========================================================================
-xdr.struct("HashIdPreimageSourceAccountContractId", [
-  ["networkId", xdr.lookup("Hash")],
-  ["sourceAccount", xdr.lookup("AccountId")],
-  ["salt", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           Hash networkID;
-//           SCContractExecutable source;
-//           uint256 salt;
-//       }
-//
-// ===========================================================================
-xdr.struct("HashIdPreimageCreateContractArgs", [
-  ["networkId", xdr.lookup("Hash")],
-  ["source", xdr.lookup("ScContractExecutable")],
-  ["salt", xdr.lookup("Uint256")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           Hash networkID;
-//           uint64 nonce;
-//           AuthorizedInvocation invocation;
-//       }
-//
-// ===========================================================================
-xdr.struct("HashIdPreimageContractAuth", [
-  ["networkId", xdr.lookup("Hash")],
-  ["nonce", xdr.lookup("Uint64")],
-  ["invocation", xdr.lookup("AuthorizedInvocation")],
-]);
-
-// === xdr source ============================================================
-//
-//   union HashIDPreimage switch (EnvelopeType type)
-//   {
-//   case ENVELOPE_TYPE_OP_ID:
-//       struct
-//       {
-//           AccountID sourceAccount;
-//           SequenceNumber seqNum;
-//           uint32 opNum;
-//       } operationID;
-//   case ENVELOPE_TYPE_POOL_REVOKE_OP_ID:
-//       struct
-//       {
-//           AccountID sourceAccount;
-//           SequenceNumber seqNum;
-//           uint32 opNum;
-//           PoolID liquidityPoolID;
-//           Asset asset;
-//       } revokeID;
-//   case ENVELOPE_TYPE_CONTRACT_ID_FROM_ED25519:
-//       struct
-//       {
-//           Hash networkID;
-//           uint256 ed25519;
-//           uint256 salt;
-//       } ed25519ContractID;
-//   case ENVELOPE_TYPE_CONTRACT_ID_FROM_CONTRACT:
-//       struct
-//       {
-//           Hash networkID;
-//           Hash contractID;
-//           uint256 salt;
-//       } contractID;
-//   case ENVELOPE_TYPE_CONTRACT_ID_FROM_ASSET:
-//       struct
-//       {
-//           Hash networkID;
-//           Asset asset;
-//       } fromAsset;
-//   case ENVELOPE_TYPE_CONTRACT_ID_FROM_SOURCE_ACCOUNT:
-//       struct
-//       {
-//           Hash networkID;
-//           AccountID sourceAccount;
-//           uint256 salt;
-//       } sourceAccountContractID;
-//   case ENVELOPE_TYPE_CREATE_CONTRACT_ARGS:
-//       struct
-//       {
-//           Hash networkID;
-//           SCContractExecutable source;
-//           uint256 salt;
-//       } createContractArgs;
-//   case ENVELOPE_TYPE_CONTRACT_AUTH:
-//       struct
-//       {
-//           Hash networkID;
-//           uint64 nonce;
-//           AuthorizedInvocation invocation;
-//       } contractAuth;
-//   };
-//
-// ===========================================================================
-xdr.union("HashIdPreimage", {
-  switchOn: xdr.lookup("EnvelopeType"),
-  switchName: "type",
-  switches: [
-    ["envelopeTypeOpId", "operationId"],
-    ["envelopeTypePoolRevokeOpId", "revokeId"],
-    ["envelopeTypeContractIdFromEd25519", "ed25519ContractId"],
-    ["envelopeTypeContractIdFromContract", "contractId"],
-    ["envelopeTypeContractIdFromAsset", "fromAsset"],
-    ["envelopeTypeContractIdFromSourceAccount", "sourceAccountContractId"],
-    ["envelopeTypeCreateContractArgs", "createContractArgs"],
-    ["envelopeTypeContractAuth", "contractAuth"],
-  ],
-  arms: {
-    operationId: xdr.lookup("HashIdPreimageOperationId"),
-    revokeId: xdr.lookup("HashIdPreimageRevokeId"),
-    ed25519ContractId: xdr.lookup("HashIdPreimageEd25519ContractId"),
-    contractId: xdr.lookup("HashIdPreimageContractId"),
-    fromAsset: xdr.lookup("HashIdPreimageFromAsset"),
-    sourceAccountContractId: xdr.lookup("HashIdPreimageSourceAccountContractId"),
-    createContractArgs: xdr.lookup("HashIdPreimageCreateContractArgs"),
-    contractAuth: xdr.lookup("HashIdPreimageContractAuth"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum MemoType
-//   {
-//       MEMO_NONE = 0,
-//       MEMO_TEXT = 1,
-//       MEMO_ID = 2,
-//       MEMO_HASH = 3,
-//       MEMO_RETURN = 4
-//   };
-//
-// ===========================================================================
-xdr.enum("MemoType", {
-  memoNone: 0,
-  memoText: 1,
-  memoId: 2,
-  memoHash: 3,
-  memoReturn: 4,
-});
-
-// === xdr source ============================================================
-//
-//   union Memo switch (MemoType type)
-//   {
-//   case MEMO_NONE:
-//       void;
-//   case MEMO_TEXT:
-//       string text<28>;
-//   case MEMO_ID:
-//       uint64 id;
-//   case MEMO_HASH:
-//       Hash hash; // the hash of what to pull from the content server
-//   case MEMO_RETURN:
-//       Hash retHash; // the hash of the tx you are rejecting
-//   };
-//
-// ===========================================================================
-xdr.union("Memo", {
-  switchOn: xdr.lookup("MemoType"),
-  switchName: "type",
-  switches: [
-    ["memoNone", xdr.void()],
-    ["memoText", "text"],
-    ["memoId", "id"],
-    ["memoHash", "hash"],
-    ["memoReturn", "retHash"],
-  ],
-  arms: {
-    text: xdr.string(28),
-    id: xdr.lookup("Uint64"),
-    hash: xdr.lookup("Hash"),
-    retHash: xdr.lookup("Hash"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TimeBounds
-//   {
-//       TimePoint minTime;
-//       TimePoint maxTime; // 0 here means no maxTime
-//   };
-//
-// ===========================================================================
-xdr.struct("TimeBounds", [
-  ["minTime", xdr.lookup("TimePoint")],
-  ["maxTime", xdr.lookup("TimePoint")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct LedgerBounds
-//   {
-//       uint32 minLedger;
-//       uint32 maxLedger; // 0 here means no maxLedger
-//   };
-//
-// ===========================================================================
-xdr.struct("LedgerBounds", [
-  ["minLedger", xdr.lookup("Uint32")],
-  ["maxLedger", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct PreconditionsV2
-//   {
-//       TimeBounds* timeBounds;
-//   
-//       // Transaction only valid for ledger numbers n such that
-//       // minLedger <= n < maxLedger (if maxLedger == 0, then
-//       // only minLedger is checked)
-//       LedgerBounds* ledgerBounds;
-//   
-//       // If NULL, only valid when sourceAccount's sequence number
-//       // is seqNum - 1.  Otherwise, valid when sourceAccount's
-//       // sequence number n satisfies minSeqNum <= n < tx.seqNum.
-//       // Note that after execution the account's sequence number
-//       // is always raised to tx.seqNum, and a transaction is not
-//       // valid if tx.seqNum is too high to ensure replay protection.
-//       SequenceNumber* minSeqNum;
-//   
-//       // For the transaction to be valid, the current ledger time must
-//       // be at least minSeqAge greater than sourceAccount's seqTime.
-//       Duration minSeqAge;
-//   
-//       // For the transaction to be valid, the current ledger number
-//       // must be at least minSeqLedgerGap greater than sourceAccount's
-//       // seqLedger.
-//       uint32 minSeqLedgerGap;
-//   
-//       // For the transaction to be valid, there must be a signature
-//       // corresponding to every Signer in this array, even if the
-//       // signature is not otherwise required by the sourceAccount or
-//       // operations.
-//       SignerKey extraSigners<2>;
-//   };
-//
-// ===========================================================================
-xdr.struct("PreconditionsV2", [
-  ["timeBounds", xdr.option(xdr.lookup("TimeBounds"))],
-  ["ledgerBounds", xdr.option(xdr.lookup("LedgerBounds"))],
-  ["minSeqNum", xdr.option(xdr.lookup("SequenceNumber"))],
-  ["minSeqAge", xdr.lookup("Duration")],
-  ["minSeqLedgerGap", xdr.lookup("Uint32")],
-  ["extraSigners", xdr.varArray(xdr.lookup("SignerKey"), 2)],
-]);
-
-// === xdr source ============================================================
-//
-//   enum PreconditionType
-//   {
-//       PRECOND_NONE = 0,
-//       PRECOND_TIME = 1,
-//       PRECOND_V2 = 2
-//   };
-//
-// ===========================================================================
-xdr.enum("PreconditionType", {
-  precondNone: 0,
-  precondTime: 1,
-  precondV2: 2,
-});
-
-// === xdr source ============================================================
-//
-//   union Preconditions switch (PreconditionType type)
-//   {
-//   case PRECOND_NONE:
-//       void;
-//   case PRECOND_TIME:
-//       TimeBounds timeBounds;
-//   case PRECOND_V2:
-//       PreconditionsV2 v2;
-//   };
-//
-// ===========================================================================
-xdr.union("Preconditions", {
-  switchOn: xdr.lookup("PreconditionType"),
-  switchName: "type",
-  switches: [
-    ["precondNone", xdr.void()],
-    ["precondTime", "timeBounds"],
-    ["precondV2", "v2"],
-  ],
-  arms: {
-    timeBounds: xdr.lookup("TimeBounds"),
-    v2: xdr.lookup("PreconditionsV2"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   const MAX_OPS_PER_TX = 100;
-//
-// ===========================================================================
-xdr.const("MAX_OPS_PER_TX", 100);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionV0Ext", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionV0
-//   {
-//       uint256 sourceAccountEd25519;
-//       uint32 fee;
-//       SequenceNumber seqNum;
-//       TimeBounds* timeBounds;
-//       Memo memo;
-//       Operation operations<MAX_OPS_PER_TX>;
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionV0", [
-  ["sourceAccountEd25519", xdr.lookup("Uint256")],
-  ["fee", xdr.lookup("Uint32")],
-  ["seqNum", xdr.lookup("SequenceNumber")],
-  ["timeBounds", xdr.option(xdr.lookup("TimeBounds"))],
-  ["memo", xdr.lookup("Memo")],
-  ["operations", xdr.varArray(xdr.lookup("Operation"), xdr.lookup("MAX_OPS_PER_TX"))],
-  ["ext", xdr.lookup("TransactionV0Ext")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionV0Envelope
-//   {
-//       TransactionV0 tx;
-//       /* Each decorated signature is a signature over the SHA256 hash of
-//        * a TransactionSignaturePayload */
-//       DecoratedSignature signatures<20>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionV0Envelope", [
-  ["tx", xdr.lookup("TransactionV0")],
-  ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct Transaction
-//   {
-//       // account used to run the transaction
-//       MuxedAccount sourceAccount;
-//   
-//       // the fee the sourceAccount will pay
-//       uint32 fee;
-//   
-//       // sequence number to consume in the account
-//       SequenceNumber seqNum;
-//   
-//       // validity conditions
-//       Preconditions cond;
-//   
-//       Memo memo;
-//   
-//       Operation operations<MAX_OPS_PER_TX>;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("Transaction", [
-  ["sourceAccount", xdr.lookup("MuxedAccount")],
-  ["fee", xdr.lookup("Uint32")],
-  ["seqNum", xdr.lookup("SequenceNumber")],
-  ["cond", xdr.lookup("Preconditions")],
-  ["memo", xdr.lookup("Memo")],
-  ["operations", xdr.varArray(xdr.lookup("Operation"), xdr.lookup("MAX_OPS_PER_TX"))],
-  ["ext", xdr.lookup("TransactionExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct TransactionV1Envelope
-//   {
-//       Transaction tx;
-//       /* Each decorated signature is a signature over the SHA256 hash of
-//        * a TransactionSignaturePayload */
-//       DecoratedSignature signatures<20>;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionV1Envelope", [
-  ["tx", xdr.lookup("Transaction")],
-  ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (EnvelopeType type)
-//       {
-//       case ENVELOPE_TYPE_TX:
-//           TransactionV1Envelope v1;
-//       }
-//
-// ===========================================================================
-xdr.union("FeeBumpTransactionInnerTx", {
-  switchOn: xdr.lookup("EnvelopeType"),
-  switchName: "type",
-  switches: [
-    ["envelopeTypeTx", "v1"],
-  ],
-  arms: {
-    v1: xdr.lookup("TransactionV1Envelope"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("FeeBumpTransactionExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct FeeBumpTransaction
-//   {
-//       MuxedAccount feeSource;
-//       int64 fee;
-//       union switch (EnvelopeType type)
-//       {
-//       case ENVELOPE_TYPE_TX:
-//           TransactionV1Envelope v1;
-//       }
-//       innerTx;
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("FeeBumpTransaction", [
-  ["feeSource", xdr.lookup("MuxedAccount")],
-  ["fee", xdr.lookup("Int64")],
-  ["innerTx", xdr.lookup("FeeBumpTransactionInnerTx")],
-  ["ext", xdr.lookup("FeeBumpTransactionExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct FeeBumpTransactionEnvelope
-//   {
-//       FeeBumpTransaction tx;
-//       /* Each decorated signature is a signature over the SHA256 hash of
-//        * a TransactionSignaturePayload */
-//       DecoratedSignature signatures<20>;
-//   };
-//
-// ===========================================================================
-xdr.struct("FeeBumpTransactionEnvelope", [
-  ["tx", xdr.lookup("FeeBumpTransaction")],
-  ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
-]);
-
-// === xdr source ============================================================
-//
-//   union TransactionEnvelope switch (EnvelopeType type)
-//   {
-//   case ENVELOPE_TYPE_TX_V0:
-//       TransactionV0Envelope v0;
-//   case ENVELOPE_TYPE_TX:
-//       TransactionV1Envelope v1;
-//   case ENVELOPE_TYPE_TX_FEE_BUMP:
-//       FeeBumpTransactionEnvelope feeBump;
-//   };
-//
-// ===========================================================================
-xdr.union("TransactionEnvelope", {
-  switchOn: xdr.lookup("EnvelopeType"),
-  switchName: "type",
-  switches: [
-    ["envelopeTypeTxV0", "v0"],
-    ["envelopeTypeTx", "v1"],
-    ["envelopeTypeTxFeeBump", "feeBump"],
-  ],
-  arms: {
-    v0: xdr.lookup("TransactionV0Envelope"),
-    v1: xdr.lookup("TransactionV1Envelope"),
-    feeBump: xdr.lookup("FeeBumpTransactionEnvelope"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (EnvelopeType type)
-//       {
-//       // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
-//       case ENVELOPE_TYPE_TX:
-//           Transaction tx;
-//       case ENVELOPE_TYPE_TX_FEE_BUMP:
-//           FeeBumpTransaction feeBump;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionSignaturePayloadTaggedTransaction", {
-  switchOn: xdr.lookup("EnvelopeType"),
-  switchName: "type",
-  switches: [
-    ["envelopeTypeTx", "tx"],
-    ["envelopeTypeTxFeeBump", "feeBump"],
-  ],
-  arms: {
-    tx: xdr.lookup("Transaction"),
-    feeBump: xdr.lookup("FeeBumpTransaction"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionSignaturePayload
-//   {
-//       Hash networkId;
-//       union switch (EnvelopeType type)
-//       {
-//       // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
-//       case ENVELOPE_TYPE_TX:
-//           Transaction tx;
-//       case ENVELOPE_TYPE_TX_FEE_BUMP:
-//           FeeBumpTransaction feeBump;
-//       }
-//       taggedTransaction;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionSignaturePayload", [
-  ["networkId", xdr.lookup("Hash")],
-  ["taggedTransaction", xdr.lookup("TransactionSignaturePayloadTaggedTransaction")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum ClaimAtomType
-//   {
-//       CLAIM_ATOM_TYPE_V0 = 0,
-//       CLAIM_ATOM_TYPE_ORDER_BOOK = 1,
-//       CLAIM_ATOM_TYPE_LIQUIDITY_POOL = 2
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimAtomType", {
-  claimAtomTypeV0: 0,
-  claimAtomTypeOrderBook: 1,
-  claimAtomTypeLiquidityPool: 2,
-});
-
-// === xdr source ============================================================
-//
-//   struct ClaimOfferAtomV0
-//   {
-//       // emitted to identify the offer
-//       uint256 sellerEd25519; // Account that owns the offer
-//       int64 offerID;
-//   
-//       // amount and asset taken from the owner
-//       Asset assetSold;
-//       int64 amountSold;
-//   
-//       // amount and asset sent to the owner
-//       Asset assetBought;
-//       int64 amountBought;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimOfferAtomV0", [
-  ["sellerEd25519", xdr.lookup("Uint256")],
-  ["offerId", xdr.lookup("Int64")],
-  ["assetSold", xdr.lookup("Asset")],
-  ["amountSold", xdr.lookup("Int64")],
-  ["assetBought", xdr.lookup("Asset")],
-  ["amountBought", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ClaimOfferAtom
-//   {
-//       // emitted to identify the offer
-//       AccountID sellerID; // Account that owns the offer
-//       int64 offerID;
-//   
-//       // amount and asset taken from the owner
-//       Asset assetSold;
-//       int64 amountSold;
-//   
-//       // amount and asset sent to the owner
-//       Asset assetBought;
-//       int64 amountBought;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimOfferAtom", [
-  ["sellerId", xdr.lookup("AccountId")],
-  ["offerId", xdr.lookup("Int64")],
-  ["assetSold", xdr.lookup("Asset")],
-  ["amountSold", xdr.lookup("Int64")],
-  ["assetBought", xdr.lookup("Asset")],
-  ["amountBought", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct ClaimLiquidityAtom
-//   {
-//       PoolID liquidityPoolID;
-//   
-//       // amount and asset taken from the pool
-//       Asset assetSold;
-//       int64 amountSold;
-//   
-//       // amount and asset sent to the pool
-//       Asset assetBought;
-//       int64 amountBought;
-//   };
-//
-// ===========================================================================
-xdr.struct("ClaimLiquidityAtom", [
-  ["liquidityPoolId", xdr.lookup("PoolId")],
-  ["assetSold", xdr.lookup("Asset")],
-  ["amountSold", xdr.lookup("Int64")],
-  ["assetBought", xdr.lookup("Asset")],
-  ["amountBought", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   union ClaimAtom switch (ClaimAtomType type)
-//   {
-//   case CLAIM_ATOM_TYPE_V0:
-//       ClaimOfferAtomV0 v0;
-//   case CLAIM_ATOM_TYPE_ORDER_BOOK:
-//       ClaimOfferAtom orderBook;
-//   case CLAIM_ATOM_TYPE_LIQUIDITY_POOL:
-//       ClaimLiquidityAtom liquidityPool;
-//   };
-//
-// ===========================================================================
-xdr.union("ClaimAtom", {
-  switchOn: xdr.lookup("ClaimAtomType"),
-  switchName: "type",
-  switches: [
-    ["claimAtomTypeV0", "v0"],
-    ["claimAtomTypeOrderBook", "orderBook"],
-    ["claimAtomTypeLiquidityPool", "liquidityPool"],
-  ],
-  arms: {
-    v0: xdr.lookup("ClaimOfferAtomV0"),
-    orderBook: xdr.lookup("ClaimOfferAtom"),
-    liquidityPool: xdr.lookup("ClaimLiquidityAtom"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum CreateAccountResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       CREATE_ACCOUNT_SUCCESS = 0, // account was created
-//   
-//       // codes considered as "failure" for the operation
-//       CREATE_ACCOUNT_MALFORMED = -1,   // invalid destination
-//       CREATE_ACCOUNT_UNDERFUNDED = -2, // not enough funds in source account
-//       CREATE_ACCOUNT_LOW_RESERVE =
-//           -3, // would create an account below the min reserve
-//       CREATE_ACCOUNT_ALREADY_EXIST = -4 // account already exists
-//   };
-//
-// ===========================================================================
-xdr.enum("CreateAccountResultCode", {
-  createAccountSuccess: 0,
-  createAccountMalformed: -1,
-  createAccountUnderfunded: -2,
-  createAccountLowReserve: -3,
-  createAccountAlreadyExist: -4,
-});
-
-// === xdr source ============================================================
-//
-//   union CreateAccountResult switch (CreateAccountResultCode code)
-//   {
-//   case CREATE_ACCOUNT_SUCCESS:
-//       void;
-//   case CREATE_ACCOUNT_MALFORMED:
-//   case CREATE_ACCOUNT_UNDERFUNDED:
-//   case CREATE_ACCOUNT_LOW_RESERVE:
-//   case CREATE_ACCOUNT_ALREADY_EXIST:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("CreateAccountResult", {
-  switchOn: xdr.lookup("CreateAccountResultCode"),
-  switchName: "code",
-  switches: [
-    ["createAccountSuccess", xdr.void()],
-    ["createAccountMalformed", xdr.void()],
-    ["createAccountUnderfunded", xdr.void()],
-    ["createAccountLowReserve", xdr.void()],
-    ["createAccountAlreadyExist", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum PaymentResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       PAYMENT_SUCCESS = 0, // payment successfully completed
-//   
-//       // codes considered as "failure" for the operation
-//       PAYMENT_MALFORMED = -1,          // bad input
-//       PAYMENT_UNDERFUNDED = -2,        // not enough funds in source account
-//       PAYMENT_SRC_NO_TRUST = -3,       // no trust line on source account
-//       PAYMENT_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-//       PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
-//       PAYMENT_NO_TRUST = -6,       // destination missing a trust line for asset
-//       PAYMENT_NOT_AUTHORIZED = -7, // destination not authorized to hold asset
-//       PAYMENT_LINE_FULL = -8,      // destination would go above their limit
-//       PAYMENT_NO_ISSUER = -9       // missing issuer on asset
-//   };
-//
-// ===========================================================================
-xdr.enum("PaymentResultCode", {
-  paymentSuccess: 0,
-  paymentMalformed: -1,
-  paymentUnderfunded: -2,
-  paymentSrcNoTrust: -3,
-  paymentSrcNotAuthorized: -4,
-  paymentNoDestination: -5,
-  paymentNoTrust: -6,
-  paymentNotAuthorized: -7,
-  paymentLineFull: -8,
-  paymentNoIssuer: -9,
-});
-
-// === xdr source ============================================================
-//
-//   union PaymentResult switch (PaymentResultCode code)
-//   {
-//   case PAYMENT_SUCCESS:
-//       void;
-//   case PAYMENT_MALFORMED:
-//   case PAYMENT_UNDERFUNDED:
-//   case PAYMENT_SRC_NO_TRUST:
-//   case PAYMENT_SRC_NOT_AUTHORIZED:
-//   case PAYMENT_NO_DESTINATION:
-//   case PAYMENT_NO_TRUST:
-//   case PAYMENT_NOT_AUTHORIZED:
-//   case PAYMENT_LINE_FULL:
-//   case PAYMENT_NO_ISSUER:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("PaymentResult", {
-  switchOn: xdr.lookup("PaymentResultCode"),
-  switchName: "code",
-  switches: [
-    ["paymentSuccess", xdr.void()],
-    ["paymentMalformed", xdr.void()],
-    ["paymentUnderfunded", xdr.void()],
-    ["paymentSrcNoTrust", xdr.void()],
-    ["paymentSrcNotAuthorized", xdr.void()],
-    ["paymentNoDestination", xdr.void()],
-    ["paymentNoTrust", xdr.void()],
-    ["paymentNotAuthorized", xdr.void()],
-    ["paymentLineFull", xdr.void()],
-    ["paymentNoIssuer", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum PathPaymentStrictReceiveResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
-//   
-//       // codes considered as "failure" for the operation
-//       PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1, // bad input
-//       PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED =
-//           -2, // not enough funds in source account
-//       PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST =
-//           -3, // no trust line on source account
-//       PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED =
-//           -4, // source not authorized to transfer
-//       PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION =
-//           -5, // destination account does not exist
-//       PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST =
-//           -6, // dest missing a trust line for asset
-//       PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED =
-//           -7, // dest not authorized to hold asset
-//       PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL =
-//           -8, // dest would go above their limit
-//       PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9, // missing issuer on one asset
-//       PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS =
-//           -10, // not enough offers to satisfy path
-//       PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF =
-//           -11, // would cross one of its own offers
-//       PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12 // could not satisfy sendmax
-//   };
-//
-// ===========================================================================
-xdr.enum("PathPaymentStrictReceiveResultCode", {
-  pathPaymentStrictReceiveSuccess: 0,
-  pathPaymentStrictReceiveMalformed: -1,
-  pathPaymentStrictReceiveUnderfunded: -2,
-  pathPaymentStrictReceiveSrcNoTrust: -3,
-  pathPaymentStrictReceiveSrcNotAuthorized: -4,
-  pathPaymentStrictReceiveNoDestination: -5,
-  pathPaymentStrictReceiveNoTrust: -6,
-  pathPaymentStrictReceiveNotAuthorized: -7,
-  pathPaymentStrictReceiveLineFull: -8,
-  pathPaymentStrictReceiveNoIssuer: -9,
-  pathPaymentStrictReceiveTooFewOffers: -10,
-  pathPaymentStrictReceiveOfferCrossSelf: -11,
-  pathPaymentStrictReceiveOverSendmax: -12,
-});
-
-// === xdr source ============================================================
-//
-//   struct SimplePaymentResult
-//   {
-//       AccountID destination;
-//       Asset asset;
-//       int64 amount;
-//   };
-//
-// ===========================================================================
-xdr.struct("SimplePaymentResult", [
-  ["destination", xdr.lookup("AccountId")],
-  ["asset", xdr.lookup("Asset")],
-  ["amount", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           ClaimAtom offers<>;
-//           SimplePaymentResult last;
-//       }
-//
-// ===========================================================================
-xdr.struct("PathPaymentStrictReceiveResultSuccess", [
-  ["offers", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
-  ["last", xdr.lookup("SimplePaymentResult")],
-]);
-
-// === xdr source ============================================================
-//
-//   union PathPaymentStrictReceiveResult switch (
-//       PathPaymentStrictReceiveResultCode code)
-//   {
-//   case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
-//       struct
-//       {
-//           ClaimAtom offers<>;
-//           SimplePaymentResult last;
-//       } success;
-//   case PATH_PAYMENT_STRICT_RECEIVE_MALFORMED:
-//   case PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED:
-//   case PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST:
-//   case PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED:
-//   case PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION:
-//   case PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST:
-//   case PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED:
-//   case PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL:
-//       void;
-//   case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
-//       Asset noIssuer; // the asset that caused the error
-//   case PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS:
-//   case PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF:
-//   case PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("PathPaymentStrictReceiveResult", {
-  switchOn: xdr.lookup("PathPaymentStrictReceiveResultCode"),
-  switchName: "code",
-  switches: [
-    ["pathPaymentStrictReceiveSuccess", "success"],
-    ["pathPaymentStrictReceiveMalformed", xdr.void()],
-    ["pathPaymentStrictReceiveUnderfunded", xdr.void()],
-    ["pathPaymentStrictReceiveSrcNoTrust", xdr.void()],
-    ["pathPaymentStrictReceiveSrcNotAuthorized", xdr.void()],
-    ["pathPaymentStrictReceiveNoDestination", xdr.void()],
-    ["pathPaymentStrictReceiveNoTrust", xdr.void()],
-    ["pathPaymentStrictReceiveNotAuthorized", xdr.void()],
-    ["pathPaymentStrictReceiveLineFull", xdr.void()],
-    ["pathPaymentStrictReceiveNoIssuer", "noIssuer"],
-    ["pathPaymentStrictReceiveTooFewOffers", xdr.void()],
-    ["pathPaymentStrictReceiveOfferCrossSelf", xdr.void()],
-    ["pathPaymentStrictReceiveOverSendmax", xdr.void()],
-  ],
-  arms: {
-    success: xdr.lookup("PathPaymentStrictReceiveResultSuccess"),
-    noIssuer: xdr.lookup("Asset"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum PathPaymentStrictSendResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
-//   
-//       // codes considered as "failure" for the operation
-//       PATH_PAYMENT_STRICT_SEND_MALFORMED = -1, // bad input
-//       PATH_PAYMENT_STRICT_SEND_UNDERFUNDED =
-//           -2, // not enough funds in source account
-//       PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST =
-//           -3, // no trust line on source account
-//       PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED =
-//           -4, // source not authorized to transfer
-//       PATH_PAYMENT_STRICT_SEND_NO_DESTINATION =
-//           -5, // destination account does not exist
-//       PATH_PAYMENT_STRICT_SEND_NO_TRUST =
-//           -6, // dest missing a trust line for asset
-//       PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED =
-//           -7, // dest not authorized to hold asset
-//       PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8, // dest would go above their limit
-//       PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9, // missing issuer on one asset
-//       PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS =
-//           -10, // not enough offers to satisfy path
-//       PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF =
-//           -11, // would cross one of its own offers
-//       PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12 // could not satisfy destMin
-//   };
-//
-// ===========================================================================
-xdr.enum("PathPaymentStrictSendResultCode", {
-  pathPaymentStrictSendSuccess: 0,
-  pathPaymentStrictSendMalformed: -1,
-  pathPaymentStrictSendUnderfunded: -2,
-  pathPaymentStrictSendSrcNoTrust: -3,
-  pathPaymentStrictSendSrcNotAuthorized: -4,
-  pathPaymentStrictSendNoDestination: -5,
-  pathPaymentStrictSendNoTrust: -6,
-  pathPaymentStrictSendNotAuthorized: -7,
-  pathPaymentStrictSendLineFull: -8,
-  pathPaymentStrictSendNoIssuer: -9,
-  pathPaymentStrictSendTooFewOffers: -10,
-  pathPaymentStrictSendOfferCrossSelf: -11,
-  pathPaymentStrictSendUnderDestmin: -12,
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           ClaimAtom offers<>;
-//           SimplePaymentResult last;
-//       }
-//
-// ===========================================================================
-xdr.struct("PathPaymentStrictSendResultSuccess", [
-  ["offers", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
-  ["last", xdr.lookup("SimplePaymentResult")],
-]);
-
-// === xdr source ============================================================
-//
-//   union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
-//   {
-//   case PATH_PAYMENT_STRICT_SEND_SUCCESS:
-//       struct
-//       {
-//           ClaimAtom offers<>;
-//           SimplePaymentResult last;
-//       } success;
-//   case PATH_PAYMENT_STRICT_SEND_MALFORMED:
-//   case PATH_PAYMENT_STRICT_SEND_UNDERFUNDED:
-//   case PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST:
-//   case PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED:
-//   case PATH_PAYMENT_STRICT_SEND_NO_DESTINATION:
-//   case PATH_PAYMENT_STRICT_SEND_NO_TRUST:
-//   case PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED:
-//   case PATH_PAYMENT_STRICT_SEND_LINE_FULL:
-//       void;
-//   case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
-//       Asset noIssuer; // the asset that caused the error
-//   case PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS:
-//   case PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF:
-//   case PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("PathPaymentStrictSendResult", {
-  switchOn: xdr.lookup("PathPaymentStrictSendResultCode"),
-  switchName: "code",
-  switches: [
-    ["pathPaymentStrictSendSuccess", "success"],
-    ["pathPaymentStrictSendMalformed", xdr.void()],
-    ["pathPaymentStrictSendUnderfunded", xdr.void()],
-    ["pathPaymentStrictSendSrcNoTrust", xdr.void()],
-    ["pathPaymentStrictSendSrcNotAuthorized", xdr.void()],
-    ["pathPaymentStrictSendNoDestination", xdr.void()],
-    ["pathPaymentStrictSendNoTrust", xdr.void()],
-    ["pathPaymentStrictSendNotAuthorized", xdr.void()],
-    ["pathPaymentStrictSendLineFull", xdr.void()],
-    ["pathPaymentStrictSendNoIssuer", "noIssuer"],
-    ["pathPaymentStrictSendTooFewOffers", xdr.void()],
-    ["pathPaymentStrictSendOfferCrossSelf", xdr.void()],
-    ["pathPaymentStrictSendUnderDestmin", xdr.void()],
-  ],
-  arms: {
-    success: xdr.lookup("PathPaymentStrictSendResultSuccess"),
-    noIssuer: xdr.lookup("Asset"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ManageSellOfferResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       MANAGE_SELL_OFFER_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       MANAGE_SELL_OFFER_MALFORMED = -1, // generated offer would be invalid
-//       MANAGE_SELL_OFFER_SELL_NO_TRUST =
-//           -2,                              // no trust line for what we're selling
-//       MANAGE_SELL_OFFER_BUY_NO_TRUST = -3, // no trust line for what we're buying
-//       MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
-//       MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-//       MANAGE_SELL_OFFER_LINE_FULL = -6, // can't receive more of what it's buying
-//       MANAGE_SELL_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
-//       MANAGE_SELL_OFFER_CROSS_SELF =
-//           -8, // would cross an offer from the same user
-//       MANAGE_SELL_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
-//       MANAGE_SELL_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
-//   
-//       // update errors
-//       MANAGE_SELL_OFFER_NOT_FOUND =
-//           -11, // offerID does not match an existing offer
-//   
-//       MANAGE_SELL_OFFER_LOW_RESERVE =
-//           -12 // not enough funds to create a new Offer
-//   };
-//
-// ===========================================================================
-xdr.enum("ManageSellOfferResultCode", {
-  manageSellOfferSuccess: 0,
-  manageSellOfferMalformed: -1,
-  manageSellOfferSellNoTrust: -2,
-  manageSellOfferBuyNoTrust: -3,
-  manageSellOfferSellNotAuthorized: -4,
-  manageSellOfferBuyNotAuthorized: -5,
-  manageSellOfferLineFull: -6,
-  manageSellOfferUnderfunded: -7,
-  manageSellOfferCrossSelf: -8,
-  manageSellOfferSellNoIssuer: -9,
-  manageSellOfferBuyNoIssuer: -10,
-  manageSellOfferNotFound: -11,
-  manageSellOfferLowReserve: -12,
-});
-
-// === xdr source ============================================================
-//
-//   enum ManageOfferEffect
-//   {
-//       MANAGE_OFFER_CREATED = 0,
-//       MANAGE_OFFER_UPDATED = 1,
-//       MANAGE_OFFER_DELETED = 2
-//   };
-//
-// ===========================================================================
-xdr.enum("ManageOfferEffect", {
-  manageOfferCreated: 0,
-  manageOfferUpdated: 1,
-  manageOfferDeleted: 2,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (ManageOfferEffect effect)
-//       {
-//       case MANAGE_OFFER_CREATED:
-//       case MANAGE_OFFER_UPDATED:
-//           OfferEntry offer;
-//       case MANAGE_OFFER_DELETED:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("ManageOfferSuccessResultOffer", {
-  switchOn: xdr.lookup("ManageOfferEffect"),
-  switchName: "effect",
-  switches: [
-    ["manageOfferCreated", "offer"],
-    ["manageOfferUpdated", "offer"],
-    ["manageOfferDeleted", xdr.void()],
-  ],
-  arms: {
-    offer: xdr.lookup("OfferEntry"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ManageOfferSuccessResult
-//   {
-//       // offers that got claimed while creating this offer
-//       ClaimAtom offersClaimed<>;
-//   
-//       union switch (ManageOfferEffect effect)
-//       {
-//       case MANAGE_OFFER_CREATED:
-//       case MANAGE_OFFER_UPDATED:
-//           OfferEntry offer;
-//       case MANAGE_OFFER_DELETED:
-//           void;
-//       }
-//       offer;
-//   };
-//
-// ===========================================================================
-xdr.struct("ManageOfferSuccessResult", [
-  ["offersClaimed", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
-  ["offer", xdr.lookup("ManageOfferSuccessResultOffer")],
-]);
-
-// === xdr source ============================================================
-//
-//   union ManageSellOfferResult switch (ManageSellOfferResultCode code)
-//   {
-//   case MANAGE_SELL_OFFER_SUCCESS:
-//       ManageOfferSuccessResult success;
-//   case MANAGE_SELL_OFFER_MALFORMED:
-//   case MANAGE_SELL_OFFER_SELL_NO_TRUST:
-//   case MANAGE_SELL_OFFER_BUY_NO_TRUST:
-//   case MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED:
-//   case MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED:
-//   case MANAGE_SELL_OFFER_LINE_FULL:
-//   case MANAGE_SELL_OFFER_UNDERFUNDED:
-//   case MANAGE_SELL_OFFER_CROSS_SELF:
-//   case MANAGE_SELL_OFFER_SELL_NO_ISSUER:
-//   case MANAGE_SELL_OFFER_BUY_NO_ISSUER:
-//   case MANAGE_SELL_OFFER_NOT_FOUND:
-//   case MANAGE_SELL_OFFER_LOW_RESERVE:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ManageSellOfferResult", {
-  switchOn: xdr.lookup("ManageSellOfferResultCode"),
-  switchName: "code",
-  switches: [
-    ["manageSellOfferSuccess", "success"],
-    ["manageSellOfferMalformed", xdr.void()],
-    ["manageSellOfferSellNoTrust", xdr.void()],
-    ["manageSellOfferBuyNoTrust", xdr.void()],
-    ["manageSellOfferSellNotAuthorized", xdr.void()],
-    ["manageSellOfferBuyNotAuthorized", xdr.void()],
-    ["manageSellOfferLineFull", xdr.void()],
-    ["manageSellOfferUnderfunded", xdr.void()],
-    ["manageSellOfferCrossSelf", xdr.void()],
-    ["manageSellOfferSellNoIssuer", xdr.void()],
-    ["manageSellOfferBuyNoIssuer", xdr.void()],
-    ["manageSellOfferNotFound", xdr.void()],
-    ["manageSellOfferLowReserve", xdr.void()],
-  ],
-  arms: {
-    success: xdr.lookup("ManageOfferSuccessResult"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ManageBuyOfferResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       MANAGE_BUY_OFFER_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       MANAGE_BUY_OFFER_MALFORMED = -1,     // generated offer would be invalid
-//       MANAGE_BUY_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
-//       MANAGE_BUY_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
-//       MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
-//       MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-//       MANAGE_BUY_OFFER_LINE_FULL = -6,   // can't receive more of what it's buying
-//       MANAGE_BUY_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
-//       MANAGE_BUY_OFFER_CROSS_SELF = -8, // would cross an offer from the same user
-//       MANAGE_BUY_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
-//       MANAGE_BUY_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
-//   
-//       // update errors
-//       MANAGE_BUY_OFFER_NOT_FOUND =
-//           -11, // offerID does not match an existing offer
-//   
-//       MANAGE_BUY_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
-//   };
-//
-// ===========================================================================
-xdr.enum("ManageBuyOfferResultCode", {
-  manageBuyOfferSuccess: 0,
-  manageBuyOfferMalformed: -1,
-  manageBuyOfferSellNoTrust: -2,
-  manageBuyOfferBuyNoTrust: -3,
-  manageBuyOfferSellNotAuthorized: -4,
-  manageBuyOfferBuyNotAuthorized: -5,
-  manageBuyOfferLineFull: -6,
-  manageBuyOfferUnderfunded: -7,
-  manageBuyOfferCrossSelf: -8,
-  manageBuyOfferSellNoIssuer: -9,
-  manageBuyOfferBuyNoIssuer: -10,
-  manageBuyOfferNotFound: -11,
-  manageBuyOfferLowReserve: -12,
-});
-
-// === xdr source ============================================================
-//
-//   union ManageBuyOfferResult switch (ManageBuyOfferResultCode code)
-//   {
-//   case MANAGE_BUY_OFFER_SUCCESS:
-//       ManageOfferSuccessResult success;
-//   case MANAGE_BUY_OFFER_MALFORMED:
-//   case MANAGE_BUY_OFFER_SELL_NO_TRUST:
-//   case MANAGE_BUY_OFFER_BUY_NO_TRUST:
-//   case MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED:
-//   case MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED:
-//   case MANAGE_BUY_OFFER_LINE_FULL:
-//   case MANAGE_BUY_OFFER_UNDERFUNDED:
-//   case MANAGE_BUY_OFFER_CROSS_SELF:
-//   case MANAGE_BUY_OFFER_SELL_NO_ISSUER:
-//   case MANAGE_BUY_OFFER_BUY_NO_ISSUER:
-//   case MANAGE_BUY_OFFER_NOT_FOUND:
-//   case MANAGE_BUY_OFFER_LOW_RESERVE:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ManageBuyOfferResult", {
-  switchOn: xdr.lookup("ManageBuyOfferResultCode"),
-  switchName: "code",
-  switches: [
-    ["manageBuyOfferSuccess", "success"],
-    ["manageBuyOfferMalformed", xdr.void()],
-    ["manageBuyOfferSellNoTrust", xdr.void()],
-    ["manageBuyOfferBuyNoTrust", xdr.void()],
-    ["manageBuyOfferSellNotAuthorized", xdr.void()],
-    ["manageBuyOfferBuyNotAuthorized", xdr.void()],
-    ["manageBuyOfferLineFull", xdr.void()],
-    ["manageBuyOfferUnderfunded", xdr.void()],
-    ["manageBuyOfferCrossSelf", xdr.void()],
-    ["manageBuyOfferSellNoIssuer", xdr.void()],
-    ["manageBuyOfferBuyNoIssuer", xdr.void()],
-    ["manageBuyOfferNotFound", xdr.void()],
-    ["manageBuyOfferLowReserve", xdr.void()],
-  ],
-  arms: {
-    success: xdr.lookup("ManageOfferSuccessResult"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum SetOptionsResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       SET_OPTIONS_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       SET_OPTIONS_LOW_RESERVE = -1,      // not enough funds to add a signer
-//       SET_OPTIONS_TOO_MANY_SIGNERS = -2, // max number of signers already reached
-//       SET_OPTIONS_BAD_FLAGS = -3,        // invalid combination of clear/set flags
-//       SET_OPTIONS_INVALID_INFLATION = -4,      // inflation account does not exist
-//       SET_OPTIONS_CANT_CHANGE = -5,            // can no longer change this option
-//       SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
-//       SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
-//       SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
-//       SET_OPTIONS_INVALID_HOME_DOMAIN = -9,    // malformed home domain
-//       SET_OPTIONS_AUTH_REVOCABLE_REQUIRED =
-//           -10 // auth revocable is required for clawback
-//   };
-//
-// ===========================================================================
-xdr.enum("SetOptionsResultCode", {
-  setOptionsSuccess: 0,
-  setOptionsLowReserve: -1,
-  setOptionsTooManySigners: -2,
-  setOptionsBadFlags: -3,
-  setOptionsInvalidInflation: -4,
-  setOptionsCantChange: -5,
-  setOptionsUnknownFlag: -6,
-  setOptionsThresholdOutOfRange: -7,
-  setOptionsBadSigner: -8,
-  setOptionsInvalidHomeDomain: -9,
-  setOptionsAuthRevocableRequired: -10,
-});
-
-// === xdr source ============================================================
-//
-//   union SetOptionsResult switch (SetOptionsResultCode code)
-//   {
-//   case SET_OPTIONS_SUCCESS:
-//       void;
-//   case SET_OPTIONS_LOW_RESERVE:
-//   case SET_OPTIONS_TOO_MANY_SIGNERS:
-//   case SET_OPTIONS_BAD_FLAGS:
-//   case SET_OPTIONS_INVALID_INFLATION:
-//   case SET_OPTIONS_CANT_CHANGE:
-//   case SET_OPTIONS_UNKNOWN_FLAG:
-//   case SET_OPTIONS_THRESHOLD_OUT_OF_RANGE:
-//   case SET_OPTIONS_BAD_SIGNER:
-//   case SET_OPTIONS_INVALID_HOME_DOMAIN:
-//   case SET_OPTIONS_AUTH_REVOCABLE_REQUIRED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("SetOptionsResult", {
-  switchOn: xdr.lookup("SetOptionsResultCode"),
-  switchName: "code",
-  switches: [
-    ["setOptionsSuccess", xdr.void()],
-    ["setOptionsLowReserve", xdr.void()],
-    ["setOptionsTooManySigners", xdr.void()],
-    ["setOptionsBadFlags", xdr.void()],
-    ["setOptionsInvalidInflation", xdr.void()],
-    ["setOptionsCantChange", xdr.void()],
-    ["setOptionsUnknownFlag", xdr.void()],
-    ["setOptionsThresholdOutOfRange", xdr.void()],
-    ["setOptionsBadSigner", xdr.void()],
-    ["setOptionsInvalidHomeDomain", xdr.void()],
-    ["setOptionsAuthRevocableRequired", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ChangeTrustResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       CHANGE_TRUST_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       CHANGE_TRUST_MALFORMED = -1,     // bad input
-//       CHANGE_TRUST_NO_ISSUER = -2,     // could not find issuer
-//       CHANGE_TRUST_INVALID_LIMIT = -3, // cannot drop limit below balance
-//                                        // cannot create with a limit of 0
-//       CHANGE_TRUST_LOW_RESERVE =
-//           -4, // not enough funds to create a new trust line,
-//       CHANGE_TRUST_SELF_NOT_ALLOWED = -5,   // trusting self is not allowed
-//       CHANGE_TRUST_TRUST_LINE_MISSING = -6, // Asset trustline is missing for pool
-//       CHANGE_TRUST_CANNOT_DELETE =
-//           -7, // Asset trustline is still referenced in a pool
-//       CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES =
-//           -8 // Asset trustline is deauthorized
-//   };
-//
-// ===========================================================================
-xdr.enum("ChangeTrustResultCode", {
-  changeTrustSuccess: 0,
-  changeTrustMalformed: -1,
-  changeTrustNoIssuer: -2,
-  changeTrustInvalidLimit: -3,
-  changeTrustLowReserve: -4,
-  changeTrustSelfNotAllowed: -5,
-  changeTrustTrustLineMissing: -6,
-  changeTrustCannotDelete: -7,
-  changeTrustNotAuthMaintainLiabilities: -8,
-});
-
-// === xdr source ============================================================
-//
-//   union ChangeTrustResult switch (ChangeTrustResultCode code)
-//   {
-//   case CHANGE_TRUST_SUCCESS:
-//       void;
-//   case CHANGE_TRUST_MALFORMED:
-//   case CHANGE_TRUST_NO_ISSUER:
-//   case CHANGE_TRUST_INVALID_LIMIT:
-//   case CHANGE_TRUST_LOW_RESERVE:
-//   case CHANGE_TRUST_SELF_NOT_ALLOWED:
-//   case CHANGE_TRUST_TRUST_LINE_MISSING:
-//   case CHANGE_TRUST_CANNOT_DELETE:
-//   case CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ChangeTrustResult", {
-  switchOn: xdr.lookup("ChangeTrustResultCode"),
-  switchName: "code",
-  switches: [
-    ["changeTrustSuccess", xdr.void()],
-    ["changeTrustMalformed", xdr.void()],
-    ["changeTrustNoIssuer", xdr.void()],
-    ["changeTrustInvalidLimit", xdr.void()],
-    ["changeTrustLowReserve", xdr.void()],
-    ["changeTrustSelfNotAllowed", xdr.void()],
-    ["changeTrustTrustLineMissing", xdr.void()],
-    ["changeTrustCannotDelete", xdr.void()],
-    ["changeTrustNotAuthMaintainLiabilities", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum AllowTrustResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       ALLOW_TRUST_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       ALLOW_TRUST_MALFORMED = -1,     // asset is not ASSET_TYPE_ALPHANUM
-//       ALLOW_TRUST_NO_TRUST_LINE = -2, // trustor does not have a trustline
-//                                       // source account does not require trust
-//       ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
-//       ALLOW_TRUST_CANT_REVOKE = -4,      // source account can't revoke trust,
-//       ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
-//       ALLOW_TRUST_LOW_RESERVE = -6       // claimable balances can't be created
-//                                          // on revoke due to low reserves
-//   };
-//
-// ===========================================================================
-xdr.enum("AllowTrustResultCode", {
-  allowTrustSuccess: 0,
-  allowTrustMalformed: -1,
-  allowTrustNoTrustLine: -2,
-  allowTrustTrustNotRequired: -3,
-  allowTrustCantRevoke: -4,
-  allowTrustSelfNotAllowed: -5,
-  allowTrustLowReserve: -6,
-});
-
-// === xdr source ============================================================
-//
-//   union AllowTrustResult switch (AllowTrustResultCode code)
-//   {
-//   case ALLOW_TRUST_SUCCESS:
-//       void;
-//   case ALLOW_TRUST_MALFORMED:
-//   case ALLOW_TRUST_NO_TRUST_LINE:
-//   case ALLOW_TRUST_TRUST_NOT_REQUIRED:
-//   case ALLOW_TRUST_CANT_REVOKE:
-//   case ALLOW_TRUST_SELF_NOT_ALLOWED:
-//   case ALLOW_TRUST_LOW_RESERVE:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("AllowTrustResult", {
-  switchOn: xdr.lookup("AllowTrustResultCode"),
-  switchName: "code",
-  switches: [
-    ["allowTrustSuccess", xdr.void()],
-    ["allowTrustMalformed", xdr.void()],
-    ["allowTrustNoTrustLine", xdr.void()],
-    ["allowTrustTrustNotRequired", xdr.void()],
-    ["allowTrustCantRevoke", xdr.void()],
-    ["allowTrustSelfNotAllowed", xdr.void()],
-    ["allowTrustLowReserve", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum AccountMergeResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       ACCOUNT_MERGE_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       ACCOUNT_MERGE_MALFORMED = -1,       // can't merge onto itself
-//       ACCOUNT_MERGE_NO_ACCOUNT = -2,      // destination does not exist
-//       ACCOUNT_MERGE_IMMUTABLE_SET = -3,   // source account has AUTH_IMMUTABLE set
-//       ACCOUNT_MERGE_HAS_SUB_ENTRIES = -4, // account has trust lines/offers
-//       ACCOUNT_MERGE_SEQNUM_TOO_FAR = -5,  // sequence number is over max allowed
-//       ACCOUNT_MERGE_DEST_FULL = -6,       // can't add source balance to
-//                                           // destination balance
-//       ACCOUNT_MERGE_IS_SPONSOR = -7       // can't merge account that is a sponsor
-//   };
-//
-// ===========================================================================
-xdr.enum("AccountMergeResultCode", {
-  accountMergeSuccess: 0,
-  accountMergeMalformed: -1,
-  accountMergeNoAccount: -2,
-  accountMergeImmutableSet: -3,
-  accountMergeHasSubEntries: -4,
-  accountMergeSeqnumTooFar: -5,
-  accountMergeDestFull: -6,
-  accountMergeIsSponsor: -7,
-});
-
-// === xdr source ============================================================
-//
-//   union AccountMergeResult switch (AccountMergeResultCode code)
-//   {
-//   case ACCOUNT_MERGE_SUCCESS:
-//       int64 sourceAccountBalance; // how much got transferred from source account
-//   case ACCOUNT_MERGE_MALFORMED:
-//   case ACCOUNT_MERGE_NO_ACCOUNT:
-//   case ACCOUNT_MERGE_IMMUTABLE_SET:
-//   case ACCOUNT_MERGE_HAS_SUB_ENTRIES:
-//   case ACCOUNT_MERGE_SEQNUM_TOO_FAR:
-//   case ACCOUNT_MERGE_DEST_FULL:
-//   case ACCOUNT_MERGE_IS_SPONSOR:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("AccountMergeResult", {
-  switchOn: xdr.lookup("AccountMergeResultCode"),
-  switchName: "code",
-  switches: [
-    ["accountMergeSuccess", "sourceAccountBalance"],
-    ["accountMergeMalformed", xdr.void()],
-    ["accountMergeNoAccount", xdr.void()],
-    ["accountMergeImmutableSet", xdr.void()],
-    ["accountMergeHasSubEntries", xdr.void()],
-    ["accountMergeSeqnumTooFar", xdr.void()],
-    ["accountMergeDestFull", xdr.void()],
-    ["accountMergeIsSponsor", xdr.void()],
-  ],
-  arms: {
-    sourceAccountBalance: xdr.lookup("Int64"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum InflationResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       INFLATION_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       INFLATION_NOT_TIME = -1
-//   };
-//
-// ===========================================================================
-xdr.enum("InflationResultCode", {
-  inflationSuccess: 0,
-  inflationNotTime: -1,
-});
-
-// === xdr source ============================================================
-//
-//   struct InflationPayout // or use PaymentResultAtom to limit types?
-//   {
-//       AccountID destination;
-//       int64 amount;
-//   };
-//
-// ===========================================================================
-xdr.struct("InflationPayout", [
-  ["destination", xdr.lookup("AccountId")],
-  ["amount", xdr.lookup("Int64")],
-]);
-
-// === xdr source ============================================================
-//
-//   union InflationResult switch (InflationResultCode code)
-//   {
-//   case INFLATION_SUCCESS:
-//       InflationPayout payouts<>;
-//   case INFLATION_NOT_TIME:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("InflationResult", {
-  switchOn: xdr.lookup("InflationResultCode"),
-  switchName: "code",
-  switches: [
-    ["inflationSuccess", "payouts"],
-    ["inflationNotTime", xdr.void()],
-  ],
-  arms: {
-    payouts: xdr.varArray(xdr.lookup("InflationPayout"), 2147483647),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ManageDataResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       MANAGE_DATA_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       MANAGE_DATA_NOT_SUPPORTED_YET =
-//           -1, // The network hasn't moved to this protocol change yet
-//       MANAGE_DATA_NAME_NOT_FOUND =
-//           -2, // Trying to remove a Data Entry that isn't there
-//       MANAGE_DATA_LOW_RESERVE = -3, // not enough funds to create a new Data Entry
-//       MANAGE_DATA_INVALID_NAME = -4 // Name not a valid string
-//   };
-//
-// ===========================================================================
-xdr.enum("ManageDataResultCode", {
-  manageDataSuccess: 0,
-  manageDataNotSupportedYet: -1,
-  manageDataNameNotFound: -2,
-  manageDataLowReserve: -3,
-  manageDataInvalidName: -4,
-});
-
-// === xdr source ============================================================
-//
-//   union ManageDataResult switch (ManageDataResultCode code)
-//   {
-//   case MANAGE_DATA_SUCCESS:
-//       void;
-//   case MANAGE_DATA_NOT_SUPPORTED_YET:
-//   case MANAGE_DATA_NAME_NOT_FOUND:
-//   case MANAGE_DATA_LOW_RESERVE:
-//   case MANAGE_DATA_INVALID_NAME:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ManageDataResult", {
-  switchOn: xdr.lookup("ManageDataResultCode"),
-  switchName: "code",
-  switches: [
-    ["manageDataSuccess", xdr.void()],
-    ["manageDataNotSupportedYet", xdr.void()],
-    ["manageDataNameNotFound", xdr.void()],
-    ["manageDataLowReserve", xdr.void()],
-    ["manageDataInvalidName", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum BumpSequenceResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       BUMP_SEQUENCE_SUCCESS = 0,
-//       // codes considered as "failure" for the operation
-//       BUMP_SEQUENCE_BAD_SEQ = -1 // `bumpTo` is not within bounds
-//   };
-//
-// ===========================================================================
-xdr.enum("BumpSequenceResultCode", {
-  bumpSequenceSuccess: 0,
-  bumpSequenceBadSeq: -1,
-});
-
-// === xdr source ============================================================
-//
-//   union BumpSequenceResult switch (BumpSequenceResultCode code)
-//   {
-//   case BUMP_SEQUENCE_SUCCESS:
-//       void;
-//   case BUMP_SEQUENCE_BAD_SEQ:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("BumpSequenceResult", {
-  switchOn: xdr.lookup("BumpSequenceResultCode"),
-  switchName: "code",
-  switches: [
-    ["bumpSequenceSuccess", xdr.void()],
-    ["bumpSequenceBadSeq", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum CreateClaimableBalanceResultCode
-//   {
-//       CREATE_CLAIMABLE_BALANCE_SUCCESS = 0,
-//       CREATE_CLAIMABLE_BALANCE_MALFORMED = -1,
-//       CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
-//       CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
-//       CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
-//       CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5
-//   };
-//
-// ===========================================================================
-xdr.enum("CreateClaimableBalanceResultCode", {
-  createClaimableBalanceSuccess: 0,
-  createClaimableBalanceMalformed: -1,
-  createClaimableBalanceLowReserve: -2,
-  createClaimableBalanceNoTrust: -3,
-  createClaimableBalanceNotAuthorized: -4,
-  createClaimableBalanceUnderfunded: -5,
-});
-
-// === xdr source ============================================================
-//
-//   union CreateClaimableBalanceResult switch (
-//       CreateClaimableBalanceResultCode code)
-//   {
-//   case CREATE_CLAIMABLE_BALANCE_SUCCESS:
-//       ClaimableBalanceID balanceID;
-//   case CREATE_CLAIMABLE_BALANCE_MALFORMED:
-//   case CREATE_CLAIMABLE_BALANCE_LOW_RESERVE:
-//   case CREATE_CLAIMABLE_BALANCE_NO_TRUST:
-//   case CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
-//   case CREATE_CLAIMABLE_BALANCE_UNDERFUNDED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("CreateClaimableBalanceResult", {
-  switchOn: xdr.lookup("CreateClaimableBalanceResultCode"),
-  switchName: "code",
-  switches: [
-    ["createClaimableBalanceSuccess", "balanceId"],
-    ["createClaimableBalanceMalformed", xdr.void()],
-    ["createClaimableBalanceLowReserve", xdr.void()],
-    ["createClaimableBalanceNoTrust", xdr.void()],
-    ["createClaimableBalanceNotAuthorized", xdr.void()],
-    ["createClaimableBalanceUnderfunded", xdr.void()],
-  ],
-  arms: {
-    balanceId: xdr.lookup("ClaimableBalanceId"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClaimClaimableBalanceResultCode
-//   {
-//       CLAIM_CLAIMABLE_BALANCE_SUCCESS = 0,
-//       CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
-//       CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM = -2,
-//       CLAIM_CLAIMABLE_BALANCE_LINE_FULL = -3,
-//       CLAIM_CLAIMABLE_BALANCE_NO_TRUST = -4,
-//       CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -5
-//   };
-//
-// ===========================================================================
-xdr.enum("ClaimClaimableBalanceResultCode", {
-  claimClaimableBalanceSuccess: 0,
-  claimClaimableBalanceDoesNotExist: -1,
-  claimClaimableBalanceCannotClaim: -2,
-  claimClaimableBalanceLineFull: -3,
-  claimClaimableBalanceNoTrust: -4,
-  claimClaimableBalanceNotAuthorized: -5,
-});
-
-// === xdr source ============================================================
-//
-//   union ClaimClaimableBalanceResult switch (ClaimClaimableBalanceResultCode code)
-//   {
-//   case CLAIM_CLAIMABLE_BALANCE_SUCCESS:
-//       void;
-//   case CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
-//   case CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM:
-//   case CLAIM_CLAIMABLE_BALANCE_LINE_FULL:
-//   case CLAIM_CLAIMABLE_BALANCE_NO_TRUST:
-//   case CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ClaimClaimableBalanceResult", {
-  switchOn: xdr.lookup("ClaimClaimableBalanceResultCode"),
-  switchName: "code",
-  switches: [
-    ["claimClaimableBalanceSuccess", xdr.void()],
-    ["claimClaimableBalanceDoesNotExist", xdr.void()],
-    ["claimClaimableBalanceCannotClaim", xdr.void()],
-    ["claimClaimableBalanceLineFull", xdr.void()],
-    ["claimClaimableBalanceNoTrust", xdr.void()],
-    ["claimClaimableBalanceNotAuthorized", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum BeginSponsoringFutureReservesResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED = -1,
-//       BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED = -2,
-//       BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE = -3
-//   };
-//
-// ===========================================================================
-xdr.enum("BeginSponsoringFutureReservesResultCode", {
-  beginSponsoringFutureReservesSuccess: 0,
-  beginSponsoringFutureReservesMalformed: -1,
-  beginSponsoringFutureReservesAlreadySponsored: -2,
-  beginSponsoringFutureReservesRecursive: -3,
-});
-
-// === xdr source ============================================================
-//
-//   union BeginSponsoringFutureReservesResult switch (
-//       BeginSponsoringFutureReservesResultCode code)
-//   {
-//   case BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS:
-//       void;
-//   case BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED:
-//   case BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED:
-//   case BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("BeginSponsoringFutureReservesResult", {
-  switchOn: xdr.lookup("BeginSponsoringFutureReservesResultCode"),
-  switchName: "code",
-  switches: [
-    ["beginSponsoringFutureReservesSuccess", xdr.void()],
-    ["beginSponsoringFutureReservesMalformed", xdr.void()],
-    ["beginSponsoringFutureReservesAlreadySponsored", xdr.void()],
-    ["beginSponsoringFutureReservesRecursive", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum EndSponsoringFutureReservesResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       END_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED = -1
-//   };
-//
-// ===========================================================================
-xdr.enum("EndSponsoringFutureReservesResultCode", {
-  endSponsoringFutureReservesSuccess: 0,
-  endSponsoringFutureReservesNotSponsored: -1,
-});
-
-// === xdr source ============================================================
-//
-//   union EndSponsoringFutureReservesResult switch (
-//       EndSponsoringFutureReservesResultCode code)
-//   {
-//   case END_SPONSORING_FUTURE_RESERVES_SUCCESS:
-//       void;
-//   case END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("EndSponsoringFutureReservesResult", {
-  switchOn: xdr.lookup("EndSponsoringFutureReservesResultCode"),
-  switchName: "code",
-  switches: [
-    ["endSponsoringFutureReservesSuccess", xdr.void()],
-    ["endSponsoringFutureReservesNotSponsored", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum RevokeSponsorshipResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       REVOKE_SPONSORSHIP_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       REVOKE_SPONSORSHIP_DOES_NOT_EXIST = -1,
-//       REVOKE_SPONSORSHIP_NOT_SPONSOR = -2,
-//       REVOKE_SPONSORSHIP_LOW_RESERVE = -3,
-//       REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE = -4,
-//       REVOKE_SPONSORSHIP_MALFORMED = -5
-//   };
-//
-// ===========================================================================
-xdr.enum("RevokeSponsorshipResultCode", {
-  revokeSponsorshipSuccess: 0,
-  revokeSponsorshipDoesNotExist: -1,
-  revokeSponsorshipNotSponsor: -2,
-  revokeSponsorshipLowReserve: -3,
-  revokeSponsorshipOnlyTransferable: -4,
-  revokeSponsorshipMalformed: -5,
-});
-
-// === xdr source ============================================================
-//
-//   union RevokeSponsorshipResult switch (RevokeSponsorshipResultCode code)
-//   {
-//   case REVOKE_SPONSORSHIP_SUCCESS:
-//       void;
-//   case REVOKE_SPONSORSHIP_DOES_NOT_EXIST:
-//   case REVOKE_SPONSORSHIP_NOT_SPONSOR:
-//   case REVOKE_SPONSORSHIP_LOW_RESERVE:
-//   case REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE:
-//   case REVOKE_SPONSORSHIP_MALFORMED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("RevokeSponsorshipResult", {
-  switchOn: xdr.lookup("RevokeSponsorshipResultCode"),
-  switchName: "code",
-  switches: [
-    ["revokeSponsorshipSuccess", xdr.void()],
-    ["revokeSponsorshipDoesNotExist", xdr.void()],
-    ["revokeSponsorshipNotSponsor", xdr.void()],
-    ["revokeSponsorshipLowReserve", xdr.void()],
-    ["revokeSponsorshipOnlyTransferable", xdr.void()],
-    ["revokeSponsorshipMalformed", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClawbackResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       CLAWBACK_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       CLAWBACK_MALFORMED = -1,
-//       CLAWBACK_NOT_CLAWBACK_ENABLED = -2,
-//       CLAWBACK_NO_TRUST = -3,
-//       CLAWBACK_UNDERFUNDED = -4
-//   };
-//
-// ===========================================================================
-xdr.enum("ClawbackResultCode", {
-  clawbackSuccess: 0,
-  clawbackMalformed: -1,
-  clawbackNotClawbackEnabled: -2,
-  clawbackNoTrust: -3,
-  clawbackUnderfunded: -4,
-});
-
-// === xdr source ============================================================
-//
-//   union ClawbackResult switch (ClawbackResultCode code)
-//   {
-//   case CLAWBACK_SUCCESS:
-//       void;
-//   case CLAWBACK_MALFORMED:
-//   case CLAWBACK_NOT_CLAWBACK_ENABLED:
-//   case CLAWBACK_NO_TRUST:
-//   case CLAWBACK_UNDERFUNDED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ClawbackResult", {
-  switchOn: xdr.lookup("ClawbackResultCode"),
-  switchName: "code",
-  switches: [
-    ["clawbackSuccess", xdr.void()],
-    ["clawbackMalformed", xdr.void()],
-    ["clawbackNotClawbackEnabled", xdr.void()],
-    ["clawbackNoTrust", xdr.void()],
-    ["clawbackUnderfunded", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum ClawbackClaimableBalanceResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       CLAWBACK_CLAIMABLE_BALANCE_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
-//       CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER = -2,
-//       CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED = -3
-//   };
-//
-// ===========================================================================
-xdr.enum("ClawbackClaimableBalanceResultCode", {
-  clawbackClaimableBalanceSuccess: 0,
-  clawbackClaimableBalanceDoesNotExist: -1,
-  clawbackClaimableBalanceNotIssuer: -2,
-  clawbackClaimableBalanceNotClawbackEnabled: -3,
-});
-
-// === xdr source ============================================================
-//
-//   union ClawbackClaimableBalanceResult switch (
-//       ClawbackClaimableBalanceResultCode code)
-//   {
-//   case CLAWBACK_CLAIMABLE_BALANCE_SUCCESS:
-//       void;
-//   case CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
-//   case CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER:
-//   case CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ClawbackClaimableBalanceResult", {
-  switchOn: xdr.lookup("ClawbackClaimableBalanceResultCode"),
-  switchName: "code",
-  switches: [
-    ["clawbackClaimableBalanceSuccess", xdr.void()],
-    ["clawbackClaimableBalanceDoesNotExist", xdr.void()],
-    ["clawbackClaimableBalanceNotIssuer", xdr.void()],
-    ["clawbackClaimableBalanceNotClawbackEnabled", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum SetTrustLineFlagsResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       SET_TRUST_LINE_FLAGS_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       SET_TRUST_LINE_FLAGS_MALFORMED = -1,
-//       SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
-//       SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
-//       SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
-//       SET_TRUST_LINE_FLAGS_LOW_RESERVE = -5 // claimable balances can't be created
-//                                             // on revoke due to low reserves
-//   };
-//
-// ===========================================================================
-xdr.enum("SetTrustLineFlagsResultCode", {
-  setTrustLineFlagsSuccess: 0,
-  setTrustLineFlagsMalformed: -1,
-  setTrustLineFlagsNoTrustLine: -2,
-  setTrustLineFlagsCantRevoke: -3,
-  setTrustLineFlagsInvalidState: -4,
-  setTrustLineFlagsLowReserve: -5,
-});
-
-// === xdr source ============================================================
-//
-//   union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
-//   {
-//   case SET_TRUST_LINE_FLAGS_SUCCESS:
-//       void;
-//   case SET_TRUST_LINE_FLAGS_MALFORMED:
-//   case SET_TRUST_LINE_FLAGS_NO_TRUST_LINE:
-//   case SET_TRUST_LINE_FLAGS_CANT_REVOKE:
-//   case SET_TRUST_LINE_FLAGS_INVALID_STATE:
-//   case SET_TRUST_LINE_FLAGS_LOW_RESERVE:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("SetTrustLineFlagsResult", {
-  switchOn: xdr.lookup("SetTrustLineFlagsResultCode"),
-  switchName: "code",
-  switches: [
-    ["setTrustLineFlagsSuccess", xdr.void()],
-    ["setTrustLineFlagsMalformed", xdr.void()],
-    ["setTrustLineFlagsNoTrustLine", xdr.void()],
-    ["setTrustLineFlagsCantRevoke", xdr.void()],
-    ["setTrustLineFlagsInvalidState", xdr.void()],
-    ["setTrustLineFlagsLowReserve", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum LiquidityPoolDepositResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       LIQUIDITY_POOL_DEPOSIT_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       LIQUIDITY_POOL_DEPOSIT_MALFORMED = -1,      // bad input
-//       LIQUIDITY_POOL_DEPOSIT_NO_TRUST = -2,       // no trust line for one of the
-//                                                   // assets
-//       LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED = -3, // not authorized for one of the
-//                                                   // assets
-//       LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED = -4,    // not enough balance for one of
-//                                                   // the assets
-//       LIQUIDITY_POOL_DEPOSIT_LINE_FULL = -5,      // pool share trust line doesn't
-//                                                   // have sufficient limit
-//       LIQUIDITY_POOL_DEPOSIT_BAD_PRICE = -6,      // deposit price outside bounds
-//       LIQUIDITY_POOL_DEPOSIT_POOL_FULL = -7       // pool reserves are full
-//   };
-//
-// ===========================================================================
-xdr.enum("LiquidityPoolDepositResultCode", {
-  liquidityPoolDepositSuccess: 0,
-  liquidityPoolDepositMalformed: -1,
-  liquidityPoolDepositNoTrust: -2,
-  liquidityPoolDepositNotAuthorized: -3,
-  liquidityPoolDepositUnderfunded: -4,
-  liquidityPoolDepositLineFull: -5,
-  liquidityPoolDepositBadPrice: -6,
-  liquidityPoolDepositPoolFull: -7,
-});
-
-// === xdr source ============================================================
-//
-//   union LiquidityPoolDepositResult switch (LiquidityPoolDepositResultCode code)
-//   {
-//   case LIQUIDITY_POOL_DEPOSIT_SUCCESS:
-//       void;
-//   case LIQUIDITY_POOL_DEPOSIT_MALFORMED:
-//   case LIQUIDITY_POOL_DEPOSIT_NO_TRUST:
-//   case LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED:
-//   case LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED:
-//   case LIQUIDITY_POOL_DEPOSIT_LINE_FULL:
-//   case LIQUIDITY_POOL_DEPOSIT_BAD_PRICE:
-//   case LIQUIDITY_POOL_DEPOSIT_POOL_FULL:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("LiquidityPoolDepositResult", {
-  switchOn: xdr.lookup("LiquidityPoolDepositResultCode"),
-  switchName: "code",
-  switches: [
-    ["liquidityPoolDepositSuccess", xdr.void()],
-    ["liquidityPoolDepositMalformed", xdr.void()],
-    ["liquidityPoolDepositNoTrust", xdr.void()],
-    ["liquidityPoolDepositNotAuthorized", xdr.void()],
-    ["liquidityPoolDepositUnderfunded", xdr.void()],
-    ["liquidityPoolDepositLineFull", xdr.void()],
-    ["liquidityPoolDepositBadPrice", xdr.void()],
-    ["liquidityPoolDepositPoolFull", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum LiquidityPoolWithdrawResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       LIQUIDITY_POOL_WITHDRAW_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       LIQUIDITY_POOL_WITHDRAW_MALFORMED = -1,    // bad input
-//       LIQUIDITY_POOL_WITHDRAW_NO_TRUST = -2,     // no trust line for one of the
-//                                                  // assets
-//       LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED = -3,  // not enough balance of the
-//                                                  // pool share
-//       LIQUIDITY_POOL_WITHDRAW_LINE_FULL = -4,    // would go above limit for one
-//                                                  // of the assets
-//       LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM = -5 // didn't withdraw enough
-//   };
-//
-// ===========================================================================
-xdr.enum("LiquidityPoolWithdrawResultCode", {
-  liquidityPoolWithdrawSuccess: 0,
-  liquidityPoolWithdrawMalformed: -1,
-  liquidityPoolWithdrawNoTrust: -2,
-  liquidityPoolWithdrawUnderfunded: -3,
-  liquidityPoolWithdrawLineFull: -4,
-  liquidityPoolWithdrawUnderMinimum: -5,
-});
-
-// === xdr source ============================================================
-//
-//   union LiquidityPoolWithdrawResult switch (LiquidityPoolWithdrawResultCode code)
-//   {
-//   case LIQUIDITY_POOL_WITHDRAW_SUCCESS:
-//       void;
-//   case LIQUIDITY_POOL_WITHDRAW_MALFORMED:
-//   case LIQUIDITY_POOL_WITHDRAW_NO_TRUST:
-//   case LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED:
-//   case LIQUIDITY_POOL_WITHDRAW_LINE_FULL:
-//   case LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("LiquidityPoolWithdrawResult", {
-  switchOn: xdr.lookup("LiquidityPoolWithdrawResultCode"),
-  switchName: "code",
-  switches: [
-    ["liquidityPoolWithdrawSuccess", xdr.void()],
-    ["liquidityPoolWithdrawMalformed", xdr.void()],
-    ["liquidityPoolWithdrawNoTrust", xdr.void()],
-    ["liquidityPoolWithdrawUnderfunded", xdr.void()],
-    ["liquidityPoolWithdrawLineFull", xdr.void()],
-    ["liquidityPoolWithdrawUnderMinimum", xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum InvokeHostFunctionResultCode
-//   {
-//       // codes considered as "success" for the operation
-//       INVOKE_HOST_FUNCTION_SUCCESS = 0,
-//   
-//       // codes considered as "failure" for the operation
-//       INVOKE_HOST_FUNCTION_MALFORMED = -1,
-//       INVOKE_HOST_FUNCTION_TRAPPED = -2
-//   };
-//
-// ===========================================================================
-xdr.enum("InvokeHostFunctionResultCode", {
-  invokeHostFunctionSuccess: 0,
-  invokeHostFunctionMalformed: -1,
-  invokeHostFunctionTrapped: -2,
-});
-
-// === xdr source ============================================================
-//
-//   union InvokeHostFunctionResult switch (InvokeHostFunctionResultCode code)
-//   {
-//   case INVOKE_HOST_FUNCTION_SUCCESS:
-//       SCVal success;
-//   case INVOKE_HOST_FUNCTION_MALFORMED:
-//   case INVOKE_HOST_FUNCTION_TRAPPED:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("InvokeHostFunctionResult", {
-  switchOn: xdr.lookup("InvokeHostFunctionResultCode"),
-  switchName: "code",
-  switches: [
-    ["invokeHostFunctionSuccess", "success"],
-    ["invokeHostFunctionMalformed", xdr.void()],
-    ["invokeHostFunctionTrapped", xdr.void()],
-  ],
-  arms: {
-    success: xdr.lookup("ScVal"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum OperationResultCode
-//   {
-//       opINNER = 0, // inner object result is valid
-//   
-//       opBAD_AUTH = -1,            // too few valid signatures / wrong network
-//       opNO_ACCOUNT = -2,          // source account was not found
-//       opNOT_SUPPORTED = -3,       // operation not supported at this time
-//       opTOO_MANY_SUBENTRIES = -4, // max number of subentries already reached
-//       opEXCEEDED_WORK_LIMIT = -5, // operation did too much work
-//       opTOO_MANY_SPONSORING = -6  // account is sponsoring too many entries
-//   };
-//
-// ===========================================================================
-xdr.enum("OperationResultCode", {
-  opInner: 0,
-  opBadAuth: -1,
-  opNoAccount: -2,
-  opNotSupported: -3,
-  opTooManySubentries: -4,
-  opExceededWorkLimit: -5,
-  opTooManySponsoring: -6,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (OperationType type)
-//       {
-//       case CREATE_ACCOUNT:
-//           CreateAccountResult createAccountResult;
-//       case PAYMENT:
-//           PaymentResult paymentResult;
-//       case PATH_PAYMENT_STRICT_RECEIVE:
-//           PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
-//       case MANAGE_SELL_OFFER:
-//           ManageSellOfferResult manageSellOfferResult;
-//       case CREATE_PASSIVE_SELL_OFFER:
-//           ManageSellOfferResult createPassiveSellOfferResult;
-//       case SET_OPTIONS:
-//           SetOptionsResult setOptionsResult;
-//       case CHANGE_TRUST:
-//           ChangeTrustResult changeTrustResult;
-//       case ALLOW_TRUST:
-//           AllowTrustResult allowTrustResult;
-//       case ACCOUNT_MERGE:
-//           AccountMergeResult accountMergeResult;
-//       case INFLATION:
-//           InflationResult inflationResult;
-//       case MANAGE_DATA:
-//           ManageDataResult manageDataResult;
-//       case BUMP_SEQUENCE:
-//           BumpSequenceResult bumpSeqResult;
-//       case MANAGE_BUY_OFFER:
-//           ManageBuyOfferResult manageBuyOfferResult;
-//       case PATH_PAYMENT_STRICT_SEND:
-//           PathPaymentStrictSendResult pathPaymentStrictSendResult;
-//       case CREATE_CLAIMABLE_BALANCE:
-//           CreateClaimableBalanceResult createClaimableBalanceResult;
-//       case CLAIM_CLAIMABLE_BALANCE:
-//           ClaimClaimableBalanceResult claimClaimableBalanceResult;
-//       case BEGIN_SPONSORING_FUTURE_RESERVES:
-//           BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
-//       case END_SPONSORING_FUTURE_RESERVES:
-//           EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
-//       case REVOKE_SPONSORSHIP:
-//           RevokeSponsorshipResult revokeSponsorshipResult;
-//       case CLAWBACK:
-//           ClawbackResult clawbackResult;
-//       case CLAWBACK_CLAIMABLE_BALANCE:
-//           ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
-//       case SET_TRUST_LINE_FLAGS:
-//           SetTrustLineFlagsResult setTrustLineFlagsResult;
-//       case LIQUIDITY_POOL_DEPOSIT:
-//           LiquidityPoolDepositResult liquidityPoolDepositResult;
-//       case LIQUIDITY_POOL_WITHDRAW:
-//           LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
-//       case INVOKE_HOST_FUNCTION:
-//           InvokeHostFunctionResult invokeHostFunctionResult;
-//       }
-//
-// ===========================================================================
-xdr.union("OperationResultTr", {
-  switchOn: xdr.lookup("OperationType"),
-  switchName: "type",
-  switches: [
-    ["createAccount", "createAccountResult"],
-    ["payment", "paymentResult"],
-    ["pathPaymentStrictReceive", "pathPaymentStrictReceiveResult"],
-    ["manageSellOffer", "manageSellOfferResult"],
-    ["createPassiveSellOffer", "createPassiveSellOfferResult"],
-    ["setOptions", "setOptionsResult"],
-    ["changeTrust", "changeTrustResult"],
-    ["allowTrust", "allowTrustResult"],
-    ["accountMerge", "accountMergeResult"],
-    ["inflation", "inflationResult"],
-    ["manageData", "manageDataResult"],
-    ["bumpSequence", "bumpSeqResult"],
-    ["manageBuyOffer", "manageBuyOfferResult"],
-    ["pathPaymentStrictSend", "pathPaymentStrictSendResult"],
-    ["createClaimableBalance", "createClaimableBalanceResult"],
-    ["claimClaimableBalance", "claimClaimableBalanceResult"],
-    ["beginSponsoringFutureReserves", "beginSponsoringFutureReservesResult"],
-    ["endSponsoringFutureReserves", "endSponsoringFutureReservesResult"],
-    ["revokeSponsorship", "revokeSponsorshipResult"],
-    ["clawback", "clawbackResult"],
-    ["clawbackClaimableBalance", "clawbackClaimableBalanceResult"],
-    ["setTrustLineFlags", "setTrustLineFlagsResult"],
-    ["liquidityPoolDeposit", "liquidityPoolDepositResult"],
-    ["liquidityPoolWithdraw", "liquidityPoolWithdrawResult"],
-    ["invokeHostFunction", "invokeHostFunctionResult"],
-  ],
-  arms: {
-    createAccountResult: xdr.lookup("CreateAccountResult"),
-    paymentResult: xdr.lookup("PaymentResult"),
-    pathPaymentStrictReceiveResult: xdr.lookup("PathPaymentStrictReceiveResult"),
-    manageSellOfferResult: xdr.lookup("ManageSellOfferResult"),
-    createPassiveSellOfferResult: xdr.lookup("ManageSellOfferResult"),
-    setOptionsResult: xdr.lookup("SetOptionsResult"),
-    changeTrustResult: xdr.lookup("ChangeTrustResult"),
-    allowTrustResult: xdr.lookup("AllowTrustResult"),
-    accountMergeResult: xdr.lookup("AccountMergeResult"),
-    inflationResult: xdr.lookup("InflationResult"),
-    manageDataResult: xdr.lookup("ManageDataResult"),
-    bumpSeqResult: xdr.lookup("BumpSequenceResult"),
-    manageBuyOfferResult: xdr.lookup("ManageBuyOfferResult"),
-    pathPaymentStrictSendResult: xdr.lookup("PathPaymentStrictSendResult"),
-    createClaimableBalanceResult: xdr.lookup("CreateClaimableBalanceResult"),
-    claimClaimableBalanceResult: xdr.lookup("ClaimClaimableBalanceResult"),
-    beginSponsoringFutureReservesResult: xdr.lookup("BeginSponsoringFutureReservesResult"),
-    endSponsoringFutureReservesResult: xdr.lookup("EndSponsoringFutureReservesResult"),
-    revokeSponsorshipResult: xdr.lookup("RevokeSponsorshipResult"),
-    clawbackResult: xdr.lookup("ClawbackResult"),
-    clawbackClaimableBalanceResult: xdr.lookup("ClawbackClaimableBalanceResult"),
-    setTrustLineFlagsResult: xdr.lookup("SetTrustLineFlagsResult"),
-    liquidityPoolDepositResult: xdr.lookup("LiquidityPoolDepositResult"),
-    liquidityPoolWithdrawResult: xdr.lookup("LiquidityPoolWithdrawResult"),
-    invokeHostFunctionResult: xdr.lookup("InvokeHostFunctionResult"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union OperationResult switch (OperationResultCode code)
-//   {
-//   case opINNER:
-//       union switch (OperationType type)
-//       {
-//       case CREATE_ACCOUNT:
-//           CreateAccountResult createAccountResult;
-//       case PAYMENT:
-//           PaymentResult paymentResult;
-//       case PATH_PAYMENT_STRICT_RECEIVE:
-//           PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
-//       case MANAGE_SELL_OFFER:
-//           ManageSellOfferResult manageSellOfferResult;
-//       case CREATE_PASSIVE_SELL_OFFER:
-//           ManageSellOfferResult createPassiveSellOfferResult;
-//       case SET_OPTIONS:
-//           SetOptionsResult setOptionsResult;
-//       case CHANGE_TRUST:
-//           ChangeTrustResult changeTrustResult;
-//       case ALLOW_TRUST:
-//           AllowTrustResult allowTrustResult;
-//       case ACCOUNT_MERGE:
-//           AccountMergeResult accountMergeResult;
-//       case INFLATION:
-//           InflationResult inflationResult;
-//       case MANAGE_DATA:
-//           ManageDataResult manageDataResult;
-//       case BUMP_SEQUENCE:
-//           BumpSequenceResult bumpSeqResult;
-//       case MANAGE_BUY_OFFER:
-//           ManageBuyOfferResult manageBuyOfferResult;
-//       case PATH_PAYMENT_STRICT_SEND:
-//           PathPaymentStrictSendResult pathPaymentStrictSendResult;
-//       case CREATE_CLAIMABLE_BALANCE:
-//           CreateClaimableBalanceResult createClaimableBalanceResult;
-//       case CLAIM_CLAIMABLE_BALANCE:
-//           ClaimClaimableBalanceResult claimClaimableBalanceResult;
-//       case BEGIN_SPONSORING_FUTURE_RESERVES:
-//           BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
-//       case END_SPONSORING_FUTURE_RESERVES:
-//           EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
-//       case REVOKE_SPONSORSHIP:
-//           RevokeSponsorshipResult revokeSponsorshipResult;
-//       case CLAWBACK:
-//           ClawbackResult clawbackResult;
-//       case CLAWBACK_CLAIMABLE_BALANCE:
-//           ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
-//       case SET_TRUST_LINE_FLAGS:
-//           SetTrustLineFlagsResult setTrustLineFlagsResult;
-//       case LIQUIDITY_POOL_DEPOSIT:
-//           LiquidityPoolDepositResult liquidityPoolDepositResult;
-//       case LIQUIDITY_POOL_WITHDRAW:
-//           LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
-//       case INVOKE_HOST_FUNCTION:
-//           InvokeHostFunctionResult invokeHostFunctionResult;
-//       }
-//       tr;
-//   case opBAD_AUTH:
-//   case opNO_ACCOUNT:
-//   case opNOT_SUPPORTED:
-//   case opTOO_MANY_SUBENTRIES:
-//   case opEXCEEDED_WORK_LIMIT:
-//   case opTOO_MANY_SPONSORING:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("OperationResult", {
-  switchOn: xdr.lookup("OperationResultCode"),
-  switchName: "code",
-  switches: [
-    ["opInner", "tr"],
-    ["opBadAuth", xdr.void()],
-    ["opNoAccount", xdr.void()],
-    ["opNotSupported", xdr.void()],
-    ["opTooManySubentries", xdr.void()],
-    ["opExceededWorkLimit", xdr.void()],
-    ["opTooManySponsoring", xdr.void()],
-  ],
-  arms: {
-    tr: xdr.lookup("OperationResultTr"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum TransactionResultCode
-//   {
-//       txFEE_BUMP_INNER_SUCCESS = 1, // fee bump inner transaction succeeded
-//       txSUCCESS = 0,                // all operations succeeded
-//   
-//       txFAILED = -1, // one of the operations failed (none were applied)
-//   
-//       txTOO_EARLY = -2,         // ledger closeTime before minTime
-//       txTOO_LATE = -3,          // ledger closeTime after maxTime
-//       txMISSING_OPERATION = -4, // no operation was specified
-//       txBAD_SEQ = -5,           // sequence number does not match source account
-//   
-//       txBAD_AUTH = -6,             // too few valid signatures / wrong network
-//       txINSUFFICIENT_BALANCE = -7, // fee would bring account below reserve
-//       txNO_ACCOUNT = -8,           // source account not found
-//       txINSUFFICIENT_FEE = -9,     // fee is too small
-//       txBAD_AUTH_EXTRA = -10,      // unused signatures attached to transaction
-//       txINTERNAL_ERROR = -11,      // an unknown error occurred
-//   
-//       txNOT_SUPPORTED = -12,         // transaction type not supported
-//       txFEE_BUMP_INNER_FAILED = -13, // fee bump inner transaction failed
-//       txBAD_SPONSORSHIP = -14,       // sponsorship not confirmed
-//       txBAD_MIN_SEQ_AGE_OR_GAP =
-//           -15, // minSeqAge or minSeqLedgerGap conditions not met
-//       txMALFORMED = -16 // precondition is invalid
-//   };
-//
-// ===========================================================================
-xdr.enum("TransactionResultCode", {
-  txFeeBumpInnerSuccess: 1,
-  txSuccess: 0,
-  txFailed: -1,
-  txTooEarly: -2,
-  txTooLate: -3,
-  txMissingOperation: -4,
-  txBadSeq: -5,
-  txBadAuth: -6,
-  txInsufficientBalance: -7,
-  txNoAccount: -8,
-  txInsufficientFee: -9,
-  txBadAuthExtra: -10,
-  txInternalError: -11,
-  txNotSupported: -12,
-  txFeeBumpInnerFailed: -13,
-  txBadSponsorship: -14,
-  txBadMinSeqAgeOrGap: -15,
-  txMalformed: -16,
-});
-
-// === xdr source ============================================================
-//
-//   union switch (TransactionResultCode code)
-//       {
-//       // txFEE_BUMP_INNER_SUCCESS is not included
-//       case txSUCCESS:
-//       case txFAILED:
-//           OperationResult results<>;
-//       case txTOO_EARLY:
-//       case txTOO_LATE:
-//       case txMISSING_OPERATION:
-//       case txBAD_SEQ:
-//       case txBAD_AUTH:
-//       case txINSUFFICIENT_BALANCE:
-//       case txNO_ACCOUNT:
-//       case txINSUFFICIENT_FEE:
-//       case txBAD_AUTH_EXTRA:
-//       case txINTERNAL_ERROR:
-//       case txNOT_SUPPORTED:
-//       // txFEE_BUMP_INNER_FAILED is not included
-//       case txBAD_SPONSORSHIP:
-//       case txBAD_MIN_SEQ_AGE_OR_GAP:
-//       case txMALFORMED:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("InnerTransactionResultResult", {
-  switchOn: xdr.lookup("TransactionResultCode"),
-  switchName: "code",
-  switches: [
-    ["txSuccess", "results"],
-    ["txFailed", "results"],
-    ["txTooEarly", xdr.void()],
-    ["txTooLate", xdr.void()],
-    ["txMissingOperation", xdr.void()],
-    ["txBadSeq", xdr.void()],
-    ["txBadAuth", xdr.void()],
-    ["txInsufficientBalance", xdr.void()],
-    ["txNoAccount", xdr.void()],
-    ["txInsufficientFee", xdr.void()],
-    ["txBadAuthExtra", xdr.void()],
-    ["txInternalError", xdr.void()],
-    ["txNotSupported", xdr.void()],
-    ["txBadSponsorship", xdr.void()],
-    ["txBadMinSeqAgeOrGap", xdr.void()],
-    ["txMalformed", xdr.void()],
-  ],
-  arms: {
-    results: xdr.varArray(xdr.lookup("OperationResult"), 2147483647),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("InnerTransactionResultExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct InnerTransactionResult
-//   {
-//       // Always 0. Here for binary compatibility.
-//       int64 feeCharged;
-//   
-//       union switch (TransactionResultCode code)
-//       {
-//       // txFEE_BUMP_INNER_SUCCESS is not included
-//       case txSUCCESS:
-//       case txFAILED:
-//           OperationResult results<>;
-//       case txTOO_EARLY:
-//       case txTOO_LATE:
-//       case txMISSING_OPERATION:
-//       case txBAD_SEQ:
-//       case txBAD_AUTH:
-//       case txINSUFFICIENT_BALANCE:
-//       case txNO_ACCOUNT:
-//       case txINSUFFICIENT_FEE:
-//       case txBAD_AUTH_EXTRA:
-//       case txINTERNAL_ERROR:
-//       case txNOT_SUPPORTED:
-//       // txFEE_BUMP_INNER_FAILED is not included
-//       case txBAD_SPONSORSHIP:
-//       case txBAD_MIN_SEQ_AGE_OR_GAP:
-//       case txMALFORMED:
-//           void;
-//       }
-//       result;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("InnerTransactionResult", [
-  ["feeCharged", xdr.lookup("Int64")],
-  ["result", xdr.lookup("InnerTransactionResultResult")],
-  ["ext", xdr.lookup("InnerTransactionResultExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct InnerTransactionResultPair
-//   {
-//       Hash transactionHash;          // hash of the inner transaction
-//       InnerTransactionResult result; // result for the inner transaction
-//   };
-//
-// ===========================================================================
-xdr.struct("InnerTransactionResultPair", [
-  ["transactionHash", xdr.lookup("Hash")],
-  ["result", xdr.lookup("InnerTransactionResult")],
-]);
-
-// === xdr source ============================================================
-//
-//   union switch (TransactionResultCode code)
-//       {
-//       case txFEE_BUMP_INNER_SUCCESS:
-//       case txFEE_BUMP_INNER_FAILED:
-//           InnerTransactionResultPair innerResultPair;
-//       case txSUCCESS:
-//       case txFAILED:
-//           OperationResult results<>;
-//       case txTOO_EARLY:
-//       case txTOO_LATE:
-//       case txMISSING_OPERATION:
-//       case txBAD_SEQ:
-//       case txBAD_AUTH:
-//       case txINSUFFICIENT_BALANCE:
-//       case txNO_ACCOUNT:
-//       case txINSUFFICIENT_FEE:
-//       case txBAD_AUTH_EXTRA:
-//       case txINTERNAL_ERROR:
-//       case txNOT_SUPPORTED:
-//       // case txFEE_BUMP_INNER_FAILED: handled above
-//       case txBAD_SPONSORSHIP:
-//       case txBAD_MIN_SEQ_AGE_OR_GAP:
-//       case txMALFORMED:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionResultResult", {
-  switchOn: xdr.lookup("TransactionResultCode"),
-  switchName: "code",
-  switches: [
-    ["txFeeBumpInnerSuccess", "innerResultPair"],
-    ["txFeeBumpInnerFailed", "innerResultPair"],
-    ["txSuccess", "results"],
-    ["txFailed", "results"],
-    ["txTooEarly", xdr.void()],
-    ["txTooLate", xdr.void()],
-    ["txMissingOperation", xdr.void()],
-    ["txBadSeq", xdr.void()],
-    ["txBadAuth", xdr.void()],
-    ["txInsufficientBalance", xdr.void()],
-    ["txNoAccount", xdr.void()],
-    ["txInsufficientFee", xdr.void()],
-    ["txBadAuthExtra", xdr.void()],
-    ["txInternalError", xdr.void()],
-    ["txNotSupported", xdr.void()],
-    ["txBadSponsorship", xdr.void()],
-    ["txBadMinSeqAgeOrGap", xdr.void()],
-    ["txMalformed", xdr.void()],
-  ],
-  arms: {
-    innerResultPair: xdr.lookup("InnerTransactionResultPair"),
-    results: xdr.varArray(xdr.lookup("OperationResult"), 2147483647),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("TransactionResultExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct TransactionResult
-//   {
-//       int64 feeCharged; // actual fee charged for the transaction
-//   
-//       union switch (TransactionResultCode code)
-//       {
-//       case txFEE_BUMP_INNER_SUCCESS:
-//       case txFEE_BUMP_INNER_FAILED:
-//           InnerTransactionResultPair innerResultPair;
-//       case txSUCCESS:
-//       case txFAILED:
-//           OperationResult results<>;
-//       case txTOO_EARLY:
-//       case txTOO_LATE:
-//       case txMISSING_OPERATION:
-//       case txBAD_SEQ:
-//       case txBAD_AUTH:
-//       case txINSUFFICIENT_BALANCE:
-//       case txNO_ACCOUNT:
-//       case txINSUFFICIENT_FEE:
-//       case txBAD_AUTH_EXTRA:
-//       case txINTERNAL_ERROR:
-//       case txNOT_SUPPORTED:
-//       // case txFEE_BUMP_INNER_FAILED: handled above
-//       case txBAD_SPONSORSHIP:
-//       case txBAD_MIN_SEQ_AGE_OR_GAP:
-//       case txMALFORMED:
-//           void;
-//       }
-//       result;
-//   
-//       // reserved for future use
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
-//   };
-//
-// ===========================================================================
-xdr.struct("TransactionResult", [
-  ["feeCharged", xdr.lookup("Int64")],
-  ["result", xdr.lookup("TransactionResultResult")],
-  ["ext", xdr.lookup("TransactionResultExt")],
-]);
-
-// === xdr source ============================================================
-//
-//   typedef opaque Hash[32];
-//
-// ===========================================================================
-xdr.typedef("Hash", xdr.opaque(32));
-
-// === xdr source ============================================================
-//
-//   typedef opaque uint256[32];
-//
-// ===========================================================================
-xdr.typedef("Uint256", xdr.opaque(32));
-
-// === xdr source ============================================================
-//
-//   typedef unsigned int uint32;
-//
-// ===========================================================================
-xdr.typedef("Uint32", xdr.uint());
-
-// === xdr source ============================================================
-//
-//   typedef int int32;
-//
-// ===========================================================================
-xdr.typedef("Int32", xdr.int());
-
-// === xdr source ============================================================
-//
-//   typedef unsigned hyper uint64;
-//
-// ===========================================================================
-xdr.typedef("Uint64", xdr.uhyper());
-
-// === xdr source ============================================================
-//
-//   typedef hyper int64;
-//
-// ===========================================================================
-xdr.typedef("Int64", xdr.hyper());
-
-// === xdr source ============================================================
-//
-//   typedef uint64 TimePoint;
-//
-// ===========================================================================
-xdr.typedef("TimePoint", xdr.lookup("Uint64"));
-
-// === xdr source ============================================================
-//
-//   typedef uint64 Duration;
-//
-// ===========================================================================
-xdr.typedef("Duration", xdr.lookup("Uint64"));
-
-// === xdr source ============================================================
-//
-//   union ExtensionPoint switch (int v)
-//   {
-//   case 0:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ExtensionPoint", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum CryptoKeyType
-//   {
-//       KEY_TYPE_ED25519 = 0,
-//       KEY_TYPE_PRE_AUTH_TX = 1,
-//       KEY_TYPE_HASH_X = 2,
-//       KEY_TYPE_ED25519_SIGNED_PAYLOAD = 3,
-//       // MUXED enum values for supported type are derived from the enum values
-//       // above by ORing them with 0x100
-//       KEY_TYPE_MUXED_ED25519 = 0x100
-//   };
-//
-// ===========================================================================
-xdr.enum("CryptoKeyType", {
-  keyTypeEd25519: 0,
-  keyTypePreAuthTx: 1,
-  keyTypeHashX: 2,
-  keyTypeEd25519SignedPayload: 3,
-  keyTypeMuxedEd25519: 256,
-});
-
-// === xdr source ============================================================
-//
-//   enum PublicKeyType
-//   {
-//       PUBLIC_KEY_TYPE_ED25519 = KEY_TYPE_ED25519
-//   };
-//
-// ===========================================================================
-xdr.enum("PublicKeyType", {
-  publicKeyTypeEd25519: 0,
-});
-
-// === xdr source ============================================================
-//
-//   enum SignerKeyType
-//   {
-//       SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
-//       SIGNER_KEY_TYPE_PRE_AUTH_TX = KEY_TYPE_PRE_AUTH_TX,
-//       SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X,
-//       SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD = KEY_TYPE_ED25519_SIGNED_PAYLOAD
-//   };
-//
-// ===========================================================================
-xdr.enum("SignerKeyType", {
-  signerKeyTypeEd25519: 0,
-  signerKeyTypePreAuthTx: 1,
-  signerKeyTypeHashX: 2,
-  signerKeyTypeEd25519SignedPayload: 3,
-});
-
-// === xdr source ============================================================
-//
-//   union PublicKey switch (PublicKeyType type)
-//   {
-//   case PUBLIC_KEY_TYPE_ED25519:
-//       uint256 ed25519;
-//   };
-//
-// ===========================================================================
-xdr.union("PublicKey", {
-  switchOn: xdr.lookup("PublicKeyType"),
-  switchName: "type",
-  switches: [
-    ["publicKeyTypeEd25519", "ed25519"],
-  ],
-  arms: {
-    ed25519: xdr.lookup("Uint256"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct
-//       {
-//           /* Public key that must sign the payload. */
-//           uint256 ed25519;
-//           /* Payload to be raw signed by ed25519. */
-//           opaque payload<64>;
-//       }
-//
-// ===========================================================================
-xdr.struct("SignerKeyEd25519SignedPayload", [
-  ["ed25519", xdr.lookup("Uint256")],
-  ["payload", xdr.varOpaque(64)],
-]);
-
-// === xdr source ============================================================
-//
-//   union SignerKey switch (SignerKeyType type)
-//   {
-//   case SIGNER_KEY_TYPE_ED25519:
-//       uint256 ed25519;
-//   case SIGNER_KEY_TYPE_PRE_AUTH_TX:
-//       /* SHA-256 Hash of TransactionSignaturePayload structure */
-//       uint256 preAuthTx;
-//   case SIGNER_KEY_TYPE_HASH_X:
-//       /* Hash of random 256 bit preimage X */
-//       uint256 hashX;
-//   case SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD:
-//       struct
-//       {
-//           /* Public key that must sign the payload. */
-//           uint256 ed25519;
-//           /* Payload to be raw signed by ed25519. */
-//           opaque payload<64>;
-//       } ed25519SignedPayload;
-//   };
-//
-// ===========================================================================
-xdr.union("SignerKey", {
-  switchOn: xdr.lookup("SignerKeyType"),
-  switchName: "type",
-  switches: [
-    ["signerKeyTypeEd25519", "ed25519"],
-    ["signerKeyTypePreAuthTx", "preAuthTx"],
-    ["signerKeyTypeHashX", "hashX"],
-    ["signerKeyTypeEd25519SignedPayload", "ed25519SignedPayload"],
-  ],
-  arms: {
-    ed25519: xdr.lookup("Uint256"),
-    preAuthTx: xdr.lookup("Uint256"),
-    hashX: xdr.lookup("Uint256"),
-    ed25519SignedPayload: xdr.lookup("SignerKeyEd25519SignedPayload"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   typedef opaque Signature<64>;
-//
-// ===========================================================================
-xdr.typedef("Signature", xdr.varOpaque(64));
-
-// === xdr source ============================================================
-//
-//   typedef opaque SignatureHint[4];
-//
-// ===========================================================================
-xdr.typedef("SignatureHint", xdr.opaque(4));
-
-// === xdr source ============================================================
-//
-//   typedef PublicKey NodeID;
-//
-// ===========================================================================
-xdr.typedef("NodeId", xdr.lookup("PublicKey"));
-
-// === xdr source ============================================================
-//
-//   typedef PublicKey AccountID;
-//
-// ===========================================================================
-xdr.typedef("AccountId", xdr.lookup("PublicKey"));
-
-// === xdr source ============================================================
-//
-//   struct Curve25519Secret
-//   {
-//       opaque key[32];
-//   };
-//
-// ===========================================================================
-xdr.struct("Curve25519Secret", [
-  ["key", xdr.opaque(32)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct Curve25519Public
-//   {
-//       opaque key[32];
-//   };
-//
-// ===========================================================================
-xdr.struct("Curve25519Public", [
-  ["key", xdr.opaque(32)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct HmacSha256Key
-//   {
-//       opaque key[32];
-//   };
-//
-// ===========================================================================
-xdr.struct("HmacSha256Key", [
-  ["key", xdr.opaque(32)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct HmacSha256Mac
-//   {
-//       opaque mac[32];
-//   };
-//
-// ===========================================================================
-xdr.struct("HmacSha256Mac", [
-  ["mac", xdr.opaque(32)],
-]);
-
-// === xdr source ============================================================
-//
-//   enum SCValType
-//   {
-//       SCV_BOOL = 0,
-//       SCV_VOID = 1,
-//       SCV_STATUS = 2,
-//   
-//       // 32 bits is the smallest type in WASM or XDR; no need for u8/u16.
-//       SCV_U32 = 3,
-//       SCV_I32 = 4,
-//   
-//       // 64 bits is naturally supported by both WASM and XDR also.
-//       SCV_U64 = 5,
-//       SCV_I64 = 6,
-//   
-//       // Time-related u64 subtypes with their own functions and formatting.
-//       SCV_TIMEPOINT = 7,
-//       SCV_DURATION = 8,
-//   
-//       // 128 bits is naturally supported by Rust and we use it for Soroban
-//       // fixed-point arithmetic prices / balances / similar "quantities". These
-//       // are represented in XDR as a pair of 2 u64s, unlike {u,i}256 which is
-//       // represented as an array of 32 bytes.
-//       SCV_U128 = 9,
-//       SCV_I128 = 10,
-//   
-//       // 256 bits is the size of sha256 output, ed25519 keys, and the EVM machine
-//       // word, so for interop use we include this even though it requires a small
-//       // amount of Rust guest and/or host library code.
-//       SCV_U256 = 11,
-//       SCV_I256 = 12,
-//   
-//       // TODO: possibly allocate subtypes of i64, i128 and/or u256 for
-//       // fixed-precision with a specific number of decimals.
-//   
-//       // Bytes come in 3 flavors, 2 of which have meaningfully different
-//       // formatting and validity-checking / domain-restriction.
-//       SCV_BYTES = 13,
-//       SCV_STRING = 14,
-//       SCV_SYMBOL = 15,
-//   
-//       // Vecs and maps are just polymorphic containers of other ScVals.
-//       SCV_VEC = 16,
-//       SCV_MAP = 17,
-//   
-//       // SCContractExecutable and SCAddressType are types that gets used separately from
-//       // SCVal so we do not flatten their structures into separate SCVal cases.
-//       SCV_CONTRACT_EXECUTABLE = 18,
-//       SCV_ADDRESS = 19,
-//   
-//       // SCV_LEDGER_KEY_CONTRACT_EXECUTABLE and SCV_LEDGER_KEY_NONCE are unique
-//       // symbolic SCVals used as the key for ledger entries for a contract's code
-//       // and an address' nonce, respectively.
-//       SCV_LEDGER_KEY_CONTRACT_EXECUTABLE = 20,
-//       SCV_LEDGER_KEY_NONCE = 21
-//   };
-//
-// ===========================================================================
-xdr.enum("ScValType", {
-  scvBool: 0,
-  scvVoid: 1,
-  scvStatus: 2,
-  scvU32: 3,
-  scvI32: 4,
-  scvU64: 5,
-  scvI64: 6,
-  scvTimepoint: 7,
-  scvDuration: 8,
-  scvU128: 9,
-  scvI128: 10,
-  scvU256: 11,
-  scvI256: 12,
-  scvBytes: 13,
-  scvString: 14,
-  scvSymbol: 15,
-  scvVec: 16,
-  scvMap: 17,
-  scvContractExecutable: 18,
-  scvAddress: 19,
-  scvLedgerKeyContractExecutable: 20,
-  scvLedgerKeyNonce: 21,
-});
-
-// === xdr source ============================================================
-//
-//   enum SCStatusType
-//   {
-//       SST_OK = 0,
-//       SST_UNKNOWN_ERROR = 1,
-//       SST_HOST_VALUE_ERROR = 2,
-//       SST_HOST_OBJECT_ERROR = 3,
-//       SST_HOST_FUNCTION_ERROR = 4,
-//       SST_HOST_STORAGE_ERROR = 5,
-//       SST_HOST_CONTEXT_ERROR = 6,
-//       SST_VM_ERROR = 7,
-//       SST_CONTRACT_ERROR = 8,
-//       SST_HOST_AUTH_ERROR = 9
-//       // TODO: add more
-//   };
-//
-// ===========================================================================
-xdr.enum("ScStatusType", {
-  sstOk: 0,
-  sstUnknownError: 1,
-  sstHostValueError: 2,
-  sstHostObjectError: 3,
-  sstHostFunctionError: 4,
-  sstHostStorageError: 5,
-  sstHostContextError: 6,
-  sstVmError: 7,
-  sstContractError: 8,
-  sstHostAuthError: 9,
-});
-
-// === xdr source ============================================================
-//
-//   enum SCHostValErrorCode
-//   {
-//       HOST_VALUE_UNKNOWN_ERROR = 0,
-//       HOST_VALUE_RESERVED_TAG_VALUE = 1,
-//       HOST_VALUE_UNEXPECTED_VAL_TYPE = 2,
-//       HOST_VALUE_U63_OUT_OF_RANGE = 3,
-//       HOST_VALUE_U32_OUT_OF_RANGE = 4,
-//       HOST_VALUE_STATIC_UNKNOWN = 5,
-//       HOST_VALUE_MISSING_OBJECT = 6,
-//       HOST_VALUE_SYMBOL_TOO_LONG = 7,
-//       HOST_VALUE_SYMBOL_BAD_CHAR = 8,
-//       HOST_VALUE_SYMBOL_CONTAINS_NON_UTF8 = 9,
-//       HOST_VALUE_BITSET_TOO_MANY_BITS = 10,
-//       HOST_VALUE_STATUS_UNKNOWN = 11
-//   };
-//
-// ===========================================================================
-xdr.enum("ScHostValErrorCode", {
-  hostValueUnknownError: 0,
-  hostValueReservedTagValue: 1,
-  hostValueUnexpectedValType: 2,
-  hostValueU63OutOfRange: 3,
-  hostValueU32OutOfRange: 4,
-  hostValueStaticUnknown: 5,
-  hostValueMissingObject: 6,
-  hostValueSymbolTooLong: 7,
-  hostValueSymbolBadChar: 8,
-  hostValueSymbolContainsNonUtf8: 9,
-  hostValueBitsetTooManyBits: 10,
-  hostValueStatusUnknown: 11,
-});
-
-// === xdr source ============================================================
-//
-//   enum SCHostObjErrorCode
-//   {
-//       HOST_OBJECT_UNKNOWN_ERROR = 0,
-//       HOST_OBJECT_UNKNOWN_REFERENCE = 1,
-//       HOST_OBJECT_UNEXPECTED_TYPE = 2,
-//       HOST_OBJECT_OBJECT_COUNT_EXCEEDS_U32_MAX = 3,
-//       HOST_OBJECT_OBJECT_NOT_EXIST = 4,
-//       HOST_OBJECT_VEC_INDEX_OUT_OF_BOUND = 5,
-//       HOST_OBJECT_CONTRACT_HASH_WRONG_LENGTH = 6
-//   };
-//
-// ===========================================================================
-xdr.enum("ScHostObjErrorCode", {
-  hostObjectUnknownError: 0,
-  hostObjectUnknownReference: 1,
-  hostObjectUnexpectedType: 2,
-  hostObjectObjectCountExceedsU32Max: 3,
-  hostObjectObjectNotExist: 4,
-  hostObjectVecIndexOutOfBound: 5,
-  hostObjectContractHashWrongLength: 6,
-});
-
-// === xdr source ============================================================
-//
-//   enum SCHostFnErrorCode
-//   {
-//       HOST_FN_UNKNOWN_ERROR = 0,
-//       HOST_FN_UNEXPECTED_HOST_FUNCTION_ACTION = 1,
-//       HOST_FN_INPUT_ARGS_WRONG_LENGTH = 2,
-//       HOST_FN_INPUT_ARGS_WRONG_TYPE = 3,
-//       HOST_FN_INPUT_ARGS_INVALID = 4
-//   };
-//
-// ===========================================================================
-xdr.enum("ScHostFnErrorCode", {
-  hostFnUnknownError: 0,
-  hostFnUnexpectedHostFunctionAction: 1,
-  hostFnInputArgsWrongLength: 2,
-  hostFnInputArgsWrongType: 3,
-  hostFnInputArgsInvalid: 4,
-});
-
-// === xdr source ============================================================
-//
-//   enum SCHostStorageErrorCode
-//   {
-//       HOST_STORAGE_UNKNOWN_ERROR = 0,
-//       HOST_STORAGE_EXPECT_CONTRACT_DATA = 1,
-//       HOST_STORAGE_READWRITE_ACCESS_TO_READONLY_ENTRY = 2,
-//       HOST_STORAGE_ACCESS_TO_UNKNOWN_ENTRY = 3,
-//       HOST_STORAGE_MISSING_KEY_IN_GET = 4,
-//       HOST_STORAGE_GET_ON_DELETED_KEY = 5
-//   };
-//
-// ===========================================================================
-xdr.enum("ScHostStorageErrorCode", {
-  hostStorageUnknownError: 0,
-  hostStorageExpectContractData: 1,
-  hostStorageReadwriteAccessToReadonlyEntry: 2,
-  hostStorageAccessToUnknownEntry: 3,
-  hostStorageMissingKeyInGet: 4,
-  hostStorageGetOnDeletedKey: 5,
-});
-
-// === xdr source ============================================================
-//
-//   enum SCHostAuthErrorCode
-//   {
-//       HOST_AUTH_UNKNOWN_ERROR = 0,
-//       HOST_AUTH_NONCE_ERROR = 1,
-//       HOST_AUTH_DUPLICATE_AUTHORIZATION = 2,
-//       HOST_AUTH_NOT_AUTHORIZED = 3
-//   };
-//
-// ===========================================================================
-xdr.enum("ScHostAuthErrorCode", {
-  hostAuthUnknownError: 0,
-  hostAuthNonceError: 1,
-  hostAuthDuplicateAuthorization: 2,
-  hostAuthNotAuthorized: 3,
-});
-
-// === xdr source ============================================================
-//
-//   enum SCHostContextErrorCode
-//   {
-//       HOST_CONTEXT_UNKNOWN_ERROR = 0,
-//       HOST_CONTEXT_NO_CONTRACT_RUNNING = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("ScHostContextErrorCode", {
-  hostContextUnknownError: 0,
-  hostContextNoContractRunning: 1,
-});
-
-// === xdr source ============================================================
-//
-//   enum SCVmErrorCode {
-//       VM_UNKNOWN = 0,
-//       VM_VALIDATION = 1,
-//       VM_INSTANTIATION = 2,
-//       VM_FUNCTION = 3,
-//       VM_TABLE = 4,
-//       VM_MEMORY = 5,
-//       VM_GLOBAL = 6,
-//       VM_VALUE = 7,
-//       VM_TRAP_UNREACHABLE = 8,
-//       VM_TRAP_MEMORY_ACCESS_OUT_OF_BOUNDS = 9,
-//       VM_TRAP_TABLE_ACCESS_OUT_OF_BOUNDS = 10,
-//       VM_TRAP_ELEM_UNINITIALIZED = 11,
-//       VM_TRAP_DIVISION_BY_ZERO = 12,
-//       VM_TRAP_INTEGER_OVERFLOW = 13,
-//       VM_TRAP_INVALID_CONVERSION_TO_INT = 14,
-//       VM_TRAP_STACK_OVERFLOW = 15,
-//       VM_TRAP_UNEXPECTED_SIGNATURE = 16,
-//       VM_TRAP_MEM_LIMIT_EXCEEDED = 17,
-//       VM_TRAP_CPU_LIMIT_EXCEEDED = 18
-//   };
-//
-// ===========================================================================
-xdr.enum("ScVmErrorCode", {
-  vmUnknown: 0,
-  vmValidation: 1,
-  vmInstantiation: 2,
-  vmFunction: 3,
-  vmTable: 4,
-  vmMemory: 5,
-  vmGlobal: 6,
-  vmValue: 7,
-  vmTrapUnreachable: 8,
-  vmTrapMemoryAccessOutOfBounds: 9,
-  vmTrapTableAccessOutOfBounds: 10,
-  vmTrapElemUninitialized: 11,
-  vmTrapDivisionByZero: 12,
-  vmTrapIntegerOverflow: 13,
-  vmTrapInvalidConversionToInt: 14,
-  vmTrapStackOverflow: 15,
-  vmTrapUnexpectedSignature: 16,
-  vmTrapMemLimitExceeded: 17,
-  vmTrapCpuLimitExceeded: 18,
-});
-
-// === xdr source ============================================================
-//
-//   enum SCUnknownErrorCode
-//   {
-//       UNKNOWN_ERROR_GENERAL = 0,
-//       UNKNOWN_ERROR_XDR = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("ScUnknownErrorCode", {
-  unknownErrorGeneral: 0,
-  unknownErrorXdr: 1,
-});
-
-// === xdr source ============================================================
-//
-//   union SCStatus switch (SCStatusType type)
-//   {
-//   case SST_OK:
-//       void;
-//   case SST_UNKNOWN_ERROR:
-//       SCUnknownErrorCode unknownCode;
-//   case SST_HOST_VALUE_ERROR:
-//       SCHostValErrorCode valCode;
-//   case SST_HOST_OBJECT_ERROR:
-//       SCHostObjErrorCode objCode;
-//   case SST_HOST_FUNCTION_ERROR:
-//       SCHostFnErrorCode fnCode;
-//   case SST_HOST_STORAGE_ERROR:
-//       SCHostStorageErrorCode storageCode;
-//   case SST_HOST_CONTEXT_ERROR:
-//       SCHostContextErrorCode contextCode;
-//   case SST_VM_ERROR:
-//       SCVmErrorCode vmCode;
-//   case SST_CONTRACT_ERROR:
-//       uint32 contractCode;
-//   case SST_HOST_AUTH_ERROR:
-//       SCHostAuthErrorCode authCode;
-//   };
-//
-// ===========================================================================
-xdr.union("ScStatus", {
-  switchOn: xdr.lookup("ScStatusType"),
-  switchName: "type",
-  switches: [
-    ["sstOk", xdr.void()],
-    ["sstUnknownError", "unknownCode"],
-    ["sstHostValueError", "valCode"],
-    ["sstHostObjectError", "objCode"],
-    ["sstHostFunctionError", "fnCode"],
-    ["sstHostStorageError", "storageCode"],
-    ["sstHostContextError", "contextCode"],
-    ["sstVmError", "vmCode"],
-    ["sstContractError", "contractCode"],
-    ["sstHostAuthError", "authCode"],
-  ],
-  arms: {
-    unknownCode: xdr.lookup("ScUnknownErrorCode"),
-    valCode: xdr.lookup("ScHostValErrorCode"),
-    objCode: xdr.lookup("ScHostObjErrorCode"),
-    fnCode: xdr.lookup("ScHostFnErrorCode"),
-    storageCode: xdr.lookup("ScHostStorageErrorCode"),
-    contextCode: xdr.lookup("ScHostContextErrorCode"),
-    vmCode: xdr.lookup("ScVmErrorCode"),
-    contractCode: xdr.lookup("Uint32"),
-    authCode: xdr.lookup("ScHostAuthErrorCode"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct UInt128Parts {
-//       uint64 hi;
-//       uint64 lo;
-//   };
-//
-// ===========================================================================
-xdr.struct("UInt128Parts", [
-  ["hi", xdr.lookup("Uint64")],
-  ["lo", xdr.lookup("Uint64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct Int128Parts {
-//       int64 hi;
-//       uint64 lo;
-//   };
-//
-// ===========================================================================
-xdr.struct("Int128Parts", [
-  ["hi", xdr.lookup("Int64")],
-  ["lo", xdr.lookup("Uint64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct UInt256Parts {
-//       uint64 hi_hi;
-//       uint64 hi_lo;
-//       uint64 lo_hi;
-//       uint64 lo_lo;
-//   };
-//
-// ===========================================================================
-xdr.struct("UInt256Parts", [
-  ["hiHi", xdr.lookup("Uint64")],
-  ["hiLo", xdr.lookup("Uint64")],
-  ["loHi", xdr.lookup("Uint64")],
-  ["loLo", xdr.lookup("Uint64")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct Int256Parts {
-//       int64 hi_hi;
-//       uint64 hi_lo;
-//       uint64 lo_hi;
-//       uint64 lo_lo;
-//   };
-//
-// ===========================================================================
-xdr.struct("Int256Parts", [
-  ["hiHi", xdr.lookup("Int64")],
-  ["hiLo", xdr.lookup("Uint64")],
-  ["loHi", xdr.lookup("Uint64")],
-  ["loLo", xdr.lookup("Uint64")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum SCContractExecutableType
-//   {
-//       SCCONTRACT_EXECUTABLE_WASM_REF = 0,
-//       SCCONTRACT_EXECUTABLE_TOKEN = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("ScContractExecutableType", {
-  sccontractExecutableWasmRef: 0,
-  sccontractExecutableToken: 1,
-});
-
-// === xdr source ============================================================
-//
-//   union SCContractExecutable switch (SCContractExecutableType type)
-//   {
-//   case SCCONTRACT_EXECUTABLE_WASM_REF:
-//       Hash wasm_id;
-//   case SCCONTRACT_EXECUTABLE_TOKEN:
-//       void;
-//   };
-//
-// ===========================================================================
-xdr.union("ScContractExecutable", {
-  switchOn: xdr.lookup("ScContractExecutableType"),
-  switchName: "type",
-  switches: [
-    ["sccontractExecutableWasmRef", "wasmId"],
-    ["sccontractExecutableToken", xdr.void()],
-  ],
-  arms: {
-    wasmId: xdr.lookup("Hash"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   enum SCAddressType
-//   {
-//       SC_ADDRESS_TYPE_ACCOUNT = 0,
-//       SC_ADDRESS_TYPE_CONTRACT = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("ScAddressType", {
-  scAddressTypeAccount: 0,
-  scAddressTypeContract: 1,
-});
-
-// === xdr source ============================================================
-//
-//   union SCAddress switch (SCAddressType type)
-//   {
-//   case SC_ADDRESS_TYPE_ACCOUNT:
-//       AccountID accountId;
-//   case SC_ADDRESS_TYPE_CONTRACT:
-//       Hash contractId;
-//   };
-//
-// ===========================================================================
-xdr.union("ScAddress", {
-  switchOn: xdr.lookup("ScAddressType"),
-  switchName: "type",
-  switches: [
-    ["scAddressTypeAccount", "accountId"],
-    ["scAddressTypeContract", "contractId"],
-  ],
-  arms: {
-    accountId: xdr.lookup("AccountId"),
-    contractId: xdr.lookup("Hash"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   const SCVAL_LIMIT = 256000;
-//
-// ===========================================================================
-xdr.const("SCVAL_LIMIT", 256000);
-
-// === xdr source ============================================================
-//
-//   const SCSYMBOL_LIMIT = 32;
-//
-// ===========================================================================
-xdr.const("SCSYMBOL_LIMIT", 32);
-
-// === xdr source ============================================================
-//
-//   typedef SCVal SCVec<SCVAL_LIMIT>;
-//
-// ===========================================================================
-xdr.typedef("ScVec", xdr.varArray(xdr.lookup("ScVal"), xdr.lookup("SCVAL_LIMIT")));
-
-// === xdr source ============================================================
-//
-//   typedef SCMapEntry SCMap<SCVAL_LIMIT>;
-//
-// ===========================================================================
-xdr.typedef("ScMap", xdr.varArray(xdr.lookup("ScMapEntry"), xdr.lookup("SCVAL_LIMIT")));
-
-// === xdr source ============================================================
-//
-//   typedef opaque SCBytes<SCVAL_LIMIT>;
-//
-// ===========================================================================
-xdr.typedef("ScBytes", xdr.varOpaque(SCVAL_LIMIT));
-
-// === xdr source ============================================================
-//
-//   typedef string SCString<SCVAL_LIMIT>;
-//
-// ===========================================================================
-xdr.typedef("ScString", xdr.string(SCVAL_LIMIT));
-
-// === xdr source ============================================================
-//
-//   typedef string SCSymbol<SCSYMBOL_LIMIT>;
-//
-// ===========================================================================
-xdr.typedef("ScSymbol", xdr.string(SCSYMBOL_LIMIT));
-
-// === xdr source ============================================================
-//
-//   struct SCNonceKey {
-//       SCAddress nonce_address;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScNonceKey", [
-  ["nonceAddress", xdr.lookup("ScAddress")],
-]);
-
-// === xdr source ============================================================
-//
-//   union SCVal switch (SCValType type)
-//   {
-//   
-//   case SCV_BOOL:
-//       bool b;
-//   case SCV_VOID:
-//       void;
-//   case SCV_STATUS:
-//       SCStatus error;
-//   
-//   case SCV_U32:
-//       uint32 u32;
-//   case SCV_I32:
-//       int32 i32;
-//   
-//   case SCV_U64:
-//       uint64 u64;
-//   case SCV_I64:
-//       int64 i64;
-//   case SCV_TIMEPOINT:
-//       TimePoint timepoint;
-//   case SCV_DURATION:
-//       Duration duration;
-//   
-//   case SCV_U128:
-//       UInt128Parts u128;
-//   case SCV_I128:
-//       Int128Parts i128;
-//   
-//   case SCV_U256:
-//       UInt256Parts u256;
-//   case SCV_I256:
-//       Int256Parts i256;
-//   
-//   case SCV_BYTES:
-//       SCBytes bytes;
-//   case SCV_STRING:
-//       SCString str;
-//   case SCV_SYMBOL:
-//       SCSymbol sym;
-//   
-//   // Vec and Map are recursive so need to live
-//   // behind an option, due to xdrpp limitations.
-//   case SCV_VEC:
-//       SCVec *vec;
-//   case SCV_MAP:
-//       SCMap *map;
-//   
-//   case SCV_CONTRACT_EXECUTABLE:
-//       SCContractExecutable exec;
-//   case SCV_ADDRESS:
-//       SCAddress address;
-//   
-//   // Special SCVals reserved for system-constructed contract-data
-//   // ledger keys, not generally usable elsewhere.
-//   case SCV_LEDGER_KEY_CONTRACT_EXECUTABLE:
-//       void;
-//   case SCV_LEDGER_KEY_NONCE:
-//       SCNonceKey nonce_key;
-//   };
-//
-// ===========================================================================
-xdr.union("ScVal", {
-  switchOn: xdr.lookup("ScValType"),
-  switchName: "type",
-  switches: [
-    ["scvBool", "b"],
-    ["scvVoid", xdr.void()],
-    ["scvStatus", "error"],
-    ["scvU32", "u32"],
-    ["scvI32", "i32"],
-    ["scvU64", "u64"],
-    ["scvI64", "i64"],
-    ["scvTimepoint", "timepoint"],
-    ["scvDuration", "duration"],
-    ["scvU128", "u128"],
-    ["scvI128", "i128"],
-    ["scvU256", "u256"],
-    ["scvI256", "i256"],
-    ["scvBytes", "bytes"],
-    ["scvString", "str"],
-    ["scvSymbol", "sym"],
-    ["scvVec", "vec"],
-    ["scvMap", "map"],
-    ["scvContractExecutable", "exec"],
-    ["scvAddress", "address"],
-    ["scvLedgerKeyContractExecutable", xdr.void()],
-    ["scvLedgerKeyNonce", "nonceKey"],
-  ],
-  arms: {
-    b: xdr.bool(),
-    error: xdr.lookup("ScStatus"),
-    u32: xdr.lookup("Uint32"),
-    i32: xdr.lookup("Int32"),
-    u64: xdr.lookup("Uint64"),
-    i64: xdr.lookup("Int64"),
-    timepoint: xdr.lookup("TimePoint"),
-    duration: xdr.lookup("Duration"),
-    u128: xdr.lookup("UInt128Parts"),
-    i128: xdr.lookup("Int128Parts"),
-    u256: xdr.lookup("UInt256Parts"),
-    i256: xdr.lookup("Int256Parts"),
-    bytes: xdr.lookup("ScBytes"),
-    str: xdr.lookup("ScString"),
-    sym: xdr.lookup("ScSymbol"),
-    vec: xdr.option(xdr.lookup("ScVec")),
-    map: xdr.option(xdr.lookup("ScMap")),
-    exec: xdr.lookup("ScContractExecutable"),
-    address: xdr.lookup("ScAddress"),
-    nonceKey: xdr.lookup("ScNonceKey"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct SCMapEntry
-//   {
-//       SCVal key;
-//       SCVal val;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScMapEntry", [
-  ["key", xdr.lookup("ScVal")],
-  ["val", xdr.lookup("ScVal")],
-]);
-
-// === xdr source ============================================================
-//
-//   enum SCEnvMetaKind
-//   {
-//       SC_ENV_META_KIND_INTERFACE_VERSION = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("ScEnvMetaKind", {
-  scEnvMetaKindInterfaceVersion: 0,
-});
-
-// === xdr source ============================================================
-//
-//   union SCEnvMetaEntry switch (SCEnvMetaKind kind)
-//   {
-//   case SC_ENV_META_KIND_INTERFACE_VERSION:
-//       uint64 interfaceVersion;
-//   };
-//
-// ===========================================================================
-xdr.union("ScEnvMetaEntry", {
-  switchOn: xdr.lookup("ScEnvMetaKind"),
-  switchName: "kind",
-  switches: [
-    ["scEnvMetaKindInterfaceVersion", "interfaceVersion"],
-  ],
-  arms: {
-    interfaceVersion: xdr.lookup("Uint64"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   const SC_SPEC_DOC_LIMIT = 1024;
-//
-// ===========================================================================
-xdr.const("SC_SPEC_DOC_LIMIT", 1024);
-
-// === xdr source ============================================================
-//
-//   enum SCSpecType
-//   {
-//       SC_SPEC_TYPE_VAL = 0,
-//   
-//       // Types with no parameters.
-//       SC_SPEC_TYPE_BOOL = 1,
-//       SC_SPEC_TYPE_VOID = 2,
-//       SC_SPEC_TYPE_STATUS = 3,
-//       SC_SPEC_TYPE_U32 = 4,
-//       SC_SPEC_TYPE_I32 = 5,
-//       SC_SPEC_TYPE_U64 = 6,
-//       SC_SPEC_TYPE_I64 = 7,
-//       SC_SPEC_TYPE_TIMEPOINT = 8,
-//       SC_SPEC_TYPE_DURATION = 9,
-//       SC_SPEC_TYPE_U128 = 10,
-//       SC_SPEC_TYPE_I128 = 11,
-//       SC_SPEC_TYPE_U256 = 12,
-//       SC_SPEC_TYPE_I256 = 13,
-//       SC_SPEC_TYPE_BYTES = 14,
-//       SC_SPEC_TYPE_STRING = 16,
-//       SC_SPEC_TYPE_SYMBOL = 17,
-//       SC_SPEC_TYPE_ADDRESS = 19,
-//   
-//       // Types with parameters.
-//       SC_SPEC_TYPE_OPTION = 1000,
-//       SC_SPEC_TYPE_RESULT = 1001,
-//       SC_SPEC_TYPE_VEC = 1002,
-//       SC_SPEC_TYPE_SET = 1003,
-//       SC_SPEC_TYPE_MAP = 1004,
-//       SC_SPEC_TYPE_TUPLE = 1005,
-//       SC_SPEC_TYPE_BYTES_N = 1006,
-//   
-//       // User defined types.
-//       SC_SPEC_TYPE_UDT = 2000
-//   };
-//
-// ===========================================================================
-xdr.enum("ScSpecType", {
-  scSpecTypeVal: 0,
-  scSpecTypeBool: 1,
-  scSpecTypeVoid: 2,
-  scSpecTypeStatus: 3,
-  scSpecTypeU32: 4,
-  scSpecTypeI32: 5,
-  scSpecTypeU64: 6,
-  scSpecTypeI64: 7,
-  scSpecTypeTimepoint: 8,
-  scSpecTypeDuration: 9,
-  scSpecTypeU128: 10,
-  scSpecTypeI128: 11,
-  scSpecTypeU256: 12,
-  scSpecTypeI256: 13,
-  scSpecTypeBytes: 14,
-  scSpecTypeString: 16,
-  scSpecTypeSymbol: 17,
-  scSpecTypeAddress: 19,
-  scSpecTypeOption: 1000,
-  scSpecTypeResult: 1001,
-  scSpecTypeVec: 1002,
-  scSpecTypeSet: 1003,
-  scSpecTypeMap: 1004,
-  scSpecTypeTuple: 1005,
-  scSpecTypeBytesN: 1006,
-  scSpecTypeUdt: 2000,
-});
-
-// === xdr source ============================================================
-//
-//   struct SCSpecTypeOption
-//   {
-//       SCSpecTypeDef valueType;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecTypeOption", [
-  ["valueType", xdr.lookup("ScSpecTypeDef")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecTypeResult
-//   {
-//       SCSpecTypeDef okType;
-//       SCSpecTypeDef errorType;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecTypeResult", [
-  ["okType", xdr.lookup("ScSpecTypeDef")],
-  ["errorType", xdr.lookup("ScSpecTypeDef")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecTypeVec
-//   {
-//       SCSpecTypeDef elementType;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecTypeVec", [
-  ["elementType", xdr.lookup("ScSpecTypeDef")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecTypeMap
-//   {
-//       SCSpecTypeDef keyType;
-//       SCSpecTypeDef valueType;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecTypeMap", [
-  ["keyType", xdr.lookup("ScSpecTypeDef")],
-  ["valueType", xdr.lookup("ScSpecTypeDef")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecTypeSet
-//   {
-//       SCSpecTypeDef elementType;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecTypeSet", [
-  ["elementType", xdr.lookup("ScSpecTypeDef")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecTypeTuple
-//   {
-//       SCSpecTypeDef valueTypes<12>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecTypeTuple", [
-  ["valueTypes", xdr.varArray(xdr.lookup("ScSpecTypeDef"), 12)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecTypeBytesN
-//   {
-//       uint32 n;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecTypeBytesN", [
-  ["n", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecTypeUDT
-//   {
-//       string name<60>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecTypeUdt", [
-  ["name", xdr.string(60)],
-]);
-
-// === xdr source ============================================================
-//
-//   union SCSpecTypeDef switch (SCSpecType type)
-//   {
-//   case SC_SPEC_TYPE_VAL:
-//   case SC_SPEC_TYPE_BOOL:
-//   case SC_SPEC_TYPE_VOID:
-//   case SC_SPEC_TYPE_STATUS:
-//   case SC_SPEC_TYPE_U32:
-//   case SC_SPEC_TYPE_I32:
-//   case SC_SPEC_TYPE_U64:
-//   case SC_SPEC_TYPE_I64:
-//   case SC_SPEC_TYPE_TIMEPOINT:
-//   case SC_SPEC_TYPE_DURATION:
-//   case SC_SPEC_TYPE_U128:
-//   case SC_SPEC_TYPE_I128:
-//   case SC_SPEC_TYPE_U256:
-//   case SC_SPEC_TYPE_I256:
-//   case SC_SPEC_TYPE_BYTES:
-//   case SC_SPEC_TYPE_STRING:
-//   case SC_SPEC_TYPE_SYMBOL:
-//   case SC_SPEC_TYPE_ADDRESS:
-//       void;
-//   case SC_SPEC_TYPE_OPTION:
-//       SCSpecTypeOption option;
-//   case SC_SPEC_TYPE_RESULT:
-//       SCSpecTypeResult result;
-//   case SC_SPEC_TYPE_VEC:
-//       SCSpecTypeVec vec;
-//   case SC_SPEC_TYPE_MAP:
-//       SCSpecTypeMap map;
-//   case SC_SPEC_TYPE_SET:
-//       SCSpecTypeSet set;
-//   case SC_SPEC_TYPE_TUPLE:
-//       SCSpecTypeTuple tuple;
-//   case SC_SPEC_TYPE_BYTES_N:
-//       SCSpecTypeBytesN bytesN;
-//   case SC_SPEC_TYPE_UDT:
-//       SCSpecTypeUDT udt;
-//   };
-//
-// ===========================================================================
-xdr.union("ScSpecTypeDef", {
-  switchOn: xdr.lookup("ScSpecType"),
-  switchName: "type",
-  switches: [
-    ["scSpecTypeVal", xdr.void()],
-    ["scSpecTypeBool", xdr.void()],
-    ["scSpecTypeVoid", xdr.void()],
-    ["scSpecTypeStatus", xdr.void()],
-    ["scSpecTypeU32", xdr.void()],
-    ["scSpecTypeI32", xdr.void()],
-    ["scSpecTypeU64", xdr.void()],
-    ["scSpecTypeI64", xdr.void()],
-    ["scSpecTypeTimepoint", xdr.void()],
-    ["scSpecTypeDuration", xdr.void()],
-    ["scSpecTypeU128", xdr.void()],
-    ["scSpecTypeI128", xdr.void()],
-    ["scSpecTypeU256", xdr.void()],
-    ["scSpecTypeI256", xdr.void()],
-    ["scSpecTypeBytes", xdr.void()],
-    ["scSpecTypeString", xdr.void()],
-    ["scSpecTypeSymbol", xdr.void()],
-    ["scSpecTypeAddress", xdr.void()],
-    ["scSpecTypeOption", "option"],
-    ["scSpecTypeResult", "result"],
-    ["scSpecTypeVec", "vec"],
-    ["scSpecTypeMap", "map"],
-    ["scSpecTypeSet", "set"],
-    ["scSpecTypeTuple", "tuple"],
-    ["scSpecTypeBytesN", "bytesN"],
-    ["scSpecTypeUdt", "udt"],
-  ],
-  arms: {
-    option: xdr.lookup("ScSpecTypeOption"),
-    result: xdr.lookup("ScSpecTypeResult"),
-    vec: xdr.lookup("ScSpecTypeVec"),
-    map: xdr.lookup("ScSpecTypeMap"),
-    set: xdr.lookup("ScSpecTypeSet"),
-    tuple: xdr.lookup("ScSpecTypeTuple"),
-    bytesN: xdr.lookup("ScSpecTypeBytesN"),
-    udt: xdr.lookup("ScSpecTypeUdt"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct SCSpecUDTStructFieldV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       string name<30>;
-//       SCSpecTypeDef type;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecUdtStructFieldV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["name", xdr.string(30)],
-  ["type", xdr.lookup("ScSpecTypeDef")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecUDTStructV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       string lib<80>;
-//       string name<60>;
-//       SCSpecUDTStructFieldV0 fields<40>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecUdtStructV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["lib", xdr.string(80)],
-  ["name", xdr.string(60)],
-  ["fields", xdr.varArray(xdr.lookup("ScSpecUdtStructFieldV0"), 40)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecUDTUnionCaseVoidV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       string name<60>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecUdtUnionCaseVoidV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["name", xdr.string(60)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecUDTUnionCaseTupleV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       string name<60>;
-//       SCSpecTypeDef type<12>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecUdtUnionCaseTupleV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["name", xdr.string(60)],
-  ["type", xdr.varArray(xdr.lookup("ScSpecTypeDef"), 12)],
-]);
-
-// === xdr source ============================================================
-//
-//   enum SCSpecUDTUnionCaseV0Kind
-//   {
-//       SC_SPEC_UDT_UNION_CASE_VOID_V0 = 0,
-//       SC_SPEC_UDT_UNION_CASE_TUPLE_V0 = 1
-//   };
-//
-// ===========================================================================
-xdr.enum("ScSpecUdtUnionCaseV0Kind", {
-  scSpecUdtUnionCaseVoidV0: 0,
-  scSpecUdtUnionCaseTupleV0: 1,
-});
-
-// === xdr source ============================================================
-//
-//   union SCSpecUDTUnionCaseV0 switch (SCSpecUDTUnionCaseV0Kind kind)
-//   {
-//   case SC_SPEC_UDT_UNION_CASE_VOID_V0:
-//       SCSpecUDTUnionCaseVoidV0 voidCase;
-//   case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
-//       SCSpecUDTUnionCaseTupleV0 tupleCase;
-//   };
-//
-// ===========================================================================
-xdr.union("ScSpecUdtUnionCaseV0", {
-  switchOn: xdr.lookup("ScSpecUdtUnionCaseV0Kind"),
-  switchName: "kind",
-  switches: [
-    ["scSpecUdtUnionCaseVoidV0", "voidCase"],
-    ["scSpecUdtUnionCaseTupleV0", "tupleCase"],
-  ],
-  arms: {
-    voidCase: xdr.lookup("ScSpecUdtUnionCaseVoidV0"),
-    tupleCase: xdr.lookup("ScSpecUdtUnionCaseTupleV0"),
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct SCSpecUDTUnionV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       string lib<80>;
-//       string name<60>;
-//       SCSpecUDTUnionCaseV0 cases<50>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecUdtUnionV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["lib", xdr.string(80)],
-  ["name", xdr.string(60)],
-  ["cases", xdr.varArray(xdr.lookup("ScSpecUdtUnionCaseV0"), 50)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecUDTEnumCaseV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       string name<60>;
-//       uint32 value;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecUdtEnumCaseV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["name", xdr.string(60)],
-  ["value", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecUDTEnumV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       string lib<80>;
-//       string name<60>;
-//       SCSpecUDTEnumCaseV0 cases<50>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecUdtEnumV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["lib", xdr.string(80)],
-  ["name", xdr.string(60)],
-  ["cases", xdr.varArray(xdr.lookup("ScSpecUdtEnumCaseV0"), 50)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecUDTErrorEnumCaseV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       string name<60>;
-//       uint32 value;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecUdtErrorEnumCaseV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["name", xdr.string(60)],
-  ["value", xdr.lookup("Uint32")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecUDTErrorEnumV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       string lib<80>;
-//       string name<60>;
-//       SCSpecUDTErrorEnumCaseV0 cases<50>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecUdtErrorEnumV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["lib", xdr.string(80)],
-  ["name", xdr.string(60)],
-  ["cases", xdr.varArray(xdr.lookup("ScSpecUdtErrorEnumCaseV0"), 50)],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecFunctionInputV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       string name<30>;
-//       SCSpecTypeDef type;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecFunctionInputV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["name", xdr.string(30)],
-  ["type", xdr.lookup("ScSpecTypeDef")],
-]);
-
-// === xdr source ============================================================
-//
-//   struct SCSpecFunctionV0
-//   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
-//       SCSymbol name;
-//       SCSpecFunctionInputV0 inputs<10>;
-//       SCSpecTypeDef outputs<1>;
-//   };
-//
-// ===========================================================================
-xdr.struct("ScSpecFunctionV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
-  ["name", xdr.lookup("ScSymbol")],
-  ["inputs", xdr.varArray(xdr.lookup("ScSpecFunctionInputV0"), 10)],
-  ["outputs", xdr.varArray(xdr.lookup("ScSpecTypeDef"), 1)],
-]);
-
-// === xdr source ============================================================
-//
-//   enum SCSpecEntryKind
-//   {
-//       SC_SPEC_ENTRY_FUNCTION_V0 = 0,
-//       SC_SPEC_ENTRY_UDT_STRUCT_V0 = 1,
-//       SC_SPEC_ENTRY_UDT_UNION_V0 = 2,
-//       SC_SPEC_ENTRY_UDT_ENUM_V0 = 3,
-//       SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0 = 4
-//   };
-//
-// ===========================================================================
-xdr.enum("ScSpecEntryKind", {
-  scSpecEntryFunctionV0: 0,
-  scSpecEntryUdtStructV0: 1,
-  scSpecEntryUdtUnionV0: 2,
-  scSpecEntryUdtEnumV0: 3,
-  scSpecEntryUdtErrorEnumV0: 4,
-});
-
-// === xdr source ============================================================
-//
-//   union SCSpecEntry switch (SCSpecEntryKind kind)
-//   {
-//   case SC_SPEC_ENTRY_FUNCTION_V0:
-//       SCSpecFunctionV0 functionV0;
-//   case SC_SPEC_ENTRY_UDT_STRUCT_V0:
-//       SCSpecUDTStructV0 udtStructV0;
-//   case SC_SPEC_ENTRY_UDT_UNION_V0:
-//       SCSpecUDTUnionV0 udtUnionV0;
-//   case SC_SPEC_ENTRY_UDT_ENUM_V0:
-//       SCSpecUDTEnumV0 udtEnumV0;
-//   case SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0:
-//       SCSpecUDTErrorEnumV0 udtErrorEnumV0;
-//   };
-//
-// ===========================================================================
-xdr.union("ScSpecEntry", {
-  switchOn: xdr.lookup("ScSpecEntryKind"),
-  switchName: "kind",
-  switches: [
-    ["scSpecEntryFunctionV0", "functionV0"],
-    ["scSpecEntryUdtStructV0", "udtStructV0"],
-    ["scSpecEntryUdtUnionV0", "udtUnionV0"],
-    ["scSpecEntryUdtEnumV0", "udtEnumV0"],
-    ["scSpecEntryUdtErrorEnumV0", "udtErrorEnumV0"],
-  ],
-  arms: {
-    functionV0: xdr.lookup("ScSpecFunctionV0"),
-    udtStructV0: xdr.lookup("ScSpecUdtStructV0"),
-    udtUnionV0: xdr.lookup("ScSpecUdtUnionV0"),
-    udtEnumV0: xdr.lookup("ScSpecUdtEnumV0"),
-    udtErrorEnumV0: xdr.lookup("ScSpecUdtErrorEnumV0"),
-  },
-});
-
+import * as XDR from "js-xdr";
+
+var types = XDR.config((xdr) => {
+  // === xdr source ============================================================
+  //
+  //   typedef opaque Value<>;
+  //
+  // ===========================================================================
+  xdr.typedef("Value", xdr.varOpaque());
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPBallot
+  //   {
+  //       uint32 counter; // n
+  //       Value value;    // x
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpBallot", [
+    ["counter", xdr.lookup("Uint32")],
+    ["value", xdr.lookup("Value")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum SCPStatementType
+  //   {
+  //       SCP_ST_PREPARE = 0,
+  //       SCP_ST_CONFIRM = 1,
+  //       SCP_ST_EXTERNALIZE = 2,
+  //       SCP_ST_NOMINATE = 3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScpStatementType", {
+    scpStPrepare: 0,
+    scpStConfirm: 1,
+    scpStExternalize: 2,
+    scpStNominate: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPNomination
+  //   {
+  //       Hash quorumSetHash; // D
+  //       Value votes<>;      // X
+  //       Value accepted<>;   // Y
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpNomination", [
+    ["quorumSetHash", xdr.lookup("Hash")],
+    ["votes", xdr.varArray(xdr.lookup("Value"), 2147483647)],
+    ["accepted", xdr.varArray(xdr.lookup("Value"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               Hash quorumSetHash;       // D
+  //               SCPBallot ballot;         // b
+  //               SCPBallot* prepared;      // p
+  //               SCPBallot* preparedPrime; // p'
+  //               uint32 nC;                // c.n
+  //               uint32 nH;                // h.n
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("ScpStatementPrepare", [
+    ["quorumSetHash", xdr.lookup("Hash")],
+    ["ballot", xdr.lookup("ScpBallot")],
+    ["prepared", xdr.option(xdr.lookup("ScpBallot"))],
+    ["preparedPrime", xdr.option(xdr.lookup("ScpBallot"))],
+    ["nC", xdr.lookup("Uint32")],
+    ["nH", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               SCPBallot ballot;   // b
+  //               uint32 nPrepared;   // p.n
+  //               uint32 nCommit;     // c.n
+  //               uint32 nH;          // h.n
+  //               Hash quorumSetHash; // D
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("ScpStatementConfirm", [
+    ["ballot", xdr.lookup("ScpBallot")],
+    ["nPrepared", xdr.lookup("Uint32")],
+    ["nCommit", xdr.lookup("Uint32")],
+    ["nH", xdr.lookup("Uint32")],
+    ["quorumSetHash", xdr.lookup("Hash")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               SCPBallot commit;         // c
+  //               uint32 nH;                // h.n
+  //               Hash commitQuorumSetHash; // D used before EXTERNALIZE
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("ScpStatementExternalize", [
+    ["commit", xdr.lookup("ScpBallot")],
+    ["nH", xdr.lookup("Uint32")],
+    ["commitQuorumSetHash", xdr.lookup("Hash")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (SCPStatementType type)
+  //       {
+  //       case SCP_ST_PREPARE:
+  //           struct
+  //           {
+  //               Hash quorumSetHash;       // D
+  //               SCPBallot ballot;         // b
+  //               SCPBallot* prepared;      // p
+  //               SCPBallot* preparedPrime; // p'
+  //               uint32 nC;                // c.n
+  //               uint32 nH;                // h.n
+  //           } prepare;
+  //       case SCP_ST_CONFIRM:
+  //           struct
+  //           {
+  //               SCPBallot ballot;   // b
+  //               uint32 nPrepared;   // p.n
+  //               uint32 nCommit;     // c.n
+  //               uint32 nH;          // h.n
+  //               Hash quorumSetHash; // D
+  //           } confirm;
+  //       case SCP_ST_EXTERNALIZE:
+  //           struct
+  //           {
+  //               SCPBallot commit;         // c
+  //               uint32 nH;                // h.n
+  //               Hash commitQuorumSetHash; // D used before EXTERNALIZE
+  //           } externalize;
+  //       case SCP_ST_NOMINATE:
+  //           SCPNomination nominate;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("ScpStatementPledges", {
+    switchOn: xdr.lookup("ScpStatementType"),
+    switchName: "type",
+    switches: [
+      ["scpStPrepare", "prepare"],
+      ["scpStConfirm", "confirm"],
+      ["scpStExternalize", "externalize"],
+      ["scpStNominate", "nominate"],
+    ],
+    arms: {
+      prepare: xdr.lookup("ScpStatementPrepare"),
+      confirm: xdr.lookup("ScpStatementConfirm"),
+      externalize: xdr.lookup("ScpStatementExternalize"),
+      nominate: xdr.lookup("ScpNomination"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPStatement
+  //   {
+  //       NodeID nodeID;    // v
+  //       uint64 slotIndex; // i
+  //
+  //       union switch (SCPStatementType type)
+  //       {
+  //       case SCP_ST_PREPARE:
+  //           struct
+  //           {
+  //               Hash quorumSetHash;       // D
+  //               SCPBallot ballot;         // b
+  //               SCPBallot* prepared;      // p
+  //               SCPBallot* preparedPrime; // p'
+  //               uint32 nC;                // c.n
+  //               uint32 nH;                // h.n
+  //           } prepare;
+  //       case SCP_ST_CONFIRM:
+  //           struct
+  //           {
+  //               SCPBallot ballot;   // b
+  //               uint32 nPrepared;   // p.n
+  //               uint32 nCommit;     // c.n
+  //               uint32 nH;          // h.n
+  //               Hash quorumSetHash; // D
+  //           } confirm;
+  //       case SCP_ST_EXTERNALIZE:
+  //           struct
+  //           {
+  //               SCPBallot commit;         // c
+  //               uint32 nH;                // h.n
+  //               Hash commitQuorumSetHash; // D used before EXTERNALIZE
+  //           } externalize;
+  //       case SCP_ST_NOMINATE:
+  //           SCPNomination nominate;
+  //       }
+  //       pledges;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpStatement", [
+    ["nodeId", xdr.lookup("NodeId")],
+    ["slotIndex", xdr.lookup("Uint64")],
+    ["pledges", xdr.lookup("ScpStatementPledges")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPEnvelope
+  //   {
+  //       SCPStatement statement;
+  //       Signature signature;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpEnvelope", [
+    ["statement", xdr.lookup("ScpStatement")],
+    ["signature", xdr.lookup("Signature")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPQuorumSet
+  //   {
+  //       uint32 threshold;
+  //       NodeID validators<>;
+  //       SCPQuorumSet innerSets<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpQuorumSet", [
+    ["threshold", xdr.lookup("Uint32")],
+    ["validators", xdr.varArray(xdr.lookup("NodeId"), 2147483647)],
+    ["innerSets", xdr.varArray(xdr.lookup("ScpQuorumSet"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque Thresholds[4];
+  //
+  // ===========================================================================
+  xdr.typedef("Thresholds", xdr.opaque(4));
+
+  // === xdr source ============================================================
+  //
+  //   typedef string string32<32>;
+  //
+  // ===========================================================================
+  xdr.typedef("String32", xdr.string(32));
+
+  // === xdr source ============================================================
+  //
+  //   typedef string string64<64>;
+  //
+  // ===========================================================================
+  xdr.typedef("String64", xdr.string(64));
+
+  // === xdr source ============================================================
+  //
+  //   typedef int64 SequenceNumber;
+  //
+  // ===========================================================================
+  xdr.typedef("SequenceNumber", xdr.lookup("Int64"));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque DataValue<64>;
+  //
+  // ===========================================================================
+  xdr.typedef("DataValue", xdr.varOpaque(64));
+
+  // === xdr source ============================================================
+  //
+  //   typedef Hash PoolID;
+  //
+  // ===========================================================================
+  xdr.typedef("PoolId", xdr.lookup("Hash"));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque AssetCode4[4];
+  //
+  // ===========================================================================
+  xdr.typedef("AssetCode4", xdr.opaque(4));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque AssetCode12[12];
+  //
+  // ===========================================================================
+  xdr.typedef("AssetCode12", xdr.opaque(12));
+
+  // === xdr source ============================================================
+  //
+  //   enum AssetType
+  //   {
+  //       ASSET_TYPE_NATIVE = 0,
+  //       ASSET_TYPE_CREDIT_ALPHANUM4 = 1,
+  //       ASSET_TYPE_CREDIT_ALPHANUM12 = 2,
+  //       ASSET_TYPE_POOL_SHARE = 3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("AssetType", {
+    assetTypeNative: 0,
+    assetTypeCreditAlphanum4: 1,
+    assetTypeCreditAlphanum12: 2,
+    assetTypePoolShare: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union AssetCode switch (AssetType type)
+  //   {
+  //   case ASSET_TYPE_CREDIT_ALPHANUM4:
+  //       AssetCode4 assetCode4;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM12:
+  //       AssetCode12 assetCode12;
+  //
+  //       // add other asset types here in the future
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("AssetCode", {
+    switchOn: xdr.lookup("AssetType"),
+    switchName: "type",
+    switches: [
+      ["assetTypeCreditAlphanum4", "assetCode4"],
+      ["assetTypeCreditAlphanum12", "assetCode12"],
+    ],
+    arms: {
+      assetCode4: xdr.lookup("AssetCode4"),
+      assetCode12: xdr.lookup("AssetCode12"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct AlphaNum4
+  //   {
+  //       AssetCode4 assetCode;
+  //       AccountID issuer;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AlphaNum4", [
+    ["assetCode", xdr.lookup("AssetCode4")],
+    ["issuer", xdr.lookup("AccountId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct AlphaNum12
+  //   {
+  //       AssetCode12 assetCode;
+  //       AccountID issuer;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AlphaNum12", [
+    ["assetCode", xdr.lookup("AssetCode12")],
+    ["issuer", xdr.lookup("AccountId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union Asset switch (AssetType type)
+  //   {
+  //   case ASSET_TYPE_NATIVE: // Not credit
+  //       void;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM4:
+  //       AlphaNum4 alphaNum4;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM12:
+  //       AlphaNum12 alphaNum12;
+  //
+  //       // add other asset types here in the future
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("Asset", {
+    switchOn: xdr.lookup("AssetType"),
+    switchName: "type",
+    switches: [
+      ["assetTypeNative", xdr.void()],
+      ["assetTypeCreditAlphanum4", "alphaNum4"],
+      ["assetTypeCreditAlphanum12", "alphaNum12"],
+    ],
+    arms: {
+      alphaNum4: xdr.lookup("AlphaNum4"),
+      alphaNum12: xdr.lookup("AlphaNum12"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct Price
+  //   {
+  //       int32 n; // numerator
+  //       int32 d; // denominator
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Price", [
+    ["n", xdr.lookup("Int32")],
+    ["d", xdr.lookup("Int32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct Liabilities
+  //   {
+  //       int64 buying;
+  //       int64 selling;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Liabilities", [
+    ["buying", xdr.lookup("Int64")],
+    ["selling", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum ThresholdIndexes
+  //   {
+  //       THRESHOLD_MASTER_WEIGHT = 0,
+  //       THRESHOLD_LOW = 1,
+  //       THRESHOLD_MED = 2,
+  //       THRESHOLD_HIGH = 3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ThresholdIndices", {
+    thresholdMasterWeight: 0,
+    thresholdLow: 1,
+    thresholdMed: 2,
+    thresholdHigh: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum LedgerEntryType
+  //   {
+  //       ACCOUNT = 0,
+  //       TRUSTLINE = 1,
+  //       OFFER = 2,
+  //       DATA = 3,
+  //       CLAIMABLE_BALANCE = 4,
+  //       LIQUIDITY_POOL = 5,
+  //       CONTRACT_DATA = 6,
+  //       CONTRACT_CODE = 7,
+  //       CONFIG_SETTING = 8
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LedgerEntryType", {
+    account: 0,
+    trustline: 1,
+    offer: 2,
+    data: 3,
+    claimableBalance: 4,
+    liquidityPool: 5,
+    contractData: 6,
+    contractCode: 7,
+    configSetting: 8,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct Signer
+  //   {
+  //       SignerKey key;
+  //       uint32 weight; // really only need 1 byte
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Signer", [
+    ["key", xdr.lookup("SignerKey")],
+    ["weight", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum AccountFlags
+  //   { // masks for each flag
+  //
+  //       // Flags set on issuer accounts
+  //       // TrustLines are created with authorized set to "false" requiring
+  //       // the issuer to set it for each TrustLine
+  //       AUTH_REQUIRED_FLAG = 0x1,
+  //       // If set, the authorized flag in TrustLines can be cleared
+  //       // otherwise, authorization cannot be revoked
+  //       AUTH_REVOCABLE_FLAG = 0x2,
+  //       // Once set, causes all AUTH_* flags to be read-only
+  //       AUTH_IMMUTABLE_FLAG = 0x4,
+  //       // Trustlines are created with clawback enabled set to "true",
+  //       // and claimable balances created from those trustlines are created
+  //       // with clawback enabled set to "true"
+  //       AUTH_CLAWBACK_ENABLED_FLAG = 0x8
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("AccountFlags", {
+    authRequiredFlag: 1,
+    authRevocableFlag: 2,
+    authImmutableFlag: 4,
+    authClawbackEnabledFlag: 8,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_ACCOUNT_FLAGS = 0x7;
+  //
+  // ===========================================================================
+  xdr.const("MASK_ACCOUNT_FLAGS", 0x7);
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_ACCOUNT_FLAGS_V17 = 0xF;
+  //
+  // ===========================================================================
+  xdr.const("MASK_ACCOUNT_FLAGS_V17", 0xf);
+
+  // === xdr source ============================================================
+  //
+  //   const MAX_SIGNERS = 20;
+  //
+  // ===========================================================================
+  xdr.const("MAX_SIGNERS", 20);
+
+  // === xdr source ============================================================
+  //
+  //   typedef AccountID* SponsorshipDescriptor;
+  //
+  // ===========================================================================
+  xdr.typedef("SponsorshipDescriptor", xdr.option(xdr.lookup("AccountId")));
+
+  // === xdr source ============================================================
+  //
+  //   struct AccountEntryExtensionV3
+  //   {
+  //       // We can use this to add more fields, or because it is first, to
+  //       // change AccountEntryExtensionV3 into a union.
+  //       ExtensionPoint ext;
+  //
+  //       // Ledger number at which `seqNum` took on its present value.
+  //       uint32 seqLedger;
+  //
+  //       // Time at which `seqNum` took on its present value.
+  //       TimePoint seqTime;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AccountEntryExtensionV3", [
+    ["ext", xdr.lookup("ExtensionPoint")],
+    ["seqLedger", xdr.lookup("Uint32")],
+    ["seqTime", xdr.lookup("TimePoint")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 3:
+  //           AccountEntryExtensionV3 v3;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("AccountEntryExtensionV2Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [3, "v3"],
+    ],
+    arms: {
+      v3: xdr.lookup("AccountEntryExtensionV3"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct AccountEntryExtensionV2
+  //   {
+  //       uint32 numSponsored;
+  //       uint32 numSponsoring;
+  //       SponsorshipDescriptor signerSponsoringIDs<MAX_SIGNERS>;
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 3:
+  //           AccountEntryExtensionV3 v3;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AccountEntryExtensionV2", [
+    ["numSponsored", xdr.lookup("Uint32")],
+    ["numSponsoring", xdr.lookup("Uint32")],
+    [
+      "signerSponsoringIDs",
+      xdr.varArray(
+        xdr.lookup("SponsorshipDescriptor"),
+        xdr.lookup("MAX_SIGNERS")
+      ),
+    ],
+    ["ext", xdr.lookup("AccountEntryExtensionV2Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 2:
+  //           AccountEntryExtensionV2 v2;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("AccountEntryExtensionV1Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [2, "v2"],
+    ],
+    arms: {
+      v2: xdr.lookup("AccountEntryExtensionV2"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct AccountEntryExtensionV1
+  //   {
+  //       Liabilities liabilities;
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 2:
+  //           AccountEntryExtensionV2 v2;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AccountEntryExtensionV1", [
+    ["liabilities", xdr.lookup("Liabilities")],
+    ["ext", xdr.lookup("AccountEntryExtensionV1Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           AccountEntryExtensionV1 v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("AccountEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "v1"],
+    ],
+    arms: {
+      v1: xdr.lookup("AccountEntryExtensionV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct AccountEntry
+  //   {
+  //       AccountID accountID;      // master public key for this account
+  //       int64 balance;            // in stroops
+  //       SequenceNumber seqNum;    // last sequence number used for this account
+  //       uint32 numSubEntries;     // number of sub-entries this account has
+  //                                 // drives the reserve
+  //       AccountID* inflationDest; // Account to vote for during inflation
+  //       uint32 flags;             // see AccountFlags
+  //
+  //       string32 homeDomain; // can be used for reverse federation and memo lookup
+  //
+  //       // fields used for signatures
+  //       // thresholds stores unsigned bytes: [weight of master|low|medium|high]
+  //       Thresholds thresholds;
+  //
+  //       Signer signers<MAX_SIGNERS>; // possible signers for this account
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           AccountEntryExtensionV1 v1;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AccountEntry", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["balance", xdr.lookup("Int64")],
+    ["seqNum", xdr.lookup("SequenceNumber")],
+    ["numSubEntries", xdr.lookup("Uint32")],
+    ["inflationDest", xdr.option(xdr.lookup("AccountId"))],
+    ["flags", xdr.lookup("Uint32")],
+    ["homeDomain", xdr.lookup("String32")],
+    ["thresholds", xdr.lookup("Thresholds")],
+    ["signers", xdr.varArray(xdr.lookup("Signer"), xdr.lookup("MAX_SIGNERS"))],
+    ["ext", xdr.lookup("AccountEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum TrustLineFlags
+  //   {
+  //       // issuer has authorized account to perform transactions with its credit
+  //       AUTHORIZED_FLAG = 1,
+  //       // issuer has authorized account to maintain and reduce liabilities for its
+  //       // credit
+  //       AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
+  //       // issuer has specified that it may clawback its credit, and that claimable
+  //       // balances created with its credit may also be clawed back
+  //       TRUSTLINE_CLAWBACK_ENABLED_FLAG = 4
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("TrustLineFlags", {
+    authorizedFlag: 1,
+    authorizedToMaintainLiabilitiesFlag: 2,
+    trustlineClawbackEnabledFlag: 4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_TRUSTLINE_FLAGS = 1;
+  //
+  // ===========================================================================
+  xdr.const("MASK_TRUSTLINE_FLAGS", 1);
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_TRUSTLINE_FLAGS_V13 = 3;
+  //
+  // ===========================================================================
+  xdr.const("MASK_TRUSTLINE_FLAGS_V13", 3);
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_TRUSTLINE_FLAGS_V17 = 7;
+  //
+  // ===========================================================================
+  xdr.const("MASK_TRUSTLINE_FLAGS_V17", 7);
+
+  // === xdr source ============================================================
+  //
+  //   enum LiquidityPoolType
+  //   {
+  //       LIQUIDITY_POOL_CONSTANT_PRODUCT = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LiquidityPoolType", {
+    liquidityPoolConstantProduct: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union TrustLineAsset switch (AssetType type)
+  //   {
+  //   case ASSET_TYPE_NATIVE: // Not credit
+  //       void;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM4:
+  //       AlphaNum4 alphaNum4;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM12:
+  //       AlphaNum12 alphaNum12;
+  //
+  //   case ASSET_TYPE_POOL_SHARE:
+  //       PoolID liquidityPoolID;
+  //
+  //       // add other asset types here in the future
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("TrustLineAsset", {
+    switchOn: xdr.lookup("AssetType"),
+    switchName: "type",
+    switches: [
+      ["assetTypeNative", xdr.void()],
+      ["assetTypeCreditAlphanum4", "alphaNum4"],
+      ["assetTypeCreditAlphanum12", "alphaNum12"],
+      ["assetTypePoolShare", "liquidityPoolId"],
+    ],
+    arms: {
+      alphaNum4: xdr.lookup("AlphaNum4"),
+      alphaNum12: xdr.lookup("AlphaNum12"),
+      liquidityPoolId: xdr.lookup("PoolId"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TrustLineEntryExtensionV2Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TrustLineEntryExtensionV2
+  //   {
+  //       int32 liquidityPoolUseCount;
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TrustLineEntryExtensionV2", [
+    ["liquidityPoolUseCount", xdr.lookup("Int32")],
+    ["ext", xdr.lookup("TrustLineEntryExtensionV2Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //               {
+  //               case 0:
+  //                   void;
+  //               case 2:
+  //                   TrustLineEntryExtensionV2 v2;
+  //               }
+  //
+  // ===========================================================================
+  xdr.union("TrustLineEntryV1Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [2, "v2"],
+    ],
+    arms: {
+      v2: xdr.lookup("TrustLineEntryExtensionV2"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               Liabilities liabilities;
+  //
+  //               union switch (int v)
+  //               {
+  //               case 0:
+  //                   void;
+  //               case 2:
+  //                   TrustLineEntryExtensionV2 v2;
+  //               }
+  //               ext;
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("TrustLineEntryV1", [
+    ["liabilities", xdr.lookup("Liabilities")],
+    ["ext", xdr.lookup("TrustLineEntryV1Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           struct
+  //           {
+  //               Liabilities liabilities;
+  //
+  //               union switch (int v)
+  //               {
+  //               case 0:
+  //                   void;
+  //               case 2:
+  //                   TrustLineEntryExtensionV2 v2;
+  //               }
+  //               ext;
+  //           } v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TrustLineEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "v1"],
+    ],
+    arms: {
+      v1: xdr.lookup("TrustLineEntryV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TrustLineEntry
+  //   {
+  //       AccountID accountID;  // account this trustline belongs to
+  //       TrustLineAsset asset; // type of asset (with issuer)
+  //       int64 balance;        // how much of this asset the user has.
+  //                             // Asset defines the unit for this;
+  //
+  //       int64 limit;  // balance cannot be above this
+  //       uint32 flags; // see TrustLineFlags
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           struct
+  //           {
+  //               Liabilities liabilities;
+  //
+  //               union switch (int v)
+  //               {
+  //               case 0:
+  //                   void;
+  //               case 2:
+  //                   TrustLineEntryExtensionV2 v2;
+  //               }
+  //               ext;
+  //           } v1;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TrustLineEntry", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["asset", xdr.lookup("TrustLineAsset")],
+    ["balance", xdr.lookup("Int64")],
+    ["limit", xdr.lookup("Int64")],
+    ["flags", xdr.lookup("Uint32")],
+    ["ext", xdr.lookup("TrustLineEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum OfferEntryFlags
+  //   {
+  //       // an offer with this flag will not act on and take a reverse offer of equal
+  //       // price
+  //       PASSIVE_FLAG = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("OfferEntryFlags", {
+    passiveFlag: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_OFFERENTRY_FLAGS = 1;
+  //
+  // ===========================================================================
+  xdr.const("MASK_OFFERENTRY_FLAGS", 1);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("OfferEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct OfferEntry
+  //   {
+  //       AccountID sellerID;
+  //       int64 offerID;
+  //       Asset selling; // A
+  //       Asset buying;  // B
+  //       int64 amount;  // amount of A
+  //
+  //       /* price for this offer:
+  //           price of A in terms of B
+  //           price=AmountB/AmountA=priceNumerator/priceDenominator
+  //           price is after fees
+  //       */
+  //       Price price;
+  //       uint32 flags; // see OfferEntryFlags
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("OfferEntry", [
+    ["sellerId", xdr.lookup("AccountId")],
+    ["offerId", xdr.lookup("Int64")],
+    ["selling", xdr.lookup("Asset")],
+    ["buying", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+    ["price", xdr.lookup("Price")],
+    ["flags", xdr.lookup("Uint32")],
+    ["ext", xdr.lookup("OfferEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("DataEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct DataEntry
+  //   {
+  //       AccountID accountID; // account this data belongs to
+  //       string64 dataName;
+  //       DataValue dataValue;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("DataEntry", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["dataName", xdr.lookup("String64")],
+    ["dataValue", xdr.lookup("DataValue")],
+    ["ext", xdr.lookup("DataEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimPredicateType
+  //   {
+  //       CLAIM_PREDICATE_UNCONDITIONAL = 0,
+  //       CLAIM_PREDICATE_AND = 1,
+  //       CLAIM_PREDICATE_OR = 2,
+  //       CLAIM_PREDICATE_NOT = 3,
+  //       CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
+  //       CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimPredicateType", {
+    claimPredicateUnconditional: 0,
+    claimPredicateAnd: 1,
+    claimPredicateOr: 2,
+    claimPredicateNot: 3,
+    claimPredicateBeforeAbsoluteTime: 4,
+    claimPredicateBeforeRelativeTime: 5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ClaimPredicate switch (ClaimPredicateType type)
+  //   {
+  //   case CLAIM_PREDICATE_UNCONDITIONAL:
+  //       void;
+  //   case CLAIM_PREDICATE_AND:
+  //       ClaimPredicate andPredicates<2>;
+  //   case CLAIM_PREDICATE_OR:
+  //       ClaimPredicate orPredicates<2>;
+  //   case CLAIM_PREDICATE_NOT:
+  //       ClaimPredicate* notPredicate;
+  //   case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
+  //       int64 absBefore; // Predicate will be true if closeTime < absBefore
+  //   case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
+  //       int64 relBefore; // Seconds since closeTime of the ledger in which the
+  //                        // ClaimableBalanceEntry was created
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClaimPredicate", {
+    switchOn: xdr.lookup("ClaimPredicateType"),
+    switchName: "type",
+    switches: [
+      ["claimPredicateUnconditional", xdr.void()],
+      ["claimPredicateAnd", "andPredicates"],
+      ["claimPredicateOr", "orPredicates"],
+      ["claimPredicateNot", "notPredicate"],
+      ["claimPredicateBeforeAbsoluteTime", "absBefore"],
+      ["claimPredicateBeforeRelativeTime", "relBefore"],
+    ],
+    arms: {
+      andPredicates: xdr.varArray(xdr.lookup("ClaimPredicate"), 2),
+      orPredicates: xdr.varArray(xdr.lookup("ClaimPredicate"), 2),
+      notPredicate: xdr.option(xdr.lookup("ClaimPredicate")),
+      absBefore: xdr.lookup("Int64"),
+      relBefore: xdr.lookup("Int64"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimantType
+  //   {
+  //       CLAIMANT_TYPE_V0 = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimantType", {
+    claimantTypeV0: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID destination;    // The account that can use this condition
+  //           ClaimPredicate predicate; // Claimable if predicate is true
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("ClaimantV0", [
+    ["destination", xdr.lookup("AccountId")],
+    ["predicate", xdr.lookup("ClaimPredicate")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union Claimant switch (ClaimantType type)
+  //   {
+  //   case CLAIMANT_TYPE_V0:
+  //       struct
+  //       {
+  //           AccountID destination;    // The account that can use this condition
+  //           ClaimPredicate predicate; // Claimable if predicate is true
+  //       } v0;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("Claimant", {
+    switchOn: xdr.lookup("ClaimantType"),
+    switchName: "type",
+    switches: [["claimantTypeV0", "v0"]],
+    arms: {
+      v0: xdr.lookup("ClaimantV0"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimableBalanceIDType
+  //   {
+  //       CLAIMABLE_BALANCE_ID_TYPE_V0 = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimableBalanceIdType", {
+    claimableBalanceIdTypeV0: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ClaimableBalanceID switch (ClaimableBalanceIDType type)
+  //   {
+  //   case CLAIMABLE_BALANCE_ID_TYPE_V0:
+  //       Hash v0;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClaimableBalanceId", {
+    switchOn: xdr.lookup("ClaimableBalanceIdType"),
+    switchName: "type",
+    switches: [["claimableBalanceIdTypeV0", "v0"]],
+    arms: {
+      v0: xdr.lookup("Hash"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimableBalanceFlags
+  //   {
+  //       // If set, the issuer account of the asset held by the claimable balance may
+  //       // clawback the claimable balance
+  //       CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG = 0x1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimableBalanceFlags", {
+    claimableBalanceClawbackEnabledFlag: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1;
+  //
+  // ===========================================================================
+  xdr.const("MASK_CLAIMABLE_BALANCE_FLAGS", 0x1);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("ClaimableBalanceEntryExtensionV1Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimableBalanceEntryExtensionV1
+  //   {
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //
+  //       uint32 flags; // see ClaimableBalanceFlags
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimableBalanceEntryExtensionV1", [
+    ["ext", xdr.lookup("ClaimableBalanceEntryExtensionV1Ext")],
+    ["flags", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           ClaimableBalanceEntryExtensionV1 v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("ClaimableBalanceEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "v1"],
+    ],
+    arms: {
+      v1: xdr.lookup("ClaimableBalanceEntryExtensionV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimableBalanceEntry
+  //   {
+  //       // Unique identifier for this ClaimableBalanceEntry
+  //       ClaimableBalanceID balanceID;
+  //
+  //       // List of claimants with associated predicate
+  //       Claimant claimants<10>;
+  //
+  //       // Any asset including native
+  //       Asset asset;
+  //
+  //       // Amount of asset
+  //       int64 amount;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           ClaimableBalanceEntryExtensionV1 v1;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimableBalanceEntry", [
+    ["balanceId", xdr.lookup("ClaimableBalanceId")],
+    ["claimants", xdr.varArray(xdr.lookup("Claimant"), 10)],
+    ["asset", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+    ["ext", xdr.lookup("ClaimableBalanceEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LiquidityPoolConstantProductParameters
+  //   {
+  //       Asset assetA; // assetA < assetB
+  //       Asset assetB;
+  //       int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LiquidityPoolConstantProductParameters", [
+    ["assetA", xdr.lookup("Asset")],
+    ["assetB", xdr.lookup("Asset")],
+    ["fee", xdr.lookup("Int32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               LiquidityPoolConstantProductParameters params;
+  //
+  //               int64 reserveA;        // amount of A in the pool
+  //               int64 reserveB;        // amount of B in the pool
+  //               int64 totalPoolShares; // total number of pool shares issued
+  //               int64 poolSharesTrustLineCount; // number of trust lines for the
+  //                                               // associated pool shares
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("LiquidityPoolEntryConstantProduct", [
+    ["params", xdr.lookup("LiquidityPoolConstantProductParameters")],
+    ["reserveA", xdr.lookup("Int64")],
+    ["reserveB", xdr.lookup("Int64")],
+    ["totalPoolShares", xdr.lookup("Int64")],
+    ["poolSharesTrustLineCount", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (LiquidityPoolType type)
+  //       {
+  //       case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+  //           struct
+  //           {
+  //               LiquidityPoolConstantProductParameters params;
+  //
+  //               int64 reserveA;        // amount of A in the pool
+  //               int64 reserveB;        // amount of B in the pool
+  //               int64 totalPoolShares; // total number of pool shares issued
+  //               int64 poolSharesTrustLineCount; // number of trust lines for the
+  //                                               // associated pool shares
+  //           } constantProduct;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LiquidityPoolEntryBody", {
+    switchOn: xdr.lookup("LiquidityPoolType"),
+    switchName: "type",
+    switches: [["liquidityPoolConstantProduct", "constantProduct"]],
+    arms: {
+      constantProduct: xdr.lookup("LiquidityPoolEntryConstantProduct"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LiquidityPoolEntry
+  //   {
+  //       PoolID liquidityPoolID;
+  //
+  //       union switch (LiquidityPoolType type)
+  //       {
+  //       case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+  //           struct
+  //           {
+  //               LiquidityPoolConstantProductParameters params;
+  //
+  //               int64 reserveA;        // amount of A in the pool
+  //               int64 reserveB;        // amount of B in the pool
+  //               int64 totalPoolShares; // total number of pool shares issued
+  //               int64 poolSharesTrustLineCount; // number of trust lines for the
+  //                                               // associated pool shares
+  //           } constantProduct;
+  //       }
+  //       body;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LiquidityPoolEntry", [
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+    ["body", xdr.lookup("LiquidityPoolEntryBody")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ContractDataEntry {
+  //       Hash contractID;
+  //       SCVal key;
+  //       SCVal val;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ContractDataEntry", [
+    ["contractId", xdr.lookup("Hash")],
+    ["key", xdr.lookup("ScVal")],
+    ["val", xdr.lookup("ScVal")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ContractCodeEntry {
+  //       ExtensionPoint ext;
+  //
+  //       Hash hash;
+  //       opaque code<SCVAL_LIMIT>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ContractCodeEntry", [
+    ["ext", xdr.lookup("ExtensionPoint")],
+    ["hash", xdr.lookup("Hash")],
+    ["code", xdr.varOpaque(xdr.lookup("SCVAL_LIMIT"))],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum ConfigSettingID
+  //   {
+  //       CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES = 0,
+  //       CONFIG_SETTING_CONTRACT_COMPUTE_V0 = 1,
+  //       CONFIG_SETTING_CONTRACT_LEDGER_COST_V0 = 2,
+  //       CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0 = 3,
+  //       CONFIG_SETTING_CONTRACT_META_DATA_V0 = 4,
+  //       CONFIG_SETTING_CONTRACT_BANDWIDTH_V0 = 5,
+  //       CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION = 6
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ConfigSettingId", {
+    configSettingContractMaxSizeBytes: 0,
+    configSettingContractComputeV0: 1,
+    configSettingContractLedgerCostV0: 2,
+    configSettingContractHistoricalDataV0: 3,
+    configSettingContractMetaDataV0: 4,
+    configSettingContractBandwidthV0: 5,
+    configSettingContractHostLogicVersion: 6,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ConfigSettingContractComputeV0
+  //   {
+  //       // Maximum instructions per ledger
+  //       int64 ledgerMaxInstructions;
+  //       // Maximum instructions per transaction
+  //       int64 txMaxInstructions;
+  //       // Cost of 10000 instructions
+  //       int64 feeRatePerInstructionsIncrement;
+  //
+  //       // Memory limit per contract/host function invocation. Unlike
+  //       // instructions, there is no fee for memory and it's not
+  //       // accumulated between operations - the same limit is applied
+  //       // to every operation.
+  //       uint32 memoryLimit;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ConfigSettingContractComputeV0", [
+    ["ledgerMaxInstructions", xdr.lookup("Int64")],
+    ["txMaxInstructions", xdr.lookup("Int64")],
+    ["feeRatePerInstructionsIncrement", xdr.lookup("Int64")],
+    ["memoryLimit", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ConfigSettingContractLedgerCostV0
+  //   {
+  //       // Maximum number of ledger entry read operations per ledger
+  //       uint32 ledgerMaxReadLedgerEntries;
+  //       // Maximum number of bytes that can be read per ledger
+  //       uint32 ledgerMaxReadBytes;
+  //       // Maximum number of ledger entry write operations per ledger
+  //       uint32 ledgerMaxWriteLedgerEntries;
+  //       // Maximum number of bytes that can be written per ledger
+  //       uint32 ledgerMaxWriteBytes;
+  //
+  //       // Maximum number of ledger entry read operations per transaction
+  //       uint32 txMaxReadLedgerEntries;
+  //       // Maximum number of bytes that can be read per transaction
+  //       uint32 txMaxReadBytes;
+  //       // Maximum number of ledger entry write operations per transaction
+  //       uint32 txMaxWriteLedgerEntries;
+  //       // Maximum number of bytes that can be written per transaction
+  //       uint32 txMaxWriteBytes;
+  //
+  //       int64 feeReadLedgerEntry;  // Fee per ledger entry read
+  //       int64 feeWriteLedgerEntry; // Fee per ledger entry write
+  //
+  //       int64 feeRead1KB;  // Fee for reading 1KB
+  //       int64 feeWrite1KB; // Fee for writing 1KB
+  //
+  //       // Bucket list fees grow slowly up to that size
+  //       int64 bucketListSizeBytes;
+  //       // Fee rate in stroops when the bucket list is empty
+  //       int64 bucketListFeeRateLow;
+  //       // Fee rate in stroops when the bucket list reached bucketListSizeBytes
+  //       int64 bucketListFeeRateHigh;
+  //       // Rate multiplier for any additional data past the first bucketListSizeBytes
+  //       uint32 bucketListGrowthFactor;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ConfigSettingContractLedgerCostV0", [
+    ["ledgerMaxReadLedgerEntries", xdr.lookup("Uint32")],
+    ["ledgerMaxReadBytes", xdr.lookup("Uint32")],
+    ["ledgerMaxWriteLedgerEntries", xdr.lookup("Uint32")],
+    ["ledgerMaxWriteBytes", xdr.lookup("Uint32")],
+    ["txMaxReadLedgerEntries", xdr.lookup("Uint32")],
+    ["txMaxReadBytes", xdr.lookup("Uint32")],
+    ["txMaxWriteLedgerEntries", xdr.lookup("Uint32")],
+    ["txMaxWriteBytes", xdr.lookup("Uint32")],
+    ["feeReadLedgerEntry", xdr.lookup("Int64")],
+    ["feeWriteLedgerEntry", xdr.lookup("Int64")],
+    ["feeRead1Kb", xdr.lookup("Int64")],
+    ["feeWrite1Kb", xdr.lookup("Int64")],
+    ["bucketListSizeBytes", xdr.lookup("Int64")],
+    ["bucketListFeeRateLow", xdr.lookup("Int64")],
+    ["bucketListFeeRateHigh", xdr.lookup("Int64")],
+    ["bucketListGrowthFactor", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ConfigSettingContractHistoricalDataV0
+  //   {
+  //       int64 feeHistorical1KB; // Fee for storing 1KB in archives
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ConfigSettingContractHistoricalDataV0", [
+    ["feeHistorical1Kb", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ConfigSettingContractMetaDataV0
+  //   {
+  //       // Maximum size of extended meta data produced by a transaction
+  //       uint32 txMaxExtendedMetaDataSizeBytes;
+  //       // Fee for generating 1KB of extended meta data
+  //       int64 feeExtendedMetaData1KB;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ConfigSettingContractMetaDataV0", [
+    ["txMaxExtendedMetaDataSizeBytes", xdr.lookup("Uint32")],
+    ["feeExtendedMetaData1Kb", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ConfigSettingContractBandwidthV0
+  //   {
+  //       // Maximum size in bytes to propagate per ledger
+  //       uint32 ledgerMaxPropagateSizeBytes;
+  //       // Maximum size in bytes for a transaction
+  //       uint32 txMaxSizeBytes;
+  //
+  //       // Fee for propagating 1KB of data
+  //       int64 feePropagateData1KB;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ConfigSettingContractBandwidthV0", [
+    ["ledgerMaxPropagateSizeBytes", xdr.lookup("Uint32")],
+    ["txMaxSizeBytes", xdr.lookup("Uint32")],
+    ["feePropagateData1Kb", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union ConfigSettingEntry switch (ConfigSettingID configSettingID)
+  //   {
+  //   case CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES:
+  //       uint32 contractMaxSizeBytes;
+  //   case CONFIG_SETTING_CONTRACT_COMPUTE_V0:
+  //       ConfigSettingContractComputeV0 contractCompute;
+  //   case CONFIG_SETTING_CONTRACT_LEDGER_COST_V0:
+  //       ConfigSettingContractLedgerCostV0 contractLedgerCost;
+  //   case CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0:
+  //       ConfigSettingContractHistoricalDataV0 contractHistoricalData;
+  //   case CONFIG_SETTING_CONTRACT_META_DATA_V0:
+  //       ConfigSettingContractMetaDataV0 contractMetaData;
+  //   case CONFIG_SETTING_CONTRACT_BANDWIDTH_V0:
+  //       ConfigSettingContractBandwidthV0 contractBandwidth;
+  //   case CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION:
+  //       uint32 contractHostLogicVersion;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ConfigSettingEntry", {
+    switchOn: xdr.lookup("ConfigSettingId"),
+    switchName: "configSettingId",
+    switches: [
+      ["configSettingContractMaxSizeBytes", "contractMaxSizeBytes"],
+      ["configSettingContractComputeV0", "contractCompute"],
+      ["configSettingContractLedgerCostV0", "contractLedgerCost"],
+      ["configSettingContractHistoricalDataV0", "contractHistoricalData"],
+      ["configSettingContractMetaDataV0", "contractMetaData"],
+      ["configSettingContractBandwidthV0", "contractBandwidth"],
+      ["configSettingContractHostLogicVersion", "contractHostLogicVersion"],
+    ],
+    arms: {
+      contractMaxSizeBytes: xdr.lookup("Uint32"),
+      contractCompute: xdr.lookup("ConfigSettingContractComputeV0"),
+      contractLedgerCost: xdr.lookup("ConfigSettingContractLedgerCostV0"),
+      contractHistoricalData: xdr.lookup(
+        "ConfigSettingContractHistoricalDataV0"
+      ),
+      contractMetaData: xdr.lookup("ConfigSettingContractMetaDataV0"),
+      contractBandwidth: xdr.lookup("ConfigSettingContractBandwidthV0"),
+      contractHostLogicVersion: xdr.lookup("Uint32"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerEntryExtensionV1Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerEntryExtensionV1
+  //   {
+  //       SponsorshipDescriptor sponsoringID;
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerEntryExtensionV1", [
+    ["sponsoringId", xdr.lookup("SponsorshipDescriptor")],
+    ["ext", xdr.lookup("LedgerEntryExtensionV1Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (LedgerEntryType type)
+  //       {
+  //       case ACCOUNT:
+  //           AccountEntry account;
+  //       case TRUSTLINE:
+  //           TrustLineEntry trustLine;
+  //       case OFFER:
+  //           OfferEntry offer;
+  //       case DATA:
+  //           DataEntry data;
+  //       case CLAIMABLE_BALANCE:
+  //           ClaimableBalanceEntry claimableBalance;
+  //       case LIQUIDITY_POOL:
+  //           LiquidityPoolEntry liquidityPool;
+  //       case CONTRACT_DATA:
+  //           ContractDataEntry contractData;
+  //       case CONTRACT_CODE:
+  //           ContractCodeEntry contractCode;
+  //       case CONFIG_SETTING:
+  //           ConfigSettingEntry configSetting;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerEntryData", {
+    switchOn: xdr.lookup("LedgerEntryType"),
+    switchName: "type",
+    switches: [
+      ["account", "account"],
+      ["trustline", "trustLine"],
+      ["offer", "offer"],
+      ["data", "data"],
+      ["claimableBalance", "claimableBalance"],
+      ["liquidityPool", "liquidityPool"],
+      ["contractData", "contractData"],
+      ["contractCode", "contractCode"],
+      ["configSetting", "configSetting"],
+    ],
+    arms: {
+      account: xdr.lookup("AccountEntry"),
+      trustLine: xdr.lookup("TrustLineEntry"),
+      offer: xdr.lookup("OfferEntry"),
+      data: xdr.lookup("DataEntry"),
+      claimableBalance: xdr.lookup("ClaimableBalanceEntry"),
+      liquidityPool: xdr.lookup("LiquidityPoolEntry"),
+      contractData: xdr.lookup("ContractDataEntry"),
+      contractCode: xdr.lookup("ContractCodeEntry"),
+      configSetting: xdr.lookup("ConfigSettingEntry"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           LedgerEntryExtensionV1 v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "v1"],
+    ],
+    arms: {
+      v1: xdr.lookup("LedgerEntryExtensionV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerEntry
+  //   {
+  //       uint32 lastModifiedLedgerSeq; // ledger the LedgerEntry was last changed
+  //
+  //       union switch (LedgerEntryType type)
+  //       {
+  //       case ACCOUNT:
+  //           AccountEntry account;
+  //       case TRUSTLINE:
+  //           TrustLineEntry trustLine;
+  //       case OFFER:
+  //           OfferEntry offer;
+  //       case DATA:
+  //           DataEntry data;
+  //       case CLAIMABLE_BALANCE:
+  //           ClaimableBalanceEntry claimableBalance;
+  //       case LIQUIDITY_POOL:
+  //           LiquidityPoolEntry liquidityPool;
+  //       case CONTRACT_DATA:
+  //           ContractDataEntry contractData;
+  //       case CONTRACT_CODE:
+  //           ContractCodeEntry contractCode;
+  //       case CONFIG_SETTING:
+  //           ConfigSettingEntry configSetting;
+  //       }
+  //       data;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           LedgerEntryExtensionV1 v1;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerEntry", [
+    ["lastModifiedLedgerSeq", xdr.lookup("Uint32")],
+    ["data", xdr.lookup("LedgerEntryData")],
+    ["ext", xdr.lookup("LedgerEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID accountID;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyAccount", [["accountId", xdr.lookup("AccountId")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID accountID;
+  //           TrustLineAsset asset;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyTrustLine", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["asset", xdr.lookup("TrustLineAsset")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID sellerID;
+  //           int64 offerID;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyOffer", [
+    ["sellerId", xdr.lookup("AccountId")],
+    ["offerId", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID accountID;
+  //           string64 dataName;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyData", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["dataName", xdr.lookup("String64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           ClaimableBalanceID balanceID;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyClaimableBalance", [
+    ["balanceId", xdr.lookup("ClaimableBalanceId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           PoolID liquidityPoolID;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyLiquidityPool", [
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           Hash contractID;
+  //           SCVal key;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyContractData", [
+    ["contractId", xdr.lookup("Hash")],
+    ["key", xdr.lookup("ScVal")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           Hash hash;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyContractCode", [["hash", xdr.lookup("Hash")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           ConfigSettingID configSettingID;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("LedgerKeyConfigSetting", [
+    ["configSettingId", xdr.lookup("ConfigSettingId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union LedgerKey switch (LedgerEntryType type)
+  //   {
+  //   case ACCOUNT:
+  //       struct
+  //       {
+  //           AccountID accountID;
+  //       } account;
+  //
+  //   case TRUSTLINE:
+  //       struct
+  //       {
+  //           AccountID accountID;
+  //           TrustLineAsset asset;
+  //       } trustLine;
+  //
+  //   case OFFER:
+  //       struct
+  //       {
+  //           AccountID sellerID;
+  //           int64 offerID;
+  //       } offer;
+  //
+  //   case DATA:
+  //       struct
+  //       {
+  //           AccountID accountID;
+  //           string64 dataName;
+  //       } data;
+  //
+  //   case CLAIMABLE_BALANCE:
+  //       struct
+  //       {
+  //           ClaimableBalanceID balanceID;
+  //       } claimableBalance;
+  //
+  //   case LIQUIDITY_POOL:
+  //       struct
+  //       {
+  //           PoolID liquidityPoolID;
+  //       } liquidityPool;
+  //   case CONTRACT_DATA:
+  //       struct
+  //       {
+  //           Hash contractID;
+  //           SCVal key;
+  //       } contractData;
+  //   case CONTRACT_CODE:
+  //       struct
+  //       {
+  //           Hash hash;
+  //       } contractCode;
+  //   case CONFIG_SETTING:
+  //       struct
+  //       {
+  //           ConfigSettingID configSettingID;
+  //       } configSetting;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LedgerKey", {
+    switchOn: xdr.lookup("LedgerEntryType"),
+    switchName: "type",
+    switches: [
+      ["account", "account"],
+      ["trustline", "trustLine"],
+      ["offer", "offer"],
+      ["data", "data"],
+      ["claimableBalance", "claimableBalance"],
+      ["liquidityPool", "liquidityPool"],
+      ["contractData", "contractData"],
+      ["contractCode", "contractCode"],
+      ["configSetting", "configSetting"],
+    ],
+    arms: {
+      account: xdr.lookup("LedgerKeyAccount"),
+      trustLine: xdr.lookup("LedgerKeyTrustLine"),
+      offer: xdr.lookup("LedgerKeyOffer"),
+      data: xdr.lookup("LedgerKeyData"),
+      claimableBalance: xdr.lookup("LedgerKeyClaimableBalance"),
+      liquidityPool: xdr.lookup("LedgerKeyLiquidityPool"),
+      contractData: xdr.lookup("LedgerKeyContractData"),
+      contractCode: xdr.lookup("LedgerKeyContractCode"),
+      configSetting: xdr.lookup("LedgerKeyConfigSetting"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum EnvelopeType
+  //   {
+  //       ENVELOPE_TYPE_TX_V0 = 0,
+  //       ENVELOPE_TYPE_SCP = 1,
+  //       ENVELOPE_TYPE_TX = 2,
+  //       ENVELOPE_TYPE_AUTH = 3,
+  //       ENVELOPE_TYPE_SCPVALUE = 4,
+  //       ENVELOPE_TYPE_TX_FEE_BUMP = 5,
+  //       ENVELOPE_TYPE_OP_ID = 6,
+  //       ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7,
+  //       ENVELOPE_TYPE_CONTRACT_ID_FROM_ED25519 = 8,
+  //       ENVELOPE_TYPE_CONTRACT_ID_FROM_CONTRACT = 9,
+  //       ENVELOPE_TYPE_CONTRACT_ID_FROM_ASSET = 10,
+  //       ENVELOPE_TYPE_CONTRACT_ID_FROM_SOURCE_ACCOUNT = 11,
+  //       ENVELOPE_TYPE_CREATE_CONTRACT_ARGS = 12,
+  //       ENVELOPE_TYPE_CONTRACT_AUTH = 13
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("EnvelopeType", {
+    envelopeTypeTxV0: 0,
+    envelopeTypeScp: 1,
+    envelopeTypeTx: 2,
+    envelopeTypeAuth: 3,
+    envelopeTypeScpvalue: 4,
+    envelopeTypeTxFeeBump: 5,
+    envelopeTypeOpId: 6,
+    envelopeTypePoolRevokeOpId: 7,
+    envelopeTypeContractIdFromEd25519: 8,
+    envelopeTypeContractIdFromContract: 9,
+    envelopeTypeContractIdFromAsset: 10,
+    envelopeTypeContractIdFromSourceAccount: 11,
+    envelopeTypeCreateContractArgs: 12,
+    envelopeTypeContractAuth: 13,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque UpgradeType<128>;
+  //
+  // ===========================================================================
+  xdr.typedef("UpgradeType", xdr.varOpaque(128));
+
+  // === xdr source ============================================================
+  //
+  //   enum StellarValueType
+  //   {
+  //       STELLAR_VALUE_BASIC = 0,
+  //       STELLAR_VALUE_SIGNED = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("StellarValueType", {
+    stellarValueBasic: 0,
+    stellarValueSigned: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerCloseValueSignature
+  //   {
+  //       NodeID nodeID;       // which node introduced the value
+  //       Signature signature; // nodeID's signature
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerCloseValueSignature", [
+    ["nodeId", xdr.lookup("NodeId")],
+    ["signature", xdr.lookup("Signature")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (StellarValueType v)
+  //       {
+  //       case STELLAR_VALUE_BASIC:
+  //           void;
+  //       case STELLAR_VALUE_SIGNED:
+  //           LedgerCloseValueSignature lcValueSignature;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("StellarValueExt", {
+    switchOn: xdr.lookup("StellarValueType"),
+    switchName: "v",
+    switches: [
+      ["stellarValueBasic", xdr.void()],
+      ["stellarValueSigned", "lcValueSignature"],
+    ],
+    arms: {
+      lcValueSignature: xdr.lookup("LedgerCloseValueSignature"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct StellarValue
+  //   {
+  //       Hash txSetHash;      // transaction set to apply to previous ledger
+  //       TimePoint closeTime; // network close time
+  //
+  //       // upgrades to apply to the previous ledger (usually empty)
+  //       // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
+  //       // unknown steps during consensus if needed.
+  //       // see notes below on 'LedgerUpgrade' for more detail
+  //       // max size is dictated by number of upgrade types (+ room for future)
+  //       UpgradeType upgrades<6>;
+  //
+  //       // reserved for future use
+  //       union switch (StellarValueType v)
+  //       {
+  //       case STELLAR_VALUE_BASIC:
+  //           void;
+  //       case STELLAR_VALUE_SIGNED:
+  //           LedgerCloseValueSignature lcValueSignature;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("StellarValue", [
+    ["txSetHash", xdr.lookup("Hash")],
+    ["closeTime", xdr.lookup("TimePoint")],
+    ["upgrades", xdr.varArray(xdr.lookup("UpgradeType"), 6)],
+    ["ext", xdr.lookup("StellarValueExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   const MASK_LEDGER_HEADER_FLAGS = 0x7F;
+  //
+  // ===========================================================================
+  xdr.const("MASK_LEDGER_HEADER_FLAGS", 0x7f);
+
+  // === xdr source ============================================================
+  //
+  //   enum LedgerHeaderFlags
+  //   {
+  //       DISABLE_LIQUIDITY_POOL_TRADING_FLAG = 0x1,
+  //       DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG = 0x2,
+  //       DISABLE_LIQUIDITY_POOL_WITHDRAWAL_FLAG = 0x4,
+  //       DISABLE_CONTRACT_CREATE = 0x8,
+  //       DISABLE_CONTRACT_UPDATE = 0x10,
+  //       DISABLE_CONTRACT_REMOVE = 0x20,
+  //       DISABLE_CONTRACT_INVOKE = 0x40
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LedgerHeaderFlags", {
+    disableLiquidityPoolTradingFlag: 1,
+    disableLiquidityPoolDepositFlag: 2,
+    disableLiquidityPoolWithdrawalFlag: 4,
+    disableContractCreate: 8,
+    disableContractUpdate: 16,
+    disableContractRemove: 32,
+    disableContractInvoke: 64,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerHeaderExtensionV1Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerHeaderExtensionV1
+  //   {
+  //       uint32 flags; // LedgerHeaderFlags
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerHeaderExtensionV1", [
+    ["flags", xdr.lookup("Uint32")],
+    ["ext", xdr.lookup("LedgerHeaderExtensionV1Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           LedgerHeaderExtensionV1 v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerHeaderExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "v1"],
+    ],
+    arms: {
+      v1: xdr.lookup("LedgerHeaderExtensionV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerHeader
+  //   {
+  //       uint32 ledgerVersion;    // the protocol version of the ledger
+  //       Hash previousLedgerHash; // hash of the previous ledger header
+  //       StellarValue scpValue;   // what consensus agreed to
+  //       Hash txSetResultHash;    // the TransactionResultSet that led to this ledger
+  //       Hash bucketListHash;     // hash of the ledger state
+  //
+  //       uint32 ledgerSeq; // sequence number of this ledger
+  //
+  //       int64 totalCoins; // total number of stroops in existence.
+  //                         // 10,000,000 stroops in 1 XLM
+  //
+  //       int64 feePool;       // fees burned since last inflation run
+  //       uint32 inflationSeq; // inflation sequence number
+  //
+  //       uint64 idPool; // last used global ID, used for generating objects
+  //
+  //       uint32 baseFee;     // base fee per operation in stroops
+  //       uint32 baseReserve; // account base reserve in stroops
+  //
+  //       uint32 maxTxSetSize; // maximum size a transaction set can be
+  //
+  //       Hash skipList[4]; // hashes of ledgers in the past. allows you to jump back
+  //                         // in time without walking the chain back ledger by ledger
+  //                         // each slot contains the oldest ledger that is mod of
+  //                         // either 50  5000  50000 or 500000 depending on index
+  //                         // skipList[0] mod(50), skipList[1] mod(5000), etc
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           LedgerHeaderExtensionV1 v1;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerHeader", [
+    ["ledgerVersion", xdr.lookup("Uint32")],
+    ["previousLedgerHash", xdr.lookup("Hash")],
+    ["scpValue", xdr.lookup("StellarValue")],
+    ["txSetResultHash", xdr.lookup("Hash")],
+    ["bucketListHash", xdr.lookup("Hash")],
+    ["ledgerSeq", xdr.lookup("Uint32")],
+    ["totalCoins", xdr.lookup("Int64")],
+    ["feePool", xdr.lookup("Int64")],
+    ["inflationSeq", xdr.lookup("Uint32")],
+    ["idPool", xdr.lookup("Uint64")],
+    ["baseFee", xdr.lookup("Uint32")],
+    ["baseReserve", xdr.lookup("Uint32")],
+    ["maxTxSetSize", xdr.lookup("Uint32")],
+    ["skipList", xdr.array(xdr.lookup("Hash"), 4)],
+    ["ext", xdr.lookup("LedgerHeaderExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum LedgerUpgradeType
+  //   {
+  //       LEDGER_UPGRADE_VERSION = 1,
+  //       LEDGER_UPGRADE_BASE_FEE = 2,
+  //       LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3,
+  //       LEDGER_UPGRADE_BASE_RESERVE = 4,
+  //       LEDGER_UPGRADE_FLAGS = 5,
+  //       LEDGER_UPGRADE_CONFIG = 6
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LedgerUpgradeType", {
+    ledgerUpgradeVersion: 1,
+    ledgerUpgradeBaseFee: 2,
+    ledgerUpgradeMaxTxSetSize: 3,
+    ledgerUpgradeBaseReserve: 4,
+    ledgerUpgradeFlags: 5,
+    ledgerUpgradeConfig: 6,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ConfigUpgradeSetKey {
+  //       Hash contractID;
+  //       Hash contentHash;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ConfigUpgradeSetKey", [
+    ["contractId", xdr.lookup("Hash")],
+    ["contentHash", xdr.lookup("Hash")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union LedgerUpgrade switch (LedgerUpgradeType type)
+  //   {
+  //   case LEDGER_UPGRADE_VERSION:
+  //       uint32 newLedgerVersion; // update ledgerVersion
+  //   case LEDGER_UPGRADE_BASE_FEE:
+  //       uint32 newBaseFee; // update baseFee
+  //   case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
+  //       uint32 newMaxTxSetSize; // update maxTxSetSize
+  //   case LEDGER_UPGRADE_BASE_RESERVE:
+  //       uint32 newBaseReserve; // update baseReserve
+  //   case LEDGER_UPGRADE_FLAGS:
+  //       uint32 newFlags; // update flags
+  //   case LEDGER_UPGRADE_CONFIG:
+  //       ConfigUpgradeSetKey newConfig;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LedgerUpgrade", {
+    switchOn: xdr.lookup("LedgerUpgradeType"),
+    switchName: "type",
+    switches: [
+      ["ledgerUpgradeVersion", "newLedgerVersion"],
+      ["ledgerUpgradeBaseFee", "newBaseFee"],
+      ["ledgerUpgradeMaxTxSetSize", "newMaxTxSetSize"],
+      ["ledgerUpgradeBaseReserve", "newBaseReserve"],
+      ["ledgerUpgradeFlags", "newFlags"],
+      ["ledgerUpgradeConfig", "newConfig"],
+    ],
+    arms: {
+      newLedgerVersion: xdr.lookup("Uint32"),
+      newBaseFee: xdr.lookup("Uint32"),
+      newMaxTxSetSize: xdr.lookup("Uint32"),
+      newBaseReserve: xdr.lookup("Uint32"),
+      newFlags: xdr.lookup("Uint32"),
+      newConfig: xdr.lookup("ConfigUpgradeSetKey"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ConfigUpgradeSet {
+  //       ConfigSettingEntry updatedEntry<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ConfigUpgradeSet", [
+    [
+      "updatedEntry",
+      xdr.varArray(xdr.lookup("ConfigSettingEntry"), 2147483647),
+    ],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum BucketEntryType
+  //   {
+  //       METAENTRY =
+  //           -1, // At-and-after protocol 11: bucket metadata, should come first.
+  //       LIVEENTRY = 0, // Before protocol 11: created-or-updated;
+  //                      // At-and-after protocol 11: only updated.
+  //       DEADENTRY = 1,
+  //       INITENTRY = 2 // At-and-after protocol 11: only created.
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("BucketEntryType", {
+    metaentry: -1,
+    liveentry: 0,
+    deadentry: 1,
+    initentry: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("BucketMetadataExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct BucketMetadata
+  //   {
+  //       // Indicates the protocol version used to create / merge this bucket.
+  //       uint32 ledgerVersion;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("BucketMetadata", [
+    ["ledgerVersion", xdr.lookup("Uint32")],
+    ["ext", xdr.lookup("BucketMetadataExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union BucketEntry switch (BucketEntryType type)
+  //   {
+  //   case LIVEENTRY:
+  //   case INITENTRY:
+  //       LedgerEntry liveEntry;
+  //
+  //   case DEADENTRY:
+  //       LedgerKey deadEntry;
+  //   case METAENTRY:
+  //       BucketMetadata metaEntry;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("BucketEntry", {
+    switchOn: xdr.lookup("BucketEntryType"),
+    switchName: "type",
+    switches: [
+      ["liveentry", "liveEntry"],
+      ["initentry", "liveEntry"],
+      ["deadentry", "deadEntry"],
+      ["metaentry", "metaEntry"],
+    ],
+    arms: {
+      liveEntry: xdr.lookup("LedgerEntry"),
+      deadEntry: xdr.lookup("LedgerKey"),
+      metaEntry: xdr.lookup("BucketMetadata"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum TxSetComponentType
+  //   {
+  //     // txs with effective fee <= bid derived from a base fee (if any).
+  //     // If base fee is not specified, no discount is applied.
+  //     TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("TxSetComponentType", {
+    txsetCompTxsMaybeDiscountedFee: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //     {
+  //       int64* baseFee;
+  //       TransactionEnvelope txs<>;
+  //     }
+  //
+  // ===========================================================================
+  xdr.struct("TxSetComponentTxsMaybeDiscountedFee", [
+    ["baseFee", xdr.option(xdr.lookup("Int64"))],
+    ["txes", xdr.varArray(xdr.lookup("TransactionEnvelope"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union TxSetComponent switch (TxSetComponentType type)
+  //   {
+  //   case TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE:
+  //     struct
+  //     {
+  //       int64* baseFee;
+  //       TransactionEnvelope txs<>;
+  //     } txsMaybeDiscountedFee;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("TxSetComponent", {
+    switchOn: xdr.lookup("TxSetComponentType"),
+    switchName: "type",
+    switches: [["txsetCompTxsMaybeDiscountedFee", "txsMaybeDiscountedFee"]],
+    arms: {
+      txsMaybeDiscountedFee: xdr.lookup("TxSetComponentTxsMaybeDiscountedFee"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union TransactionPhase switch (int v)
+  //   {
+  //   case 0:
+  //       TxSetComponent v0Components<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("TransactionPhase", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, "v0Components"]],
+    arms: {
+      v0Components: xdr.varArray(xdr.lookup("TxSetComponent"), 2147483647),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionSet
+  //   {
+  //       Hash previousLedgerHash;
+  //       TransactionEnvelope txs<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionSet", [
+    ["previousLedgerHash", xdr.lookup("Hash")],
+    ["txes", xdr.varArray(xdr.lookup("TransactionEnvelope"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionSetV1
+  //   {
+  //       Hash previousLedgerHash;
+  //       TransactionPhase phases<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionSetV1", [
+    ["previousLedgerHash", xdr.lookup("Hash")],
+    ["phases", xdr.varArray(xdr.lookup("TransactionPhase"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union GeneralizedTransactionSet switch (int v)
+  //   {
+  //   // We consider the legacy TransactionSet to be v0.
+  //   case 1:
+  //       TransactionSetV1 v1TxSet;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("GeneralizedTransactionSet", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[1, "v1TxSet"]],
+    arms: {
+      v1TxSet: xdr.lookup("TransactionSetV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResultPair
+  //   {
+  //       Hash transactionHash;
+  //       TransactionResult result; // result for the transaction
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResultPair", [
+    ["transactionHash", xdr.lookup("Hash")],
+    ["result", xdr.lookup("TransactionResult")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResultSet
+  //   {
+  //       TransactionResultPair results<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResultSet", [
+    ["results", xdr.varArray(xdr.lookup("TransactionResultPair"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           GeneralizedTransactionSet generalizedTxSet;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionHistoryEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, xdr.void()],
+      [1, "generalizedTxSet"],
+    ],
+    arms: {
+      generalizedTxSet: xdr.lookup("GeneralizedTransactionSet"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionHistoryEntry
+  //   {
+  //       uint32 ledgerSeq;
+  //       TransactionSet txSet;
+  //
+  //       // when v != 0, txSet must be empty
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       case 1:
+  //           GeneralizedTransactionSet generalizedTxSet;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionHistoryEntry", [
+    ["ledgerSeq", xdr.lookup("Uint32")],
+    ["txSet", xdr.lookup("TransactionSet")],
+    ["ext", xdr.lookup("TransactionHistoryEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionHistoryResultEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionHistoryResultEntry
+  //   {
+  //       uint32 ledgerSeq;
+  //       TransactionResultSet txResultSet;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionHistoryResultEntry", [
+    ["ledgerSeq", xdr.lookup("Uint32")],
+    ["txResultSet", xdr.lookup("TransactionResultSet")],
+    ["ext", xdr.lookup("TransactionHistoryResultEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResultPairV2
+  //   {
+  //       Hash transactionHash;
+  //       Hash hashOfMetaHashes; // hash of hashes in TransactionMetaV3
+  //                              // TransactionResult is in the meta
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResultPairV2", [
+    ["transactionHash", xdr.lookup("Hash")],
+    ["hashOfMetaHashes", xdr.lookup("Hash")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResultSetV2
+  //   {
+  //       TransactionResultPairV2 results<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResultSetV2", [
+    [
+      "results",
+      xdr.varArray(xdr.lookup("TransactionResultPairV2"), 2147483647),
+    ],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionHistoryResultEntryV2Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionHistoryResultEntryV2
+  //   {
+  //       uint32 ledgerSeq;
+  //       TransactionResultSetV2 txResultSet;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionHistoryResultEntryV2", [
+    ["ledgerSeq", xdr.lookup("Uint32")],
+    ["txResultSet", xdr.lookup("TransactionResultSetV2")],
+    ["ext", xdr.lookup("TransactionHistoryResultEntryV2Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("LedgerHeaderHistoryEntryExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerHeaderHistoryEntry
+  //   {
+  //       Hash hash;
+  //       LedgerHeader header;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerHeaderHistoryEntry", [
+    ["hash", xdr.lookup("Hash")],
+    ["header", xdr.lookup("LedgerHeader")],
+    ["ext", xdr.lookup("LedgerHeaderHistoryEntryExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerSCPMessages
+  //   {
+  //       uint32 ledgerSeq;
+  //       SCPEnvelope messages<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerScpMessages", [
+    ["ledgerSeq", xdr.lookup("Uint32")],
+    ["messages", xdr.varArray(xdr.lookup("ScpEnvelope"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCPHistoryEntryV0
+  //   {
+  //       SCPQuorumSet quorumSets<>; // additional quorum sets used by ledgerMessages
+  //       LedgerSCPMessages ledgerMessages;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScpHistoryEntryV0", [
+    ["quorumSets", xdr.varArray(xdr.lookup("ScpQuorumSet"), 2147483647)],
+    ["ledgerMessages", xdr.lookup("LedgerScpMessages")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union SCPHistoryEntry switch (int v)
+  //   {
+  //   case 0:
+  //       SCPHistoryEntryV0 v0;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ScpHistoryEntry", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, "v0"]],
+    arms: {
+      v0: xdr.lookup("ScpHistoryEntryV0"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum LedgerEntryChangeType
+  //   {
+  //       LEDGER_ENTRY_CREATED = 0, // entry was added to the ledger
+  //       LEDGER_ENTRY_UPDATED = 1, // entry was modified in the ledger
+  //       LEDGER_ENTRY_REMOVED = 2, // entry was removed from the ledger
+  //       LEDGER_ENTRY_STATE = 3    // value of the entry
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LedgerEntryChangeType", {
+    ledgerEntryCreated: 0,
+    ledgerEntryUpdated: 1,
+    ledgerEntryRemoved: 2,
+    ledgerEntryState: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union LedgerEntryChange switch (LedgerEntryChangeType type)
+  //   {
+  //   case LEDGER_ENTRY_CREATED:
+  //       LedgerEntry created;
+  //   case LEDGER_ENTRY_UPDATED:
+  //       LedgerEntry updated;
+  //   case LEDGER_ENTRY_REMOVED:
+  //       LedgerKey removed;
+  //   case LEDGER_ENTRY_STATE:
+  //       LedgerEntry state;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LedgerEntryChange", {
+    switchOn: xdr.lookup("LedgerEntryChangeType"),
+    switchName: "type",
+    switches: [
+      ["ledgerEntryCreated", "created"],
+      ["ledgerEntryUpdated", "updated"],
+      ["ledgerEntryRemoved", "removed"],
+      ["ledgerEntryState", "state"],
+    ],
+    arms: {
+      created: xdr.lookup("LedgerEntry"),
+      updated: xdr.lookup("LedgerEntry"),
+      removed: xdr.lookup("LedgerKey"),
+      state: xdr.lookup("LedgerEntry"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   typedef LedgerEntryChange LedgerEntryChanges<>;
+  //
+  // ===========================================================================
+  xdr.typedef(
+    "LedgerEntryChanges",
+    xdr.varArray(xdr.lookup("LedgerEntryChange"), 2147483647)
+  );
+
+  // === xdr source ============================================================
+  //
+  //   struct OperationMeta
+  //   {
+  //       LedgerEntryChanges changes;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("OperationMeta", [["changes", xdr.lookup("LedgerEntryChanges")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionMetaV1
+  //   {
+  //       LedgerEntryChanges txChanges; // tx level changes if any
+  //       OperationMeta operations<>;   // meta for each operation
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionMetaV1", [
+    ["txChanges", xdr.lookup("LedgerEntryChanges")],
+    ["operations", xdr.varArray(xdr.lookup("OperationMeta"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionMetaV2
+  //   {
+  //       LedgerEntryChanges txChangesBefore; // tx level changes before operations
+  //                                           // are applied if any
+  //       OperationMeta operations<>;         // meta for each operation
+  //       LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
+  //                                           // applied if any
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionMetaV2", [
+    ["txChangesBefore", xdr.lookup("LedgerEntryChanges")],
+    ["operations", xdr.varArray(xdr.lookup("OperationMeta"), 2147483647)],
+    ["txChangesAfter", xdr.lookup("LedgerEntryChanges")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum ContractEventType
+  //   {
+  //       SYSTEM = 0,
+  //       CONTRACT = 1,
+  //       DIAGNOSTIC = 2
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ContractEventType", {
+    system: 0,
+    contract: 1,
+    diagnostic: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //           {
+  //               SCVec topics;
+  //               SCVal data;
+  //           }
+  //
+  // ===========================================================================
+  xdr.struct("ContractEventV0", [
+    ["topics", xdr.lookup("ScVec")],
+    ["data", xdr.lookup("ScVal")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           struct
+  //           {
+  //               SCVec topics;
+  //               SCVal data;
+  //           } v0;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("ContractEventBody", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, "v0"]],
+    arms: {
+      v0: xdr.lookup("ContractEventV0"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ContractEvent
+  //   {
+  //       // We can use this to add more fields, or because it
+  //       // is first, to change ContractEvent into a union.
+  //       ExtensionPoint ext;
+  //
+  //       Hash* contractID;
+  //       ContractEventType type;
+  //
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           struct
+  //           {
+  //               SCVec topics;
+  //               SCVal data;
+  //           } v0;
+  //       }
+  //       body;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ContractEvent", [
+    ["ext", xdr.lookup("ExtensionPoint")],
+    ["contractId", xdr.option(xdr.lookup("Hash"))],
+    ["type", xdr.lookup("ContractEventType")],
+    ["body", xdr.lookup("ContractEventBody")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct DiagnosticEvent
+  //   {
+  //       bool inSuccessfulContractCall;
+  //       ContractEvent event;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("DiagnosticEvent", [
+    ["inSuccessfulContractCall", xdr.bool()],
+    ["event", xdr.lookup("ContractEvent")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct OperationDiagnosticEvents
+  //   {
+  //       DiagnosticEvent events<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("OperationDiagnosticEvents", [
+    ["events", xdr.varArray(xdr.lookup("DiagnosticEvent"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct OperationEvents
+  //   {
+  //       ContractEvent events<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("OperationEvents", [
+    ["events", xdr.varArray(xdr.lookup("ContractEvent"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionMetaV3
+  //   {
+  //       LedgerEntryChanges txChangesBefore; // tx level changes before operations
+  //                                           // are applied if any
+  //       OperationMeta operations<>;         // meta for each operation
+  //       LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
+  //                                           // applied if any
+  //       OperationEvents events<>;           // custom events populated by the
+  //                                           // contracts themselves. One list per operation.
+  //       TransactionResult txResult;
+  //
+  //       Hash hashes[3];                     // stores sha256(txChangesBefore, operations, txChangesAfter),
+  //                                           // sha256(events), and sha256(txResult)
+  //
+  //       // Diagnostics events that are not hashed. One list per operation.
+  //       // This will contain all contract and diagnostic events. Even ones
+  //       // that were emitted in a failed contract call.
+  //       OperationDiagnosticEvents diagnosticEvents<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionMetaV3", [
+    ["txChangesBefore", xdr.lookup("LedgerEntryChanges")],
+    ["operations", xdr.varArray(xdr.lookup("OperationMeta"), 2147483647)],
+    ["txChangesAfter", xdr.lookup("LedgerEntryChanges")],
+    ["events", xdr.varArray(xdr.lookup("OperationEvents"), 2147483647)],
+    ["txResult", xdr.lookup("TransactionResult")],
+    ["hashes", xdr.array(xdr.lookup("Hash"), 3)],
+    [
+      "diagnosticEvents",
+      xdr.varArray(xdr.lookup("OperationDiagnosticEvents"), 2147483647),
+    ],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union TransactionMeta switch (int v)
+  //   {
+  //   case 0:
+  //       OperationMeta operations<>;
+  //   case 1:
+  //       TransactionMetaV1 v1;
+  //   case 2:
+  //       TransactionMetaV2 v2;
+  //   case 3:
+  //       TransactionMetaV3 v3;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("TransactionMeta", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, "operations"],
+      [1, "v1"],
+      [2, "v2"],
+      [3, "v3"],
+    ],
+    arms: {
+      operations: xdr.varArray(xdr.lookup("OperationMeta"), 2147483647),
+      v1: xdr.lookup("TransactionMetaV1"),
+      v2: xdr.lookup("TransactionMetaV2"),
+      v3: xdr.lookup("TransactionMetaV3"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResultMeta
+  //   {
+  //       TransactionResultPair result;
+  //       LedgerEntryChanges feeProcessing;
+  //       TransactionMeta txApplyProcessing;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResultMeta", [
+    ["result", xdr.lookup("TransactionResultPair")],
+    ["feeProcessing", xdr.lookup("LedgerEntryChanges")],
+    ["txApplyProcessing", xdr.lookup("TransactionMeta")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResultMetaV2
+  //   {
+  //       TransactionResultPairV2 result;
+  //       LedgerEntryChanges feeProcessing;
+  //       TransactionMeta txApplyProcessing;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResultMetaV2", [
+    ["result", xdr.lookup("TransactionResultPairV2")],
+    ["feeProcessing", xdr.lookup("LedgerEntryChanges")],
+    ["txApplyProcessing", xdr.lookup("TransactionMeta")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct UpgradeEntryMeta
+  //   {
+  //       LedgerUpgrade upgrade;
+  //       LedgerEntryChanges changes;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("UpgradeEntryMeta", [
+    ["upgrade", xdr.lookup("LedgerUpgrade")],
+    ["changes", xdr.lookup("LedgerEntryChanges")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerCloseMetaV0
+  //   {
+  //       LedgerHeaderHistoryEntry ledgerHeader;
+  //       // NB: txSet is sorted in "Hash order"
+  //       TransactionSet txSet;
+  //
+  //       // NB: transactions are sorted in apply order here
+  //       // fees for all transactions are processed first
+  //       // followed by applying transactions
+  //       TransactionResultMeta txProcessing<>;
+  //
+  //       // upgrades are applied last
+  //       UpgradeEntryMeta upgradesProcessing<>;
+  //
+  //       // other misc information attached to the ledger close
+  //       SCPHistoryEntry scpInfo<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerCloseMetaV0", [
+    ["ledgerHeader", xdr.lookup("LedgerHeaderHistoryEntry")],
+    ["txSet", xdr.lookup("TransactionSet")],
+    [
+      "txProcessing",
+      xdr.varArray(xdr.lookup("TransactionResultMeta"), 2147483647),
+    ],
+    [
+      "upgradesProcessing",
+      xdr.varArray(xdr.lookup("UpgradeEntryMeta"), 2147483647),
+    ],
+    ["scpInfo", xdr.varArray(xdr.lookup("ScpHistoryEntry"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerCloseMetaV1
+  //   {
+  //       LedgerHeaderHistoryEntry ledgerHeader;
+  //
+  //       GeneralizedTransactionSet txSet;
+  //
+  //       // NB: transactions are sorted in apply order here
+  //       // fees for all transactions are processed first
+  //       // followed by applying transactions
+  //       TransactionResultMeta txProcessing<>;
+  //
+  //       // upgrades are applied last
+  //       UpgradeEntryMeta upgradesProcessing<>;
+  //
+  //       // other misc information attached to the ledger close
+  //       SCPHistoryEntry scpInfo<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerCloseMetaV1", [
+    ["ledgerHeader", xdr.lookup("LedgerHeaderHistoryEntry")],
+    ["txSet", xdr.lookup("GeneralizedTransactionSet")],
+    [
+      "txProcessing",
+      xdr.varArray(xdr.lookup("TransactionResultMeta"), 2147483647),
+    ],
+    [
+      "upgradesProcessing",
+      xdr.varArray(xdr.lookup("UpgradeEntryMeta"), 2147483647),
+    ],
+    ["scpInfo", xdr.varArray(xdr.lookup("ScpHistoryEntry"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerCloseMetaV2
+  //   {
+  //       LedgerHeaderHistoryEntry ledgerHeader;
+  //
+  //       GeneralizedTransactionSet txSet;
+  //
+  //       // NB: transactions are sorted in apply order here
+  //       // fees for all transactions are processed first
+  //       // followed by applying transactions
+  //       TransactionResultMetaV2 txProcessing<>;
+  //
+  //       // upgrades are applied last
+  //       UpgradeEntryMeta upgradesProcessing<>;
+  //
+  //       // other misc information attached to the ledger close
+  //       SCPHistoryEntry scpInfo<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerCloseMetaV2", [
+    ["ledgerHeader", xdr.lookup("LedgerHeaderHistoryEntry")],
+    ["txSet", xdr.lookup("GeneralizedTransactionSet")],
+    [
+      "txProcessing",
+      xdr.varArray(xdr.lookup("TransactionResultMetaV2"), 2147483647),
+    ],
+    [
+      "upgradesProcessing",
+      xdr.varArray(xdr.lookup("UpgradeEntryMeta"), 2147483647),
+    ],
+    ["scpInfo", xdr.varArray(xdr.lookup("ScpHistoryEntry"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union LedgerCloseMeta switch (int v)
+  //   {
+  //   case 0:
+  //       LedgerCloseMetaV0 v0;
+  //   case 1:
+  //       LedgerCloseMetaV1 v1;
+  //   case 2:
+  //       LedgerCloseMetaV2 v2;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LedgerCloseMeta", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [
+      [0, "v0"],
+      [1, "v1"],
+      [2, "v2"],
+    ],
+    arms: {
+      v0: xdr.lookup("LedgerCloseMetaV0"),
+      v1: xdr.lookup("LedgerCloseMetaV1"),
+      v2: xdr.lookup("LedgerCloseMetaV2"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ErrorCode
+  //   {
+  //       ERR_MISC = 0, // Unspecific error
+  //       ERR_DATA = 1, // Malformed data
+  //       ERR_CONF = 2, // Misconfiguration error
+  //       ERR_AUTH = 3, // Authentication failure
+  //       ERR_LOAD = 4  // System overloaded
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ErrorCode", {
+    errMisc: 0,
+    errData: 1,
+    errConf: 2,
+    errAuth: 3,
+    errLoad: 4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct Error
+  //   {
+  //       ErrorCode code;
+  //       string msg<100>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Error", [
+    ["code", xdr.lookup("ErrorCode")],
+    ["msg", xdr.string(100)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SendMore
+  //   {
+  //       uint32 numMessages;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SendMore", [["numMessages", xdr.lookup("Uint32")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct AuthCert
+  //   {
+  //       Curve25519Public pubkey;
+  //       uint64 expiration;
+  //       Signature sig;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AuthCert", [
+    ["pubkey", xdr.lookup("Curve25519Public")],
+    ["expiration", xdr.lookup("Uint64")],
+    ["sig", xdr.lookup("Signature")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct Hello
+  //   {
+  //       uint32 ledgerVersion;
+  //       uint32 overlayVersion;
+  //       uint32 overlayMinVersion;
+  //       Hash networkID;
+  //       string versionStr<100>;
+  //       int listeningPort;
+  //       NodeID peerID;
+  //       AuthCert cert;
+  //       uint256 nonce;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Hello", [
+    ["ledgerVersion", xdr.lookup("Uint32")],
+    ["overlayVersion", xdr.lookup("Uint32")],
+    ["overlayMinVersion", xdr.lookup("Uint32")],
+    ["networkId", xdr.lookup("Hash")],
+    ["versionStr", xdr.string(100)],
+    ["listeningPort", xdr.int()],
+    ["peerId", xdr.lookup("NodeId")],
+    ["cert", xdr.lookup("AuthCert")],
+    ["nonce", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   const AUTH_MSG_FLAG_PULL_MODE_REQUESTED = 100;
+  //
+  // ===========================================================================
+  xdr.const("AUTH_MSG_FLAG_PULL_MODE_REQUESTED", 100);
+
+  // === xdr source ============================================================
+  //
+  //   struct Auth
+  //   {
+  //       int flags;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Auth", [["flags", xdr.int()]]);
+
+  // === xdr source ============================================================
+  //
+  //   enum IPAddrType
+  //   {
+  //       IPv4 = 0,
+  //       IPv6 = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("IpAddrType", {
+    iPv4: 0,
+    iPv6: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (IPAddrType type)
+  //       {
+  //       case IPv4:
+  //           opaque ipv4[4];
+  //       case IPv6:
+  //           opaque ipv6[16];
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("PeerAddressIp", {
+    switchOn: xdr.lookup("IpAddrType"),
+    switchName: "type",
+    switches: [
+      ["iPv4", "ipv4"],
+      ["iPv6", "ipv6"],
+    ],
+    arms: {
+      ipv4: xdr.opaque(4),
+      ipv6: xdr.opaque(16),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct PeerAddress
+  //   {
+  //       union switch (IPAddrType type)
+  //       {
+  //       case IPv4:
+  //           opaque ipv4[4];
+  //       case IPv6:
+  //           opaque ipv6[16];
+  //       }
+  //       ip;
+  //       uint32 port;
+  //       uint32 numFailures;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PeerAddress", [
+    ["ip", xdr.lookup("PeerAddressIp")],
+    ["port", xdr.lookup("Uint32")],
+    ["numFailures", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum MessageType
+  //   {
+  //       ERROR_MSG = 0,
+  //       AUTH = 2,
+  //       DONT_HAVE = 3,
+  //
+  //       GET_PEERS = 4, // gets a list of peers this guy knows about
+  //       PEERS = 5,
+  //
+  //       GET_TX_SET = 6, // gets a particular txset by hash
+  //       TX_SET = 7,
+  //       GENERALIZED_TX_SET = 17,
+  //
+  //       TRANSACTION = 8, // pass on a tx you have heard about
+  //
+  //       // SCP
+  //       GET_SCP_QUORUMSET = 9,
+  //       SCP_QUORUMSET = 10,
+  //       SCP_MESSAGE = 11,
+  //       GET_SCP_STATE = 12,
+  //
+  //       // new messages
+  //       HELLO = 13,
+  //
+  //       SURVEY_REQUEST = 14,
+  //       SURVEY_RESPONSE = 15,
+  //
+  //       SEND_MORE = 16,
+  //       FLOOD_ADVERT = 18,
+  //       FLOOD_DEMAND = 19
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("MessageType", {
+    errorMsg: 0,
+    auth: 2,
+    dontHave: 3,
+    getPeers: 4,
+    peers: 5,
+    getTxSet: 6,
+    txSet: 7,
+    generalizedTxSet: 17,
+    transaction: 8,
+    getScpQuorumset: 9,
+    scpQuorumset: 10,
+    scpMessage: 11,
+    getScpState: 12,
+    hello: 13,
+    surveyRequest: 14,
+    surveyResponse: 15,
+    sendMore: 16,
+    floodAdvert: 18,
+    floodDemand: 19,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct DontHave
+  //   {
+  //       MessageType type;
+  //       uint256 reqHash;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("DontHave", [
+    ["type", xdr.lookup("MessageType")],
+    ["reqHash", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum SurveyMessageCommandType
+  //   {
+  //       SURVEY_TOPOLOGY = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("SurveyMessageCommandType", {
+    surveyTopology: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SurveyMessageResponseType
+  //   {
+  //       SURVEY_TOPOLOGY_RESPONSE_V0 = 0,
+  //       SURVEY_TOPOLOGY_RESPONSE_V1 = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("SurveyMessageResponseType", {
+    surveyTopologyResponseV0: 0,
+    surveyTopologyResponseV1: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SurveyRequestMessage
+  //   {
+  //       NodeID surveyorPeerID;
+  //       NodeID surveyedPeerID;
+  //       uint32 ledgerNum;
+  //       Curve25519Public encryptionKey;
+  //       SurveyMessageCommandType commandType;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SurveyRequestMessage", [
+    ["surveyorPeerId", xdr.lookup("NodeId")],
+    ["surveyedPeerId", xdr.lookup("NodeId")],
+    ["ledgerNum", xdr.lookup("Uint32")],
+    ["encryptionKey", xdr.lookup("Curve25519Public")],
+    ["commandType", xdr.lookup("SurveyMessageCommandType")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SignedSurveyRequestMessage
+  //   {
+  //       Signature requestSignature;
+  //       SurveyRequestMessage request;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SignedSurveyRequestMessage", [
+    ["requestSignature", xdr.lookup("Signature")],
+    ["request", xdr.lookup("SurveyRequestMessage")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque EncryptedBody<64000>;
+  //
+  // ===========================================================================
+  xdr.typedef("EncryptedBody", xdr.varOpaque(64000));
+
+  // === xdr source ============================================================
+  //
+  //   struct SurveyResponseMessage
+  //   {
+  //       NodeID surveyorPeerID;
+  //       NodeID surveyedPeerID;
+  //       uint32 ledgerNum;
+  //       SurveyMessageCommandType commandType;
+  //       EncryptedBody encryptedBody;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SurveyResponseMessage", [
+    ["surveyorPeerId", xdr.lookup("NodeId")],
+    ["surveyedPeerId", xdr.lookup("NodeId")],
+    ["ledgerNum", xdr.lookup("Uint32")],
+    ["commandType", xdr.lookup("SurveyMessageCommandType")],
+    ["encryptedBody", xdr.lookup("EncryptedBody")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SignedSurveyResponseMessage
+  //   {
+  //       Signature responseSignature;
+  //       SurveyResponseMessage response;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SignedSurveyResponseMessage", [
+    ["responseSignature", xdr.lookup("Signature")],
+    ["response", xdr.lookup("SurveyResponseMessage")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct PeerStats
+  //   {
+  //       NodeID id;
+  //       string versionStr<100>;
+  //       uint64 messagesRead;
+  //       uint64 messagesWritten;
+  //       uint64 bytesRead;
+  //       uint64 bytesWritten;
+  //       uint64 secondsConnected;
+  //
+  //       uint64 uniqueFloodBytesRecv;
+  //       uint64 duplicateFloodBytesRecv;
+  //       uint64 uniqueFetchBytesRecv;
+  //       uint64 duplicateFetchBytesRecv;
+  //
+  //       uint64 uniqueFloodMessageRecv;
+  //       uint64 duplicateFloodMessageRecv;
+  //       uint64 uniqueFetchMessageRecv;
+  //       uint64 duplicateFetchMessageRecv;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PeerStats", [
+    ["id", xdr.lookup("NodeId")],
+    ["versionStr", xdr.string(100)],
+    ["messagesRead", xdr.lookup("Uint64")],
+    ["messagesWritten", xdr.lookup("Uint64")],
+    ["bytesRead", xdr.lookup("Uint64")],
+    ["bytesWritten", xdr.lookup("Uint64")],
+    ["secondsConnected", xdr.lookup("Uint64")],
+    ["uniqueFloodBytesRecv", xdr.lookup("Uint64")],
+    ["duplicateFloodBytesRecv", xdr.lookup("Uint64")],
+    ["uniqueFetchBytesRecv", xdr.lookup("Uint64")],
+    ["duplicateFetchBytesRecv", xdr.lookup("Uint64")],
+    ["uniqueFloodMessageRecv", xdr.lookup("Uint64")],
+    ["duplicateFloodMessageRecv", xdr.lookup("Uint64")],
+    ["uniqueFetchMessageRecv", xdr.lookup("Uint64")],
+    ["duplicateFetchMessageRecv", xdr.lookup("Uint64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   typedef PeerStats PeerStatList<25>;
+  //
+  // ===========================================================================
+  xdr.typedef("PeerStatList", xdr.varArray(xdr.lookup("PeerStats"), 25));
+
+  // === xdr source ============================================================
+  //
+  //   struct TopologyResponseBodyV0
+  //   {
+  //       PeerStatList inboundPeers;
+  //       PeerStatList outboundPeers;
+  //
+  //       uint32 totalInboundPeerCount;
+  //       uint32 totalOutboundPeerCount;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TopologyResponseBodyV0", [
+    ["inboundPeers", xdr.lookup("PeerStatList")],
+    ["outboundPeers", xdr.lookup("PeerStatList")],
+    ["totalInboundPeerCount", xdr.lookup("Uint32")],
+    ["totalOutboundPeerCount", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TopologyResponseBodyV1
+  //   {
+  //       PeerStatList inboundPeers;
+  //       PeerStatList outboundPeers;
+  //
+  //       uint32 totalInboundPeerCount;
+  //       uint32 totalOutboundPeerCount;
+  //
+  //       uint32 maxInboundPeerCount;
+  //       uint32 maxOutboundPeerCount;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TopologyResponseBodyV1", [
+    ["inboundPeers", xdr.lookup("PeerStatList")],
+    ["outboundPeers", xdr.lookup("PeerStatList")],
+    ["totalInboundPeerCount", xdr.lookup("Uint32")],
+    ["totalOutboundPeerCount", xdr.lookup("Uint32")],
+    ["maxInboundPeerCount", xdr.lookup("Uint32")],
+    ["maxOutboundPeerCount", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union SurveyResponseBody switch (SurveyMessageResponseType type)
+  //   {
+  //   case SURVEY_TOPOLOGY_RESPONSE_V0:
+  //       TopologyResponseBodyV0 topologyResponseBodyV0;
+  //   case SURVEY_TOPOLOGY_RESPONSE_V1:
+  //       TopologyResponseBodyV1 topologyResponseBodyV1;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("SurveyResponseBody", {
+    switchOn: xdr.lookup("SurveyMessageResponseType"),
+    switchName: "type",
+    switches: [
+      ["surveyTopologyResponseV0", "topologyResponseBodyV0"],
+      ["surveyTopologyResponseV1", "topologyResponseBodyV1"],
+    ],
+    arms: {
+      topologyResponseBodyV0: xdr.lookup("TopologyResponseBodyV0"),
+      topologyResponseBodyV1: xdr.lookup("TopologyResponseBodyV1"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
+  //
+  // ===========================================================================
+  xdr.const("TX_ADVERT_VECTOR_MAX_SIZE", 1000);
+
+  // === xdr source ============================================================
+  //
+  //   typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
+  //
+  // ===========================================================================
+  xdr.typedef(
+    "TxAdvertVector",
+    xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_ADVERT_VECTOR_MAX_SIZE"))
+  );
+
+  // === xdr source ============================================================
+  //
+  //   struct FloodAdvert
+  //   {
+  //       TxAdvertVector txHashes;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("FloodAdvert", [["txHashes", xdr.lookup("TxAdvertVector")]]);
+
+  // === xdr source ============================================================
+  //
+  //   const TX_DEMAND_VECTOR_MAX_SIZE = 1000;
+  //
+  // ===========================================================================
+  xdr.const("TX_DEMAND_VECTOR_MAX_SIZE", 1000);
+
+  // === xdr source ============================================================
+  //
+  //   typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
+  //
+  // ===========================================================================
+  xdr.typedef(
+    "TxDemandVector",
+    xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_DEMAND_VECTOR_MAX_SIZE"))
+  );
+
+  // === xdr source ============================================================
+  //
+  //   struct FloodDemand
+  //   {
+  //       TxDemandVector txHashes;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("FloodDemand", [["txHashes", xdr.lookup("TxDemandVector")]]);
+
+  // === xdr source ============================================================
+  //
+  //   union StellarMessage switch (MessageType type)
+  //   {
+  //   case ERROR_MSG:
+  //       Error error;
+  //   case HELLO:
+  //       Hello hello;
+  //   case AUTH:
+  //       Auth auth;
+  //   case DONT_HAVE:
+  //       DontHave dontHave;
+  //   case GET_PEERS:
+  //       void;
+  //   case PEERS:
+  //       PeerAddress peers<100>;
+  //
+  //   case GET_TX_SET:
+  //       uint256 txSetHash;
+  //   case TX_SET:
+  //       TransactionSet txSet;
+  //   case GENERALIZED_TX_SET:
+  //       GeneralizedTransactionSet generalizedTxSet;
+  //
+  //   case TRANSACTION:
+  //       TransactionEnvelope transaction;
+  //
+  //   case SURVEY_REQUEST:
+  //       SignedSurveyRequestMessage signedSurveyRequestMessage;
+  //
+  //   case SURVEY_RESPONSE:
+  //       SignedSurveyResponseMessage signedSurveyResponseMessage;
+  //
+  //   // SCP
+  //   case GET_SCP_QUORUMSET:
+  //       uint256 qSetHash;
+  //   case SCP_QUORUMSET:
+  //       SCPQuorumSet qSet;
+  //   case SCP_MESSAGE:
+  //       SCPEnvelope envelope;
+  //   case GET_SCP_STATE:
+  //       uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
+  //   case SEND_MORE:
+  //       SendMore sendMoreMessage;
+  //
+  //   // Pull mode
+  //   case FLOOD_ADVERT:
+  //        FloodAdvert floodAdvert;
+  //   case FLOOD_DEMAND:
+  //        FloodDemand floodDemand;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("StellarMessage", {
+    switchOn: xdr.lookup("MessageType"),
+    switchName: "type",
+    switches: [
+      ["errorMsg", "error"],
+      ["hello", "hello"],
+      ["auth", "auth"],
+      ["dontHave", "dontHave"],
+      ["getPeers", xdr.void()],
+      ["peers", "peers"],
+      ["getTxSet", "txSetHash"],
+      ["txSet", "txSet"],
+      ["generalizedTxSet", "generalizedTxSet"],
+      ["transaction", "transaction"],
+      ["surveyRequest", "signedSurveyRequestMessage"],
+      ["surveyResponse", "signedSurveyResponseMessage"],
+      ["getScpQuorumset", "qSetHash"],
+      ["scpQuorumset", "qSet"],
+      ["scpMessage", "envelope"],
+      ["getScpState", "getScpLedgerSeq"],
+      ["sendMore", "sendMoreMessage"],
+      ["floodAdvert", "floodAdvert"],
+      ["floodDemand", "floodDemand"],
+    ],
+    arms: {
+      error: xdr.lookup("Error"),
+      hello: xdr.lookup("Hello"),
+      auth: xdr.lookup("Auth"),
+      dontHave: xdr.lookup("DontHave"),
+      peers: xdr.varArray(xdr.lookup("PeerAddress"), 100),
+      txSetHash: xdr.lookup("Uint256"),
+      txSet: xdr.lookup("TransactionSet"),
+      generalizedTxSet: xdr.lookup("GeneralizedTransactionSet"),
+      transaction: xdr.lookup("TransactionEnvelope"),
+      signedSurveyRequestMessage: xdr.lookup("SignedSurveyRequestMessage"),
+      signedSurveyResponseMessage: xdr.lookup("SignedSurveyResponseMessage"),
+      qSetHash: xdr.lookup("Uint256"),
+      qSet: xdr.lookup("ScpQuorumSet"),
+      envelope: xdr.lookup("ScpEnvelope"),
+      getScpLedgerSeq: xdr.lookup("Uint32"),
+      sendMoreMessage: xdr.lookup("SendMore"),
+      floodAdvert: xdr.lookup("FloodAdvert"),
+      floodDemand: xdr.lookup("FloodDemand"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           uint64 sequence;
+  //           StellarMessage message;
+  //           HmacSha256Mac mac;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("AuthenticatedMessageV0", [
+    ["sequence", xdr.lookup("Uint64")],
+    ["message", xdr.lookup("StellarMessage")],
+    ["mac", xdr.lookup("HmacSha256Mac")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union AuthenticatedMessage switch (uint32 v)
+  //   {
+  //   case 0:
+  //       struct
+  //       {
+  //           uint64 sequence;
+  //           StellarMessage message;
+  //           HmacSha256Mac mac;
+  //       } v0;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("AuthenticatedMessage", {
+    switchOn: xdr.lookup("Uint32"),
+    switchName: "v",
+    switches: [[0, "v0"]],
+    arms: {
+      v0: xdr.lookup("AuthenticatedMessageV0"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union LiquidityPoolParameters switch (LiquidityPoolType type)
+  //   {
+  //   case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+  //       LiquidityPoolConstantProductParameters constantProduct;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LiquidityPoolParameters", {
+    switchOn: xdr.lookup("LiquidityPoolType"),
+    switchName: "type",
+    switches: [["liquidityPoolConstantProduct", "constantProduct"]],
+    arms: {
+      constantProduct: xdr.lookup("LiquidityPoolConstantProductParameters"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           uint64 id;
+  //           uint256 ed25519;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("MuxedAccountMed25519", [
+    ["id", xdr.lookup("Uint64")],
+    ["ed25519", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union MuxedAccount switch (CryptoKeyType type)
+  //   {
+  //   case KEY_TYPE_ED25519:
+  //       uint256 ed25519;
+  //   case KEY_TYPE_MUXED_ED25519:
+  //       struct
+  //       {
+  //           uint64 id;
+  //           uint256 ed25519;
+  //       } med25519;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("MuxedAccount", {
+    switchOn: xdr.lookup("CryptoKeyType"),
+    switchName: "type",
+    switches: [
+      ["keyTypeEd25519", "ed25519"],
+      ["keyTypeMuxedEd25519", "med25519"],
+    ],
+    arms: {
+      ed25519: xdr.lookup("Uint256"),
+      med25519: xdr.lookup("MuxedAccountMed25519"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct DecoratedSignature
+  //   {
+  //       SignatureHint hint;  // last 4 bytes of the public key, used as a hint
+  //       Signature signature; // actual signature
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("DecoratedSignature", [
+    ["hint", xdr.lookup("SignatureHint")],
+    ["signature", xdr.lookup("Signature")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerFootprint
+  //   {
+  //       LedgerKey readOnly<>;
+  //       LedgerKey readWrite<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerFootprint", [
+    ["readOnly", xdr.varArray(xdr.lookup("LedgerKey"), 2147483647)],
+    ["readWrite", xdr.varArray(xdr.lookup("LedgerKey"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum OperationType
+  //   {
+  //       CREATE_ACCOUNT = 0,
+  //       PAYMENT = 1,
+  //       PATH_PAYMENT_STRICT_RECEIVE = 2,
+  //       MANAGE_SELL_OFFER = 3,
+  //       CREATE_PASSIVE_SELL_OFFER = 4,
+  //       SET_OPTIONS = 5,
+  //       CHANGE_TRUST = 6,
+  //       ALLOW_TRUST = 7,
+  //       ACCOUNT_MERGE = 8,
+  //       INFLATION = 9,
+  //       MANAGE_DATA = 10,
+  //       BUMP_SEQUENCE = 11,
+  //       MANAGE_BUY_OFFER = 12,
+  //       PATH_PAYMENT_STRICT_SEND = 13,
+  //       CREATE_CLAIMABLE_BALANCE = 14,
+  //       CLAIM_CLAIMABLE_BALANCE = 15,
+  //       BEGIN_SPONSORING_FUTURE_RESERVES = 16,
+  //       END_SPONSORING_FUTURE_RESERVES = 17,
+  //       REVOKE_SPONSORSHIP = 18,
+  //       CLAWBACK = 19,
+  //       CLAWBACK_CLAIMABLE_BALANCE = 20,
+  //       SET_TRUST_LINE_FLAGS = 21,
+  //       LIQUIDITY_POOL_DEPOSIT = 22,
+  //       LIQUIDITY_POOL_WITHDRAW = 23,
+  //       INVOKE_HOST_FUNCTION = 24
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("OperationType", {
+    createAccount: 0,
+    payment: 1,
+    pathPaymentStrictReceive: 2,
+    manageSellOffer: 3,
+    createPassiveSellOffer: 4,
+    setOptions: 5,
+    changeTrust: 6,
+    allowTrust: 7,
+    accountMerge: 8,
+    inflation: 9,
+    manageData: 10,
+    bumpSequence: 11,
+    manageBuyOffer: 12,
+    pathPaymentStrictSend: 13,
+    createClaimableBalance: 14,
+    claimClaimableBalance: 15,
+    beginSponsoringFutureReserves: 16,
+    endSponsoringFutureReserves: 17,
+    revokeSponsorship: 18,
+    clawback: 19,
+    clawbackClaimableBalance: 20,
+    setTrustLineFlags: 21,
+    liquidityPoolDeposit: 22,
+    liquidityPoolWithdraw: 23,
+    invokeHostFunction: 24,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct CreateAccountOp
+  //   {
+  //       AccountID destination; // account to create
+  //       int64 startingBalance; // amount they end up with
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("CreateAccountOp", [
+    ["destination", xdr.lookup("AccountId")],
+    ["startingBalance", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct PaymentOp
+  //   {
+  //       MuxedAccount destination; // recipient of the payment
+  //       Asset asset;              // what they end up with
+  //       int64 amount;             // amount they end up with
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PaymentOp", [
+    ["destination", xdr.lookup("MuxedAccount")],
+    ["asset", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct PathPaymentStrictReceiveOp
+  //   {
+  //       Asset sendAsset; // asset we pay with
+  //       int64 sendMax;   // the maximum amount of sendAsset to
+  //                        // send (excluding fees).
+  //                        // The operation will fail if can't be met
+  //
+  //       MuxedAccount destination; // recipient of the payment
+  //       Asset destAsset;          // what they end up with
+  //       int64 destAmount;         // amount they end up with
+  //
+  //       Asset path<5>; // additional hops it must go through to get there
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PathPaymentStrictReceiveOp", [
+    ["sendAsset", xdr.lookup("Asset")],
+    ["sendMax", xdr.lookup("Int64")],
+    ["destination", xdr.lookup("MuxedAccount")],
+    ["destAsset", xdr.lookup("Asset")],
+    ["destAmount", xdr.lookup("Int64")],
+    ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct PathPaymentStrictSendOp
+  //   {
+  //       Asset sendAsset;  // asset we pay with
+  //       int64 sendAmount; // amount of sendAsset to send (excluding fees)
+  //
+  //       MuxedAccount destination; // recipient of the payment
+  //       Asset destAsset;          // what they end up with
+  //       int64 destMin;            // the minimum amount of dest asset to
+  //                                 // be received
+  //                                 // The operation will fail if it can't be met
+  //
+  //       Asset path<5>; // additional hops it must go through to get there
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PathPaymentStrictSendOp", [
+    ["sendAsset", xdr.lookup("Asset")],
+    ["sendAmount", xdr.lookup("Int64")],
+    ["destination", xdr.lookup("MuxedAccount")],
+    ["destAsset", xdr.lookup("Asset")],
+    ["destMin", xdr.lookup("Int64")],
+    ["path", xdr.varArray(xdr.lookup("Asset"), 5)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ManageSellOfferOp
+  //   {
+  //       Asset selling;
+  //       Asset buying;
+  //       int64 amount; // amount being sold. if set to 0, delete the offer
+  //       Price price;  // price of thing being sold in terms of what you are buying
+  //
+  //       // 0=create a new offer, otherwise edit an existing offer
+  //       int64 offerID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ManageSellOfferOp", [
+    ["selling", xdr.lookup("Asset")],
+    ["buying", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+    ["price", xdr.lookup("Price")],
+    ["offerId", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ManageBuyOfferOp
+  //   {
+  //       Asset selling;
+  //       Asset buying;
+  //       int64 buyAmount; // amount being bought. if set to 0, delete the offer
+  //       Price price;     // price of thing being bought in terms of what you are
+  //                        // selling
+  //
+  //       // 0=create a new offer, otherwise edit an existing offer
+  //       int64 offerID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ManageBuyOfferOp", [
+    ["selling", xdr.lookup("Asset")],
+    ["buying", xdr.lookup("Asset")],
+    ["buyAmount", xdr.lookup("Int64")],
+    ["price", xdr.lookup("Price")],
+    ["offerId", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct CreatePassiveSellOfferOp
+  //   {
+  //       Asset selling; // A
+  //       Asset buying;  // B
+  //       int64 amount;  // amount taker gets
+  //       Price price;   // cost of A in terms of B
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("CreatePassiveSellOfferOp", [
+    ["selling", xdr.lookup("Asset")],
+    ["buying", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+    ["price", xdr.lookup("Price")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SetOptionsOp
+  //   {
+  //       AccountID* inflationDest; // sets the inflation destination
+  //
+  //       uint32* clearFlags; // which flags to clear
+  //       uint32* setFlags;   // which flags to set
+  //
+  //       // account threshold manipulation
+  //       uint32* masterWeight; // weight of the master account
+  //       uint32* lowThreshold;
+  //       uint32* medThreshold;
+  //       uint32* highThreshold;
+  //
+  //       string32* homeDomain; // sets the home domain
+  //
+  //       // Add, update or remove a signer for the account
+  //       // signer is deleted if the weight is 0
+  //       Signer* signer;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SetOptionsOp", [
+    ["inflationDest", xdr.option(xdr.lookup("AccountId"))],
+    ["clearFlags", xdr.option(xdr.lookup("Uint32"))],
+    ["setFlags", xdr.option(xdr.lookup("Uint32"))],
+    ["masterWeight", xdr.option(xdr.lookup("Uint32"))],
+    ["lowThreshold", xdr.option(xdr.lookup("Uint32"))],
+    ["medThreshold", xdr.option(xdr.lookup("Uint32"))],
+    ["highThreshold", xdr.option(xdr.lookup("Uint32"))],
+    ["homeDomain", xdr.option(xdr.lookup("String32"))],
+    ["signer", xdr.option(xdr.lookup("Signer"))],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union ChangeTrustAsset switch (AssetType type)
+  //   {
+  //   case ASSET_TYPE_NATIVE: // Not credit
+  //       void;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM4:
+  //       AlphaNum4 alphaNum4;
+  //
+  //   case ASSET_TYPE_CREDIT_ALPHANUM12:
+  //       AlphaNum12 alphaNum12;
+  //
+  //   case ASSET_TYPE_POOL_SHARE:
+  //       LiquidityPoolParameters liquidityPool;
+  //
+  //       // add other asset types here in the future
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ChangeTrustAsset", {
+    switchOn: xdr.lookup("AssetType"),
+    switchName: "type",
+    switches: [
+      ["assetTypeNative", xdr.void()],
+      ["assetTypeCreditAlphanum4", "alphaNum4"],
+      ["assetTypeCreditAlphanum12", "alphaNum12"],
+      ["assetTypePoolShare", "liquidityPool"],
+    ],
+    arms: {
+      alphaNum4: xdr.lookup("AlphaNum4"),
+      alphaNum12: xdr.lookup("AlphaNum12"),
+      liquidityPool: xdr.lookup("LiquidityPoolParameters"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ChangeTrustOp
+  //   {
+  //       ChangeTrustAsset line;
+  //
+  //       // if limit is set to 0, deletes the trust line
+  //       int64 limit;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ChangeTrustOp", [
+    ["line", xdr.lookup("ChangeTrustAsset")],
+    ["limit", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct AllowTrustOp
+  //   {
+  //       AccountID trustor;
+  //       AssetCode asset;
+  //
+  //       // One of 0, AUTHORIZED_FLAG, or AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG
+  //       uint32 authorize;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AllowTrustOp", [
+    ["trustor", xdr.lookup("AccountId")],
+    ["asset", xdr.lookup("AssetCode")],
+    ["authorize", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ManageDataOp
+  //   {
+  //       string64 dataName;
+  //       DataValue* dataValue; // set to null to clear
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ManageDataOp", [
+    ["dataName", xdr.lookup("String64")],
+    ["dataValue", xdr.option(xdr.lookup("DataValue"))],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct BumpSequenceOp
+  //   {
+  //       SequenceNumber bumpTo;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("BumpSequenceOp", [["bumpTo", xdr.lookup("SequenceNumber")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct CreateClaimableBalanceOp
+  //   {
+  //       Asset asset;
+  //       int64 amount;
+  //       Claimant claimants<10>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("CreateClaimableBalanceOp", [
+    ["asset", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+    ["claimants", xdr.varArray(xdr.lookup("Claimant"), 10)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimClaimableBalanceOp
+  //   {
+  //       ClaimableBalanceID balanceID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimClaimableBalanceOp", [
+    ["balanceId", xdr.lookup("ClaimableBalanceId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct BeginSponsoringFutureReservesOp
+  //   {
+  //       AccountID sponsoredID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("BeginSponsoringFutureReservesOp", [
+    ["sponsoredId", xdr.lookup("AccountId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum RevokeSponsorshipType
+  //   {
+  //       REVOKE_SPONSORSHIP_LEDGER_ENTRY = 0,
+  //       REVOKE_SPONSORSHIP_SIGNER = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("RevokeSponsorshipType", {
+    revokeSponsorshipLedgerEntry: 0,
+    revokeSponsorshipSigner: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID accountID;
+  //           SignerKey signerKey;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("RevokeSponsorshipOpSigner", [
+    ["accountId", xdr.lookup("AccountId")],
+    ["signerKey", xdr.lookup("SignerKey")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union RevokeSponsorshipOp switch (RevokeSponsorshipType type)
+  //   {
+  //   case REVOKE_SPONSORSHIP_LEDGER_ENTRY:
+  //       LedgerKey ledgerKey;
+  //   case REVOKE_SPONSORSHIP_SIGNER:
+  //       struct
+  //       {
+  //           AccountID accountID;
+  //           SignerKey signerKey;
+  //       } signer;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("RevokeSponsorshipOp", {
+    switchOn: xdr.lookup("RevokeSponsorshipType"),
+    switchName: "type",
+    switches: [
+      ["revokeSponsorshipLedgerEntry", "ledgerKey"],
+      ["revokeSponsorshipSigner", "signer"],
+    ],
+    arms: {
+      ledgerKey: xdr.lookup("LedgerKey"),
+      signer: xdr.lookup("RevokeSponsorshipOpSigner"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ClawbackOp
+  //   {
+  //       Asset asset;
+  //       MuxedAccount from;
+  //       int64 amount;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClawbackOp", [
+    ["asset", xdr.lookup("Asset")],
+    ["from", xdr.lookup("MuxedAccount")],
+    ["amount", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ClawbackClaimableBalanceOp
+  //   {
+  //       ClaimableBalanceID balanceID;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClawbackClaimableBalanceOp", [
+    ["balanceId", xdr.lookup("ClaimableBalanceId")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SetTrustLineFlagsOp
+  //   {
+  //       AccountID trustor;
+  //       Asset asset;
+  //
+  //       uint32 clearFlags; // which flags to clear
+  //       uint32 setFlags;   // which flags to set
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SetTrustLineFlagsOp", [
+    ["trustor", xdr.lookup("AccountId")],
+    ["asset", xdr.lookup("Asset")],
+    ["clearFlags", xdr.lookup("Uint32")],
+    ["setFlags", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   const LIQUIDITY_POOL_FEE_V18 = 30;
+  //
+  // ===========================================================================
+  xdr.const("LIQUIDITY_POOL_FEE_V18", 30);
+
+  // === xdr source ============================================================
+  //
+  //   struct LiquidityPoolDepositOp
+  //   {
+  //       PoolID liquidityPoolID;
+  //       int64 maxAmountA; // maximum amount of first asset to deposit
+  //       int64 maxAmountB; // maximum amount of second asset to deposit
+  //       Price minPrice;   // minimum depositA/depositB
+  //       Price maxPrice;   // maximum depositA/depositB
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LiquidityPoolDepositOp", [
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+    ["maxAmountA", xdr.lookup("Int64")],
+    ["maxAmountB", xdr.lookup("Int64")],
+    ["minPrice", xdr.lookup("Price")],
+    ["maxPrice", xdr.lookup("Price")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LiquidityPoolWithdrawOp
+  //   {
+  //       PoolID liquidityPoolID;
+  //       int64 amount;     // amount of pool shares to withdraw
+  //       int64 minAmountA; // minimum amount of first asset to withdraw
+  //       int64 minAmountB; // minimum amount of second asset to withdraw
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LiquidityPoolWithdrawOp", [
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+    ["amount", xdr.lookup("Int64")],
+    ["minAmountA", xdr.lookup("Int64")],
+    ["minAmountB", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum HostFunctionType
+  //   {
+  //       HOST_FUNCTION_TYPE_INVOKE_CONTRACT = 0,
+  //       HOST_FUNCTION_TYPE_CREATE_CONTRACT = 1,
+  //       HOST_FUNCTION_TYPE_INSTALL_CONTRACT_CODE = 2
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("HostFunctionType", {
+    hostFunctionTypeInvokeContract: 0,
+    hostFunctionTypeCreateContract: 1,
+    hostFunctionTypeInstallContractCode: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ContractIDType
+  //   {
+  //       CONTRACT_ID_FROM_SOURCE_ACCOUNT = 0,
+  //       CONTRACT_ID_FROM_ED25519_PUBLIC_KEY = 1,
+  //       CONTRACT_ID_FROM_ASSET = 2
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ContractIdType", {
+    contractIdFromSourceAccount: 0,
+    contractIdFromEd25519PublicKey: 1,
+    contractIdFromAsset: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ContractIDPublicKeyType
+  //   {
+  //       CONTRACT_ID_PUBLIC_KEY_SOURCE_ACCOUNT = 0,
+  //       CONTRACT_ID_PUBLIC_KEY_ED25519 = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ContractIdPublicKeyType", {
+    contractIdPublicKeySourceAccount: 0,
+    contractIdPublicKeyEd25519: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct InstallContractCodeArgs
+  //   {
+  //       opaque code<SCVAL_LIMIT>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("InstallContractCodeArgs", [
+    ["code", xdr.varOpaque(xdr.lookup("SCVAL_LIMIT"))],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           uint256 key;
+  //           Signature signature;
+  //           uint256 salt;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("ContractIdFromEd25519PublicKey", [
+    ["key", xdr.lookup("Uint256")],
+    ["signature", xdr.lookup("Signature")],
+    ["salt", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union ContractID switch (ContractIDType type)
+  //   {
+  //   case CONTRACT_ID_FROM_SOURCE_ACCOUNT:
+  //       uint256 salt;
+  //   case CONTRACT_ID_FROM_ED25519_PUBLIC_KEY:
+  //       struct
+  //       {
+  //           uint256 key;
+  //           Signature signature;
+  //           uint256 salt;
+  //       } fromEd25519PublicKey;
+  //   case CONTRACT_ID_FROM_ASSET:
+  //       Asset asset;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ContractId", {
+    switchOn: xdr.lookup("ContractIdType"),
+    switchName: "type",
+    switches: [
+      ["contractIdFromSourceAccount", "salt"],
+      ["contractIdFromEd25519PublicKey", "fromEd25519PublicKey"],
+      ["contractIdFromAsset", "asset"],
+    ],
+    arms: {
+      salt: xdr.lookup("Uint256"),
+      fromEd25519PublicKey: xdr.lookup("ContractIdFromEd25519PublicKey"),
+      asset: xdr.lookup("Asset"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct CreateContractArgs
+  //   {
+  //       ContractID contractID;
+  //       SCContractExecutable source;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("CreateContractArgs", [
+    ["contractId", xdr.lookup("ContractId")],
+    ["source", xdr.lookup("ScContractExecutable")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union HostFunction switch (HostFunctionType type)
+  //   {
+  //   case HOST_FUNCTION_TYPE_INVOKE_CONTRACT:
+  //       SCVec invokeArgs;
+  //   case HOST_FUNCTION_TYPE_CREATE_CONTRACT:
+  //       CreateContractArgs createContractArgs;
+  //   case HOST_FUNCTION_TYPE_INSTALL_CONTRACT_CODE:
+  //       InstallContractCodeArgs installContractCodeArgs;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("HostFunction", {
+    switchOn: xdr.lookup("HostFunctionType"),
+    switchName: "type",
+    switches: [
+      ["hostFunctionTypeInvokeContract", "invokeArgs"],
+      ["hostFunctionTypeCreateContract", "createContractArgs"],
+      ["hostFunctionTypeInstallContractCode", "installContractCodeArgs"],
+    ],
+    arms: {
+      invokeArgs: xdr.lookup("ScVec"),
+      createContractArgs: xdr.lookup("CreateContractArgs"),
+      installContractCodeArgs: xdr.lookup("InstallContractCodeArgs"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct AuthorizedInvocation
+  //   {
+  //       Hash contractID;
+  //       SCSymbol functionName;
+  //       SCVec args;
+  //       AuthorizedInvocation subInvocations<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AuthorizedInvocation", [
+    ["contractId", xdr.lookup("Hash")],
+    ["functionName", xdr.lookup("ScSymbol")],
+    ["args", xdr.lookup("ScVec")],
+    [
+      "subInvocations",
+      xdr.varArray(xdr.lookup("AuthorizedInvocation"), 2147483647),
+    ],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct AddressWithNonce
+  //   {
+  //       SCAddress address;
+  //       uint64 nonce;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("AddressWithNonce", [
+    ["address", xdr.lookup("ScAddress")],
+    ["nonce", xdr.lookup("Uint64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ContractAuth
+  //   {
+  //       AddressWithNonce* addressWithNonce; // not present for invoker
+  //       AuthorizedInvocation rootInvocation;
+  //       SCVec signatureArgs;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ContractAuth", [
+    ["addressWithNonce", xdr.option(xdr.lookup("AddressWithNonce"))],
+    ["rootInvocation", xdr.lookup("AuthorizedInvocation")],
+    ["signatureArgs", xdr.lookup("ScVec")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct InvokeHostFunctionOp
+  //   {
+  //       // The host function to invoke
+  //       HostFunction function;
+  //       // The footprint for this invocation
+  //       LedgerFootprint footprint;
+  //       // Per-address authorizations for this host fn
+  //       // Currently only supported for INVOKE_CONTRACT function
+  //       ContractAuth auth<>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("InvokeHostFunctionOp", [
+    ["function", xdr.lookup("HostFunction")],
+    ["footprint", xdr.lookup("LedgerFootprint")],
+    ["auth", xdr.varArray(xdr.lookup("ContractAuth"), 2147483647)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (OperationType type)
+  //       {
+  //       case CREATE_ACCOUNT:
+  //           CreateAccountOp createAccountOp;
+  //       case PAYMENT:
+  //           PaymentOp paymentOp;
+  //       case PATH_PAYMENT_STRICT_RECEIVE:
+  //           PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
+  //       case MANAGE_SELL_OFFER:
+  //           ManageSellOfferOp manageSellOfferOp;
+  //       case CREATE_PASSIVE_SELL_OFFER:
+  //           CreatePassiveSellOfferOp createPassiveSellOfferOp;
+  //       case SET_OPTIONS:
+  //           SetOptionsOp setOptionsOp;
+  //       case CHANGE_TRUST:
+  //           ChangeTrustOp changeTrustOp;
+  //       case ALLOW_TRUST:
+  //           AllowTrustOp allowTrustOp;
+  //       case ACCOUNT_MERGE:
+  //           MuxedAccount destination;
+  //       case INFLATION:
+  //           void;
+  //       case MANAGE_DATA:
+  //           ManageDataOp manageDataOp;
+  //       case BUMP_SEQUENCE:
+  //           BumpSequenceOp bumpSequenceOp;
+  //       case MANAGE_BUY_OFFER:
+  //           ManageBuyOfferOp manageBuyOfferOp;
+  //       case PATH_PAYMENT_STRICT_SEND:
+  //           PathPaymentStrictSendOp pathPaymentStrictSendOp;
+  //       case CREATE_CLAIMABLE_BALANCE:
+  //           CreateClaimableBalanceOp createClaimableBalanceOp;
+  //       case CLAIM_CLAIMABLE_BALANCE:
+  //           ClaimClaimableBalanceOp claimClaimableBalanceOp;
+  //       case BEGIN_SPONSORING_FUTURE_RESERVES:
+  //           BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
+  //       case END_SPONSORING_FUTURE_RESERVES:
+  //           void;
+  //       case REVOKE_SPONSORSHIP:
+  //           RevokeSponsorshipOp revokeSponsorshipOp;
+  //       case CLAWBACK:
+  //           ClawbackOp clawbackOp;
+  //       case CLAWBACK_CLAIMABLE_BALANCE:
+  //           ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
+  //       case SET_TRUST_LINE_FLAGS:
+  //           SetTrustLineFlagsOp setTrustLineFlagsOp;
+  //       case LIQUIDITY_POOL_DEPOSIT:
+  //           LiquidityPoolDepositOp liquidityPoolDepositOp;
+  //       case LIQUIDITY_POOL_WITHDRAW:
+  //           LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
+  //       case INVOKE_HOST_FUNCTION:
+  //           InvokeHostFunctionOp invokeHostFunctionOp;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("OperationBody", {
+    switchOn: xdr.lookup("OperationType"),
+    switchName: "type",
+    switches: [
+      ["createAccount", "createAccountOp"],
+      ["payment", "paymentOp"],
+      ["pathPaymentStrictReceive", "pathPaymentStrictReceiveOp"],
+      ["manageSellOffer", "manageSellOfferOp"],
+      ["createPassiveSellOffer", "createPassiveSellOfferOp"],
+      ["setOptions", "setOptionsOp"],
+      ["changeTrust", "changeTrustOp"],
+      ["allowTrust", "allowTrustOp"],
+      ["accountMerge", "destination"],
+      ["inflation", xdr.void()],
+      ["manageData", "manageDataOp"],
+      ["bumpSequence", "bumpSequenceOp"],
+      ["manageBuyOffer", "manageBuyOfferOp"],
+      ["pathPaymentStrictSend", "pathPaymentStrictSendOp"],
+      ["createClaimableBalance", "createClaimableBalanceOp"],
+      ["claimClaimableBalance", "claimClaimableBalanceOp"],
+      ["beginSponsoringFutureReserves", "beginSponsoringFutureReservesOp"],
+      ["endSponsoringFutureReserves", xdr.void()],
+      ["revokeSponsorship", "revokeSponsorshipOp"],
+      ["clawback", "clawbackOp"],
+      ["clawbackClaimableBalance", "clawbackClaimableBalanceOp"],
+      ["setTrustLineFlags", "setTrustLineFlagsOp"],
+      ["liquidityPoolDeposit", "liquidityPoolDepositOp"],
+      ["liquidityPoolWithdraw", "liquidityPoolWithdrawOp"],
+      ["invokeHostFunction", "invokeHostFunctionOp"],
+    ],
+    arms: {
+      createAccountOp: xdr.lookup("CreateAccountOp"),
+      paymentOp: xdr.lookup("PaymentOp"),
+      pathPaymentStrictReceiveOp: xdr.lookup("PathPaymentStrictReceiveOp"),
+      manageSellOfferOp: xdr.lookup("ManageSellOfferOp"),
+      createPassiveSellOfferOp: xdr.lookup("CreatePassiveSellOfferOp"),
+      setOptionsOp: xdr.lookup("SetOptionsOp"),
+      changeTrustOp: xdr.lookup("ChangeTrustOp"),
+      allowTrustOp: xdr.lookup("AllowTrustOp"),
+      destination: xdr.lookup("MuxedAccount"),
+      manageDataOp: xdr.lookup("ManageDataOp"),
+      bumpSequenceOp: xdr.lookup("BumpSequenceOp"),
+      manageBuyOfferOp: xdr.lookup("ManageBuyOfferOp"),
+      pathPaymentStrictSendOp: xdr.lookup("PathPaymentStrictSendOp"),
+      createClaimableBalanceOp: xdr.lookup("CreateClaimableBalanceOp"),
+      claimClaimableBalanceOp: xdr.lookup("ClaimClaimableBalanceOp"),
+      beginSponsoringFutureReservesOp: xdr.lookup(
+        "BeginSponsoringFutureReservesOp"
+      ),
+      revokeSponsorshipOp: xdr.lookup("RevokeSponsorshipOp"),
+      clawbackOp: xdr.lookup("ClawbackOp"),
+      clawbackClaimableBalanceOp: xdr.lookup("ClawbackClaimableBalanceOp"),
+      setTrustLineFlagsOp: xdr.lookup("SetTrustLineFlagsOp"),
+      liquidityPoolDepositOp: xdr.lookup("LiquidityPoolDepositOp"),
+      liquidityPoolWithdrawOp: xdr.lookup("LiquidityPoolWithdrawOp"),
+      invokeHostFunctionOp: xdr.lookup("InvokeHostFunctionOp"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct Operation
+  //   {
+  //       // sourceAccount is the account used to run the operation
+  //       // if not set, the runtime defaults to "sourceAccount" specified at
+  //       // the transaction level
+  //       MuxedAccount* sourceAccount;
+  //
+  //       union switch (OperationType type)
+  //       {
+  //       case CREATE_ACCOUNT:
+  //           CreateAccountOp createAccountOp;
+  //       case PAYMENT:
+  //           PaymentOp paymentOp;
+  //       case PATH_PAYMENT_STRICT_RECEIVE:
+  //           PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
+  //       case MANAGE_SELL_OFFER:
+  //           ManageSellOfferOp manageSellOfferOp;
+  //       case CREATE_PASSIVE_SELL_OFFER:
+  //           CreatePassiveSellOfferOp createPassiveSellOfferOp;
+  //       case SET_OPTIONS:
+  //           SetOptionsOp setOptionsOp;
+  //       case CHANGE_TRUST:
+  //           ChangeTrustOp changeTrustOp;
+  //       case ALLOW_TRUST:
+  //           AllowTrustOp allowTrustOp;
+  //       case ACCOUNT_MERGE:
+  //           MuxedAccount destination;
+  //       case INFLATION:
+  //           void;
+  //       case MANAGE_DATA:
+  //           ManageDataOp manageDataOp;
+  //       case BUMP_SEQUENCE:
+  //           BumpSequenceOp bumpSequenceOp;
+  //       case MANAGE_BUY_OFFER:
+  //           ManageBuyOfferOp manageBuyOfferOp;
+  //       case PATH_PAYMENT_STRICT_SEND:
+  //           PathPaymentStrictSendOp pathPaymentStrictSendOp;
+  //       case CREATE_CLAIMABLE_BALANCE:
+  //           CreateClaimableBalanceOp createClaimableBalanceOp;
+  //       case CLAIM_CLAIMABLE_BALANCE:
+  //           ClaimClaimableBalanceOp claimClaimableBalanceOp;
+  //       case BEGIN_SPONSORING_FUTURE_RESERVES:
+  //           BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
+  //       case END_SPONSORING_FUTURE_RESERVES:
+  //           void;
+  //       case REVOKE_SPONSORSHIP:
+  //           RevokeSponsorshipOp revokeSponsorshipOp;
+  //       case CLAWBACK:
+  //           ClawbackOp clawbackOp;
+  //       case CLAWBACK_CLAIMABLE_BALANCE:
+  //           ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
+  //       case SET_TRUST_LINE_FLAGS:
+  //           SetTrustLineFlagsOp setTrustLineFlagsOp;
+  //       case LIQUIDITY_POOL_DEPOSIT:
+  //           LiquidityPoolDepositOp liquidityPoolDepositOp;
+  //       case LIQUIDITY_POOL_WITHDRAW:
+  //           LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
+  //       case INVOKE_HOST_FUNCTION:
+  //           InvokeHostFunctionOp invokeHostFunctionOp;
+  //       }
+  //       body;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Operation", [
+    ["sourceAccount", xdr.option(xdr.lookup("MuxedAccount"))],
+    ["body", xdr.lookup("OperationBody")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID sourceAccount;
+  //           SequenceNumber seqNum;
+  //           uint32 opNum;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("HashIdPreimageOperationId", [
+    ["sourceAccount", xdr.lookup("AccountId")],
+    ["seqNum", xdr.lookup("SequenceNumber")],
+    ["opNum", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           AccountID sourceAccount;
+  //           SequenceNumber seqNum;
+  //           uint32 opNum;
+  //           PoolID liquidityPoolID;
+  //           Asset asset;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("HashIdPreimageRevokeId", [
+    ["sourceAccount", xdr.lookup("AccountId")],
+    ["seqNum", xdr.lookup("SequenceNumber")],
+    ["opNum", xdr.lookup("Uint32")],
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+    ["asset", xdr.lookup("Asset")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           Hash networkID;
+  //           uint256 ed25519;
+  //           uint256 salt;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("HashIdPreimageEd25519ContractId", [
+    ["networkId", xdr.lookup("Hash")],
+    ["ed25519", xdr.lookup("Uint256")],
+    ["salt", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           Hash networkID;
+  //           Hash contractID;
+  //           uint256 salt;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("HashIdPreimageContractId", [
+    ["networkId", xdr.lookup("Hash")],
+    ["contractId", xdr.lookup("Hash")],
+    ["salt", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           Hash networkID;
+  //           Asset asset;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("HashIdPreimageFromAsset", [
+    ["networkId", xdr.lookup("Hash")],
+    ["asset", xdr.lookup("Asset")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           Hash networkID;
+  //           AccountID sourceAccount;
+  //           uint256 salt;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("HashIdPreimageSourceAccountContractId", [
+    ["networkId", xdr.lookup("Hash")],
+    ["sourceAccount", xdr.lookup("AccountId")],
+    ["salt", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           Hash networkID;
+  //           SCContractExecutable source;
+  //           uint256 salt;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("HashIdPreimageCreateContractArgs", [
+    ["networkId", xdr.lookup("Hash")],
+    ["source", xdr.lookup("ScContractExecutable")],
+    ["salt", xdr.lookup("Uint256")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           Hash networkID;
+  //           uint64 nonce;
+  //           AuthorizedInvocation invocation;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("HashIdPreimageContractAuth", [
+    ["networkId", xdr.lookup("Hash")],
+    ["nonce", xdr.lookup("Uint64")],
+    ["invocation", xdr.lookup("AuthorizedInvocation")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union HashIDPreimage switch (EnvelopeType type)
+  //   {
+  //   case ENVELOPE_TYPE_OP_ID:
+  //       struct
+  //       {
+  //           AccountID sourceAccount;
+  //           SequenceNumber seqNum;
+  //           uint32 opNum;
+  //       } operationID;
+  //   case ENVELOPE_TYPE_POOL_REVOKE_OP_ID:
+  //       struct
+  //       {
+  //           AccountID sourceAccount;
+  //           SequenceNumber seqNum;
+  //           uint32 opNum;
+  //           PoolID liquidityPoolID;
+  //           Asset asset;
+  //       } revokeID;
+  //   case ENVELOPE_TYPE_CONTRACT_ID_FROM_ED25519:
+  //       struct
+  //       {
+  //           Hash networkID;
+  //           uint256 ed25519;
+  //           uint256 salt;
+  //       } ed25519ContractID;
+  //   case ENVELOPE_TYPE_CONTRACT_ID_FROM_CONTRACT:
+  //       struct
+  //       {
+  //           Hash networkID;
+  //           Hash contractID;
+  //           uint256 salt;
+  //       } contractID;
+  //   case ENVELOPE_TYPE_CONTRACT_ID_FROM_ASSET:
+  //       struct
+  //       {
+  //           Hash networkID;
+  //           Asset asset;
+  //       } fromAsset;
+  //   case ENVELOPE_TYPE_CONTRACT_ID_FROM_SOURCE_ACCOUNT:
+  //       struct
+  //       {
+  //           Hash networkID;
+  //           AccountID sourceAccount;
+  //           uint256 salt;
+  //       } sourceAccountContractID;
+  //   case ENVELOPE_TYPE_CREATE_CONTRACT_ARGS:
+  //       struct
+  //       {
+  //           Hash networkID;
+  //           SCContractExecutable source;
+  //           uint256 salt;
+  //       } createContractArgs;
+  //   case ENVELOPE_TYPE_CONTRACT_AUTH:
+  //       struct
+  //       {
+  //           Hash networkID;
+  //           uint64 nonce;
+  //           AuthorizedInvocation invocation;
+  //       } contractAuth;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("HashIdPreimage", {
+    switchOn: xdr.lookup("EnvelopeType"),
+    switchName: "type",
+    switches: [
+      ["envelopeTypeOpId", "operationId"],
+      ["envelopeTypePoolRevokeOpId", "revokeId"],
+      ["envelopeTypeContractIdFromEd25519", "ed25519ContractId"],
+      ["envelopeTypeContractIdFromContract", "contractId"],
+      ["envelopeTypeContractIdFromAsset", "fromAsset"],
+      ["envelopeTypeContractIdFromSourceAccount", "sourceAccountContractId"],
+      ["envelopeTypeCreateContractArgs", "createContractArgs"],
+      ["envelopeTypeContractAuth", "contractAuth"],
+    ],
+    arms: {
+      operationId: xdr.lookup("HashIdPreimageOperationId"),
+      revokeId: xdr.lookup("HashIdPreimageRevokeId"),
+      ed25519ContractId: xdr.lookup("HashIdPreimageEd25519ContractId"),
+      contractId: xdr.lookup("HashIdPreimageContractId"),
+      fromAsset: xdr.lookup("HashIdPreimageFromAsset"),
+      sourceAccountContractId: xdr.lookup(
+        "HashIdPreimageSourceAccountContractId"
+      ),
+      createContractArgs: xdr.lookup("HashIdPreimageCreateContractArgs"),
+      contractAuth: xdr.lookup("HashIdPreimageContractAuth"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum MemoType
+  //   {
+  //       MEMO_NONE = 0,
+  //       MEMO_TEXT = 1,
+  //       MEMO_ID = 2,
+  //       MEMO_HASH = 3,
+  //       MEMO_RETURN = 4
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("MemoType", {
+    memoNone: 0,
+    memoText: 1,
+    memoId: 2,
+    memoHash: 3,
+    memoReturn: 4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union Memo switch (MemoType type)
+  //   {
+  //   case MEMO_NONE:
+  //       void;
+  //   case MEMO_TEXT:
+  //       string text<28>;
+  //   case MEMO_ID:
+  //       uint64 id;
+  //   case MEMO_HASH:
+  //       Hash hash; // the hash of what to pull from the content server
+  //   case MEMO_RETURN:
+  //       Hash retHash; // the hash of the tx you are rejecting
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("Memo", {
+    switchOn: xdr.lookup("MemoType"),
+    switchName: "type",
+    switches: [
+      ["memoNone", xdr.void()],
+      ["memoText", "text"],
+      ["memoId", "id"],
+      ["memoHash", "hash"],
+      ["memoReturn", "retHash"],
+    ],
+    arms: {
+      text: xdr.string(28),
+      id: xdr.lookup("Uint64"),
+      hash: xdr.lookup("Hash"),
+      retHash: xdr.lookup("Hash"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TimeBounds
+  //   {
+  //       TimePoint minTime;
+  //       TimePoint maxTime; // 0 here means no maxTime
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TimeBounds", [
+    ["minTime", xdr.lookup("TimePoint")],
+    ["maxTime", xdr.lookup("TimePoint")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct LedgerBounds
+  //   {
+  //       uint32 minLedger;
+  //       uint32 maxLedger; // 0 here means no maxLedger
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("LedgerBounds", [
+    ["minLedger", xdr.lookup("Uint32")],
+    ["maxLedger", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct PreconditionsV2
+  //   {
+  //       TimeBounds* timeBounds;
+  //
+  //       // Transaction only valid for ledger numbers n such that
+  //       // minLedger <= n < maxLedger (if maxLedger == 0, then
+  //       // only minLedger is checked)
+  //       LedgerBounds* ledgerBounds;
+  //
+  //       // If NULL, only valid when sourceAccount's sequence number
+  //       // is seqNum - 1.  Otherwise, valid when sourceAccount's
+  //       // sequence number n satisfies minSeqNum <= n < tx.seqNum.
+  //       // Note that after execution the account's sequence number
+  //       // is always raised to tx.seqNum, and a transaction is not
+  //       // valid if tx.seqNum is too high to ensure replay protection.
+  //       SequenceNumber* minSeqNum;
+  //
+  //       // For the transaction to be valid, the current ledger time must
+  //       // be at least minSeqAge greater than sourceAccount's seqTime.
+  //       Duration minSeqAge;
+  //
+  //       // For the transaction to be valid, the current ledger number
+  //       // must be at least minSeqLedgerGap greater than sourceAccount's
+  //       // seqLedger.
+  //       uint32 minSeqLedgerGap;
+  //
+  //       // For the transaction to be valid, there must be a signature
+  //       // corresponding to every Signer in this array, even if the
+  //       // signature is not otherwise required by the sourceAccount or
+  //       // operations.
+  //       SignerKey extraSigners<2>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("PreconditionsV2", [
+    ["timeBounds", xdr.option(xdr.lookup("TimeBounds"))],
+    ["ledgerBounds", xdr.option(xdr.lookup("LedgerBounds"))],
+    ["minSeqNum", xdr.option(xdr.lookup("SequenceNumber"))],
+    ["minSeqAge", xdr.lookup("Duration")],
+    ["minSeqLedgerGap", xdr.lookup("Uint32")],
+    ["extraSigners", xdr.varArray(xdr.lookup("SignerKey"), 2)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum PreconditionType
+  //   {
+  //       PRECOND_NONE = 0,
+  //       PRECOND_TIME = 1,
+  //       PRECOND_V2 = 2
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("PreconditionType", {
+    precondNone: 0,
+    precondTime: 1,
+    precondV2: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union Preconditions switch (PreconditionType type)
+  //   {
+  //   case PRECOND_NONE:
+  //       void;
+  //   case PRECOND_TIME:
+  //       TimeBounds timeBounds;
+  //   case PRECOND_V2:
+  //       PreconditionsV2 v2;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("Preconditions", {
+    switchOn: xdr.lookup("PreconditionType"),
+    switchName: "type",
+    switches: [
+      ["precondNone", xdr.void()],
+      ["precondTime", "timeBounds"],
+      ["precondV2", "v2"],
+    ],
+    arms: {
+      timeBounds: xdr.lookup("TimeBounds"),
+      v2: xdr.lookup("PreconditionsV2"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const MAX_OPS_PER_TX = 100;
+  //
+  // ===========================================================================
+  xdr.const("MAX_OPS_PER_TX", 100);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionV0Ext", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionV0
+  //   {
+  //       uint256 sourceAccountEd25519;
+  //       uint32 fee;
+  //       SequenceNumber seqNum;
+  //       TimeBounds* timeBounds;
+  //       Memo memo;
+  //       Operation operations<MAX_OPS_PER_TX>;
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionV0", [
+    ["sourceAccountEd25519", xdr.lookup("Uint256")],
+    ["fee", xdr.lookup("Uint32")],
+    ["seqNum", xdr.lookup("SequenceNumber")],
+    ["timeBounds", xdr.option(xdr.lookup("TimeBounds"))],
+    ["memo", xdr.lookup("Memo")],
+    [
+      "operations",
+      xdr.varArray(xdr.lookup("Operation"), xdr.lookup("MAX_OPS_PER_TX")),
+    ],
+    ["ext", xdr.lookup("TransactionV0Ext")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionV0Envelope
+  //   {
+  //       TransactionV0 tx;
+  //       /* Each decorated signature is a signature over the SHA256 hash of
+  //        * a TransactionSignaturePayload */
+  //       DecoratedSignature signatures<20>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionV0Envelope", [
+    ["tx", xdr.lookup("TransactionV0")],
+    ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct Transaction
+  //   {
+  //       // account used to run the transaction
+  //       MuxedAccount sourceAccount;
+  //
+  //       // the fee the sourceAccount will pay
+  //       uint32 fee;
+  //
+  //       // sequence number to consume in the account
+  //       SequenceNumber seqNum;
+  //
+  //       // validity conditions
+  //       Preconditions cond;
+  //
+  //       Memo memo;
+  //
+  //       Operation operations<MAX_OPS_PER_TX>;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Transaction", [
+    ["sourceAccount", xdr.lookup("MuxedAccount")],
+    ["fee", xdr.lookup("Uint32")],
+    ["seqNum", xdr.lookup("SequenceNumber")],
+    ["cond", xdr.lookup("Preconditions")],
+    ["memo", xdr.lookup("Memo")],
+    [
+      "operations",
+      xdr.varArray(xdr.lookup("Operation"), xdr.lookup("MAX_OPS_PER_TX")),
+    ],
+    ["ext", xdr.lookup("TransactionExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionV1Envelope
+  //   {
+  //       Transaction tx;
+  //       /* Each decorated signature is a signature over the SHA256 hash of
+  //        * a TransactionSignaturePayload */
+  //       DecoratedSignature signatures<20>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionV1Envelope", [
+    ["tx", xdr.lookup("Transaction")],
+    ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (EnvelopeType type)
+  //       {
+  //       case ENVELOPE_TYPE_TX:
+  //           TransactionV1Envelope v1;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("FeeBumpTransactionInnerTx", {
+    switchOn: xdr.lookup("EnvelopeType"),
+    switchName: "type",
+    switches: [["envelopeTypeTx", "v1"]],
+    arms: {
+      v1: xdr.lookup("TransactionV1Envelope"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("FeeBumpTransactionExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct FeeBumpTransaction
+  //   {
+  //       MuxedAccount feeSource;
+  //       int64 fee;
+  //       union switch (EnvelopeType type)
+  //       {
+  //       case ENVELOPE_TYPE_TX:
+  //           TransactionV1Envelope v1;
+  //       }
+  //       innerTx;
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("FeeBumpTransaction", [
+    ["feeSource", xdr.lookup("MuxedAccount")],
+    ["fee", xdr.lookup("Int64")],
+    ["innerTx", xdr.lookup("FeeBumpTransactionInnerTx")],
+    ["ext", xdr.lookup("FeeBumpTransactionExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct FeeBumpTransactionEnvelope
+  //   {
+  //       FeeBumpTransaction tx;
+  //       /* Each decorated signature is a signature over the SHA256 hash of
+  //        * a TransactionSignaturePayload */
+  //       DecoratedSignature signatures<20>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("FeeBumpTransactionEnvelope", [
+    ["tx", xdr.lookup("FeeBumpTransaction")],
+    ["signatures", xdr.varArray(xdr.lookup("DecoratedSignature"), 20)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union TransactionEnvelope switch (EnvelopeType type)
+  //   {
+  //   case ENVELOPE_TYPE_TX_V0:
+  //       TransactionV0Envelope v0;
+  //   case ENVELOPE_TYPE_TX:
+  //       TransactionV1Envelope v1;
+  //   case ENVELOPE_TYPE_TX_FEE_BUMP:
+  //       FeeBumpTransactionEnvelope feeBump;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("TransactionEnvelope", {
+    switchOn: xdr.lookup("EnvelopeType"),
+    switchName: "type",
+    switches: [
+      ["envelopeTypeTxV0", "v0"],
+      ["envelopeTypeTx", "v1"],
+      ["envelopeTypeTxFeeBump", "feeBump"],
+    ],
+    arms: {
+      v0: xdr.lookup("TransactionV0Envelope"),
+      v1: xdr.lookup("TransactionV1Envelope"),
+      feeBump: xdr.lookup("FeeBumpTransactionEnvelope"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (EnvelopeType type)
+  //       {
+  //       // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
+  //       case ENVELOPE_TYPE_TX:
+  //           Transaction tx;
+  //       case ENVELOPE_TYPE_TX_FEE_BUMP:
+  //           FeeBumpTransaction feeBump;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionSignaturePayloadTaggedTransaction", {
+    switchOn: xdr.lookup("EnvelopeType"),
+    switchName: "type",
+    switches: [
+      ["envelopeTypeTx", "tx"],
+      ["envelopeTypeTxFeeBump", "feeBump"],
+    ],
+    arms: {
+      tx: xdr.lookup("Transaction"),
+      feeBump: xdr.lookup("FeeBumpTransaction"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionSignaturePayload
+  //   {
+  //       Hash networkId;
+  //       union switch (EnvelopeType type)
+  //       {
+  //       // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
+  //       case ENVELOPE_TYPE_TX:
+  //           Transaction tx;
+  //       case ENVELOPE_TYPE_TX_FEE_BUMP:
+  //           FeeBumpTransaction feeBump;
+  //       }
+  //       taggedTransaction;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionSignaturePayload", [
+    ["networkId", xdr.lookup("Hash")],
+    [
+      "taggedTransaction",
+      xdr.lookup("TransactionSignaturePayloadTaggedTransaction"),
+    ],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimAtomType
+  //   {
+  //       CLAIM_ATOM_TYPE_V0 = 0,
+  //       CLAIM_ATOM_TYPE_ORDER_BOOK = 1,
+  //       CLAIM_ATOM_TYPE_LIQUIDITY_POOL = 2
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimAtomType", {
+    claimAtomTypeV0: 0,
+    claimAtomTypeOrderBook: 1,
+    claimAtomTypeLiquidityPool: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimOfferAtomV0
+  //   {
+  //       // emitted to identify the offer
+  //       uint256 sellerEd25519; // Account that owns the offer
+  //       int64 offerID;
+  //
+  //       // amount and asset taken from the owner
+  //       Asset assetSold;
+  //       int64 amountSold;
+  //
+  //       // amount and asset sent to the owner
+  //       Asset assetBought;
+  //       int64 amountBought;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimOfferAtomV0", [
+    ["sellerEd25519", xdr.lookup("Uint256")],
+    ["offerId", xdr.lookup("Int64")],
+    ["assetSold", xdr.lookup("Asset")],
+    ["amountSold", xdr.lookup("Int64")],
+    ["assetBought", xdr.lookup("Asset")],
+    ["amountBought", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimOfferAtom
+  //   {
+  //       // emitted to identify the offer
+  //       AccountID sellerID; // Account that owns the offer
+  //       int64 offerID;
+  //
+  //       // amount and asset taken from the owner
+  //       Asset assetSold;
+  //       int64 amountSold;
+  //
+  //       // amount and asset sent to the owner
+  //       Asset assetBought;
+  //       int64 amountBought;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimOfferAtom", [
+    ["sellerId", xdr.lookup("AccountId")],
+    ["offerId", xdr.lookup("Int64")],
+    ["assetSold", xdr.lookup("Asset")],
+    ["amountSold", xdr.lookup("Int64")],
+    ["assetBought", xdr.lookup("Asset")],
+    ["amountBought", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct ClaimLiquidityAtom
+  //   {
+  //       PoolID liquidityPoolID;
+  //
+  //       // amount and asset taken from the pool
+  //       Asset assetSold;
+  //       int64 amountSold;
+  //
+  //       // amount and asset sent to the pool
+  //       Asset assetBought;
+  //       int64 amountBought;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ClaimLiquidityAtom", [
+    ["liquidityPoolId", xdr.lookup("PoolId")],
+    ["assetSold", xdr.lookup("Asset")],
+    ["amountSold", xdr.lookup("Int64")],
+    ["assetBought", xdr.lookup("Asset")],
+    ["amountBought", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union ClaimAtom switch (ClaimAtomType type)
+  //   {
+  //   case CLAIM_ATOM_TYPE_V0:
+  //       ClaimOfferAtomV0 v0;
+  //   case CLAIM_ATOM_TYPE_ORDER_BOOK:
+  //       ClaimOfferAtom orderBook;
+  //   case CLAIM_ATOM_TYPE_LIQUIDITY_POOL:
+  //       ClaimLiquidityAtom liquidityPool;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClaimAtom", {
+    switchOn: xdr.lookup("ClaimAtomType"),
+    switchName: "type",
+    switches: [
+      ["claimAtomTypeV0", "v0"],
+      ["claimAtomTypeOrderBook", "orderBook"],
+      ["claimAtomTypeLiquidityPool", "liquidityPool"],
+    ],
+    arms: {
+      v0: xdr.lookup("ClaimOfferAtomV0"),
+      orderBook: xdr.lookup("ClaimOfferAtom"),
+      liquidityPool: xdr.lookup("ClaimLiquidityAtom"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum CreateAccountResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       CREATE_ACCOUNT_SUCCESS = 0, // account was created
+  //
+  //       // codes considered as "failure" for the operation
+  //       CREATE_ACCOUNT_MALFORMED = -1,   // invalid destination
+  //       CREATE_ACCOUNT_UNDERFUNDED = -2, // not enough funds in source account
+  //       CREATE_ACCOUNT_LOW_RESERVE =
+  //           -3, // would create an account below the min reserve
+  //       CREATE_ACCOUNT_ALREADY_EXIST = -4 // account already exists
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("CreateAccountResultCode", {
+    createAccountSuccess: 0,
+    createAccountMalformed: -1,
+    createAccountUnderfunded: -2,
+    createAccountLowReserve: -3,
+    createAccountAlreadyExist: -4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union CreateAccountResult switch (CreateAccountResultCode code)
+  //   {
+  //   case CREATE_ACCOUNT_SUCCESS:
+  //       void;
+  //   case CREATE_ACCOUNT_MALFORMED:
+  //   case CREATE_ACCOUNT_UNDERFUNDED:
+  //   case CREATE_ACCOUNT_LOW_RESERVE:
+  //   case CREATE_ACCOUNT_ALREADY_EXIST:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("CreateAccountResult", {
+    switchOn: xdr.lookup("CreateAccountResultCode"),
+    switchName: "code",
+    switches: [
+      ["createAccountSuccess", xdr.void()],
+      ["createAccountMalformed", xdr.void()],
+      ["createAccountUnderfunded", xdr.void()],
+      ["createAccountLowReserve", xdr.void()],
+      ["createAccountAlreadyExist", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum PaymentResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       PAYMENT_SUCCESS = 0, // payment successfully completed
+  //
+  //       // codes considered as "failure" for the operation
+  //       PAYMENT_MALFORMED = -1,          // bad input
+  //       PAYMENT_UNDERFUNDED = -2,        // not enough funds in source account
+  //       PAYMENT_SRC_NO_TRUST = -3,       // no trust line on source account
+  //       PAYMENT_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+  //       PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
+  //       PAYMENT_NO_TRUST = -6,       // destination missing a trust line for asset
+  //       PAYMENT_NOT_AUTHORIZED = -7, // destination not authorized to hold asset
+  //       PAYMENT_LINE_FULL = -8,      // destination would go above their limit
+  //       PAYMENT_NO_ISSUER = -9       // missing issuer on asset
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("PaymentResultCode", {
+    paymentSuccess: 0,
+    paymentMalformed: -1,
+    paymentUnderfunded: -2,
+    paymentSrcNoTrust: -3,
+    paymentSrcNotAuthorized: -4,
+    paymentNoDestination: -5,
+    paymentNoTrust: -6,
+    paymentNotAuthorized: -7,
+    paymentLineFull: -8,
+    paymentNoIssuer: -9,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union PaymentResult switch (PaymentResultCode code)
+  //   {
+  //   case PAYMENT_SUCCESS:
+  //       void;
+  //   case PAYMENT_MALFORMED:
+  //   case PAYMENT_UNDERFUNDED:
+  //   case PAYMENT_SRC_NO_TRUST:
+  //   case PAYMENT_SRC_NOT_AUTHORIZED:
+  //   case PAYMENT_NO_DESTINATION:
+  //   case PAYMENT_NO_TRUST:
+  //   case PAYMENT_NOT_AUTHORIZED:
+  //   case PAYMENT_LINE_FULL:
+  //   case PAYMENT_NO_ISSUER:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("PaymentResult", {
+    switchOn: xdr.lookup("PaymentResultCode"),
+    switchName: "code",
+    switches: [
+      ["paymentSuccess", xdr.void()],
+      ["paymentMalformed", xdr.void()],
+      ["paymentUnderfunded", xdr.void()],
+      ["paymentSrcNoTrust", xdr.void()],
+      ["paymentSrcNotAuthorized", xdr.void()],
+      ["paymentNoDestination", xdr.void()],
+      ["paymentNoTrust", xdr.void()],
+      ["paymentNotAuthorized", xdr.void()],
+      ["paymentLineFull", xdr.void()],
+      ["paymentNoIssuer", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum PathPaymentStrictReceiveResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
+  //
+  //       // codes considered as "failure" for the operation
+  //       PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1, // bad input
+  //       PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED =
+  //           -2, // not enough funds in source account
+  //       PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST =
+  //           -3, // no trust line on source account
+  //       PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED =
+  //           -4, // source not authorized to transfer
+  //       PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION =
+  //           -5, // destination account does not exist
+  //       PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST =
+  //           -6, // dest missing a trust line for asset
+  //       PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED =
+  //           -7, // dest not authorized to hold asset
+  //       PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL =
+  //           -8, // dest would go above their limit
+  //       PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9, // missing issuer on one asset
+  //       PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS =
+  //           -10, // not enough offers to satisfy path
+  //       PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF =
+  //           -11, // would cross one of its own offers
+  //       PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12 // could not satisfy sendmax
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("PathPaymentStrictReceiveResultCode", {
+    pathPaymentStrictReceiveSuccess: 0,
+    pathPaymentStrictReceiveMalformed: -1,
+    pathPaymentStrictReceiveUnderfunded: -2,
+    pathPaymentStrictReceiveSrcNoTrust: -3,
+    pathPaymentStrictReceiveSrcNotAuthorized: -4,
+    pathPaymentStrictReceiveNoDestination: -5,
+    pathPaymentStrictReceiveNoTrust: -6,
+    pathPaymentStrictReceiveNotAuthorized: -7,
+    pathPaymentStrictReceiveLineFull: -8,
+    pathPaymentStrictReceiveNoIssuer: -9,
+    pathPaymentStrictReceiveTooFewOffers: -10,
+    pathPaymentStrictReceiveOfferCrossSelf: -11,
+    pathPaymentStrictReceiveOverSendmax: -12,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SimplePaymentResult
+  //   {
+  //       AccountID destination;
+  //       Asset asset;
+  //       int64 amount;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("SimplePaymentResult", [
+    ["destination", xdr.lookup("AccountId")],
+    ["asset", xdr.lookup("Asset")],
+    ["amount", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           ClaimAtom offers<>;
+  //           SimplePaymentResult last;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("PathPaymentStrictReceiveResultSuccess", [
+    ["offers", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
+    ["last", xdr.lookup("SimplePaymentResult")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union PathPaymentStrictReceiveResult switch (
+  //       PathPaymentStrictReceiveResultCode code)
+  //   {
+  //   case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
+  //       struct
+  //       {
+  //           ClaimAtom offers<>;
+  //           SimplePaymentResult last;
+  //       } success;
+  //   case PATH_PAYMENT_STRICT_RECEIVE_MALFORMED:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL:
+  //       void;
+  //   case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
+  //       Asset noIssuer; // the asset that caused the error
+  //   case PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF:
+  //   case PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("PathPaymentStrictReceiveResult", {
+    switchOn: xdr.lookup("PathPaymentStrictReceiveResultCode"),
+    switchName: "code",
+    switches: [
+      ["pathPaymentStrictReceiveSuccess", "success"],
+      ["pathPaymentStrictReceiveMalformed", xdr.void()],
+      ["pathPaymentStrictReceiveUnderfunded", xdr.void()],
+      ["pathPaymentStrictReceiveSrcNoTrust", xdr.void()],
+      ["pathPaymentStrictReceiveSrcNotAuthorized", xdr.void()],
+      ["pathPaymentStrictReceiveNoDestination", xdr.void()],
+      ["pathPaymentStrictReceiveNoTrust", xdr.void()],
+      ["pathPaymentStrictReceiveNotAuthorized", xdr.void()],
+      ["pathPaymentStrictReceiveLineFull", xdr.void()],
+      ["pathPaymentStrictReceiveNoIssuer", "noIssuer"],
+      ["pathPaymentStrictReceiveTooFewOffers", xdr.void()],
+      ["pathPaymentStrictReceiveOfferCrossSelf", xdr.void()],
+      ["pathPaymentStrictReceiveOverSendmax", xdr.void()],
+    ],
+    arms: {
+      success: xdr.lookup("PathPaymentStrictReceiveResultSuccess"),
+      noIssuer: xdr.lookup("Asset"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum PathPaymentStrictSendResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
+  //
+  //       // codes considered as "failure" for the operation
+  //       PATH_PAYMENT_STRICT_SEND_MALFORMED = -1, // bad input
+  //       PATH_PAYMENT_STRICT_SEND_UNDERFUNDED =
+  //           -2, // not enough funds in source account
+  //       PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST =
+  //           -3, // no trust line on source account
+  //       PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED =
+  //           -4, // source not authorized to transfer
+  //       PATH_PAYMENT_STRICT_SEND_NO_DESTINATION =
+  //           -5, // destination account does not exist
+  //       PATH_PAYMENT_STRICT_SEND_NO_TRUST =
+  //           -6, // dest missing a trust line for asset
+  //       PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED =
+  //           -7, // dest not authorized to hold asset
+  //       PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8, // dest would go above their limit
+  //       PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9, // missing issuer on one asset
+  //       PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS =
+  //           -10, // not enough offers to satisfy path
+  //       PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF =
+  //           -11, // would cross one of its own offers
+  //       PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12 // could not satisfy destMin
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("PathPaymentStrictSendResultCode", {
+    pathPaymentStrictSendSuccess: 0,
+    pathPaymentStrictSendMalformed: -1,
+    pathPaymentStrictSendUnderfunded: -2,
+    pathPaymentStrictSendSrcNoTrust: -3,
+    pathPaymentStrictSendSrcNotAuthorized: -4,
+    pathPaymentStrictSendNoDestination: -5,
+    pathPaymentStrictSendNoTrust: -6,
+    pathPaymentStrictSendNotAuthorized: -7,
+    pathPaymentStrictSendLineFull: -8,
+    pathPaymentStrictSendNoIssuer: -9,
+    pathPaymentStrictSendTooFewOffers: -10,
+    pathPaymentStrictSendOfferCrossSelf: -11,
+    pathPaymentStrictSendUnderDestmin: -12,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           ClaimAtom offers<>;
+  //           SimplePaymentResult last;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("PathPaymentStrictSendResultSuccess", [
+    ["offers", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
+    ["last", xdr.lookup("SimplePaymentResult")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
+  //   {
+  //   case PATH_PAYMENT_STRICT_SEND_SUCCESS:
+  //       struct
+  //       {
+  //           ClaimAtom offers<>;
+  //           SimplePaymentResult last;
+  //       } success;
+  //   case PATH_PAYMENT_STRICT_SEND_MALFORMED:
+  //   case PATH_PAYMENT_STRICT_SEND_UNDERFUNDED:
+  //   case PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST:
+  //   case PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED:
+  //   case PATH_PAYMENT_STRICT_SEND_NO_DESTINATION:
+  //   case PATH_PAYMENT_STRICT_SEND_NO_TRUST:
+  //   case PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED:
+  //   case PATH_PAYMENT_STRICT_SEND_LINE_FULL:
+  //       void;
+  //   case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
+  //       Asset noIssuer; // the asset that caused the error
+  //   case PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS:
+  //   case PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF:
+  //   case PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("PathPaymentStrictSendResult", {
+    switchOn: xdr.lookup("PathPaymentStrictSendResultCode"),
+    switchName: "code",
+    switches: [
+      ["pathPaymentStrictSendSuccess", "success"],
+      ["pathPaymentStrictSendMalformed", xdr.void()],
+      ["pathPaymentStrictSendUnderfunded", xdr.void()],
+      ["pathPaymentStrictSendSrcNoTrust", xdr.void()],
+      ["pathPaymentStrictSendSrcNotAuthorized", xdr.void()],
+      ["pathPaymentStrictSendNoDestination", xdr.void()],
+      ["pathPaymentStrictSendNoTrust", xdr.void()],
+      ["pathPaymentStrictSendNotAuthorized", xdr.void()],
+      ["pathPaymentStrictSendLineFull", xdr.void()],
+      ["pathPaymentStrictSendNoIssuer", "noIssuer"],
+      ["pathPaymentStrictSendTooFewOffers", xdr.void()],
+      ["pathPaymentStrictSendOfferCrossSelf", xdr.void()],
+      ["pathPaymentStrictSendUnderDestmin", xdr.void()],
+    ],
+    arms: {
+      success: xdr.lookup("PathPaymentStrictSendResultSuccess"),
+      noIssuer: xdr.lookup("Asset"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ManageSellOfferResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       MANAGE_SELL_OFFER_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       MANAGE_SELL_OFFER_MALFORMED = -1, // generated offer would be invalid
+  //       MANAGE_SELL_OFFER_SELL_NO_TRUST =
+  //           -2,                              // no trust line for what we're selling
+  //       MANAGE_SELL_OFFER_BUY_NO_TRUST = -3, // no trust line for what we're buying
+  //       MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
+  //       MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
+  //       MANAGE_SELL_OFFER_LINE_FULL = -6, // can't receive more of what it's buying
+  //       MANAGE_SELL_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
+  //       MANAGE_SELL_OFFER_CROSS_SELF =
+  //           -8, // would cross an offer from the same user
+  //       MANAGE_SELL_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
+  //       MANAGE_SELL_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
+  //
+  //       // update errors
+  //       MANAGE_SELL_OFFER_NOT_FOUND =
+  //           -11, // offerID does not match an existing offer
+  //
+  //       MANAGE_SELL_OFFER_LOW_RESERVE =
+  //           -12 // not enough funds to create a new Offer
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ManageSellOfferResultCode", {
+    manageSellOfferSuccess: 0,
+    manageSellOfferMalformed: -1,
+    manageSellOfferSellNoTrust: -2,
+    manageSellOfferBuyNoTrust: -3,
+    manageSellOfferSellNotAuthorized: -4,
+    manageSellOfferBuyNotAuthorized: -5,
+    manageSellOfferLineFull: -6,
+    manageSellOfferUnderfunded: -7,
+    manageSellOfferCrossSelf: -8,
+    manageSellOfferSellNoIssuer: -9,
+    manageSellOfferBuyNoIssuer: -10,
+    manageSellOfferNotFound: -11,
+    manageSellOfferLowReserve: -12,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ManageOfferEffect
+  //   {
+  //       MANAGE_OFFER_CREATED = 0,
+  //       MANAGE_OFFER_UPDATED = 1,
+  //       MANAGE_OFFER_DELETED = 2
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ManageOfferEffect", {
+    manageOfferCreated: 0,
+    manageOfferUpdated: 1,
+    manageOfferDeleted: 2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (ManageOfferEffect effect)
+  //       {
+  //       case MANAGE_OFFER_CREATED:
+  //       case MANAGE_OFFER_UPDATED:
+  //           OfferEntry offer;
+  //       case MANAGE_OFFER_DELETED:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("ManageOfferSuccessResultOffer", {
+    switchOn: xdr.lookup("ManageOfferEffect"),
+    switchName: "effect",
+    switches: [
+      ["manageOfferCreated", "offer"],
+      ["manageOfferUpdated", "offer"],
+      ["manageOfferDeleted", xdr.void()],
+    ],
+    arms: {
+      offer: xdr.lookup("OfferEntry"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct ManageOfferSuccessResult
+  //   {
+  //       // offers that got claimed while creating this offer
+  //       ClaimAtom offersClaimed<>;
+  //
+  //       union switch (ManageOfferEffect effect)
+  //       {
+  //       case MANAGE_OFFER_CREATED:
+  //       case MANAGE_OFFER_UPDATED:
+  //           OfferEntry offer;
+  //       case MANAGE_OFFER_DELETED:
+  //           void;
+  //       }
+  //       offer;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ManageOfferSuccessResult", [
+    ["offersClaimed", xdr.varArray(xdr.lookup("ClaimAtom"), 2147483647)],
+    ["offer", xdr.lookup("ManageOfferSuccessResultOffer")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union ManageSellOfferResult switch (ManageSellOfferResultCode code)
+  //   {
+  //   case MANAGE_SELL_OFFER_SUCCESS:
+  //       ManageOfferSuccessResult success;
+  //   case MANAGE_SELL_OFFER_MALFORMED:
+  //   case MANAGE_SELL_OFFER_SELL_NO_TRUST:
+  //   case MANAGE_SELL_OFFER_BUY_NO_TRUST:
+  //   case MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED:
+  //   case MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED:
+  //   case MANAGE_SELL_OFFER_LINE_FULL:
+  //   case MANAGE_SELL_OFFER_UNDERFUNDED:
+  //   case MANAGE_SELL_OFFER_CROSS_SELF:
+  //   case MANAGE_SELL_OFFER_SELL_NO_ISSUER:
+  //   case MANAGE_SELL_OFFER_BUY_NO_ISSUER:
+  //   case MANAGE_SELL_OFFER_NOT_FOUND:
+  //   case MANAGE_SELL_OFFER_LOW_RESERVE:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ManageSellOfferResult", {
+    switchOn: xdr.lookup("ManageSellOfferResultCode"),
+    switchName: "code",
+    switches: [
+      ["manageSellOfferSuccess", "success"],
+      ["manageSellOfferMalformed", xdr.void()],
+      ["manageSellOfferSellNoTrust", xdr.void()],
+      ["manageSellOfferBuyNoTrust", xdr.void()],
+      ["manageSellOfferSellNotAuthorized", xdr.void()],
+      ["manageSellOfferBuyNotAuthorized", xdr.void()],
+      ["manageSellOfferLineFull", xdr.void()],
+      ["manageSellOfferUnderfunded", xdr.void()],
+      ["manageSellOfferCrossSelf", xdr.void()],
+      ["manageSellOfferSellNoIssuer", xdr.void()],
+      ["manageSellOfferBuyNoIssuer", xdr.void()],
+      ["manageSellOfferNotFound", xdr.void()],
+      ["manageSellOfferLowReserve", xdr.void()],
+    ],
+    arms: {
+      success: xdr.lookup("ManageOfferSuccessResult"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ManageBuyOfferResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       MANAGE_BUY_OFFER_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       MANAGE_BUY_OFFER_MALFORMED = -1,     // generated offer would be invalid
+  //       MANAGE_BUY_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
+  //       MANAGE_BUY_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
+  //       MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
+  //       MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
+  //       MANAGE_BUY_OFFER_LINE_FULL = -6,   // can't receive more of what it's buying
+  //       MANAGE_BUY_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
+  //       MANAGE_BUY_OFFER_CROSS_SELF = -8, // would cross an offer from the same user
+  //       MANAGE_BUY_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
+  //       MANAGE_BUY_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
+  //
+  //       // update errors
+  //       MANAGE_BUY_OFFER_NOT_FOUND =
+  //           -11, // offerID does not match an existing offer
+  //
+  //       MANAGE_BUY_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ManageBuyOfferResultCode", {
+    manageBuyOfferSuccess: 0,
+    manageBuyOfferMalformed: -1,
+    manageBuyOfferSellNoTrust: -2,
+    manageBuyOfferBuyNoTrust: -3,
+    manageBuyOfferSellNotAuthorized: -4,
+    manageBuyOfferBuyNotAuthorized: -5,
+    manageBuyOfferLineFull: -6,
+    manageBuyOfferUnderfunded: -7,
+    manageBuyOfferCrossSelf: -8,
+    manageBuyOfferSellNoIssuer: -9,
+    manageBuyOfferBuyNoIssuer: -10,
+    manageBuyOfferNotFound: -11,
+    manageBuyOfferLowReserve: -12,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ManageBuyOfferResult switch (ManageBuyOfferResultCode code)
+  //   {
+  //   case MANAGE_BUY_OFFER_SUCCESS:
+  //       ManageOfferSuccessResult success;
+  //   case MANAGE_BUY_OFFER_MALFORMED:
+  //   case MANAGE_BUY_OFFER_SELL_NO_TRUST:
+  //   case MANAGE_BUY_OFFER_BUY_NO_TRUST:
+  //   case MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED:
+  //   case MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED:
+  //   case MANAGE_BUY_OFFER_LINE_FULL:
+  //   case MANAGE_BUY_OFFER_UNDERFUNDED:
+  //   case MANAGE_BUY_OFFER_CROSS_SELF:
+  //   case MANAGE_BUY_OFFER_SELL_NO_ISSUER:
+  //   case MANAGE_BUY_OFFER_BUY_NO_ISSUER:
+  //   case MANAGE_BUY_OFFER_NOT_FOUND:
+  //   case MANAGE_BUY_OFFER_LOW_RESERVE:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ManageBuyOfferResult", {
+    switchOn: xdr.lookup("ManageBuyOfferResultCode"),
+    switchName: "code",
+    switches: [
+      ["manageBuyOfferSuccess", "success"],
+      ["manageBuyOfferMalformed", xdr.void()],
+      ["manageBuyOfferSellNoTrust", xdr.void()],
+      ["manageBuyOfferBuyNoTrust", xdr.void()],
+      ["manageBuyOfferSellNotAuthorized", xdr.void()],
+      ["manageBuyOfferBuyNotAuthorized", xdr.void()],
+      ["manageBuyOfferLineFull", xdr.void()],
+      ["manageBuyOfferUnderfunded", xdr.void()],
+      ["manageBuyOfferCrossSelf", xdr.void()],
+      ["manageBuyOfferSellNoIssuer", xdr.void()],
+      ["manageBuyOfferBuyNoIssuer", xdr.void()],
+      ["manageBuyOfferNotFound", xdr.void()],
+      ["manageBuyOfferLowReserve", xdr.void()],
+    ],
+    arms: {
+      success: xdr.lookup("ManageOfferSuccessResult"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SetOptionsResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       SET_OPTIONS_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       SET_OPTIONS_LOW_RESERVE = -1,      // not enough funds to add a signer
+  //       SET_OPTIONS_TOO_MANY_SIGNERS = -2, // max number of signers already reached
+  //       SET_OPTIONS_BAD_FLAGS = -3,        // invalid combination of clear/set flags
+  //       SET_OPTIONS_INVALID_INFLATION = -4,      // inflation account does not exist
+  //       SET_OPTIONS_CANT_CHANGE = -5,            // can no longer change this option
+  //       SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
+  //       SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
+  //       SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
+  //       SET_OPTIONS_INVALID_HOME_DOMAIN = -9,    // malformed home domain
+  //       SET_OPTIONS_AUTH_REVOCABLE_REQUIRED =
+  //           -10 // auth revocable is required for clawback
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("SetOptionsResultCode", {
+    setOptionsSuccess: 0,
+    setOptionsLowReserve: -1,
+    setOptionsTooManySigners: -2,
+    setOptionsBadFlags: -3,
+    setOptionsInvalidInflation: -4,
+    setOptionsCantChange: -5,
+    setOptionsUnknownFlag: -6,
+    setOptionsThresholdOutOfRange: -7,
+    setOptionsBadSigner: -8,
+    setOptionsInvalidHomeDomain: -9,
+    setOptionsAuthRevocableRequired: -10,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union SetOptionsResult switch (SetOptionsResultCode code)
+  //   {
+  //   case SET_OPTIONS_SUCCESS:
+  //       void;
+  //   case SET_OPTIONS_LOW_RESERVE:
+  //   case SET_OPTIONS_TOO_MANY_SIGNERS:
+  //   case SET_OPTIONS_BAD_FLAGS:
+  //   case SET_OPTIONS_INVALID_INFLATION:
+  //   case SET_OPTIONS_CANT_CHANGE:
+  //   case SET_OPTIONS_UNKNOWN_FLAG:
+  //   case SET_OPTIONS_THRESHOLD_OUT_OF_RANGE:
+  //   case SET_OPTIONS_BAD_SIGNER:
+  //   case SET_OPTIONS_INVALID_HOME_DOMAIN:
+  //   case SET_OPTIONS_AUTH_REVOCABLE_REQUIRED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("SetOptionsResult", {
+    switchOn: xdr.lookup("SetOptionsResultCode"),
+    switchName: "code",
+    switches: [
+      ["setOptionsSuccess", xdr.void()],
+      ["setOptionsLowReserve", xdr.void()],
+      ["setOptionsTooManySigners", xdr.void()],
+      ["setOptionsBadFlags", xdr.void()],
+      ["setOptionsInvalidInflation", xdr.void()],
+      ["setOptionsCantChange", xdr.void()],
+      ["setOptionsUnknownFlag", xdr.void()],
+      ["setOptionsThresholdOutOfRange", xdr.void()],
+      ["setOptionsBadSigner", xdr.void()],
+      ["setOptionsInvalidHomeDomain", xdr.void()],
+      ["setOptionsAuthRevocableRequired", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ChangeTrustResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       CHANGE_TRUST_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       CHANGE_TRUST_MALFORMED = -1,     // bad input
+  //       CHANGE_TRUST_NO_ISSUER = -2,     // could not find issuer
+  //       CHANGE_TRUST_INVALID_LIMIT = -3, // cannot drop limit below balance
+  //                                        // cannot create with a limit of 0
+  //       CHANGE_TRUST_LOW_RESERVE =
+  //           -4, // not enough funds to create a new trust line,
+  //       CHANGE_TRUST_SELF_NOT_ALLOWED = -5,   // trusting self is not allowed
+  //       CHANGE_TRUST_TRUST_LINE_MISSING = -6, // Asset trustline is missing for pool
+  //       CHANGE_TRUST_CANNOT_DELETE =
+  //           -7, // Asset trustline is still referenced in a pool
+  //       CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES =
+  //           -8 // Asset trustline is deauthorized
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ChangeTrustResultCode", {
+    changeTrustSuccess: 0,
+    changeTrustMalformed: -1,
+    changeTrustNoIssuer: -2,
+    changeTrustInvalidLimit: -3,
+    changeTrustLowReserve: -4,
+    changeTrustSelfNotAllowed: -5,
+    changeTrustTrustLineMissing: -6,
+    changeTrustCannotDelete: -7,
+    changeTrustNotAuthMaintainLiabilities: -8,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ChangeTrustResult switch (ChangeTrustResultCode code)
+  //   {
+  //   case CHANGE_TRUST_SUCCESS:
+  //       void;
+  //   case CHANGE_TRUST_MALFORMED:
+  //   case CHANGE_TRUST_NO_ISSUER:
+  //   case CHANGE_TRUST_INVALID_LIMIT:
+  //   case CHANGE_TRUST_LOW_RESERVE:
+  //   case CHANGE_TRUST_SELF_NOT_ALLOWED:
+  //   case CHANGE_TRUST_TRUST_LINE_MISSING:
+  //   case CHANGE_TRUST_CANNOT_DELETE:
+  //   case CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ChangeTrustResult", {
+    switchOn: xdr.lookup("ChangeTrustResultCode"),
+    switchName: "code",
+    switches: [
+      ["changeTrustSuccess", xdr.void()],
+      ["changeTrustMalformed", xdr.void()],
+      ["changeTrustNoIssuer", xdr.void()],
+      ["changeTrustInvalidLimit", xdr.void()],
+      ["changeTrustLowReserve", xdr.void()],
+      ["changeTrustSelfNotAllowed", xdr.void()],
+      ["changeTrustTrustLineMissing", xdr.void()],
+      ["changeTrustCannotDelete", xdr.void()],
+      ["changeTrustNotAuthMaintainLiabilities", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum AllowTrustResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       ALLOW_TRUST_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       ALLOW_TRUST_MALFORMED = -1,     // asset is not ASSET_TYPE_ALPHANUM
+  //       ALLOW_TRUST_NO_TRUST_LINE = -2, // trustor does not have a trustline
+  //                                       // source account does not require trust
+  //       ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
+  //       ALLOW_TRUST_CANT_REVOKE = -4,      // source account can't revoke trust,
+  //       ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
+  //       ALLOW_TRUST_LOW_RESERVE = -6       // claimable balances can't be created
+  //                                          // on revoke due to low reserves
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("AllowTrustResultCode", {
+    allowTrustSuccess: 0,
+    allowTrustMalformed: -1,
+    allowTrustNoTrustLine: -2,
+    allowTrustTrustNotRequired: -3,
+    allowTrustCantRevoke: -4,
+    allowTrustSelfNotAllowed: -5,
+    allowTrustLowReserve: -6,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union AllowTrustResult switch (AllowTrustResultCode code)
+  //   {
+  //   case ALLOW_TRUST_SUCCESS:
+  //       void;
+  //   case ALLOW_TRUST_MALFORMED:
+  //   case ALLOW_TRUST_NO_TRUST_LINE:
+  //   case ALLOW_TRUST_TRUST_NOT_REQUIRED:
+  //   case ALLOW_TRUST_CANT_REVOKE:
+  //   case ALLOW_TRUST_SELF_NOT_ALLOWED:
+  //   case ALLOW_TRUST_LOW_RESERVE:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("AllowTrustResult", {
+    switchOn: xdr.lookup("AllowTrustResultCode"),
+    switchName: "code",
+    switches: [
+      ["allowTrustSuccess", xdr.void()],
+      ["allowTrustMalformed", xdr.void()],
+      ["allowTrustNoTrustLine", xdr.void()],
+      ["allowTrustTrustNotRequired", xdr.void()],
+      ["allowTrustCantRevoke", xdr.void()],
+      ["allowTrustSelfNotAllowed", xdr.void()],
+      ["allowTrustLowReserve", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum AccountMergeResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       ACCOUNT_MERGE_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       ACCOUNT_MERGE_MALFORMED = -1,       // can't merge onto itself
+  //       ACCOUNT_MERGE_NO_ACCOUNT = -2,      // destination does not exist
+  //       ACCOUNT_MERGE_IMMUTABLE_SET = -3,   // source account has AUTH_IMMUTABLE set
+  //       ACCOUNT_MERGE_HAS_SUB_ENTRIES = -4, // account has trust lines/offers
+  //       ACCOUNT_MERGE_SEQNUM_TOO_FAR = -5,  // sequence number is over max allowed
+  //       ACCOUNT_MERGE_DEST_FULL = -6,       // can't add source balance to
+  //                                           // destination balance
+  //       ACCOUNT_MERGE_IS_SPONSOR = -7       // can't merge account that is a sponsor
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("AccountMergeResultCode", {
+    accountMergeSuccess: 0,
+    accountMergeMalformed: -1,
+    accountMergeNoAccount: -2,
+    accountMergeImmutableSet: -3,
+    accountMergeHasSubEntries: -4,
+    accountMergeSeqnumTooFar: -5,
+    accountMergeDestFull: -6,
+    accountMergeIsSponsor: -7,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union AccountMergeResult switch (AccountMergeResultCode code)
+  //   {
+  //   case ACCOUNT_MERGE_SUCCESS:
+  //       int64 sourceAccountBalance; // how much got transferred from source account
+  //   case ACCOUNT_MERGE_MALFORMED:
+  //   case ACCOUNT_MERGE_NO_ACCOUNT:
+  //   case ACCOUNT_MERGE_IMMUTABLE_SET:
+  //   case ACCOUNT_MERGE_HAS_SUB_ENTRIES:
+  //   case ACCOUNT_MERGE_SEQNUM_TOO_FAR:
+  //   case ACCOUNT_MERGE_DEST_FULL:
+  //   case ACCOUNT_MERGE_IS_SPONSOR:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("AccountMergeResult", {
+    switchOn: xdr.lookup("AccountMergeResultCode"),
+    switchName: "code",
+    switches: [
+      ["accountMergeSuccess", "sourceAccountBalance"],
+      ["accountMergeMalformed", xdr.void()],
+      ["accountMergeNoAccount", xdr.void()],
+      ["accountMergeImmutableSet", xdr.void()],
+      ["accountMergeHasSubEntries", xdr.void()],
+      ["accountMergeSeqnumTooFar", xdr.void()],
+      ["accountMergeDestFull", xdr.void()],
+      ["accountMergeIsSponsor", xdr.void()],
+    ],
+    arms: {
+      sourceAccountBalance: xdr.lookup("Int64"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum InflationResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       INFLATION_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       INFLATION_NOT_TIME = -1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("InflationResultCode", {
+    inflationSuccess: 0,
+    inflationNotTime: -1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct InflationPayout // or use PaymentResultAtom to limit types?
+  //   {
+  //       AccountID destination;
+  //       int64 amount;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("InflationPayout", [
+    ["destination", xdr.lookup("AccountId")],
+    ["amount", xdr.lookup("Int64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union InflationResult switch (InflationResultCode code)
+  //   {
+  //   case INFLATION_SUCCESS:
+  //       InflationPayout payouts<>;
+  //   case INFLATION_NOT_TIME:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("InflationResult", {
+    switchOn: xdr.lookup("InflationResultCode"),
+    switchName: "code",
+    switches: [
+      ["inflationSuccess", "payouts"],
+      ["inflationNotTime", xdr.void()],
+    ],
+    arms: {
+      payouts: xdr.varArray(xdr.lookup("InflationPayout"), 2147483647),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ManageDataResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       MANAGE_DATA_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       MANAGE_DATA_NOT_SUPPORTED_YET =
+  //           -1, // The network hasn't moved to this protocol change yet
+  //       MANAGE_DATA_NAME_NOT_FOUND =
+  //           -2, // Trying to remove a Data Entry that isn't there
+  //       MANAGE_DATA_LOW_RESERVE = -3, // not enough funds to create a new Data Entry
+  //       MANAGE_DATA_INVALID_NAME = -4 // Name not a valid string
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ManageDataResultCode", {
+    manageDataSuccess: 0,
+    manageDataNotSupportedYet: -1,
+    manageDataNameNotFound: -2,
+    manageDataLowReserve: -3,
+    manageDataInvalidName: -4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ManageDataResult switch (ManageDataResultCode code)
+  //   {
+  //   case MANAGE_DATA_SUCCESS:
+  //       void;
+  //   case MANAGE_DATA_NOT_SUPPORTED_YET:
+  //   case MANAGE_DATA_NAME_NOT_FOUND:
+  //   case MANAGE_DATA_LOW_RESERVE:
+  //   case MANAGE_DATA_INVALID_NAME:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ManageDataResult", {
+    switchOn: xdr.lookup("ManageDataResultCode"),
+    switchName: "code",
+    switches: [
+      ["manageDataSuccess", xdr.void()],
+      ["manageDataNotSupportedYet", xdr.void()],
+      ["manageDataNameNotFound", xdr.void()],
+      ["manageDataLowReserve", xdr.void()],
+      ["manageDataInvalidName", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum BumpSequenceResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       BUMP_SEQUENCE_SUCCESS = 0,
+  //       // codes considered as "failure" for the operation
+  //       BUMP_SEQUENCE_BAD_SEQ = -1 // `bumpTo` is not within bounds
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("BumpSequenceResultCode", {
+    bumpSequenceSuccess: 0,
+    bumpSequenceBadSeq: -1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union BumpSequenceResult switch (BumpSequenceResultCode code)
+  //   {
+  //   case BUMP_SEQUENCE_SUCCESS:
+  //       void;
+  //   case BUMP_SEQUENCE_BAD_SEQ:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("BumpSequenceResult", {
+    switchOn: xdr.lookup("BumpSequenceResultCode"),
+    switchName: "code",
+    switches: [
+      ["bumpSequenceSuccess", xdr.void()],
+      ["bumpSequenceBadSeq", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum CreateClaimableBalanceResultCode
+  //   {
+  //       CREATE_CLAIMABLE_BALANCE_SUCCESS = 0,
+  //       CREATE_CLAIMABLE_BALANCE_MALFORMED = -1,
+  //       CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
+  //       CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
+  //       CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
+  //       CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("CreateClaimableBalanceResultCode", {
+    createClaimableBalanceSuccess: 0,
+    createClaimableBalanceMalformed: -1,
+    createClaimableBalanceLowReserve: -2,
+    createClaimableBalanceNoTrust: -3,
+    createClaimableBalanceNotAuthorized: -4,
+    createClaimableBalanceUnderfunded: -5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union CreateClaimableBalanceResult switch (
+  //       CreateClaimableBalanceResultCode code)
+  //   {
+  //   case CREATE_CLAIMABLE_BALANCE_SUCCESS:
+  //       ClaimableBalanceID balanceID;
+  //   case CREATE_CLAIMABLE_BALANCE_MALFORMED:
+  //   case CREATE_CLAIMABLE_BALANCE_LOW_RESERVE:
+  //   case CREATE_CLAIMABLE_BALANCE_NO_TRUST:
+  //   case CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
+  //   case CREATE_CLAIMABLE_BALANCE_UNDERFUNDED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("CreateClaimableBalanceResult", {
+    switchOn: xdr.lookup("CreateClaimableBalanceResultCode"),
+    switchName: "code",
+    switches: [
+      ["createClaimableBalanceSuccess", "balanceId"],
+      ["createClaimableBalanceMalformed", xdr.void()],
+      ["createClaimableBalanceLowReserve", xdr.void()],
+      ["createClaimableBalanceNoTrust", xdr.void()],
+      ["createClaimableBalanceNotAuthorized", xdr.void()],
+      ["createClaimableBalanceUnderfunded", xdr.void()],
+    ],
+    arms: {
+      balanceId: xdr.lookup("ClaimableBalanceId"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClaimClaimableBalanceResultCode
+  //   {
+  //       CLAIM_CLAIMABLE_BALANCE_SUCCESS = 0,
+  //       CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
+  //       CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM = -2,
+  //       CLAIM_CLAIMABLE_BALANCE_LINE_FULL = -3,
+  //       CLAIM_CLAIMABLE_BALANCE_NO_TRUST = -4,
+  //       CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClaimClaimableBalanceResultCode", {
+    claimClaimableBalanceSuccess: 0,
+    claimClaimableBalanceDoesNotExist: -1,
+    claimClaimableBalanceCannotClaim: -2,
+    claimClaimableBalanceLineFull: -3,
+    claimClaimableBalanceNoTrust: -4,
+    claimClaimableBalanceNotAuthorized: -5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ClaimClaimableBalanceResult switch (ClaimClaimableBalanceResultCode code)
+  //   {
+  //   case CLAIM_CLAIMABLE_BALANCE_SUCCESS:
+  //       void;
+  //   case CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
+  //   case CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM:
+  //   case CLAIM_CLAIMABLE_BALANCE_LINE_FULL:
+  //   case CLAIM_CLAIMABLE_BALANCE_NO_TRUST:
+  //   case CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClaimClaimableBalanceResult", {
+    switchOn: xdr.lookup("ClaimClaimableBalanceResultCode"),
+    switchName: "code",
+    switches: [
+      ["claimClaimableBalanceSuccess", xdr.void()],
+      ["claimClaimableBalanceDoesNotExist", xdr.void()],
+      ["claimClaimableBalanceCannotClaim", xdr.void()],
+      ["claimClaimableBalanceLineFull", xdr.void()],
+      ["claimClaimableBalanceNoTrust", xdr.void()],
+      ["claimClaimableBalanceNotAuthorized", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum BeginSponsoringFutureReservesResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED = -1,
+  //       BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED = -2,
+  //       BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE = -3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("BeginSponsoringFutureReservesResultCode", {
+    beginSponsoringFutureReservesSuccess: 0,
+    beginSponsoringFutureReservesMalformed: -1,
+    beginSponsoringFutureReservesAlreadySponsored: -2,
+    beginSponsoringFutureReservesRecursive: -3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union BeginSponsoringFutureReservesResult switch (
+  //       BeginSponsoringFutureReservesResultCode code)
+  //   {
+  //   case BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS:
+  //       void;
+  //   case BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED:
+  //   case BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED:
+  //   case BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("BeginSponsoringFutureReservesResult", {
+    switchOn: xdr.lookup("BeginSponsoringFutureReservesResultCode"),
+    switchName: "code",
+    switches: [
+      ["beginSponsoringFutureReservesSuccess", xdr.void()],
+      ["beginSponsoringFutureReservesMalformed", xdr.void()],
+      ["beginSponsoringFutureReservesAlreadySponsored", xdr.void()],
+      ["beginSponsoringFutureReservesRecursive", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum EndSponsoringFutureReservesResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       END_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED = -1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("EndSponsoringFutureReservesResultCode", {
+    endSponsoringFutureReservesSuccess: 0,
+    endSponsoringFutureReservesNotSponsored: -1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union EndSponsoringFutureReservesResult switch (
+  //       EndSponsoringFutureReservesResultCode code)
+  //   {
+  //   case END_SPONSORING_FUTURE_RESERVES_SUCCESS:
+  //       void;
+  //   case END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("EndSponsoringFutureReservesResult", {
+    switchOn: xdr.lookup("EndSponsoringFutureReservesResultCode"),
+    switchName: "code",
+    switches: [
+      ["endSponsoringFutureReservesSuccess", xdr.void()],
+      ["endSponsoringFutureReservesNotSponsored", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum RevokeSponsorshipResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       REVOKE_SPONSORSHIP_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       REVOKE_SPONSORSHIP_DOES_NOT_EXIST = -1,
+  //       REVOKE_SPONSORSHIP_NOT_SPONSOR = -2,
+  //       REVOKE_SPONSORSHIP_LOW_RESERVE = -3,
+  //       REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE = -4,
+  //       REVOKE_SPONSORSHIP_MALFORMED = -5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("RevokeSponsorshipResultCode", {
+    revokeSponsorshipSuccess: 0,
+    revokeSponsorshipDoesNotExist: -1,
+    revokeSponsorshipNotSponsor: -2,
+    revokeSponsorshipLowReserve: -3,
+    revokeSponsorshipOnlyTransferable: -4,
+    revokeSponsorshipMalformed: -5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union RevokeSponsorshipResult switch (RevokeSponsorshipResultCode code)
+  //   {
+  //   case REVOKE_SPONSORSHIP_SUCCESS:
+  //       void;
+  //   case REVOKE_SPONSORSHIP_DOES_NOT_EXIST:
+  //   case REVOKE_SPONSORSHIP_NOT_SPONSOR:
+  //   case REVOKE_SPONSORSHIP_LOW_RESERVE:
+  //   case REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE:
+  //   case REVOKE_SPONSORSHIP_MALFORMED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("RevokeSponsorshipResult", {
+    switchOn: xdr.lookup("RevokeSponsorshipResultCode"),
+    switchName: "code",
+    switches: [
+      ["revokeSponsorshipSuccess", xdr.void()],
+      ["revokeSponsorshipDoesNotExist", xdr.void()],
+      ["revokeSponsorshipNotSponsor", xdr.void()],
+      ["revokeSponsorshipLowReserve", xdr.void()],
+      ["revokeSponsorshipOnlyTransferable", xdr.void()],
+      ["revokeSponsorshipMalformed", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClawbackResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       CLAWBACK_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       CLAWBACK_MALFORMED = -1,
+  //       CLAWBACK_NOT_CLAWBACK_ENABLED = -2,
+  //       CLAWBACK_NO_TRUST = -3,
+  //       CLAWBACK_UNDERFUNDED = -4
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClawbackResultCode", {
+    clawbackSuccess: 0,
+    clawbackMalformed: -1,
+    clawbackNotClawbackEnabled: -2,
+    clawbackNoTrust: -3,
+    clawbackUnderfunded: -4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ClawbackResult switch (ClawbackResultCode code)
+  //   {
+  //   case CLAWBACK_SUCCESS:
+  //       void;
+  //   case CLAWBACK_MALFORMED:
+  //   case CLAWBACK_NOT_CLAWBACK_ENABLED:
+  //   case CLAWBACK_NO_TRUST:
+  //   case CLAWBACK_UNDERFUNDED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClawbackResult", {
+    switchOn: xdr.lookup("ClawbackResultCode"),
+    switchName: "code",
+    switches: [
+      ["clawbackSuccess", xdr.void()],
+      ["clawbackMalformed", xdr.void()],
+      ["clawbackNotClawbackEnabled", xdr.void()],
+      ["clawbackNoTrust", xdr.void()],
+      ["clawbackUnderfunded", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum ClawbackClaimableBalanceResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       CLAWBACK_CLAIMABLE_BALANCE_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
+  //       CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER = -2,
+  //       CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED = -3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ClawbackClaimableBalanceResultCode", {
+    clawbackClaimableBalanceSuccess: 0,
+    clawbackClaimableBalanceDoesNotExist: -1,
+    clawbackClaimableBalanceNotIssuer: -2,
+    clawbackClaimableBalanceNotClawbackEnabled: -3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union ClawbackClaimableBalanceResult switch (
+  //       ClawbackClaimableBalanceResultCode code)
+  //   {
+  //   case CLAWBACK_CLAIMABLE_BALANCE_SUCCESS:
+  //       void;
+  //   case CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
+  //   case CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER:
+  //   case CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ClawbackClaimableBalanceResult", {
+    switchOn: xdr.lookup("ClawbackClaimableBalanceResultCode"),
+    switchName: "code",
+    switches: [
+      ["clawbackClaimableBalanceSuccess", xdr.void()],
+      ["clawbackClaimableBalanceDoesNotExist", xdr.void()],
+      ["clawbackClaimableBalanceNotIssuer", xdr.void()],
+      ["clawbackClaimableBalanceNotClawbackEnabled", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SetTrustLineFlagsResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       SET_TRUST_LINE_FLAGS_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       SET_TRUST_LINE_FLAGS_MALFORMED = -1,
+  //       SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
+  //       SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
+  //       SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
+  //       SET_TRUST_LINE_FLAGS_LOW_RESERVE = -5 // claimable balances can't be created
+  //                                             // on revoke due to low reserves
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("SetTrustLineFlagsResultCode", {
+    setTrustLineFlagsSuccess: 0,
+    setTrustLineFlagsMalformed: -1,
+    setTrustLineFlagsNoTrustLine: -2,
+    setTrustLineFlagsCantRevoke: -3,
+    setTrustLineFlagsInvalidState: -4,
+    setTrustLineFlagsLowReserve: -5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
+  //   {
+  //   case SET_TRUST_LINE_FLAGS_SUCCESS:
+  //       void;
+  //   case SET_TRUST_LINE_FLAGS_MALFORMED:
+  //   case SET_TRUST_LINE_FLAGS_NO_TRUST_LINE:
+  //   case SET_TRUST_LINE_FLAGS_CANT_REVOKE:
+  //   case SET_TRUST_LINE_FLAGS_INVALID_STATE:
+  //   case SET_TRUST_LINE_FLAGS_LOW_RESERVE:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("SetTrustLineFlagsResult", {
+    switchOn: xdr.lookup("SetTrustLineFlagsResultCode"),
+    switchName: "code",
+    switches: [
+      ["setTrustLineFlagsSuccess", xdr.void()],
+      ["setTrustLineFlagsMalformed", xdr.void()],
+      ["setTrustLineFlagsNoTrustLine", xdr.void()],
+      ["setTrustLineFlagsCantRevoke", xdr.void()],
+      ["setTrustLineFlagsInvalidState", xdr.void()],
+      ["setTrustLineFlagsLowReserve", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum LiquidityPoolDepositResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       LIQUIDITY_POOL_DEPOSIT_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       LIQUIDITY_POOL_DEPOSIT_MALFORMED = -1,      // bad input
+  //       LIQUIDITY_POOL_DEPOSIT_NO_TRUST = -2,       // no trust line for one of the
+  //                                                   // assets
+  //       LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED = -3, // not authorized for one of the
+  //                                                   // assets
+  //       LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED = -4,    // not enough balance for one of
+  //                                                   // the assets
+  //       LIQUIDITY_POOL_DEPOSIT_LINE_FULL = -5,      // pool share trust line doesn't
+  //                                                   // have sufficient limit
+  //       LIQUIDITY_POOL_DEPOSIT_BAD_PRICE = -6,      // deposit price outside bounds
+  //       LIQUIDITY_POOL_DEPOSIT_POOL_FULL = -7       // pool reserves are full
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LiquidityPoolDepositResultCode", {
+    liquidityPoolDepositSuccess: 0,
+    liquidityPoolDepositMalformed: -1,
+    liquidityPoolDepositNoTrust: -2,
+    liquidityPoolDepositNotAuthorized: -3,
+    liquidityPoolDepositUnderfunded: -4,
+    liquidityPoolDepositLineFull: -5,
+    liquidityPoolDepositBadPrice: -6,
+    liquidityPoolDepositPoolFull: -7,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union LiquidityPoolDepositResult switch (LiquidityPoolDepositResultCode code)
+  //   {
+  //   case LIQUIDITY_POOL_DEPOSIT_SUCCESS:
+  //       void;
+  //   case LIQUIDITY_POOL_DEPOSIT_MALFORMED:
+  //   case LIQUIDITY_POOL_DEPOSIT_NO_TRUST:
+  //   case LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED:
+  //   case LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED:
+  //   case LIQUIDITY_POOL_DEPOSIT_LINE_FULL:
+  //   case LIQUIDITY_POOL_DEPOSIT_BAD_PRICE:
+  //   case LIQUIDITY_POOL_DEPOSIT_POOL_FULL:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LiquidityPoolDepositResult", {
+    switchOn: xdr.lookup("LiquidityPoolDepositResultCode"),
+    switchName: "code",
+    switches: [
+      ["liquidityPoolDepositSuccess", xdr.void()],
+      ["liquidityPoolDepositMalformed", xdr.void()],
+      ["liquidityPoolDepositNoTrust", xdr.void()],
+      ["liquidityPoolDepositNotAuthorized", xdr.void()],
+      ["liquidityPoolDepositUnderfunded", xdr.void()],
+      ["liquidityPoolDepositLineFull", xdr.void()],
+      ["liquidityPoolDepositBadPrice", xdr.void()],
+      ["liquidityPoolDepositPoolFull", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum LiquidityPoolWithdrawResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       LIQUIDITY_POOL_WITHDRAW_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       LIQUIDITY_POOL_WITHDRAW_MALFORMED = -1,    // bad input
+  //       LIQUIDITY_POOL_WITHDRAW_NO_TRUST = -2,     // no trust line for one of the
+  //                                                  // assets
+  //       LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED = -3,  // not enough balance of the
+  //                                                  // pool share
+  //       LIQUIDITY_POOL_WITHDRAW_LINE_FULL = -4,    // would go above limit for one
+  //                                                  // of the assets
+  //       LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM = -5 // didn't withdraw enough
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("LiquidityPoolWithdrawResultCode", {
+    liquidityPoolWithdrawSuccess: 0,
+    liquidityPoolWithdrawMalformed: -1,
+    liquidityPoolWithdrawNoTrust: -2,
+    liquidityPoolWithdrawUnderfunded: -3,
+    liquidityPoolWithdrawLineFull: -4,
+    liquidityPoolWithdrawUnderMinimum: -5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union LiquidityPoolWithdrawResult switch (LiquidityPoolWithdrawResultCode code)
+  //   {
+  //   case LIQUIDITY_POOL_WITHDRAW_SUCCESS:
+  //       void;
+  //   case LIQUIDITY_POOL_WITHDRAW_MALFORMED:
+  //   case LIQUIDITY_POOL_WITHDRAW_NO_TRUST:
+  //   case LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED:
+  //   case LIQUIDITY_POOL_WITHDRAW_LINE_FULL:
+  //   case LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("LiquidityPoolWithdrawResult", {
+    switchOn: xdr.lookup("LiquidityPoolWithdrawResultCode"),
+    switchName: "code",
+    switches: [
+      ["liquidityPoolWithdrawSuccess", xdr.void()],
+      ["liquidityPoolWithdrawMalformed", xdr.void()],
+      ["liquidityPoolWithdrawNoTrust", xdr.void()],
+      ["liquidityPoolWithdrawUnderfunded", xdr.void()],
+      ["liquidityPoolWithdrawLineFull", xdr.void()],
+      ["liquidityPoolWithdrawUnderMinimum", xdr.void()],
+    ],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum InvokeHostFunctionResultCode
+  //   {
+  //       // codes considered as "success" for the operation
+  //       INVOKE_HOST_FUNCTION_SUCCESS = 0,
+  //
+  //       // codes considered as "failure" for the operation
+  //       INVOKE_HOST_FUNCTION_MALFORMED = -1,
+  //       INVOKE_HOST_FUNCTION_TRAPPED = -2
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("InvokeHostFunctionResultCode", {
+    invokeHostFunctionSuccess: 0,
+    invokeHostFunctionMalformed: -1,
+    invokeHostFunctionTrapped: -2,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union InvokeHostFunctionResult switch (InvokeHostFunctionResultCode code)
+  //   {
+  //   case INVOKE_HOST_FUNCTION_SUCCESS:
+  //       SCVal success;
+  //   case INVOKE_HOST_FUNCTION_MALFORMED:
+  //   case INVOKE_HOST_FUNCTION_TRAPPED:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("InvokeHostFunctionResult", {
+    switchOn: xdr.lookup("InvokeHostFunctionResultCode"),
+    switchName: "code",
+    switches: [
+      ["invokeHostFunctionSuccess", "success"],
+      ["invokeHostFunctionMalformed", xdr.void()],
+      ["invokeHostFunctionTrapped", xdr.void()],
+    ],
+    arms: {
+      success: xdr.lookup("ScVal"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum OperationResultCode
+  //   {
+  //       opINNER = 0, // inner object result is valid
+  //
+  //       opBAD_AUTH = -1,            // too few valid signatures / wrong network
+  //       opNO_ACCOUNT = -2,          // source account was not found
+  //       opNOT_SUPPORTED = -3,       // operation not supported at this time
+  //       opTOO_MANY_SUBENTRIES = -4, // max number of subentries already reached
+  //       opEXCEEDED_WORK_LIMIT = -5, // operation did too much work
+  //       opTOO_MANY_SPONSORING = -6  // account is sponsoring too many entries
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("OperationResultCode", {
+    opInner: 0,
+    opBadAuth: -1,
+    opNoAccount: -2,
+    opNotSupported: -3,
+    opTooManySubentries: -4,
+    opExceededWorkLimit: -5,
+    opTooManySponsoring: -6,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (OperationType type)
+  //       {
+  //       case CREATE_ACCOUNT:
+  //           CreateAccountResult createAccountResult;
+  //       case PAYMENT:
+  //           PaymentResult paymentResult;
+  //       case PATH_PAYMENT_STRICT_RECEIVE:
+  //           PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
+  //       case MANAGE_SELL_OFFER:
+  //           ManageSellOfferResult manageSellOfferResult;
+  //       case CREATE_PASSIVE_SELL_OFFER:
+  //           ManageSellOfferResult createPassiveSellOfferResult;
+  //       case SET_OPTIONS:
+  //           SetOptionsResult setOptionsResult;
+  //       case CHANGE_TRUST:
+  //           ChangeTrustResult changeTrustResult;
+  //       case ALLOW_TRUST:
+  //           AllowTrustResult allowTrustResult;
+  //       case ACCOUNT_MERGE:
+  //           AccountMergeResult accountMergeResult;
+  //       case INFLATION:
+  //           InflationResult inflationResult;
+  //       case MANAGE_DATA:
+  //           ManageDataResult manageDataResult;
+  //       case BUMP_SEQUENCE:
+  //           BumpSequenceResult bumpSeqResult;
+  //       case MANAGE_BUY_OFFER:
+  //           ManageBuyOfferResult manageBuyOfferResult;
+  //       case PATH_PAYMENT_STRICT_SEND:
+  //           PathPaymentStrictSendResult pathPaymentStrictSendResult;
+  //       case CREATE_CLAIMABLE_BALANCE:
+  //           CreateClaimableBalanceResult createClaimableBalanceResult;
+  //       case CLAIM_CLAIMABLE_BALANCE:
+  //           ClaimClaimableBalanceResult claimClaimableBalanceResult;
+  //       case BEGIN_SPONSORING_FUTURE_RESERVES:
+  //           BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
+  //       case END_SPONSORING_FUTURE_RESERVES:
+  //           EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
+  //       case REVOKE_SPONSORSHIP:
+  //           RevokeSponsorshipResult revokeSponsorshipResult;
+  //       case CLAWBACK:
+  //           ClawbackResult clawbackResult;
+  //       case CLAWBACK_CLAIMABLE_BALANCE:
+  //           ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
+  //       case SET_TRUST_LINE_FLAGS:
+  //           SetTrustLineFlagsResult setTrustLineFlagsResult;
+  //       case LIQUIDITY_POOL_DEPOSIT:
+  //           LiquidityPoolDepositResult liquidityPoolDepositResult;
+  //       case LIQUIDITY_POOL_WITHDRAW:
+  //           LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
+  //       case INVOKE_HOST_FUNCTION:
+  //           InvokeHostFunctionResult invokeHostFunctionResult;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("OperationResultTr", {
+    switchOn: xdr.lookup("OperationType"),
+    switchName: "type",
+    switches: [
+      ["createAccount", "createAccountResult"],
+      ["payment", "paymentResult"],
+      ["pathPaymentStrictReceive", "pathPaymentStrictReceiveResult"],
+      ["manageSellOffer", "manageSellOfferResult"],
+      ["createPassiveSellOffer", "createPassiveSellOfferResult"],
+      ["setOptions", "setOptionsResult"],
+      ["changeTrust", "changeTrustResult"],
+      ["allowTrust", "allowTrustResult"],
+      ["accountMerge", "accountMergeResult"],
+      ["inflation", "inflationResult"],
+      ["manageData", "manageDataResult"],
+      ["bumpSequence", "bumpSeqResult"],
+      ["manageBuyOffer", "manageBuyOfferResult"],
+      ["pathPaymentStrictSend", "pathPaymentStrictSendResult"],
+      ["createClaimableBalance", "createClaimableBalanceResult"],
+      ["claimClaimableBalance", "claimClaimableBalanceResult"],
+      ["beginSponsoringFutureReserves", "beginSponsoringFutureReservesResult"],
+      ["endSponsoringFutureReserves", "endSponsoringFutureReservesResult"],
+      ["revokeSponsorship", "revokeSponsorshipResult"],
+      ["clawback", "clawbackResult"],
+      ["clawbackClaimableBalance", "clawbackClaimableBalanceResult"],
+      ["setTrustLineFlags", "setTrustLineFlagsResult"],
+      ["liquidityPoolDeposit", "liquidityPoolDepositResult"],
+      ["liquidityPoolWithdraw", "liquidityPoolWithdrawResult"],
+      ["invokeHostFunction", "invokeHostFunctionResult"],
+    ],
+    arms: {
+      createAccountResult: xdr.lookup("CreateAccountResult"),
+      paymentResult: xdr.lookup("PaymentResult"),
+      pathPaymentStrictReceiveResult: xdr.lookup(
+        "PathPaymentStrictReceiveResult"
+      ),
+      manageSellOfferResult: xdr.lookup("ManageSellOfferResult"),
+      createPassiveSellOfferResult: xdr.lookup("ManageSellOfferResult"),
+      setOptionsResult: xdr.lookup("SetOptionsResult"),
+      changeTrustResult: xdr.lookup("ChangeTrustResult"),
+      allowTrustResult: xdr.lookup("AllowTrustResult"),
+      accountMergeResult: xdr.lookup("AccountMergeResult"),
+      inflationResult: xdr.lookup("InflationResult"),
+      manageDataResult: xdr.lookup("ManageDataResult"),
+      bumpSeqResult: xdr.lookup("BumpSequenceResult"),
+      manageBuyOfferResult: xdr.lookup("ManageBuyOfferResult"),
+      pathPaymentStrictSendResult: xdr.lookup("PathPaymentStrictSendResult"),
+      createClaimableBalanceResult: xdr.lookup("CreateClaimableBalanceResult"),
+      claimClaimableBalanceResult: xdr.lookup("ClaimClaimableBalanceResult"),
+      beginSponsoringFutureReservesResult: xdr.lookup(
+        "BeginSponsoringFutureReservesResult"
+      ),
+      endSponsoringFutureReservesResult: xdr.lookup(
+        "EndSponsoringFutureReservesResult"
+      ),
+      revokeSponsorshipResult: xdr.lookup("RevokeSponsorshipResult"),
+      clawbackResult: xdr.lookup("ClawbackResult"),
+      clawbackClaimableBalanceResult: xdr.lookup(
+        "ClawbackClaimableBalanceResult"
+      ),
+      setTrustLineFlagsResult: xdr.lookup("SetTrustLineFlagsResult"),
+      liquidityPoolDepositResult: xdr.lookup("LiquidityPoolDepositResult"),
+      liquidityPoolWithdrawResult: xdr.lookup("LiquidityPoolWithdrawResult"),
+      invokeHostFunctionResult: xdr.lookup("InvokeHostFunctionResult"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union OperationResult switch (OperationResultCode code)
+  //   {
+  //   case opINNER:
+  //       union switch (OperationType type)
+  //       {
+  //       case CREATE_ACCOUNT:
+  //           CreateAccountResult createAccountResult;
+  //       case PAYMENT:
+  //           PaymentResult paymentResult;
+  //       case PATH_PAYMENT_STRICT_RECEIVE:
+  //           PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
+  //       case MANAGE_SELL_OFFER:
+  //           ManageSellOfferResult manageSellOfferResult;
+  //       case CREATE_PASSIVE_SELL_OFFER:
+  //           ManageSellOfferResult createPassiveSellOfferResult;
+  //       case SET_OPTIONS:
+  //           SetOptionsResult setOptionsResult;
+  //       case CHANGE_TRUST:
+  //           ChangeTrustResult changeTrustResult;
+  //       case ALLOW_TRUST:
+  //           AllowTrustResult allowTrustResult;
+  //       case ACCOUNT_MERGE:
+  //           AccountMergeResult accountMergeResult;
+  //       case INFLATION:
+  //           InflationResult inflationResult;
+  //       case MANAGE_DATA:
+  //           ManageDataResult manageDataResult;
+  //       case BUMP_SEQUENCE:
+  //           BumpSequenceResult bumpSeqResult;
+  //       case MANAGE_BUY_OFFER:
+  //           ManageBuyOfferResult manageBuyOfferResult;
+  //       case PATH_PAYMENT_STRICT_SEND:
+  //           PathPaymentStrictSendResult pathPaymentStrictSendResult;
+  //       case CREATE_CLAIMABLE_BALANCE:
+  //           CreateClaimableBalanceResult createClaimableBalanceResult;
+  //       case CLAIM_CLAIMABLE_BALANCE:
+  //           ClaimClaimableBalanceResult claimClaimableBalanceResult;
+  //       case BEGIN_SPONSORING_FUTURE_RESERVES:
+  //           BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
+  //       case END_SPONSORING_FUTURE_RESERVES:
+  //           EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
+  //       case REVOKE_SPONSORSHIP:
+  //           RevokeSponsorshipResult revokeSponsorshipResult;
+  //       case CLAWBACK:
+  //           ClawbackResult clawbackResult;
+  //       case CLAWBACK_CLAIMABLE_BALANCE:
+  //           ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
+  //       case SET_TRUST_LINE_FLAGS:
+  //           SetTrustLineFlagsResult setTrustLineFlagsResult;
+  //       case LIQUIDITY_POOL_DEPOSIT:
+  //           LiquidityPoolDepositResult liquidityPoolDepositResult;
+  //       case LIQUIDITY_POOL_WITHDRAW:
+  //           LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
+  //       case INVOKE_HOST_FUNCTION:
+  //           InvokeHostFunctionResult invokeHostFunctionResult;
+  //       }
+  //       tr;
+  //   case opBAD_AUTH:
+  //   case opNO_ACCOUNT:
+  //   case opNOT_SUPPORTED:
+  //   case opTOO_MANY_SUBENTRIES:
+  //   case opEXCEEDED_WORK_LIMIT:
+  //   case opTOO_MANY_SPONSORING:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("OperationResult", {
+    switchOn: xdr.lookup("OperationResultCode"),
+    switchName: "code",
+    switches: [
+      ["opInner", "tr"],
+      ["opBadAuth", xdr.void()],
+      ["opNoAccount", xdr.void()],
+      ["opNotSupported", xdr.void()],
+      ["opTooManySubentries", xdr.void()],
+      ["opExceededWorkLimit", xdr.void()],
+      ["opTooManySponsoring", xdr.void()],
+    ],
+    arms: {
+      tr: xdr.lookup("OperationResultTr"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum TransactionResultCode
+  //   {
+  //       txFEE_BUMP_INNER_SUCCESS = 1, // fee bump inner transaction succeeded
+  //       txSUCCESS = 0,                // all operations succeeded
+  //
+  //       txFAILED = -1, // one of the operations failed (none were applied)
+  //
+  //       txTOO_EARLY = -2,         // ledger closeTime before minTime
+  //       txTOO_LATE = -3,          // ledger closeTime after maxTime
+  //       txMISSING_OPERATION = -4, // no operation was specified
+  //       txBAD_SEQ = -5,           // sequence number does not match source account
+  //
+  //       txBAD_AUTH = -6,             // too few valid signatures / wrong network
+  //       txINSUFFICIENT_BALANCE = -7, // fee would bring account below reserve
+  //       txNO_ACCOUNT = -8,           // source account not found
+  //       txINSUFFICIENT_FEE = -9,     // fee is too small
+  //       txBAD_AUTH_EXTRA = -10,      // unused signatures attached to transaction
+  //       txINTERNAL_ERROR = -11,      // an unknown error occurred
+  //
+  //       txNOT_SUPPORTED = -12,         // transaction type not supported
+  //       txFEE_BUMP_INNER_FAILED = -13, // fee bump inner transaction failed
+  //       txBAD_SPONSORSHIP = -14,       // sponsorship not confirmed
+  //       txBAD_MIN_SEQ_AGE_OR_GAP =
+  //           -15, // minSeqAge or minSeqLedgerGap conditions not met
+  //       txMALFORMED = -16 // precondition is invalid
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("TransactionResultCode", {
+    txFeeBumpInnerSuccess: 1,
+    txSuccess: 0,
+    txFailed: -1,
+    txTooEarly: -2,
+    txTooLate: -3,
+    txMissingOperation: -4,
+    txBadSeq: -5,
+    txBadAuth: -6,
+    txInsufficientBalance: -7,
+    txNoAccount: -8,
+    txInsufficientFee: -9,
+    txBadAuthExtra: -10,
+    txInternalError: -11,
+    txNotSupported: -12,
+    txFeeBumpInnerFailed: -13,
+    txBadSponsorship: -14,
+    txBadMinSeqAgeOrGap: -15,
+    txMalformed: -16,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (TransactionResultCode code)
+  //       {
+  //       // txFEE_BUMP_INNER_SUCCESS is not included
+  //       case txSUCCESS:
+  //       case txFAILED:
+  //           OperationResult results<>;
+  //       case txTOO_EARLY:
+  //       case txTOO_LATE:
+  //       case txMISSING_OPERATION:
+  //       case txBAD_SEQ:
+  //       case txBAD_AUTH:
+  //       case txINSUFFICIENT_BALANCE:
+  //       case txNO_ACCOUNT:
+  //       case txINSUFFICIENT_FEE:
+  //       case txBAD_AUTH_EXTRA:
+  //       case txINTERNAL_ERROR:
+  //       case txNOT_SUPPORTED:
+  //       // txFEE_BUMP_INNER_FAILED is not included
+  //       case txBAD_SPONSORSHIP:
+  //       case txBAD_MIN_SEQ_AGE_OR_GAP:
+  //       case txMALFORMED:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("InnerTransactionResultResult", {
+    switchOn: xdr.lookup("TransactionResultCode"),
+    switchName: "code",
+    switches: [
+      ["txSuccess", "results"],
+      ["txFailed", "results"],
+      ["txTooEarly", xdr.void()],
+      ["txTooLate", xdr.void()],
+      ["txMissingOperation", xdr.void()],
+      ["txBadSeq", xdr.void()],
+      ["txBadAuth", xdr.void()],
+      ["txInsufficientBalance", xdr.void()],
+      ["txNoAccount", xdr.void()],
+      ["txInsufficientFee", xdr.void()],
+      ["txBadAuthExtra", xdr.void()],
+      ["txInternalError", xdr.void()],
+      ["txNotSupported", xdr.void()],
+      ["txBadSponsorship", xdr.void()],
+      ["txBadMinSeqAgeOrGap", xdr.void()],
+      ["txMalformed", xdr.void()],
+    ],
+    arms: {
+      results: xdr.varArray(xdr.lookup("OperationResult"), 2147483647),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("InnerTransactionResultExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct InnerTransactionResult
+  //   {
+  //       // Always 0. Here for binary compatibility.
+  //       int64 feeCharged;
+  //
+  //       union switch (TransactionResultCode code)
+  //       {
+  //       // txFEE_BUMP_INNER_SUCCESS is not included
+  //       case txSUCCESS:
+  //       case txFAILED:
+  //           OperationResult results<>;
+  //       case txTOO_EARLY:
+  //       case txTOO_LATE:
+  //       case txMISSING_OPERATION:
+  //       case txBAD_SEQ:
+  //       case txBAD_AUTH:
+  //       case txINSUFFICIENT_BALANCE:
+  //       case txNO_ACCOUNT:
+  //       case txINSUFFICIENT_FEE:
+  //       case txBAD_AUTH_EXTRA:
+  //       case txINTERNAL_ERROR:
+  //       case txNOT_SUPPORTED:
+  //       // txFEE_BUMP_INNER_FAILED is not included
+  //       case txBAD_SPONSORSHIP:
+  //       case txBAD_MIN_SEQ_AGE_OR_GAP:
+  //       case txMALFORMED:
+  //           void;
+  //       }
+  //       result;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("InnerTransactionResult", [
+    ["feeCharged", xdr.lookup("Int64")],
+    ["result", xdr.lookup("InnerTransactionResultResult")],
+    ["ext", xdr.lookup("InnerTransactionResultExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct InnerTransactionResultPair
+  //   {
+  //       Hash transactionHash;          // hash of the inner transaction
+  //       InnerTransactionResult result; // result for the inner transaction
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("InnerTransactionResultPair", [
+    ["transactionHash", xdr.lookup("Hash")],
+    ["result", xdr.lookup("InnerTransactionResult")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union switch (TransactionResultCode code)
+  //       {
+  //       case txFEE_BUMP_INNER_SUCCESS:
+  //       case txFEE_BUMP_INNER_FAILED:
+  //           InnerTransactionResultPair innerResultPair;
+  //       case txSUCCESS:
+  //       case txFAILED:
+  //           OperationResult results<>;
+  //       case txTOO_EARLY:
+  //       case txTOO_LATE:
+  //       case txMISSING_OPERATION:
+  //       case txBAD_SEQ:
+  //       case txBAD_AUTH:
+  //       case txINSUFFICIENT_BALANCE:
+  //       case txNO_ACCOUNT:
+  //       case txINSUFFICIENT_FEE:
+  //       case txBAD_AUTH_EXTRA:
+  //       case txINTERNAL_ERROR:
+  //       case txNOT_SUPPORTED:
+  //       // case txFEE_BUMP_INNER_FAILED: handled above
+  //       case txBAD_SPONSORSHIP:
+  //       case txBAD_MIN_SEQ_AGE_OR_GAP:
+  //       case txMALFORMED:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionResultResult", {
+    switchOn: xdr.lookup("TransactionResultCode"),
+    switchName: "code",
+    switches: [
+      ["txFeeBumpInnerSuccess", "innerResultPair"],
+      ["txFeeBumpInnerFailed", "innerResultPair"],
+      ["txSuccess", "results"],
+      ["txFailed", "results"],
+      ["txTooEarly", xdr.void()],
+      ["txTooLate", xdr.void()],
+      ["txMissingOperation", xdr.void()],
+      ["txBadSeq", xdr.void()],
+      ["txBadAuth", xdr.void()],
+      ["txInsufficientBalance", xdr.void()],
+      ["txNoAccount", xdr.void()],
+      ["txInsufficientFee", xdr.void()],
+      ["txBadAuthExtra", xdr.void()],
+      ["txInternalError", xdr.void()],
+      ["txNotSupported", xdr.void()],
+      ["txBadSponsorship", xdr.void()],
+      ["txBadMinSeqAgeOrGap", xdr.void()],
+      ["txMalformed", xdr.void()],
+    ],
+    arms: {
+      innerResultPair: xdr.lookup("InnerTransactionResultPair"),
+      results: xdr.varArray(xdr.lookup("OperationResult"), 2147483647),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //
+  // ===========================================================================
+  xdr.union("TransactionResultExt", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct TransactionResult
+  //   {
+  //       int64 feeCharged; // actual fee charged for the transaction
+  //
+  //       union switch (TransactionResultCode code)
+  //       {
+  //       case txFEE_BUMP_INNER_SUCCESS:
+  //       case txFEE_BUMP_INNER_FAILED:
+  //           InnerTransactionResultPair innerResultPair;
+  //       case txSUCCESS:
+  //       case txFAILED:
+  //           OperationResult results<>;
+  //       case txTOO_EARLY:
+  //       case txTOO_LATE:
+  //       case txMISSING_OPERATION:
+  //       case txBAD_SEQ:
+  //       case txBAD_AUTH:
+  //       case txINSUFFICIENT_BALANCE:
+  //       case txNO_ACCOUNT:
+  //       case txINSUFFICIENT_FEE:
+  //       case txBAD_AUTH_EXTRA:
+  //       case txINTERNAL_ERROR:
+  //       case txNOT_SUPPORTED:
+  //       // case txFEE_BUMP_INNER_FAILED: handled above
+  //       case txBAD_SPONSORSHIP:
+  //       case txBAD_MIN_SEQ_AGE_OR_GAP:
+  //       case txMALFORMED:
+  //           void;
+  //       }
+  //       result;
+  //
+  //       // reserved for future use
+  //       union switch (int v)
+  //       {
+  //       case 0:
+  //           void;
+  //       }
+  //       ext;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("TransactionResult", [
+    ["feeCharged", xdr.lookup("Int64")],
+    ["result", xdr.lookup("TransactionResultResult")],
+    ["ext", xdr.lookup("TransactionResultExt")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque Hash[32];
+  //
+  // ===========================================================================
+  xdr.typedef("Hash", xdr.opaque(32));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque uint256[32];
+  //
+  // ===========================================================================
+  xdr.typedef("Uint256", xdr.opaque(32));
+
+  // === xdr source ============================================================
+  //
+  //   typedef unsigned int uint32;
+  //
+  // ===========================================================================
+  xdr.typedef("Uint32", xdr.uint());
+
+  // === xdr source ============================================================
+  //
+  //   typedef int int32;
+  //
+  // ===========================================================================
+  xdr.typedef("Int32", xdr.int());
+
+  // === xdr source ============================================================
+  //
+  //   typedef unsigned hyper uint64;
+  //
+  // ===========================================================================
+  xdr.typedef("Uint64", xdr.uhyper());
+
+  // === xdr source ============================================================
+  //
+  //   typedef hyper int64;
+  //
+  // ===========================================================================
+  xdr.typedef("Int64", xdr.hyper());
+
+  // === xdr source ============================================================
+  //
+  //   typedef uint64 TimePoint;
+  //
+  // ===========================================================================
+  xdr.typedef("TimePoint", xdr.lookup("Uint64"));
+
+  // === xdr source ============================================================
+  //
+  //   typedef uint64 Duration;
+  //
+  // ===========================================================================
+  xdr.typedef("Duration", xdr.lookup("Uint64"));
+
+  // === xdr source ============================================================
+  //
+  //   union ExtensionPoint switch (int v)
+  //   {
+  //   case 0:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ExtensionPoint", {
+    switchOn: xdr.int(),
+    switchName: "v",
+    switches: [[0, xdr.void()]],
+    arms: {},
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum CryptoKeyType
+  //   {
+  //       KEY_TYPE_ED25519 = 0,
+  //       KEY_TYPE_PRE_AUTH_TX = 1,
+  //       KEY_TYPE_HASH_X = 2,
+  //       KEY_TYPE_ED25519_SIGNED_PAYLOAD = 3,
+  //       // MUXED enum values for supported type are derived from the enum values
+  //       // above by ORing them with 0x100
+  //       KEY_TYPE_MUXED_ED25519 = 0x100
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("CryptoKeyType", {
+    keyTypeEd25519: 0,
+    keyTypePreAuthTx: 1,
+    keyTypeHashX: 2,
+    keyTypeEd25519SignedPayload: 3,
+    keyTypeMuxedEd25519: 256,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum PublicKeyType
+  //   {
+  //       PUBLIC_KEY_TYPE_ED25519 = KEY_TYPE_ED25519
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("PublicKeyType", {
+    publicKeyTypeEd25519: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SignerKeyType
+  //   {
+  //       SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
+  //       SIGNER_KEY_TYPE_PRE_AUTH_TX = KEY_TYPE_PRE_AUTH_TX,
+  //       SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X,
+  //       SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD = KEY_TYPE_ED25519_SIGNED_PAYLOAD
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("SignerKeyType", {
+    signerKeyTypeEd25519: 0,
+    signerKeyTypePreAuthTx: 1,
+    signerKeyTypeHashX: 2,
+    signerKeyTypeEd25519SignedPayload: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union PublicKey switch (PublicKeyType type)
+  //   {
+  //   case PUBLIC_KEY_TYPE_ED25519:
+  //       uint256 ed25519;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("PublicKey", {
+    switchOn: xdr.lookup("PublicKeyType"),
+    switchName: "type",
+    switches: [["publicKeyTypeEd25519", "ed25519"]],
+    arms: {
+      ed25519: xdr.lookup("Uint256"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct
+  //       {
+  //           /* Public key that must sign the payload. */
+  //           uint256 ed25519;
+  //           /* Payload to be raw signed by ed25519. */
+  //           opaque payload<64>;
+  //       }
+  //
+  // ===========================================================================
+  xdr.struct("SignerKeyEd25519SignedPayload", [
+    ["ed25519", xdr.lookup("Uint256")],
+    ["payload", xdr.varOpaque(64)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   union SignerKey switch (SignerKeyType type)
+  //   {
+  //   case SIGNER_KEY_TYPE_ED25519:
+  //       uint256 ed25519;
+  //   case SIGNER_KEY_TYPE_PRE_AUTH_TX:
+  //       /* SHA-256 Hash of TransactionSignaturePayload structure */
+  //       uint256 preAuthTx;
+  //   case SIGNER_KEY_TYPE_HASH_X:
+  //       /* Hash of random 256 bit preimage X */
+  //       uint256 hashX;
+  //   case SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD:
+  //       struct
+  //       {
+  //           /* Public key that must sign the payload. */
+  //           uint256 ed25519;
+  //           /* Payload to be raw signed by ed25519. */
+  //           opaque payload<64>;
+  //       } ed25519SignedPayload;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("SignerKey", {
+    switchOn: xdr.lookup("SignerKeyType"),
+    switchName: "type",
+    switches: [
+      ["signerKeyTypeEd25519", "ed25519"],
+      ["signerKeyTypePreAuthTx", "preAuthTx"],
+      ["signerKeyTypeHashX", "hashX"],
+      ["signerKeyTypeEd25519SignedPayload", "ed25519SignedPayload"],
+    ],
+    arms: {
+      ed25519: xdr.lookup("Uint256"),
+      preAuthTx: xdr.lookup("Uint256"),
+      hashX: xdr.lookup("Uint256"),
+      ed25519SignedPayload: xdr.lookup("SignerKeyEd25519SignedPayload"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque Signature<64>;
+  //
+  // ===========================================================================
+  xdr.typedef("Signature", xdr.varOpaque(64));
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque SignatureHint[4];
+  //
+  // ===========================================================================
+  xdr.typedef("SignatureHint", xdr.opaque(4));
+
+  // === xdr source ============================================================
+  //
+  //   typedef PublicKey NodeID;
+  //
+  // ===========================================================================
+  xdr.typedef("NodeId", xdr.lookup("PublicKey"));
+
+  // === xdr source ============================================================
+  //
+  //   typedef PublicKey AccountID;
+  //
+  // ===========================================================================
+  xdr.typedef("AccountId", xdr.lookup("PublicKey"));
+
+  // === xdr source ============================================================
+  //
+  //   struct Curve25519Secret
+  //   {
+  //       opaque key[32];
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Curve25519Secret", [["key", xdr.opaque(32)]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct Curve25519Public
+  //   {
+  //       opaque key[32];
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Curve25519Public", [["key", xdr.opaque(32)]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct HmacSha256Key
+  //   {
+  //       opaque key[32];
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("HmacSha256Key", [["key", xdr.opaque(32)]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct HmacSha256Mac
+  //   {
+  //       opaque mac[32];
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("HmacSha256Mac", [["mac", xdr.opaque(32)]]);
+
+  // === xdr source ============================================================
+  //
+  //   enum SCValType
+  //   {
+  //       SCV_BOOL = 0,
+  //       SCV_VOID = 1,
+  //       SCV_STATUS = 2,
+  //
+  //       // 32 bits is the smallest type in WASM or XDR; no need for u8/u16.
+  //       SCV_U32 = 3,
+  //       SCV_I32 = 4,
+  //
+  //       // 64 bits is naturally supported by both WASM and XDR also.
+  //       SCV_U64 = 5,
+  //       SCV_I64 = 6,
+  //
+  //       // Time-related u64 subtypes with their own functions and formatting.
+  //       SCV_TIMEPOINT = 7,
+  //       SCV_DURATION = 8,
+  //
+  //       // 128 bits is naturally supported by Rust and we use it for Soroban
+  //       // fixed-point arithmetic prices / balances / similar "quantities". These
+  //       // are represented in XDR as a pair of 2 u64s, unlike {u,i}256 which is
+  //       // represented as an array of 32 bytes.
+  //       SCV_U128 = 9,
+  //       SCV_I128 = 10,
+  //
+  //       // 256 bits is the size of sha256 output, ed25519 keys, and the EVM machine
+  //       // word, so for interop use we include this even though it requires a small
+  //       // amount of Rust guest and/or host library code.
+  //       SCV_U256 = 11,
+  //       SCV_I256 = 12,
+  //
+  //       // TODO: possibly allocate subtypes of i64, i128 and/or u256 for
+  //       // fixed-precision with a specific number of decimals.
+  //
+  //       // Bytes come in 3 flavors, 2 of which have meaningfully different
+  //       // formatting and validity-checking / domain-restriction.
+  //       SCV_BYTES = 13,
+  //       SCV_STRING = 14,
+  //       SCV_SYMBOL = 15,
+  //
+  //       // Vecs and maps are just polymorphic containers of other ScVals.
+  //       SCV_VEC = 16,
+  //       SCV_MAP = 17,
+  //
+  //       // SCContractExecutable and SCAddressType are types that gets used separately from
+  //       // SCVal so we do not flatten their structures into separate SCVal cases.
+  //       SCV_CONTRACT_EXECUTABLE = 18,
+  //       SCV_ADDRESS = 19,
+  //
+  //       // SCV_LEDGER_KEY_CONTRACT_EXECUTABLE and SCV_LEDGER_KEY_NONCE are unique
+  //       // symbolic SCVals used as the key for ledger entries for a contract's code
+  //       // and an address' nonce, respectively.
+  //       SCV_LEDGER_KEY_CONTRACT_EXECUTABLE = 20,
+  //       SCV_LEDGER_KEY_NONCE = 21
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScValType", {
+    scvBool: 0,
+    scvVoid: 1,
+    scvStatus: 2,
+    scvU32: 3,
+    scvI32: 4,
+    scvU64: 5,
+    scvI64: 6,
+    scvTimepoint: 7,
+    scvDuration: 8,
+    scvU128: 9,
+    scvI128: 10,
+    scvU256: 11,
+    scvI256: 12,
+    scvBytes: 13,
+    scvString: 14,
+    scvSymbol: 15,
+    scvVec: 16,
+    scvMap: 17,
+    scvContractExecutable: 18,
+    scvAddress: 19,
+    scvLedgerKeyContractExecutable: 20,
+    scvLedgerKeyNonce: 21,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SCStatusType
+  //   {
+  //       SST_OK = 0,
+  //       SST_UNKNOWN_ERROR = 1,
+  //       SST_HOST_VALUE_ERROR = 2,
+  //       SST_HOST_OBJECT_ERROR = 3,
+  //       SST_HOST_FUNCTION_ERROR = 4,
+  //       SST_HOST_STORAGE_ERROR = 5,
+  //       SST_HOST_CONTEXT_ERROR = 6,
+  //       SST_VM_ERROR = 7,
+  //       SST_CONTRACT_ERROR = 8,
+  //       SST_HOST_AUTH_ERROR = 9
+  //       // TODO: add more
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScStatusType", {
+    sstOk: 0,
+    sstUnknownError: 1,
+    sstHostValueError: 2,
+    sstHostObjectError: 3,
+    sstHostFunctionError: 4,
+    sstHostStorageError: 5,
+    sstHostContextError: 6,
+    sstVmError: 7,
+    sstContractError: 8,
+    sstHostAuthError: 9,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SCHostValErrorCode
+  //   {
+  //       HOST_VALUE_UNKNOWN_ERROR = 0,
+  //       HOST_VALUE_RESERVED_TAG_VALUE = 1,
+  //       HOST_VALUE_UNEXPECTED_VAL_TYPE = 2,
+  //       HOST_VALUE_U63_OUT_OF_RANGE = 3,
+  //       HOST_VALUE_U32_OUT_OF_RANGE = 4,
+  //       HOST_VALUE_STATIC_UNKNOWN = 5,
+  //       HOST_VALUE_MISSING_OBJECT = 6,
+  //       HOST_VALUE_SYMBOL_TOO_LONG = 7,
+  //       HOST_VALUE_SYMBOL_BAD_CHAR = 8,
+  //       HOST_VALUE_SYMBOL_CONTAINS_NON_UTF8 = 9,
+  //       HOST_VALUE_BITSET_TOO_MANY_BITS = 10,
+  //       HOST_VALUE_STATUS_UNKNOWN = 11
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScHostValErrorCode", {
+    hostValueUnknownError: 0,
+    hostValueReservedTagValue: 1,
+    hostValueUnexpectedValType: 2,
+    hostValueU63OutOfRange: 3,
+    hostValueU32OutOfRange: 4,
+    hostValueStaticUnknown: 5,
+    hostValueMissingObject: 6,
+    hostValueSymbolTooLong: 7,
+    hostValueSymbolBadChar: 8,
+    hostValueSymbolContainsNonUtf8: 9,
+    hostValueBitsetTooManyBits: 10,
+    hostValueStatusUnknown: 11,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SCHostObjErrorCode
+  //   {
+  //       HOST_OBJECT_UNKNOWN_ERROR = 0,
+  //       HOST_OBJECT_UNKNOWN_REFERENCE = 1,
+  //       HOST_OBJECT_UNEXPECTED_TYPE = 2,
+  //       HOST_OBJECT_OBJECT_COUNT_EXCEEDS_U32_MAX = 3,
+  //       HOST_OBJECT_OBJECT_NOT_EXIST = 4,
+  //       HOST_OBJECT_VEC_INDEX_OUT_OF_BOUND = 5,
+  //       HOST_OBJECT_CONTRACT_HASH_WRONG_LENGTH = 6
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScHostObjErrorCode", {
+    hostObjectUnknownError: 0,
+    hostObjectUnknownReference: 1,
+    hostObjectUnexpectedType: 2,
+    hostObjectObjectCountExceedsU32Max: 3,
+    hostObjectObjectNotExist: 4,
+    hostObjectVecIndexOutOfBound: 5,
+    hostObjectContractHashWrongLength: 6,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SCHostFnErrorCode
+  //   {
+  //       HOST_FN_UNKNOWN_ERROR = 0,
+  //       HOST_FN_UNEXPECTED_HOST_FUNCTION_ACTION = 1,
+  //       HOST_FN_INPUT_ARGS_WRONG_LENGTH = 2,
+  //       HOST_FN_INPUT_ARGS_WRONG_TYPE = 3,
+  //       HOST_FN_INPUT_ARGS_INVALID = 4
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScHostFnErrorCode", {
+    hostFnUnknownError: 0,
+    hostFnUnexpectedHostFunctionAction: 1,
+    hostFnInputArgsWrongLength: 2,
+    hostFnInputArgsWrongType: 3,
+    hostFnInputArgsInvalid: 4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SCHostStorageErrorCode
+  //   {
+  //       HOST_STORAGE_UNKNOWN_ERROR = 0,
+  //       HOST_STORAGE_EXPECT_CONTRACT_DATA = 1,
+  //       HOST_STORAGE_READWRITE_ACCESS_TO_READONLY_ENTRY = 2,
+  //       HOST_STORAGE_ACCESS_TO_UNKNOWN_ENTRY = 3,
+  //       HOST_STORAGE_MISSING_KEY_IN_GET = 4,
+  //       HOST_STORAGE_GET_ON_DELETED_KEY = 5
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScHostStorageErrorCode", {
+    hostStorageUnknownError: 0,
+    hostStorageExpectContractData: 1,
+    hostStorageReadwriteAccessToReadonlyEntry: 2,
+    hostStorageAccessToUnknownEntry: 3,
+    hostStorageMissingKeyInGet: 4,
+    hostStorageGetOnDeletedKey: 5,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SCHostAuthErrorCode
+  //   {
+  //       HOST_AUTH_UNKNOWN_ERROR = 0,
+  //       HOST_AUTH_NONCE_ERROR = 1,
+  //       HOST_AUTH_DUPLICATE_AUTHORIZATION = 2,
+  //       HOST_AUTH_NOT_AUTHORIZED = 3
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScHostAuthErrorCode", {
+    hostAuthUnknownError: 0,
+    hostAuthNonceError: 1,
+    hostAuthDuplicateAuthorization: 2,
+    hostAuthNotAuthorized: 3,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SCHostContextErrorCode
+  //   {
+  //       HOST_CONTEXT_UNKNOWN_ERROR = 0,
+  //       HOST_CONTEXT_NO_CONTRACT_RUNNING = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScHostContextErrorCode", {
+    hostContextUnknownError: 0,
+    hostContextNoContractRunning: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SCVmErrorCode {
+  //       VM_UNKNOWN = 0,
+  //       VM_VALIDATION = 1,
+  //       VM_INSTANTIATION = 2,
+  //       VM_FUNCTION = 3,
+  //       VM_TABLE = 4,
+  //       VM_MEMORY = 5,
+  //       VM_GLOBAL = 6,
+  //       VM_VALUE = 7,
+  //       VM_TRAP_UNREACHABLE = 8,
+  //       VM_TRAP_MEMORY_ACCESS_OUT_OF_BOUNDS = 9,
+  //       VM_TRAP_TABLE_ACCESS_OUT_OF_BOUNDS = 10,
+  //       VM_TRAP_ELEM_UNINITIALIZED = 11,
+  //       VM_TRAP_DIVISION_BY_ZERO = 12,
+  //       VM_TRAP_INTEGER_OVERFLOW = 13,
+  //       VM_TRAP_INVALID_CONVERSION_TO_INT = 14,
+  //       VM_TRAP_STACK_OVERFLOW = 15,
+  //       VM_TRAP_UNEXPECTED_SIGNATURE = 16,
+  //       VM_TRAP_MEM_LIMIT_EXCEEDED = 17,
+  //       VM_TRAP_CPU_LIMIT_EXCEEDED = 18
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScVmErrorCode", {
+    vmUnknown: 0,
+    vmValidation: 1,
+    vmInstantiation: 2,
+    vmFunction: 3,
+    vmTable: 4,
+    vmMemory: 5,
+    vmGlobal: 6,
+    vmValue: 7,
+    vmTrapUnreachable: 8,
+    vmTrapMemoryAccessOutOfBounds: 9,
+    vmTrapTableAccessOutOfBounds: 10,
+    vmTrapElemUninitialized: 11,
+    vmTrapDivisionByZero: 12,
+    vmTrapIntegerOverflow: 13,
+    vmTrapInvalidConversionToInt: 14,
+    vmTrapStackOverflow: 15,
+    vmTrapUnexpectedSignature: 16,
+    vmTrapMemLimitExceeded: 17,
+    vmTrapCpuLimitExceeded: 18,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SCUnknownErrorCode
+  //   {
+  //       UNKNOWN_ERROR_GENERAL = 0,
+  //       UNKNOWN_ERROR_XDR = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScUnknownErrorCode", {
+    unknownErrorGeneral: 0,
+    unknownErrorXdr: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union SCStatus switch (SCStatusType type)
+  //   {
+  //   case SST_OK:
+  //       void;
+  //   case SST_UNKNOWN_ERROR:
+  //       SCUnknownErrorCode unknownCode;
+  //   case SST_HOST_VALUE_ERROR:
+  //       SCHostValErrorCode valCode;
+  //   case SST_HOST_OBJECT_ERROR:
+  //       SCHostObjErrorCode objCode;
+  //   case SST_HOST_FUNCTION_ERROR:
+  //       SCHostFnErrorCode fnCode;
+  //   case SST_HOST_STORAGE_ERROR:
+  //       SCHostStorageErrorCode storageCode;
+  //   case SST_HOST_CONTEXT_ERROR:
+  //       SCHostContextErrorCode contextCode;
+  //   case SST_VM_ERROR:
+  //       SCVmErrorCode vmCode;
+  //   case SST_CONTRACT_ERROR:
+  //       uint32 contractCode;
+  //   case SST_HOST_AUTH_ERROR:
+  //       SCHostAuthErrorCode authCode;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ScStatus", {
+    switchOn: xdr.lookup("ScStatusType"),
+    switchName: "type",
+    switches: [
+      ["sstOk", xdr.void()],
+      ["sstUnknownError", "unknownCode"],
+      ["sstHostValueError", "valCode"],
+      ["sstHostObjectError", "objCode"],
+      ["sstHostFunctionError", "fnCode"],
+      ["sstHostStorageError", "storageCode"],
+      ["sstHostContextError", "contextCode"],
+      ["sstVmError", "vmCode"],
+      ["sstContractError", "contractCode"],
+      ["sstHostAuthError", "authCode"],
+    ],
+    arms: {
+      unknownCode: xdr.lookup("ScUnknownErrorCode"),
+      valCode: xdr.lookup("ScHostValErrorCode"),
+      objCode: xdr.lookup("ScHostObjErrorCode"),
+      fnCode: xdr.lookup("ScHostFnErrorCode"),
+      storageCode: xdr.lookup("ScHostStorageErrorCode"),
+      contextCode: xdr.lookup("ScHostContextErrorCode"),
+      vmCode: xdr.lookup("ScVmErrorCode"),
+      contractCode: xdr.lookup("Uint32"),
+      authCode: xdr.lookup("ScHostAuthErrorCode"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct UInt128Parts {
+  //       uint64 hi;
+  //       uint64 lo;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("UInt128Parts", [
+    ["hi", xdr.lookup("Uint64")],
+    ["lo", xdr.lookup("Uint64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct Int128Parts {
+  //       int64 hi;
+  //       uint64 lo;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Int128Parts", [
+    ["hi", xdr.lookup("Int64")],
+    ["lo", xdr.lookup("Uint64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct UInt256Parts {
+  //       uint64 hi_hi;
+  //       uint64 hi_lo;
+  //       uint64 lo_hi;
+  //       uint64 lo_lo;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("UInt256Parts", [
+    ["hiHi", xdr.lookup("Uint64")],
+    ["hiLo", xdr.lookup("Uint64")],
+    ["loHi", xdr.lookup("Uint64")],
+    ["loLo", xdr.lookup("Uint64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct Int256Parts {
+  //       int64 hi_hi;
+  //       uint64 hi_lo;
+  //       uint64 lo_hi;
+  //       uint64 lo_lo;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("Int256Parts", [
+    ["hiHi", xdr.lookup("Int64")],
+    ["hiLo", xdr.lookup("Uint64")],
+    ["loHi", xdr.lookup("Uint64")],
+    ["loLo", xdr.lookup("Uint64")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum SCContractExecutableType
+  //   {
+  //       SCCONTRACT_EXECUTABLE_WASM_REF = 0,
+  //       SCCONTRACT_EXECUTABLE_TOKEN = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScContractExecutableType", {
+    sccontractExecutableWasmRef: 0,
+    sccontractExecutableToken: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union SCContractExecutable switch (SCContractExecutableType type)
+  //   {
+  //   case SCCONTRACT_EXECUTABLE_WASM_REF:
+  //       Hash wasm_id;
+  //   case SCCONTRACT_EXECUTABLE_TOKEN:
+  //       void;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ScContractExecutable", {
+    switchOn: xdr.lookup("ScContractExecutableType"),
+    switchName: "type",
+    switches: [
+      ["sccontractExecutableWasmRef", "wasmId"],
+      ["sccontractExecutableToken", xdr.void()],
+    ],
+    arms: {
+      wasmId: xdr.lookup("Hash"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   enum SCAddressType
+  //   {
+  //       SC_ADDRESS_TYPE_ACCOUNT = 0,
+  //       SC_ADDRESS_TYPE_CONTRACT = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScAddressType", {
+    scAddressTypeAccount: 0,
+    scAddressTypeContract: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union SCAddress switch (SCAddressType type)
+  //   {
+  //   case SC_ADDRESS_TYPE_ACCOUNT:
+  //       AccountID accountId;
+  //   case SC_ADDRESS_TYPE_CONTRACT:
+  //       Hash contractId;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ScAddress", {
+    switchOn: xdr.lookup("ScAddressType"),
+    switchName: "type",
+    switches: [
+      ["scAddressTypeAccount", "accountId"],
+      ["scAddressTypeContract", "contractId"],
+    ],
+    arms: {
+      accountId: xdr.lookup("AccountId"),
+      contractId: xdr.lookup("Hash"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const SCVAL_LIMIT = 256000;
+  //
+  // ===========================================================================
+  xdr.const("SCVAL_LIMIT", 256000);
+
+  // === xdr source ============================================================
+  //
+  //   const SCSYMBOL_LIMIT = 32;
+  //
+  // ===========================================================================
+  xdr.const("SCSYMBOL_LIMIT", 32);
+
+  // === xdr source ============================================================
+  //
+  //   typedef SCVal SCVec<SCVAL_LIMIT>;
+  //
+  // ===========================================================================
+  xdr.typedef(
+    "ScVec",
+    xdr.varArray(xdr.lookup("ScVal"), xdr.lookup("SCVAL_LIMIT"))
+  );
+
+  // === xdr source ============================================================
+  //
+  //   typedef SCMapEntry SCMap<SCVAL_LIMIT>;
+  //
+  // ===========================================================================
+  xdr.typedef(
+    "ScMap",
+    xdr.varArray(xdr.lookup("ScMapEntry"), xdr.lookup("SCVAL_LIMIT"))
+  );
+
+  // === xdr source ============================================================
+  //
+  //   typedef opaque SCBytes<SCVAL_LIMIT>;
+  //
+  // ===========================================================================
+  xdr.typedef("ScBytes", xdr.varOpaque(xdr.lookup("SCVAL_LIMIT")));
+
+  // === xdr source ============================================================
+  //
+  //   typedef string SCString<SCVAL_LIMIT>;
+  //
+  // ===========================================================================
+  xdr.typedef("ScString", xdr.string(xdr.lookup("SCVAL_LIMIT")));
+
+  // === xdr source ============================================================
+  //
+  //   typedef string SCSymbol<SCSYMBOL_LIMIT>;
+  //
+  // ===========================================================================
+  xdr.typedef("ScSymbol", xdr.string(xdr.lookup("SCSYMBOL_LIMIT")));
+
+  // === xdr source ============================================================
+  //
+  //   struct SCNonceKey {
+  //       SCAddress nonce_address;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScNonceKey", [["nonceAddress", xdr.lookup("ScAddress")]]);
+
+  // === xdr source ============================================================
+  //
+  //   union SCVal switch (SCValType type)
+  //   {
+  //
+  //   case SCV_BOOL:
+  //       bool b;
+  //   case SCV_VOID:
+  //       void;
+  //   case SCV_STATUS:
+  //       SCStatus error;
+  //
+  //   case SCV_U32:
+  //       uint32 u32;
+  //   case SCV_I32:
+  //       int32 i32;
+  //
+  //   case SCV_U64:
+  //       uint64 u64;
+  //   case SCV_I64:
+  //       int64 i64;
+  //   case SCV_TIMEPOINT:
+  //       TimePoint timepoint;
+  //   case SCV_DURATION:
+  //       Duration duration;
+  //
+  //   case SCV_U128:
+  //       UInt128Parts u128;
+  //   case SCV_I128:
+  //       Int128Parts i128;
+  //
+  //   case SCV_U256:
+  //       UInt256Parts u256;
+  //   case SCV_I256:
+  //       Int256Parts i256;
+  //
+  //   case SCV_BYTES:
+  //       SCBytes bytes;
+  //   case SCV_STRING:
+  //       SCString str;
+  //   case SCV_SYMBOL:
+  //       SCSymbol sym;
+  //
+  //   // Vec and Map are recursive so need to live
+  //   // behind an option, due to xdrpp limitations.
+  //   case SCV_VEC:
+  //       SCVec *vec;
+  //   case SCV_MAP:
+  //       SCMap *map;
+  //
+  //   case SCV_CONTRACT_EXECUTABLE:
+  //       SCContractExecutable exec;
+  //   case SCV_ADDRESS:
+  //       SCAddress address;
+  //
+  //   // Special SCVals reserved for system-constructed contract-data
+  //   // ledger keys, not generally usable elsewhere.
+  //   case SCV_LEDGER_KEY_CONTRACT_EXECUTABLE:
+  //       void;
+  //   case SCV_LEDGER_KEY_NONCE:
+  //       SCNonceKey nonce_key;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ScVal", {
+    switchOn: xdr.lookup("ScValType"),
+    switchName: "type",
+    switches: [
+      ["scvBool", "b"],
+      ["scvVoid", xdr.void()],
+      ["scvStatus", "error"],
+      ["scvU32", "u32"],
+      ["scvI32", "i32"],
+      ["scvU64", "u64"],
+      ["scvI64", "i64"],
+      ["scvTimepoint", "timepoint"],
+      ["scvDuration", "duration"],
+      ["scvU128", "u128"],
+      ["scvI128", "i128"],
+      ["scvU256", "u256"],
+      ["scvI256", "i256"],
+      ["scvBytes", "bytes"],
+      ["scvString", "str"],
+      ["scvSymbol", "sym"],
+      ["scvVec", "vec"],
+      ["scvMap", "map"],
+      ["scvContractExecutable", "exec"],
+      ["scvAddress", "address"],
+      ["scvLedgerKeyContractExecutable", xdr.void()],
+      ["scvLedgerKeyNonce", "nonceKey"],
+    ],
+    arms: {
+      b: xdr.bool(),
+      error: xdr.lookup("ScStatus"),
+      u32: xdr.lookup("Uint32"),
+      i32: xdr.lookup("Int32"),
+      u64: xdr.lookup("Uint64"),
+      i64: xdr.lookup("Int64"),
+      timepoint: xdr.lookup("TimePoint"),
+      duration: xdr.lookup("Duration"),
+      u128: xdr.lookup("UInt128Parts"),
+      i128: xdr.lookup("Int128Parts"),
+      u256: xdr.lookup("UInt256Parts"),
+      i256: xdr.lookup("Int256Parts"),
+      bytes: xdr.lookup("ScBytes"),
+      str: xdr.lookup("ScString"),
+      sym: xdr.lookup("ScSymbol"),
+      vec: xdr.option(xdr.lookup("ScVec")),
+      map: xdr.option(xdr.lookup("ScMap")),
+      exec: xdr.lookup("ScContractExecutable"),
+      address: xdr.lookup("ScAddress"),
+      nonceKey: xdr.lookup("ScNonceKey"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SCMapEntry
+  //   {
+  //       SCVal key;
+  //       SCVal val;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScMapEntry", [
+    ["key", xdr.lookup("ScVal")],
+    ["val", xdr.lookup("ScVal")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum SCEnvMetaKind
+  //   {
+  //       SC_ENV_META_KIND_INTERFACE_VERSION = 0
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScEnvMetaKind", {
+    scEnvMetaKindInterfaceVersion: 0,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union SCEnvMetaEntry switch (SCEnvMetaKind kind)
+  //   {
+  //   case SC_ENV_META_KIND_INTERFACE_VERSION:
+  //       uint64 interfaceVersion;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ScEnvMetaEntry", {
+    switchOn: xdr.lookup("ScEnvMetaKind"),
+    switchName: "kind",
+    switches: [["scEnvMetaKindInterfaceVersion", "interfaceVersion"]],
+    arms: {
+      interfaceVersion: xdr.lookup("Uint64"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   const SC_SPEC_DOC_LIMIT = 1024;
+  //
+  // ===========================================================================
+  xdr.const("SC_SPEC_DOC_LIMIT", 1024);
+
+  // === xdr source ============================================================
+  //
+  //   enum SCSpecType
+  //   {
+  //       SC_SPEC_TYPE_VAL = 0,
+  //
+  //       // Types with no parameters.
+  //       SC_SPEC_TYPE_BOOL = 1,
+  //       SC_SPEC_TYPE_VOID = 2,
+  //       SC_SPEC_TYPE_STATUS = 3,
+  //       SC_SPEC_TYPE_U32 = 4,
+  //       SC_SPEC_TYPE_I32 = 5,
+  //       SC_SPEC_TYPE_U64 = 6,
+  //       SC_SPEC_TYPE_I64 = 7,
+  //       SC_SPEC_TYPE_TIMEPOINT = 8,
+  //       SC_SPEC_TYPE_DURATION = 9,
+  //       SC_SPEC_TYPE_U128 = 10,
+  //       SC_SPEC_TYPE_I128 = 11,
+  //       SC_SPEC_TYPE_U256 = 12,
+  //       SC_SPEC_TYPE_I256 = 13,
+  //       SC_SPEC_TYPE_BYTES = 14,
+  //       SC_SPEC_TYPE_STRING = 16,
+  //       SC_SPEC_TYPE_SYMBOL = 17,
+  //       SC_SPEC_TYPE_ADDRESS = 19,
+  //
+  //       // Types with parameters.
+  //       SC_SPEC_TYPE_OPTION = 1000,
+  //       SC_SPEC_TYPE_RESULT = 1001,
+  //       SC_SPEC_TYPE_VEC = 1002,
+  //       SC_SPEC_TYPE_SET = 1003,
+  //       SC_SPEC_TYPE_MAP = 1004,
+  //       SC_SPEC_TYPE_TUPLE = 1005,
+  //       SC_SPEC_TYPE_BYTES_N = 1006,
+  //
+  //       // User defined types.
+  //       SC_SPEC_TYPE_UDT = 2000
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScSpecType", {
+    scSpecTypeVal: 0,
+    scSpecTypeBool: 1,
+    scSpecTypeVoid: 2,
+    scSpecTypeStatus: 3,
+    scSpecTypeU32: 4,
+    scSpecTypeI32: 5,
+    scSpecTypeU64: 6,
+    scSpecTypeI64: 7,
+    scSpecTypeTimepoint: 8,
+    scSpecTypeDuration: 9,
+    scSpecTypeU128: 10,
+    scSpecTypeI128: 11,
+    scSpecTypeU256: 12,
+    scSpecTypeI256: 13,
+    scSpecTypeBytes: 14,
+    scSpecTypeString: 16,
+    scSpecTypeSymbol: 17,
+    scSpecTypeAddress: 19,
+    scSpecTypeOption: 1000,
+    scSpecTypeResult: 1001,
+    scSpecTypeVec: 1002,
+    scSpecTypeSet: 1003,
+    scSpecTypeMap: 1004,
+    scSpecTypeTuple: 1005,
+    scSpecTypeBytesN: 1006,
+    scSpecTypeUdt: 2000,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecTypeOption
+  //   {
+  //       SCSpecTypeDef valueType;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecTypeOption", [["valueType", xdr.lookup("ScSpecTypeDef")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecTypeResult
+  //   {
+  //       SCSpecTypeDef okType;
+  //       SCSpecTypeDef errorType;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecTypeResult", [
+    ["okType", xdr.lookup("ScSpecTypeDef")],
+    ["errorType", xdr.lookup("ScSpecTypeDef")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecTypeVec
+  //   {
+  //       SCSpecTypeDef elementType;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecTypeVec", [["elementType", xdr.lookup("ScSpecTypeDef")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecTypeMap
+  //   {
+  //       SCSpecTypeDef keyType;
+  //       SCSpecTypeDef valueType;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecTypeMap", [
+    ["keyType", xdr.lookup("ScSpecTypeDef")],
+    ["valueType", xdr.lookup("ScSpecTypeDef")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecTypeSet
+  //   {
+  //       SCSpecTypeDef elementType;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecTypeSet", [["elementType", xdr.lookup("ScSpecTypeDef")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecTypeTuple
+  //   {
+  //       SCSpecTypeDef valueTypes<12>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecTypeTuple", [
+    ["valueTypes", xdr.varArray(xdr.lookup("ScSpecTypeDef"), 12)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecTypeBytesN
+  //   {
+  //       uint32 n;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecTypeBytesN", [["n", xdr.lookup("Uint32")]]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecTypeUDT
+  //   {
+  //       string name<60>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecTypeUdt", [["name", xdr.string(60)]]);
+
+  // === xdr source ============================================================
+  //
+  //   union SCSpecTypeDef switch (SCSpecType type)
+  //   {
+  //   case SC_SPEC_TYPE_VAL:
+  //   case SC_SPEC_TYPE_BOOL:
+  //   case SC_SPEC_TYPE_VOID:
+  //   case SC_SPEC_TYPE_STATUS:
+  //   case SC_SPEC_TYPE_U32:
+  //   case SC_SPEC_TYPE_I32:
+  //   case SC_SPEC_TYPE_U64:
+  //   case SC_SPEC_TYPE_I64:
+  //   case SC_SPEC_TYPE_TIMEPOINT:
+  //   case SC_SPEC_TYPE_DURATION:
+  //   case SC_SPEC_TYPE_U128:
+  //   case SC_SPEC_TYPE_I128:
+  //   case SC_SPEC_TYPE_U256:
+  //   case SC_SPEC_TYPE_I256:
+  //   case SC_SPEC_TYPE_BYTES:
+  //   case SC_SPEC_TYPE_STRING:
+  //   case SC_SPEC_TYPE_SYMBOL:
+  //   case SC_SPEC_TYPE_ADDRESS:
+  //       void;
+  //   case SC_SPEC_TYPE_OPTION:
+  //       SCSpecTypeOption option;
+  //   case SC_SPEC_TYPE_RESULT:
+  //       SCSpecTypeResult result;
+  //   case SC_SPEC_TYPE_VEC:
+  //       SCSpecTypeVec vec;
+  //   case SC_SPEC_TYPE_MAP:
+  //       SCSpecTypeMap map;
+  //   case SC_SPEC_TYPE_SET:
+  //       SCSpecTypeSet set;
+  //   case SC_SPEC_TYPE_TUPLE:
+  //       SCSpecTypeTuple tuple;
+  //   case SC_SPEC_TYPE_BYTES_N:
+  //       SCSpecTypeBytesN bytesN;
+  //   case SC_SPEC_TYPE_UDT:
+  //       SCSpecTypeUDT udt;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ScSpecTypeDef", {
+    switchOn: xdr.lookup("ScSpecType"),
+    switchName: "type",
+    switches: [
+      ["scSpecTypeVal", xdr.void()],
+      ["scSpecTypeBool", xdr.void()],
+      ["scSpecTypeVoid", xdr.void()],
+      ["scSpecTypeStatus", xdr.void()],
+      ["scSpecTypeU32", xdr.void()],
+      ["scSpecTypeI32", xdr.void()],
+      ["scSpecTypeU64", xdr.void()],
+      ["scSpecTypeI64", xdr.void()],
+      ["scSpecTypeTimepoint", xdr.void()],
+      ["scSpecTypeDuration", xdr.void()],
+      ["scSpecTypeU128", xdr.void()],
+      ["scSpecTypeI128", xdr.void()],
+      ["scSpecTypeU256", xdr.void()],
+      ["scSpecTypeI256", xdr.void()],
+      ["scSpecTypeBytes", xdr.void()],
+      ["scSpecTypeString", xdr.void()],
+      ["scSpecTypeSymbol", xdr.void()],
+      ["scSpecTypeAddress", xdr.void()],
+      ["scSpecTypeOption", "option"],
+      ["scSpecTypeResult", "result"],
+      ["scSpecTypeVec", "vec"],
+      ["scSpecTypeMap", "map"],
+      ["scSpecTypeSet", "set"],
+      ["scSpecTypeTuple", "tuple"],
+      ["scSpecTypeBytesN", "bytesN"],
+      ["scSpecTypeUdt", "udt"],
+    ],
+    arms: {
+      option: xdr.lookup("ScSpecTypeOption"),
+      result: xdr.lookup("ScSpecTypeResult"),
+      vec: xdr.lookup("ScSpecTypeVec"),
+      map: xdr.lookup("ScSpecTypeMap"),
+      set: xdr.lookup("ScSpecTypeSet"),
+      tuple: xdr.lookup("ScSpecTypeTuple"),
+      bytesN: xdr.lookup("ScSpecTypeBytesN"),
+      udt: xdr.lookup("ScSpecTypeUdt"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecUDTStructFieldV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       string name<30>;
+  //       SCSpecTypeDef type;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecUdtStructFieldV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["name", xdr.string(30)],
+    ["type", xdr.lookup("ScSpecTypeDef")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecUDTStructV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       string lib<80>;
+  //       string name<60>;
+  //       SCSpecUDTStructFieldV0 fields<40>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecUdtStructV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["lib", xdr.string(80)],
+    ["name", xdr.string(60)],
+    ["fields", xdr.varArray(xdr.lookup("ScSpecUdtStructFieldV0"), 40)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecUDTUnionCaseVoidV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       string name<60>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecUdtUnionCaseVoidV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["name", xdr.string(60)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecUDTUnionCaseTupleV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       string name<60>;
+  //       SCSpecTypeDef type<12>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecUdtUnionCaseTupleV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["name", xdr.string(60)],
+    ["type", xdr.varArray(xdr.lookup("ScSpecTypeDef"), 12)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum SCSpecUDTUnionCaseV0Kind
+  //   {
+  //       SC_SPEC_UDT_UNION_CASE_VOID_V0 = 0,
+  //       SC_SPEC_UDT_UNION_CASE_TUPLE_V0 = 1
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScSpecUdtUnionCaseV0Kind", {
+    scSpecUdtUnionCaseVoidV0: 0,
+    scSpecUdtUnionCaseTupleV0: 1,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union SCSpecUDTUnionCaseV0 switch (SCSpecUDTUnionCaseV0Kind kind)
+  //   {
+  //   case SC_SPEC_UDT_UNION_CASE_VOID_V0:
+  //       SCSpecUDTUnionCaseVoidV0 voidCase;
+  //   case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+  //       SCSpecUDTUnionCaseTupleV0 tupleCase;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ScSpecUdtUnionCaseV0", {
+    switchOn: xdr.lookup("ScSpecUdtUnionCaseV0Kind"),
+    switchName: "kind",
+    switches: [
+      ["scSpecUdtUnionCaseVoidV0", "voidCase"],
+      ["scSpecUdtUnionCaseTupleV0", "tupleCase"],
+    ],
+    arms: {
+      voidCase: xdr.lookup("ScSpecUdtUnionCaseVoidV0"),
+      tupleCase: xdr.lookup("ScSpecUdtUnionCaseTupleV0"),
+    },
+  });
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecUDTUnionV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       string lib<80>;
+  //       string name<60>;
+  //       SCSpecUDTUnionCaseV0 cases<50>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecUdtUnionV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["lib", xdr.string(80)],
+    ["name", xdr.string(60)],
+    ["cases", xdr.varArray(xdr.lookup("ScSpecUdtUnionCaseV0"), 50)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecUDTEnumCaseV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       string name<60>;
+  //       uint32 value;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecUdtEnumCaseV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["name", xdr.string(60)],
+    ["value", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecUDTEnumV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       string lib<80>;
+  //       string name<60>;
+  //       SCSpecUDTEnumCaseV0 cases<50>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecUdtEnumV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["lib", xdr.string(80)],
+    ["name", xdr.string(60)],
+    ["cases", xdr.varArray(xdr.lookup("ScSpecUdtEnumCaseV0"), 50)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecUDTErrorEnumCaseV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       string name<60>;
+  //       uint32 value;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecUdtErrorEnumCaseV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["name", xdr.string(60)],
+    ["value", xdr.lookup("Uint32")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecUDTErrorEnumV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       string lib<80>;
+  //       string name<60>;
+  //       SCSpecUDTErrorEnumCaseV0 cases<50>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecUdtErrorEnumV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["lib", xdr.string(80)],
+    ["name", xdr.string(60)],
+    ["cases", xdr.varArray(xdr.lookup("ScSpecUdtErrorEnumCaseV0"), 50)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecFunctionInputV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       string name<30>;
+  //       SCSpecTypeDef type;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecFunctionInputV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["name", xdr.string(30)],
+    ["type", xdr.lookup("ScSpecTypeDef")],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   struct SCSpecFunctionV0
+  //   {
+  //       string doc<SC_SPEC_DOC_LIMIT>;
+  //       SCSymbol name;
+  //       SCSpecFunctionInputV0 inputs<10>;
+  //       SCSpecTypeDef outputs<1>;
+  //   };
+  //
+  // ===========================================================================
+  xdr.struct("ScSpecFunctionV0", [
+    ["doc", xdr.string(xdr.lookup("SC_SPEC_DOC_LIMIT"))],
+    ["name", xdr.lookup("ScSymbol")],
+    ["inputs", xdr.varArray(xdr.lookup("ScSpecFunctionInputV0"), 10)],
+    ["outputs", xdr.varArray(xdr.lookup("ScSpecTypeDef"), 1)],
+  ]);
+
+  // === xdr source ============================================================
+  //
+  //   enum SCSpecEntryKind
+  //   {
+  //       SC_SPEC_ENTRY_FUNCTION_V0 = 0,
+  //       SC_SPEC_ENTRY_UDT_STRUCT_V0 = 1,
+  //       SC_SPEC_ENTRY_UDT_UNION_V0 = 2,
+  //       SC_SPEC_ENTRY_UDT_ENUM_V0 = 3,
+  //       SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0 = 4
+  //   };
+  //
+  // ===========================================================================
+  xdr.enum("ScSpecEntryKind", {
+    scSpecEntryFunctionV0: 0,
+    scSpecEntryUdtStructV0: 1,
+    scSpecEntryUdtUnionV0: 2,
+    scSpecEntryUdtEnumV0: 3,
+    scSpecEntryUdtErrorEnumV0: 4,
+  });
+
+  // === xdr source ============================================================
+  //
+  //   union SCSpecEntry switch (SCSpecEntryKind kind)
+  //   {
+  //   case SC_SPEC_ENTRY_FUNCTION_V0:
+  //       SCSpecFunctionV0 functionV0;
+  //   case SC_SPEC_ENTRY_UDT_STRUCT_V0:
+  //       SCSpecUDTStructV0 udtStructV0;
+  //   case SC_SPEC_ENTRY_UDT_UNION_V0:
+  //       SCSpecUDTUnionV0 udtUnionV0;
+  //   case SC_SPEC_ENTRY_UDT_ENUM_V0:
+  //       SCSpecUDTEnumV0 udtEnumV0;
+  //   case SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0:
+  //       SCSpecUDTErrorEnumV0 udtErrorEnumV0;
+  //   };
+  //
+  // ===========================================================================
+  xdr.union("ScSpecEntry", {
+    switchOn: xdr.lookup("ScSpecEntryKind"),
+    switchName: "kind",
+    switches: [
+      ["scSpecEntryFunctionV0", "functionV0"],
+      ["scSpecEntryUdtStructV0", "udtStructV0"],
+      ["scSpecEntryUdtUnionV0", "udtUnionV0"],
+      ["scSpecEntryUdtEnumV0", "udtEnumV0"],
+      ["scSpecEntryUdtErrorEnumV0", "udtErrorEnumV0"],
+    ],
+    arms: {
+      functionV0: xdr.lookup("ScSpecFunctionV0"),
+      udtStructV0: xdr.lookup("ScSpecUdtStructV0"),
+      udtUnionV0: xdr.lookup("ScSpecUdtUnionV0"),
+      udtEnumV0: xdr.lookup("ScSpecUdtEnumV0"),
+      udtErrorEnumV0: xdr.lookup("ScSpecUdtErrorEnumV0"),
+    },
+  });
 });
 export default types;

--- a/src/generated/next_generated.js
+++ b/src/generated/next_generated.js
@@ -1509,88 +1509,203 @@ xdr.struct("ContractCodeEntry", [
 
 // === xdr source ============================================================
 //
-//   enum ConfigSettingType
-//   {
-//       CONFIG_SETTING_TYPE_UINT32 = 0
-//   };
-//
-// ===========================================================================
-xdr.enum("ConfigSettingType", {
-  configSettingTypeUint32: 0,
-});
-
-// === xdr source ============================================================
-//
-//   union ConfigSetting switch (ConfigSettingType type)
-//   {
-//   case CONFIG_SETTING_TYPE_UINT32:
-//       uint32 uint32Val;
-//   };
-//
-// ===========================================================================
-xdr.union("ConfigSetting", {
-  switchOn: xdr.lookup("ConfigSettingType"),
-  switchName: "type",
-  switches: [
-    ["configSettingTypeUint32", "uint32Val"],
-  ],
-  arms: {
-    uint32Val: xdr.lookup("Uint32"),
-  },
-});
-
-// === xdr source ============================================================
-//
 //   enum ConfigSettingID
 //   {
-//       CONFIG_SETTING_CONTRACT_MAX_SIZE = 0
+//       CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES = 0,
+//       CONFIG_SETTING_CONTRACT_COMPUTE_V0 = 1,
+//       CONFIG_SETTING_CONTRACT_LEDGER_COST_V0 = 2,
+//       CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0 = 3,
+//       CONFIG_SETTING_CONTRACT_META_DATA_V0 = 4,
+//       CONFIG_SETTING_CONTRACT_BANDWIDTH_V0 = 5,
+//       CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION = 6
 //   };
 //
 // ===========================================================================
 xdr.enum("ConfigSettingId", {
-  configSettingContractMaxSize: 0,
+  configSettingContractMaxSizeBytes: 0,
+  configSettingContractComputeV0: 1,
+  configSettingContractLedgerCostV0: 2,
+  configSettingContractHistoricalDataV0: 3,
+  configSettingContractMetaDataV0: 4,
+  configSettingContractBandwidthV0: 5,
+  configSettingContractHostLogicVersion: 6,
 });
 
 // === xdr source ============================================================
 //
-//   union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//
-// ===========================================================================
-xdr.union("ConfigSettingEntryExt", {
-  switchOn: xdr.int(),
-  switchName: "v",
-  switches: [
-    [0, xdr.void()],
-  ],
-  arms: {
-  },
-});
-
-// === xdr source ============================================================
-//
-//   struct ConfigSettingEntry
+//   struct ConfigSettingContractComputeV0
 //   {
-//       union switch (int v)
-//       {
-//       case 0:
-//           void;
-//       }
-//       ext;
+//       // Maximum instructions per ledger
+//       int64 ledgerMaxInstructions;
+//       // Maximum instructions per transaction
+//       int64 txMaxInstructions;
+//       // Cost of 10000 instructions
+//       int64 feeRatePerInstructionsIncrement;
 //   
-//       ConfigSettingID configSettingID;
-//       ConfigSetting setting;
+//       // Memory limit per contract/host function invocation. Unlike 
+//       // instructions, there is no fee for memory and it's not
+//       // accumulated between operations - the same limit is applied 
+//       // to every operation.
+//       uint32 memoryLimit;
 //   };
 //
 // ===========================================================================
-xdr.struct("ConfigSettingEntry", [
-  ["ext", xdr.lookup("ConfigSettingEntryExt")],
-  ["configSettingId", xdr.lookup("ConfigSettingId")],
-  ["setting", xdr.lookup("ConfigSetting")],
+xdr.struct("ConfigSettingContractComputeV0", [
+  ["ledgerMaxInstructions", xdr.lookup("Int64")],
+  ["txMaxInstructions", xdr.lookup("Int64")],
+  ["feeRatePerInstructionsIncrement", xdr.lookup("Int64")],
+  ["memoryLimit", xdr.lookup("Uint32")],
 ]);
+
+// === xdr source ============================================================
+//
+//   struct ConfigSettingContractLedgerCostV0
+//   {
+//       // Maximum number of ledger entry read operations per ledger
+//       uint32 ledgerMaxReadLedgerEntries;
+//       // Maximum number of bytes that can be read per ledger
+//       uint32 ledgerMaxReadBytes;
+//       // Maximum number of ledger entry write operations per ledger
+//       uint32 ledgerMaxWriteLedgerEntries;
+//       // Maximum number of bytes that can be written per ledger
+//       uint32 ledgerMaxWriteBytes;
+//   
+//       // Maximum number of ledger entry read operations per transaction
+//       uint32 txMaxReadLedgerEntries;
+//       // Maximum number of bytes that can be read per transaction
+//       uint32 txMaxReadBytes;
+//       // Maximum number of ledger entry write operations per transaction
+//       uint32 txMaxWriteLedgerEntries;
+//       // Maximum number of bytes that can be written per transaction
+//       uint32 txMaxWriteBytes;
+//   
+//       int64 feeReadLedgerEntry;  // Fee per ledger entry read
+//       int64 feeWriteLedgerEntry; // Fee per ledger entry write
+//   
+//       int64 feeRead1KB;  // Fee for reading 1KB    
+//       int64 feeWrite1KB; // Fee for writing 1KB
+//   
+//       // Bucket list fees grow slowly up to that size
+//       int64 bucketListSizeBytes;
+//       // Fee rate in stroops when the bucket list is empty
+//       int64 bucketListFeeRateLow;
+//       // Fee rate in stroops when the bucket list reached bucketListSizeBytes
+//       int64 bucketListFeeRateHigh;
+//       // Rate multiplier for any additional data past the first bucketListSizeBytes
+//       uint32 bucketListGrowthFactor;
+//   };
+//
+// ===========================================================================
+xdr.struct("ConfigSettingContractLedgerCostV0", [
+  ["ledgerMaxReadLedgerEntries", xdr.lookup("Uint32")],
+  ["ledgerMaxReadBytes", xdr.lookup("Uint32")],
+  ["ledgerMaxWriteLedgerEntries", xdr.lookup("Uint32")],
+  ["ledgerMaxWriteBytes", xdr.lookup("Uint32")],
+  ["txMaxReadLedgerEntries", xdr.lookup("Uint32")],
+  ["txMaxReadBytes", xdr.lookup("Uint32")],
+  ["txMaxWriteLedgerEntries", xdr.lookup("Uint32")],
+  ["txMaxWriteBytes", xdr.lookup("Uint32")],
+  ["feeReadLedgerEntry", xdr.lookup("Int64")],
+  ["feeWriteLedgerEntry", xdr.lookup("Int64")],
+  ["feeRead1Kb", xdr.lookup("Int64")],
+  ["feeWrite1Kb", xdr.lookup("Int64")],
+  ["bucketListSizeBytes", xdr.lookup("Int64")],
+  ["bucketListFeeRateLow", xdr.lookup("Int64")],
+  ["bucketListFeeRateHigh", xdr.lookup("Int64")],
+  ["bucketListGrowthFactor", xdr.lookup("Uint32")],
+]);
+
+// === xdr source ============================================================
+//
+//   struct ConfigSettingContractHistoricalDataV0
+//   {
+//       int64 feeHistorical1KB; // Fee for storing 1KB in archives
+//   };
+//
+// ===========================================================================
+xdr.struct("ConfigSettingContractHistoricalDataV0", [
+  ["feeHistorical1Kb", xdr.lookup("Int64")],
+]);
+
+// === xdr source ============================================================
+//
+//   struct ConfigSettingContractMetaDataV0
+//   {
+//       // Maximum size of extended meta data produced by a transaction
+//       uint32 txMaxExtendedMetaDataSizeBytes;
+//       // Fee for generating 1KB of extended meta data
+//       int64 feeExtendedMetaData1KB;
+//   };
+//
+// ===========================================================================
+xdr.struct("ConfigSettingContractMetaDataV0", [
+  ["txMaxExtendedMetaDataSizeBytes", xdr.lookup("Uint32")],
+  ["feeExtendedMetaData1Kb", xdr.lookup("Int64")],
+]);
+
+// === xdr source ============================================================
+//
+//   struct ConfigSettingContractBandwidthV0
+//   {
+//       // Maximum size in bytes to propagate per ledger
+//       uint32 ledgerMaxPropagateSizeBytes;
+//       // Maximum size in bytes for a transaction
+//       uint32 txMaxSizeBytes;
+//   
+//       // Fee for propagating 1KB of data
+//       int64 feePropagateData1KB;
+//   };
+//
+// ===========================================================================
+xdr.struct("ConfigSettingContractBandwidthV0", [
+  ["ledgerMaxPropagateSizeBytes", xdr.lookup("Uint32")],
+  ["txMaxSizeBytes", xdr.lookup("Uint32")],
+  ["feePropagateData1Kb", xdr.lookup("Int64")],
+]);
+
+// === xdr source ============================================================
+//
+//   union ConfigSettingEntry switch (ConfigSettingID configSettingID)
+//   {
+//   case CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES:
+//       uint32 contractMaxSizeBytes;
+//   case CONFIG_SETTING_CONTRACT_COMPUTE_V0:
+//       ConfigSettingContractComputeV0 contractCompute;
+//   case CONFIG_SETTING_CONTRACT_LEDGER_COST_V0:
+//       ConfigSettingContractLedgerCostV0 contractLedgerCost;
+//   case CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0:
+//       ConfigSettingContractHistoricalDataV0 contractHistoricalData;
+//   case CONFIG_SETTING_CONTRACT_META_DATA_V0:
+//       ConfigSettingContractMetaDataV0 contractMetaData;
+//   case CONFIG_SETTING_CONTRACT_BANDWIDTH_V0:
+//       ConfigSettingContractBandwidthV0 contractBandwidth;
+//   case CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION:
+//       uint32 contractHostLogicVersion;
+//   };
+//
+// ===========================================================================
+xdr.union("ConfigSettingEntry", {
+  switchOn: xdr.lookup("ConfigSettingId"),
+  switchName: "configSettingId",
+  switches: [
+    ["configSettingContractMaxSizeBytes", "contractMaxSizeBytes"],
+    ["configSettingContractComputeV0", "contractCompute"],
+    ["configSettingContractLedgerCostV0", "contractLedgerCost"],
+    ["configSettingContractHistoricalDataV0", "contractHistoricalData"],
+    ["configSettingContractMetaDataV0", "contractMetaData"],
+    ["configSettingContractBandwidthV0", "contractBandwidth"],
+    ["configSettingContractHostLogicVersion", "contractHostLogicVersion"],
+  ],
+  arms: {
+    contractMaxSizeBytes: xdr.lookup("Uint32"),
+    contractCompute: xdr.lookup("ConfigSettingContractComputeV0"),
+    contractLedgerCost: xdr.lookup("ConfigSettingContractLedgerCostV0"),
+    contractHistoricalData: xdr.lookup("ConfigSettingContractHistoricalDataV0"),
+    contractMetaData: xdr.lookup("ConfigSettingContractMetaDataV0"),
+    contractBandwidth: xdr.lookup("ConfigSettingContractBandwidthV0"),
+    contractHostLogicVersion: xdr.lookup("Uint32"),
+  },
+});
 
 // === xdr source ============================================================
 //
@@ -2264,16 +2379,15 @@ xdr.enum("LedgerUpgradeType", {
 
 // === xdr source ============================================================
 //
-//   struct
-//       {
-//           ConfigSettingID id; // id to update
-//           ConfigSetting setting; // new value
-//       }
+//   struct ConfigUpgradeSetKey {
+//       Hash contractID;
+//       Hash contentHash;
+//   };
 //
 // ===========================================================================
-xdr.struct("LedgerUpgradeConfigSetting", [
-  ["id", xdr.lookup("ConfigSettingId")],
-  ["setting", xdr.lookup("ConfigSetting")],
+xdr.struct("ConfigUpgradeSetKey", [
+  ["contractId", xdr.lookup("Hash")],
+  ["contentHash", xdr.lookup("Hash")],
 ]);
 
 // === xdr source ============================================================
@@ -2291,11 +2405,7 @@ xdr.struct("LedgerUpgradeConfigSetting", [
 //   case LEDGER_UPGRADE_FLAGS:
 //       uint32 newFlags; // update flags
 //   case LEDGER_UPGRADE_CONFIG:
-//       struct
-//       {
-//           ConfigSettingID id; // id to update
-//           ConfigSetting setting; // new value
-//       } configSetting;
+//       ConfigUpgradeSetKey newConfig;
 //   };
 //
 // ===========================================================================
@@ -2308,7 +2418,7 @@ xdr.union("LedgerUpgrade", {
     ["ledgerUpgradeMaxTxSetSize", "newMaxTxSetSize"],
     ["ledgerUpgradeBaseReserve", "newBaseReserve"],
     ["ledgerUpgradeFlags", "newFlags"],
-    ["ledgerUpgradeConfig", "configSetting"],
+    ["ledgerUpgradeConfig", "newConfig"],
   ],
   arms: {
     newLedgerVersion: xdr.lookup("Uint32"),
@@ -2316,9 +2426,20 @@ xdr.union("LedgerUpgrade", {
     newMaxTxSetSize: xdr.lookup("Uint32"),
     newBaseReserve: xdr.lookup("Uint32"),
     newFlags: xdr.lookup("Uint32"),
-    configSetting: xdr.lookup("LedgerUpgradeConfigSetting"),
+    newConfig: xdr.lookup("ConfigUpgradeSetKey"),
   },
 });
+
+// === xdr source ============================================================
+//
+//   struct ConfigUpgradeSet {
+//       ConfigSettingEntry updatedEntry<>;
+//   };
+//
+// ===========================================================================
+xdr.struct("ConfigUpgradeSet", [
+  ["updatedEntry", xdr.varArray(xdr.lookup("ConfigSettingEntry"), 2147483647)],
+]);
 
 // === xdr source ============================================================
 //
@@ -2914,13 +3035,15 @@ xdr.struct("TransactionMetaV2", [
 //   enum ContractEventType
 //   {
 //       SYSTEM = 0,
-//       CONTRACT = 1
+//       CONTRACT = 1,
+//       DIAGNOSTIC = 2
 //   };
 //
 // ===========================================================================
 xdr.enum("ContractEventType", {
   system: 0,
   contract: 1,
+  diagnostic: 2,
 });
 
 // === xdr source ============================================================
@@ -2994,6 +3117,32 @@ xdr.struct("ContractEvent", [
 
 // === xdr source ============================================================
 //
+//   struct DiagnosticEvent
+//   {
+//       bool inSuccessfulContractCall;
+//       ContractEvent event;
+//   };
+//
+// ===========================================================================
+xdr.struct("DiagnosticEvent", [
+  ["inSuccessfulContractCall", xdr.bool()],
+  ["event", xdr.lookup("ContractEvent")],
+]);
+
+// === xdr source ============================================================
+//
+//   struct OperationDiagnosticEvents
+//   {
+//       DiagnosticEvent events<>;
+//   };
+//
+// ===========================================================================
+xdr.struct("OperationDiagnosticEvents", [
+  ["events", xdr.varArray(xdr.lookup("DiagnosticEvent"), 2147483647)],
+]);
+
+// === xdr source ============================================================
+//
 //   struct OperationEvents
 //   {
 //       ContractEvent events<>;
@@ -3019,6 +3168,11 @@ xdr.struct("OperationEvents", [
 //   
 //       Hash hashes[3];                     // stores sha256(txChangesBefore, operations, txChangesAfter),
 //                                           // sha256(events), and sha256(txResult)
+//   
+//       // Diagnostics events that are not hashed. One list per operation.
+//       // This will contain all contract and diagnostic events. Even ones
+//       // that were emitted in a failed contract call.
+//       OperationDiagnosticEvents diagnosticEvents<>;
 //   };
 //
 // ===========================================================================
@@ -3029,6 +3183,7 @@ xdr.struct("TransactionMetaV3", [
   ["events", xdr.varArray(xdr.lookup("OperationEvents"), 2147483647)],
   ["txResult", xdr.lookup("TransactionResult")],
   ["hashes", xdr.array(xdr.lookup("Hash"), 3)],
+  ["diagnosticEvents", xdr.varArray(xdr.lookup("OperationDiagnosticEvents"), 2147483647)],
 ]);
 
 // === xdr source ============================================================
@@ -8484,18 +8639,62 @@ xdr.union("ScStatus", {
 
 // === xdr source ============================================================
 //
-//   struct Int128Parts {
-//       // Both signed and unsigned 128-bit ints
-//       // are transported in a pair of uint64s
-//       // to reduce the risk of sign-extension.
-//       uint64 lo;
+//   struct UInt128Parts {
 //       uint64 hi;
+//       uint64 lo;
+//   };
+//
+// ===========================================================================
+xdr.struct("UInt128Parts", [
+  ["hi", xdr.lookup("Uint64")],
+  ["lo", xdr.lookup("Uint64")],
+]);
+
+// === xdr source ============================================================
+//
+//   struct Int128Parts {
+//       int64 hi;
+//       uint64 lo;
 //   };
 //
 // ===========================================================================
 xdr.struct("Int128Parts", [
+  ["hi", xdr.lookup("Int64")],
   ["lo", xdr.lookup("Uint64")],
-  ["hi", xdr.lookup("Uint64")],
+]);
+
+// === xdr source ============================================================
+//
+//   struct UInt256Parts {
+//       uint64 hi_hi;
+//       uint64 hi_lo;
+//       uint64 lo_hi;
+//       uint64 lo_lo;
+//   };
+//
+// ===========================================================================
+xdr.struct("UInt256Parts", [
+  ["hiHi", xdr.lookup("Uint64")],
+  ["hiLo", xdr.lookup("Uint64")],
+  ["loHi", xdr.lookup("Uint64")],
+  ["loLo", xdr.lookup("Uint64")],
+]);
+
+// === xdr source ============================================================
+//
+//   struct Int256Parts {
+//       int64 hi_hi;
+//       uint64 hi_lo;
+//       uint64 lo_hi;
+//       uint64 lo_lo;
+//   };
+//
+// ===========================================================================
+xdr.struct("Int256Parts", [
+  ["hiHi", xdr.lookup("Int64")],
+  ["hiLo", xdr.lookup("Uint64")],
+  ["loHi", xdr.lookup("Uint64")],
+  ["loLo", xdr.lookup("Uint64")],
 ]);
 
 // === xdr source ============================================================
@@ -8575,14 +8774,14 @@ xdr.union("ScAddress", {
 
 // === xdr source ============================================================
 //
-const SCVAL_LIMIT = 256000;
+//   const SCVAL_LIMIT = 256000;
 //
 // ===========================================================================
 xdr.const("SCVAL_LIMIT", 256000);
 
 // === xdr source ============================================================
 //
-const SCSYMBOL_LIMIT = 32;
+//   const SCSYMBOL_LIMIT = 32;
 //
 // ===========================================================================
 xdr.const("SCSYMBOL_LIMIT", 32);
@@ -8660,14 +8859,14 @@ xdr.struct("ScNonceKey", [
 //       Duration duration;
 //   
 //   case SCV_U128:
-//       Int128Parts u128;
+//       UInt128Parts u128;
 //   case SCV_I128:
 //       Int128Parts i128;
 //   
 //   case SCV_U256:
-//       uint256 u256;
+//       UInt256Parts u256;
 //   case SCV_I256:
-//       uint256 i256;
+//       Int256Parts i256;
 //   
 //   case SCV_BYTES:
 //       SCBytes bytes;
@@ -8733,10 +8932,10 @@ xdr.union("ScVal", {
     i64: xdr.lookup("Int64"),
     timepoint: xdr.lookup("TimePoint"),
     duration: xdr.lookup("Duration"),
-    u128: xdr.lookup("Int128Parts"),
+    u128: xdr.lookup("UInt128Parts"),
     i128: xdr.lookup("Int128Parts"),
-    u256: xdr.lookup("Uint256"),
-    i256: xdr.lookup("Uint256"),
+    u256: xdr.lookup("UInt256Parts"),
+    i256: xdr.lookup("Int256Parts"),
     bytes: xdr.lookup("ScBytes"),
     str: xdr.lookup("ScString"),
     sym: xdr.lookup("ScSymbol"),
@@ -8796,7 +8995,7 @@ xdr.union("ScEnvMetaEntry", {
 
 // === xdr source ============================================================
 //
-const SC_SPEC_DOC_LIMIT = 1024;
+//   const SC_SPEC_DOC_LIMIT = 1024;
 //
 // ===========================================================================
 xdr.const("SC_SPEC_DOC_LIMIT", 1024);

--- a/src/util/decode_encode_muxed_account.js
+++ b/src/util/decode_encode_muxed_account.js
@@ -107,8 +107,8 @@ function _decodeAddressFullyToMuxedAccount(address) {
   // for the Golang implementation of the M... parsing.
   return xdr.MuxedAccount.keyTypeMuxedEd25519(
     new xdr.MuxedAccountMed25519({
-      id: xdr.Uint64.fromXDR(rawBytes.slice(-8)),
-      ed25519: rawBytes.slice(0, -8)
+      id: xdr.Uint64.fromXDR(rawBytes.subarray(-8)),
+      ed25519: rawBytes.subarray(0, -8)
     })
   );
 }

--- a/test/unit/address_test.js
+++ b/test/unit/address_test.js
@@ -1,55 +1,55 @@
-describe('Address', function() {
+describe('Address', function () {
   const ACCOUNT = 'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB';
   const CONTRACT = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
   const MUXED_ADDRESS =
     'MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK';
 
-  describe('.constructor', function() {
-    it('fails to create Address object from an invalid address', function() {
+  describe('.constructor', function () {
+    it('fails to create Address object from an invalid address', function () {
       expect(() => new StellarBase.Address('GBBB')).to.throw(
         /Unsupported address type/
       );
     });
 
-    it('creates an Address object for accounts', function() {
+    it('creates an Address object for accounts', function () {
       let account = new StellarBase.Address(ACCOUNT);
       expect(account.toString()).to.equal(ACCOUNT);
     });
 
-    it('creates an Address object for contracts', function() {
+    it('creates an Address object for contracts', function () {
       let account = new StellarBase.Address(CONTRACT);
       expect(account.toString()).to.equal(CONTRACT);
     });
 
-    it('wont create Address objects from muxed account strings', function() {
+    it('wont create Address objects from muxed account strings', function () {
       expect(() => {
         new StellarBase.Account(MUXED_ADDRESS, '123');
       }).to.throw(/MuxedAccount/);
     });
   });
 
-  describe('static constructors', function() {
-    it('.fromString', function() {
+  describe('static constructors', function () {
+    it('.fromString', function () {
       let account = StellarBase.Address.fromString(ACCOUNT);
       expect(account.toString()).to.equal(ACCOUNT);
     });
 
-    it('.account', function() {
+    it('.account', function () {
       let account = StellarBase.Address.account(Buffer.alloc(32));
       expect(account.toString()).to.equal(
         'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
       );
     });
 
-    it('.contract', function() {
+    it('.contract', function () {
       let account = StellarBase.Address.contract(Buffer.alloc(32));
       expect(account.toString()).to.equal(
         'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4'
       );
     });
 
-    describe('.fromScAddress', function() {
-      it('creates an Address object for accounts', function() {
+    describe('.fromScAddress', function () {
+      it('creates an Address object for accounts', function () {
         let scAddress = StellarBase.xdr.ScAddress.scAddressTypeAccount(
           StellarBase.xdr.PublicKey.publicKeyTypeEd25519(
             StellarBase.StrKey.decodeEd25519PublicKey(ACCOUNT)
@@ -59,7 +59,7 @@ describe('Address', function() {
         expect(account.toString()).to.equal(ACCOUNT);
       });
 
-      it('creates an Address object for contracts', function() {
+      it('creates an Address object for contracts', function () {
         let scAddress = StellarBase.xdr.ScAddress.scAddressTypeContract(
           StellarBase.StrKey.decodeContract(CONTRACT)
         );
@@ -68,8 +68,8 @@ describe('Address', function() {
       });
     });
 
-    describe('.fromScVal', function() {
-      it('creates an Address object for accounts', function() {
+    describe('.fromScVal', function () {
+      it('creates an Address object for accounts', function () {
         let scVal = StellarBase.xdr.ScVal.scvAddress(
           StellarBase.xdr.ScAddress.scAddressTypeAccount(
             StellarBase.xdr.PublicKey.publicKeyTypeEd25519(
@@ -81,7 +81,7 @@ describe('Address', function() {
         expect(account.toString()).to.equal(ACCOUNT);
       });
 
-      it('creates an Address object for contracts', function() {
+      it('creates an Address object for contracts', function () {
         let scVal = StellarBase.xdr.ScVal.scvAddress(
           StellarBase.xdr.ScAddress.scAddressTypeContract(
             StellarBase.StrKey.decodeContract(CONTRACT)
@@ -93,8 +93,8 @@ describe('Address', function() {
     });
   });
 
-  describe('.toScAddress', function() {
-    it('converts accounts to an ScAddress', function() {
+  describe('.toScAddress', function () {
+    it('converts accounts to an ScAddress', function () {
       const a = new StellarBase.Address(ACCOUNT);
       const s = a.toScAddress();
       expect(s).to.be.instanceof(StellarBase.xdr.ScAddress);
@@ -103,7 +103,7 @@ describe('Address', function() {
       );
     });
 
-    it('converts contracts to an ScAddress', function() {
+    it('converts contracts to an ScAddress', function () {
       const a = new StellarBase.Address(CONTRACT);
       const s = a.toScAddress();
       expect(s).to.be.instanceof(StellarBase.xdr.ScAddress);
@@ -113,8 +113,8 @@ describe('Address', function() {
     });
   });
 
-  describe('.toScVal', function() {
-    it('converts to an ScAddress', function() {
+  describe('.toScVal', function () {
+    it('converts to an ScAddress', function () {
       const a = new StellarBase.Address(ACCOUNT);
       const s = a.toScVal();
       expect(s).to.be.instanceof(StellarBase.xdr.ScVal);
@@ -122,8 +122,8 @@ describe('Address', function() {
     });
   });
 
-  describe('.toBuffer', function() {
-    it('returns the raw public key bytes for accounts', function() {
+  describe('.toBuffer', function () {
+    it('returns the raw public key bytes for accounts', function () {
       const a = new StellarBase.Address(ACCOUNT);
       const b = a.toBuffer();
       expect(b).to.deep.equal(
@@ -131,7 +131,7 @@ describe('Address', function() {
       );
     });
 
-    it('returns the raw public key bytes for contracts', function() {
+    it('returns the raw public key bytes for contracts', function () {
       const a = new StellarBase.Address(CONTRACT);
       const b = a.toBuffer();
       expect(b).to.deep.equal(StellarBase.StrKey.decodeContract(CONTRACT));

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -1,5 +1,5 @@
-describe('Contract.call', function() {
-  it('includes the contract code footprint', function() {
+describe('Contract.call', function () {
+  it('includes the contract code footprint', function () {
     let contractId =
       '0000000000000000000000000000000000000000000000000000000000000001';
     let contract = new StellarBase.Contract(contractId);

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -413,7 +413,7 @@ describe('StrKey', function () {
     });
   });
 
-  describe('#invalidStrKeys', function() {
+  describe('#invalidStrKeys', function () {
     // From https://stellar.org/protocol/sep-23#invalid-test-cases
     const BAD_STRKEYS = [
       // The unused trailing bit must be zero in the encoding of the last three

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -392,8 +392,8 @@ describe('StrKey', function () {
     });
   });
 
-  describe('#contracts', function() {
-    it('valid w/ 32-byte payload', function() {
+  describe('#contracts', function () {
+    it('valid w/ 32-byte payload', function () {
       const strkey = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
       const buf = StellarBase.StrKey.decodeContract(strkey);
 
@@ -404,7 +404,7 @@ describe('StrKey', function () {
       expect(StellarBase.StrKey.encodeContract(buf)).to.equal(strkey);
     });
 
-    it('isValid', function() {
+    it('isValid', function () {
       const valid = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
       expect(StellarBase.StrKey.isValidContract(valid)).to.be.true;
       const invalid =

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -253,7 +253,7 @@ describe('Transaction', function () {
     );
   });
 
-  it('returns error when transaction includes soroban contract auth', function() {
+  it('returns error when transaction includes soroban contract auth', function () {
     let source = new StellarBase.Account(
       'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
       '0'
@@ -302,7 +302,7 @@ describe('Transaction', function () {
     );
   });
 
-  it('adds signature correctly', function() {
+  it('adds signature correctly', function () {
     const sourceKey =
       'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB';
     // make two sources so they have the same seq number

--- a/types/curr.d.ts
+++ b/types/curr.d.ts
@@ -16,25 +16,25 @@ declare namespace xdrHidden {
 
     body(value?: xdr.OperationBody): xdr.OperationBody;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
-    static read(io: Buffer): xdr.Operation;
+    static read(io: Buffer): Operation;
 
-    static write(value: xdr.Operation, io: Buffer): void;
+    static write(value: Operation, io: Buffer): void;
 
-    static isValid(value: xdr.Operation): boolean;
+    static isValid(value: Operation): boolean;
 
-    static toXDR(value: xdr.Operation): Buffer;
+    static toXDR(value: Operation): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): xdr.Operation;
+    static fromXDR(input: Buffer, format?: "raw"): Operation;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): xdr.Operation;
+    static fromXDR(input: string, format: "hex" | "base64"): Operation;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 }
 
@@ -48,10 +48,10 @@ export namespace xdr {
     write(value: number, io: Buffer): void;
     isValid(value: number): boolean;
     toXDR(value: number): Buffer;
-    fromXDR(input: Buffer, format?: 'raw'): number;
-    fromXDR(input: string, format: 'hex' | 'base64'): number;
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    fromXDR(input: Buffer, format?: "raw"): number;
+    fromXDR(input: string, format: "hex" | "base64"): number;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   interface UnsignedInt {
@@ -61,10 +61,10 @@ export namespace xdr {
     write(value: number, io: Buffer): void;
     isValid(value: number): boolean;
     toXDR(value: number): Buffer;
-    fromXDR(input: Buffer, format?: 'raw'): number;
-    fromXDR(input: string, format: 'hex' | 'base64'): number;
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    fromXDR(input: Buffer, format?: "raw"): number;
+    fromXDR(input: string, format: "hex" | "base64"): number;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   interface Bool {
@@ -72,10 +72,10 @@ export namespace xdr {
     write(value: boolean, io: Buffer): void;
     isValid(value: boolean): boolean;
     toXDR(value: boolean): Buffer;
-    fromXDR(input: Buffer, format?: 'raw'): boolean;
-    fromXDR(input: string, format: 'hex' | 'base64'): boolean;
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    fromXDR(input: Buffer, format?: "raw"): boolean;
+    fromXDR(input: string, format: "hex" | "base64"): boolean;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Hyper {
@@ -87,19 +87,19 @@ export namespace xdr {
 
     constructor(low: number, high: number);
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static toXDR(value: Hyper): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Hyper;
+    static fromXDR(input: Buffer, format?: "raw"): Hyper;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Hyper;
+    static fromXDR(input: string, format: "hex" | "base64"): Hyper;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
 
     static readonly MAX_VALUE: Hyper;
 
@@ -125,19 +125,19 @@ export namespace xdr {
 
     constructor(low: number, high: number);
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static toXDR(value: UnsignedHyper): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): UnsignedHyper;
+    static fromXDR(input: Buffer, format?: "raw"): UnsignedHyper;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): UnsignedHyper;
+    static fromXDR(input: string, format: "hex" | "base64"): UnsignedHyper;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
 
     static readonly MAX_VALUE: UnsignedHyper;
 
@@ -167,13 +167,13 @@ export namespace xdr {
 
     toXDR(value: string | Buffer): Buffer;
 
-    fromXDR(input: Buffer, format?: 'raw'): Buffer;
+    fromXDR(input: Buffer, format?: "raw"): Buffer;
 
-    fromXDR(input: string, format: 'hex' | 'base64'): Buffer;
+    fromXDR(input: string, format: "hex" | "base64"): Buffer;
 
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class XDRArray<T> {
@@ -185,13 +185,13 @@ export namespace xdr {
 
     toXDR(value: T[]): Buffer;
 
-    fromXDR(input: Buffer, format?: 'raw'): T[];
+    fromXDR(input: Buffer, format?: "raw"): T[];
 
-    fromXDR(input: string, format: 'hex' | 'base64'): T[];
+    fromXDR(input: string, format: "hex" | "base64"): T[];
 
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Opaque {
@@ -205,13 +205,13 @@ export namespace xdr {
 
     toXDR(value: Buffer): Buffer;
 
-    fromXDR(input: Buffer, format?: 'raw'): Buffer;
+    fromXDR(input: Buffer, format?: "raw"): Buffer;
 
-    fromXDR(input: string, format: 'hex' | 'base64'): Buffer;
+    fromXDR(input: string, format: "hex" | "base64"): Buffer;
 
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class VarOpaque extends Opaque {}
@@ -231,21 +231,21 @@ export namespace xdr {
 
     toXDR(value: any): Buffer;
 
-    fromXDR(input: Buffer, format?: 'raw'): any;
+    fromXDR(input: Buffer, format?: "raw"): any;
 
-    fromXDR(input: string, format: 'hex' | 'base64'): any;
+    fromXDR(input: string, format: "hex" | "base64"): any;
 
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatementType {
     readonly name:
-      | 'scpStPrepare'
-      | 'scpStConfirm'
-      | 'scpStExternalize'
-      | 'scpStNominate';
+      | "scpStPrepare"
+      | "scpStConfirm"
+      | "scpStExternalize"
+      | "scpStNominate";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -260,10 +260,10 @@ export namespace xdr {
 
   class AssetType {
     readonly name:
-      | 'assetTypeNative'
-      | 'assetTypeCreditAlphanum4'
-      | 'assetTypeCreditAlphanum12'
-      | 'assetTypePoolShare';
+      | "assetTypeNative"
+      | "assetTypeCreditAlphanum4"
+      | "assetTypeCreditAlphanum12"
+      | "assetTypePoolShare";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -278,10 +278,10 @@ export namespace xdr {
 
   class ThresholdIndices {
     readonly name:
-      | 'thresholdMasterWeight'
-      | 'thresholdLow'
-      | 'thresholdMed'
-      | 'thresholdHigh';
+      | "thresholdMasterWeight"
+      | "thresholdLow"
+      | "thresholdMed"
+      | "thresholdHigh";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -296,12 +296,12 @@ export namespace xdr {
 
   class LedgerEntryType {
     readonly name:
-      | 'account'
-      | 'trustline'
-      | 'offer'
-      | 'data'
-      | 'claimableBalance'
-      | 'liquidityPool';
+      | "account"
+      | "trustline"
+      | "offer"
+      | "data"
+      | "claimableBalance"
+      | "liquidityPool";
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -320,10 +320,10 @@ export namespace xdr {
 
   class AccountFlags {
     readonly name:
-      | 'authRequiredFlag'
-      | 'authRevocableFlag'
-      | 'authImmutableFlag'
-      | 'authClawbackEnabledFlag';
+      | "authRequiredFlag"
+      | "authRevocableFlag"
+      | "authImmutableFlag"
+      | "authClawbackEnabledFlag";
 
     readonly value: 1 | 2 | 4 | 8;
 
@@ -338,9 +338,9 @@ export namespace xdr {
 
   class TrustLineFlags {
     readonly name:
-      | 'authorizedFlag'
-      | 'authorizedToMaintainLiabilitiesFlag'
-      | 'trustlineClawbackEnabledFlag';
+      | "authorizedFlag"
+      | "authorizedToMaintainLiabilitiesFlag"
+      | "trustlineClawbackEnabledFlag";
 
     readonly value: 1 | 2 | 4;
 
@@ -352,7 +352,7 @@ export namespace xdr {
   }
 
   class LiquidityPoolType {
-    readonly name: 'liquidityPoolConstantProduct';
+    readonly name: "liquidityPoolConstantProduct";
 
     readonly value: 0;
 
@@ -360,7 +360,7 @@ export namespace xdr {
   }
 
   class OfferEntryFlags {
-    readonly name: 'passiveFlag';
+    readonly name: "passiveFlag";
 
     readonly value: 1;
 
@@ -369,12 +369,12 @@ export namespace xdr {
 
   class ClaimPredicateType {
     readonly name:
-      | 'claimPredicateUnconditional'
-      | 'claimPredicateAnd'
-      | 'claimPredicateOr'
-      | 'claimPredicateNot'
-      | 'claimPredicateBeforeAbsoluteTime'
-      | 'claimPredicateBeforeRelativeTime';
+      | "claimPredicateUnconditional"
+      | "claimPredicateAnd"
+      | "claimPredicateOr"
+      | "claimPredicateNot"
+      | "claimPredicateBeforeAbsoluteTime"
+      | "claimPredicateBeforeRelativeTime";
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -392,7 +392,7 @@ export namespace xdr {
   }
 
   class ClaimantType {
-    readonly name: 'claimantTypeV0';
+    readonly name: "claimantTypeV0";
 
     readonly value: 0;
 
@@ -400,7 +400,7 @@ export namespace xdr {
   }
 
   class ClaimableBalanceIdType {
-    readonly name: 'claimableBalanceIdTypeV0';
+    readonly name: "claimableBalanceIdTypeV0";
 
     readonly value: 0;
 
@@ -408,7 +408,7 @@ export namespace xdr {
   }
 
   class ClaimableBalanceFlags {
-    readonly name: 'claimableBalanceClawbackEnabledFlag';
+    readonly name: "claimableBalanceClawbackEnabledFlag";
 
     readonly value: 1;
 
@@ -417,14 +417,14 @@ export namespace xdr {
 
   class EnvelopeType {
     readonly name:
-      | 'envelopeTypeTxV0'
-      | 'envelopeTypeScp'
-      | 'envelopeTypeTx'
-      | 'envelopeTypeAuth'
-      | 'envelopeTypeScpvalue'
-      | 'envelopeTypeTxFeeBump'
-      | 'envelopeTypeOpId'
-      | 'envelopeTypePoolRevokeOpId';
+      | "envelopeTypeTxV0"
+      | "envelopeTypeScp"
+      | "envelopeTypeTx"
+      | "envelopeTypeAuth"
+      | "envelopeTypeScpvalue"
+      | "envelopeTypeTxFeeBump"
+      | "envelopeTypeOpId"
+      | "envelopeTypePoolRevokeOpId";
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
@@ -446,7 +446,7 @@ export namespace xdr {
   }
 
   class StellarValueType {
-    readonly name: 'stellarValueBasic' | 'stellarValueSigned';
+    readonly name: "stellarValueBasic" | "stellarValueSigned";
 
     readonly value: 0 | 1;
 
@@ -457,9 +457,9 @@ export namespace xdr {
 
   class LedgerHeaderFlags {
     readonly name:
-      | 'disableLiquidityPoolTradingFlag'
-      | 'disableLiquidityPoolDepositFlag'
-      | 'disableLiquidityPoolWithdrawalFlag';
+      | "disableLiquidityPoolTradingFlag"
+      | "disableLiquidityPoolDepositFlag"
+      | "disableLiquidityPoolWithdrawalFlag";
 
     readonly value: 1 | 2 | 4;
 
@@ -472,11 +472,11 @@ export namespace xdr {
 
   class LedgerUpgradeType {
     readonly name:
-      | 'ledgerUpgradeVersion'
-      | 'ledgerUpgradeBaseFee'
-      | 'ledgerUpgradeMaxTxSetSize'
-      | 'ledgerUpgradeBaseReserve'
-      | 'ledgerUpgradeFlags';
+      | "ledgerUpgradeVersion"
+      | "ledgerUpgradeBaseFee"
+      | "ledgerUpgradeMaxTxSetSize"
+      | "ledgerUpgradeBaseReserve"
+      | "ledgerUpgradeFlags";
 
     readonly value: 1 | 2 | 3 | 4 | 5;
 
@@ -492,7 +492,7 @@ export namespace xdr {
   }
 
   class BucketEntryType {
-    readonly name: 'metaentry' | 'liveentry' | 'deadentry' | 'initentry';
+    readonly name: "metaentry" | "liveentry" | "deadentry" | "initentry";
 
     readonly value: -1 | 0 | 1 | 2;
 
@@ -506,7 +506,7 @@ export namespace xdr {
   }
 
   class TxSetComponentType {
-    readonly name: 'txsetCompTxsMaybeDiscountedFee';
+    readonly name: "txsetCompTxsMaybeDiscountedFee";
 
     readonly value: 0;
 
@@ -515,10 +515,10 @@ export namespace xdr {
 
   class LedgerEntryChangeType {
     readonly name:
-      | 'ledgerEntryCreated'
-      | 'ledgerEntryUpdated'
-      | 'ledgerEntryRemoved'
-      | 'ledgerEntryState';
+      | "ledgerEntryCreated"
+      | "ledgerEntryUpdated"
+      | "ledgerEntryRemoved"
+      | "ledgerEntryState";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -532,7 +532,7 @@ export namespace xdr {
   }
 
   class ErrorCode {
-    readonly name: 'errMisc' | 'errData' | 'errConf' | 'errAuth' | 'errLoad';
+    readonly name: "errMisc" | "errData" | "errConf" | "errAuth" | "errLoad";
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -548,7 +548,7 @@ export namespace xdr {
   }
 
   class IpAddrType {
-    readonly name: 'iPv4' | 'iPv6';
+    readonly name: "iPv4" | "iPv6";
 
     readonly value: 0 | 1;
 
@@ -559,23 +559,25 @@ export namespace xdr {
 
   class MessageType {
     readonly name:
-      | 'errorMsg'
-      | 'auth'
-      | 'dontHave'
-      | 'getPeers'
-      | 'peers'
-      | 'getTxSet'
-      | 'txSet'
-      | 'generalizedTxSet'
-      | 'transaction'
-      | 'getScpQuorumset'
-      | 'scpQuorumset'
-      | 'scpMessage'
-      | 'getScpState'
-      | 'hello'
-      | 'surveyRequest'
-      | 'surveyResponse'
-      | 'sendMore';
+      | "errorMsg"
+      | "auth"
+      | "dontHave"
+      | "getPeers"
+      | "peers"
+      | "getTxSet"
+      | "txSet"
+      | "generalizedTxSet"
+      | "transaction"
+      | "getScpQuorumset"
+      | "scpQuorumset"
+      | "scpMessage"
+      | "getScpState"
+      | "hello"
+      | "surveyRequest"
+      | "surveyResponse"
+      | "sendMore"
+      | "floodAdvert"
+      | "floodDemand";
 
     readonly value:
       | 0
@@ -594,7 +596,9 @@ export namespace xdr {
       | 13
       | 14
       | 15
-      | 16;
+      | 16
+      | 18
+      | 19;
 
     static errorMsg(): MessageType;
 
@@ -629,10 +633,14 @@ export namespace xdr {
     static surveyResponse(): MessageType;
 
     static sendMore(): MessageType;
+
+    static floodAdvert(): MessageType;
+
+    static floodDemand(): MessageType;
   }
 
   class SurveyMessageCommandType {
-    readonly name: 'surveyTopology';
+    readonly name: "surveyTopology";
 
     readonly value: 0;
 
@@ -641,30 +649,30 @@ export namespace xdr {
 
   class OperationType {
     readonly name:
-      | 'createAccount'
-      | 'payment'
-      | 'pathPaymentStrictReceive'
-      | 'manageSellOffer'
-      | 'createPassiveSellOffer'
-      | 'setOptions'
-      | 'changeTrust'
-      | 'allowTrust'
-      | 'accountMerge'
-      | 'inflation'
-      | 'manageData'
-      | 'bumpSequence'
-      | 'manageBuyOffer'
-      | 'pathPaymentStrictSend'
-      | 'createClaimableBalance'
-      | 'claimClaimableBalance'
-      | 'beginSponsoringFutureReserves'
-      | 'endSponsoringFutureReserves'
-      | 'revokeSponsorship'
-      | 'clawback'
-      | 'clawbackClaimableBalance'
-      | 'setTrustLineFlags'
-      | 'liquidityPoolDeposit'
-      | 'liquidityPoolWithdraw';
+      | "createAccount"
+      | "payment"
+      | "pathPaymentStrictReceive"
+      | "manageSellOffer"
+      | "createPassiveSellOffer"
+      | "setOptions"
+      | "changeTrust"
+      | "allowTrust"
+      | "accountMerge"
+      | "inflation"
+      | "manageData"
+      | "bumpSequence"
+      | "manageBuyOffer"
+      | "pathPaymentStrictSend"
+      | "createClaimableBalance"
+      | "claimClaimableBalance"
+      | "beginSponsoringFutureReserves"
+      | "endSponsoringFutureReserves"
+      | "revokeSponsorship"
+      | "clawback"
+      | "clawbackClaimableBalance"
+      | "setTrustLineFlags"
+      | "liquidityPoolDeposit"
+      | "liquidityPoolWithdraw";
 
     readonly value:
       | 0
@@ -742,7 +750,7 @@ export namespace xdr {
   }
 
   class RevokeSponsorshipType {
-    readonly name: 'revokeSponsorshipLedgerEntry' | 'revokeSponsorshipSigner';
+    readonly name: "revokeSponsorshipLedgerEntry" | "revokeSponsorshipSigner";
 
     readonly value: 0 | 1;
 
@@ -753,11 +761,11 @@ export namespace xdr {
 
   class MemoType {
     readonly name:
-      | 'memoNone'
-      | 'memoText'
-      | 'memoId'
-      | 'memoHash'
-      | 'memoReturn';
+      | "memoNone"
+      | "memoText"
+      | "memoId"
+      | "memoHash"
+      | "memoReturn";
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -773,7 +781,7 @@ export namespace xdr {
   }
 
   class PreconditionType {
-    readonly name: 'precondNone' | 'precondTime' | 'precondV2';
+    readonly name: "precondNone" | "precondTime" | "precondV2";
 
     readonly value: 0 | 1 | 2;
 
@@ -786,9 +794,9 @@ export namespace xdr {
 
   class ClaimAtomType {
     readonly name:
-      | 'claimAtomTypeV0'
-      | 'claimAtomTypeOrderBook'
-      | 'claimAtomTypeLiquidityPool';
+      | "claimAtomTypeV0"
+      | "claimAtomTypeOrderBook"
+      | "claimAtomTypeLiquidityPool";
 
     readonly value: 0 | 1 | 2;
 
@@ -801,11 +809,11 @@ export namespace xdr {
 
   class CreateAccountResultCode {
     readonly name:
-      | 'createAccountSuccess'
-      | 'createAccountMalformed'
-      | 'createAccountUnderfunded'
-      | 'createAccountLowReserve'
-      | 'createAccountAlreadyExist';
+      | "createAccountSuccess"
+      | "createAccountMalformed"
+      | "createAccountUnderfunded"
+      | "createAccountLowReserve"
+      | "createAccountAlreadyExist";
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -822,16 +830,16 @@ export namespace xdr {
 
   class PaymentResultCode {
     readonly name:
-      | 'paymentSuccess'
-      | 'paymentMalformed'
-      | 'paymentUnderfunded'
-      | 'paymentSrcNoTrust'
-      | 'paymentSrcNotAuthorized'
-      | 'paymentNoDestination'
-      | 'paymentNoTrust'
-      | 'paymentNotAuthorized'
-      | 'paymentLineFull'
-      | 'paymentNoIssuer';
+      | "paymentSuccess"
+      | "paymentMalformed"
+      | "paymentUnderfunded"
+      | "paymentSrcNoTrust"
+      | "paymentSrcNotAuthorized"
+      | "paymentNoDestination"
+      | "paymentNoTrust"
+      | "paymentNotAuthorized"
+      | "paymentLineFull"
+      | "paymentNoIssuer";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9;
 
@@ -858,19 +866,19 @@ export namespace xdr {
 
   class PathPaymentStrictReceiveResultCode {
     readonly name:
-      | 'pathPaymentStrictReceiveSuccess'
-      | 'pathPaymentStrictReceiveMalformed'
-      | 'pathPaymentStrictReceiveUnderfunded'
-      | 'pathPaymentStrictReceiveSrcNoTrust'
-      | 'pathPaymentStrictReceiveSrcNotAuthorized'
-      | 'pathPaymentStrictReceiveNoDestination'
-      | 'pathPaymentStrictReceiveNoTrust'
-      | 'pathPaymentStrictReceiveNotAuthorized'
-      | 'pathPaymentStrictReceiveLineFull'
-      | 'pathPaymentStrictReceiveNoIssuer'
-      | 'pathPaymentStrictReceiveTooFewOffers'
-      | 'pathPaymentStrictReceiveOfferCrossSelf'
-      | 'pathPaymentStrictReceiveOverSendmax';
+      | "pathPaymentStrictReceiveSuccess"
+      | "pathPaymentStrictReceiveMalformed"
+      | "pathPaymentStrictReceiveUnderfunded"
+      | "pathPaymentStrictReceiveSrcNoTrust"
+      | "pathPaymentStrictReceiveSrcNotAuthorized"
+      | "pathPaymentStrictReceiveNoDestination"
+      | "pathPaymentStrictReceiveNoTrust"
+      | "pathPaymentStrictReceiveNotAuthorized"
+      | "pathPaymentStrictReceiveLineFull"
+      | "pathPaymentStrictReceiveNoIssuer"
+      | "pathPaymentStrictReceiveTooFewOffers"
+      | "pathPaymentStrictReceiveOfferCrossSelf"
+      | "pathPaymentStrictReceiveOverSendmax";
 
     readonly value:
       | 0
@@ -916,19 +924,19 @@ export namespace xdr {
 
   class PathPaymentStrictSendResultCode {
     readonly name:
-      | 'pathPaymentStrictSendSuccess'
-      | 'pathPaymentStrictSendMalformed'
-      | 'pathPaymentStrictSendUnderfunded'
-      | 'pathPaymentStrictSendSrcNoTrust'
-      | 'pathPaymentStrictSendSrcNotAuthorized'
-      | 'pathPaymentStrictSendNoDestination'
-      | 'pathPaymentStrictSendNoTrust'
-      | 'pathPaymentStrictSendNotAuthorized'
-      | 'pathPaymentStrictSendLineFull'
-      | 'pathPaymentStrictSendNoIssuer'
-      | 'pathPaymentStrictSendTooFewOffers'
-      | 'pathPaymentStrictSendOfferCrossSelf'
-      | 'pathPaymentStrictSendUnderDestmin';
+      | "pathPaymentStrictSendSuccess"
+      | "pathPaymentStrictSendMalformed"
+      | "pathPaymentStrictSendUnderfunded"
+      | "pathPaymentStrictSendSrcNoTrust"
+      | "pathPaymentStrictSendSrcNotAuthorized"
+      | "pathPaymentStrictSendNoDestination"
+      | "pathPaymentStrictSendNoTrust"
+      | "pathPaymentStrictSendNotAuthorized"
+      | "pathPaymentStrictSendLineFull"
+      | "pathPaymentStrictSendNoIssuer"
+      | "pathPaymentStrictSendTooFewOffers"
+      | "pathPaymentStrictSendOfferCrossSelf"
+      | "pathPaymentStrictSendUnderDestmin";
 
     readonly value:
       | 0
@@ -974,19 +982,19 @@ export namespace xdr {
 
   class ManageSellOfferResultCode {
     readonly name:
-      | 'manageSellOfferSuccess'
-      | 'manageSellOfferMalformed'
-      | 'manageSellOfferSellNoTrust'
-      | 'manageSellOfferBuyNoTrust'
-      | 'manageSellOfferSellNotAuthorized'
-      | 'manageSellOfferBuyNotAuthorized'
-      | 'manageSellOfferLineFull'
-      | 'manageSellOfferUnderfunded'
-      | 'manageSellOfferCrossSelf'
-      | 'manageSellOfferSellNoIssuer'
-      | 'manageSellOfferBuyNoIssuer'
-      | 'manageSellOfferNotFound'
-      | 'manageSellOfferLowReserve';
+      | "manageSellOfferSuccess"
+      | "manageSellOfferMalformed"
+      | "manageSellOfferSellNoTrust"
+      | "manageSellOfferBuyNoTrust"
+      | "manageSellOfferSellNotAuthorized"
+      | "manageSellOfferBuyNotAuthorized"
+      | "manageSellOfferLineFull"
+      | "manageSellOfferUnderfunded"
+      | "manageSellOfferCrossSelf"
+      | "manageSellOfferSellNoIssuer"
+      | "manageSellOfferBuyNoIssuer"
+      | "manageSellOfferNotFound"
+      | "manageSellOfferLowReserve";
 
     readonly value:
       | 0
@@ -1032,9 +1040,9 @@ export namespace xdr {
 
   class ManageOfferEffect {
     readonly name:
-      | 'manageOfferCreated'
-      | 'manageOfferUpdated'
-      | 'manageOfferDeleted';
+      | "manageOfferCreated"
+      | "manageOfferUpdated"
+      | "manageOfferDeleted";
 
     readonly value: 0 | 1 | 2;
 
@@ -1047,19 +1055,19 @@ export namespace xdr {
 
   class ManageBuyOfferResultCode {
     readonly name:
-      | 'manageBuyOfferSuccess'
-      | 'manageBuyOfferMalformed'
-      | 'manageBuyOfferSellNoTrust'
-      | 'manageBuyOfferBuyNoTrust'
-      | 'manageBuyOfferSellNotAuthorized'
-      | 'manageBuyOfferBuyNotAuthorized'
-      | 'manageBuyOfferLineFull'
-      | 'manageBuyOfferUnderfunded'
-      | 'manageBuyOfferCrossSelf'
-      | 'manageBuyOfferSellNoIssuer'
-      | 'manageBuyOfferBuyNoIssuer'
-      | 'manageBuyOfferNotFound'
-      | 'manageBuyOfferLowReserve';
+      | "manageBuyOfferSuccess"
+      | "manageBuyOfferMalformed"
+      | "manageBuyOfferSellNoTrust"
+      | "manageBuyOfferBuyNoTrust"
+      | "manageBuyOfferSellNotAuthorized"
+      | "manageBuyOfferBuyNotAuthorized"
+      | "manageBuyOfferLineFull"
+      | "manageBuyOfferUnderfunded"
+      | "manageBuyOfferCrossSelf"
+      | "manageBuyOfferSellNoIssuer"
+      | "manageBuyOfferBuyNoIssuer"
+      | "manageBuyOfferNotFound"
+      | "manageBuyOfferLowReserve";
 
     readonly value:
       | 0
@@ -1105,17 +1113,17 @@ export namespace xdr {
 
   class SetOptionsResultCode {
     readonly name:
-      | 'setOptionsSuccess'
-      | 'setOptionsLowReserve'
-      | 'setOptionsTooManySigners'
-      | 'setOptionsBadFlags'
-      | 'setOptionsInvalidInflation'
-      | 'setOptionsCantChange'
-      | 'setOptionsUnknownFlag'
-      | 'setOptionsThresholdOutOfRange'
-      | 'setOptionsBadSigner'
-      | 'setOptionsInvalidHomeDomain'
-      | 'setOptionsAuthRevocableRequired';
+      | "setOptionsSuccess"
+      | "setOptionsLowReserve"
+      | "setOptionsTooManySigners"
+      | "setOptionsBadFlags"
+      | "setOptionsInvalidInflation"
+      | "setOptionsCantChange"
+      | "setOptionsUnknownFlag"
+      | "setOptionsThresholdOutOfRange"
+      | "setOptionsBadSigner"
+      | "setOptionsInvalidHomeDomain"
+      | "setOptionsAuthRevocableRequired";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9 | -10;
 
@@ -1144,15 +1152,15 @@ export namespace xdr {
 
   class ChangeTrustResultCode {
     readonly name:
-      | 'changeTrustSuccess'
-      | 'changeTrustMalformed'
-      | 'changeTrustNoIssuer'
-      | 'changeTrustInvalidLimit'
-      | 'changeTrustLowReserve'
-      | 'changeTrustSelfNotAllowed'
-      | 'changeTrustTrustLineMissing'
-      | 'changeTrustCannotDelete'
-      | 'changeTrustNotAuthMaintainLiabilities';
+      | "changeTrustSuccess"
+      | "changeTrustMalformed"
+      | "changeTrustNoIssuer"
+      | "changeTrustInvalidLimit"
+      | "changeTrustLowReserve"
+      | "changeTrustSelfNotAllowed"
+      | "changeTrustTrustLineMissing"
+      | "changeTrustCannotDelete"
+      | "changeTrustNotAuthMaintainLiabilities";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8;
 
@@ -1177,13 +1185,13 @@ export namespace xdr {
 
   class AllowTrustResultCode {
     readonly name:
-      | 'allowTrustSuccess'
-      | 'allowTrustMalformed'
-      | 'allowTrustNoTrustLine'
-      | 'allowTrustTrustNotRequired'
-      | 'allowTrustCantRevoke'
-      | 'allowTrustSelfNotAllowed'
-      | 'allowTrustLowReserve';
+      | "allowTrustSuccess"
+      | "allowTrustMalformed"
+      | "allowTrustNoTrustLine"
+      | "allowTrustTrustNotRequired"
+      | "allowTrustCantRevoke"
+      | "allowTrustSelfNotAllowed"
+      | "allowTrustLowReserve";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6;
 
@@ -1204,14 +1212,14 @@ export namespace xdr {
 
   class AccountMergeResultCode {
     readonly name:
-      | 'accountMergeSuccess'
-      | 'accountMergeMalformed'
-      | 'accountMergeNoAccount'
-      | 'accountMergeImmutableSet'
-      | 'accountMergeHasSubEntries'
-      | 'accountMergeSeqnumTooFar'
-      | 'accountMergeDestFull'
-      | 'accountMergeIsSponsor';
+      | "accountMergeSuccess"
+      | "accountMergeMalformed"
+      | "accountMergeNoAccount"
+      | "accountMergeImmutableSet"
+      | "accountMergeHasSubEntries"
+      | "accountMergeSeqnumTooFar"
+      | "accountMergeDestFull"
+      | "accountMergeIsSponsor";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7;
 
@@ -1233,7 +1241,7 @@ export namespace xdr {
   }
 
   class InflationResultCode {
-    readonly name: 'inflationSuccess' | 'inflationNotTime';
+    readonly name: "inflationSuccess" | "inflationNotTime";
 
     readonly value: 0 | -1;
 
@@ -1244,11 +1252,11 @@ export namespace xdr {
 
   class ManageDataResultCode {
     readonly name:
-      | 'manageDataSuccess'
-      | 'manageDataNotSupportedYet'
-      | 'manageDataNameNotFound'
-      | 'manageDataLowReserve'
-      | 'manageDataInvalidName';
+      | "manageDataSuccess"
+      | "manageDataNotSupportedYet"
+      | "manageDataNameNotFound"
+      | "manageDataLowReserve"
+      | "manageDataInvalidName";
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -1264,7 +1272,7 @@ export namespace xdr {
   }
 
   class BumpSequenceResultCode {
-    readonly name: 'bumpSequenceSuccess' | 'bumpSequenceBadSeq';
+    readonly name: "bumpSequenceSuccess" | "bumpSequenceBadSeq";
 
     readonly value: 0 | -1;
 
@@ -1275,12 +1283,12 @@ export namespace xdr {
 
   class CreateClaimableBalanceResultCode {
     readonly name:
-      | 'createClaimableBalanceSuccess'
-      | 'createClaimableBalanceMalformed'
-      | 'createClaimableBalanceLowReserve'
-      | 'createClaimableBalanceNoTrust'
-      | 'createClaimableBalanceNotAuthorized'
-      | 'createClaimableBalanceUnderfunded';
+      | "createClaimableBalanceSuccess"
+      | "createClaimableBalanceMalformed"
+      | "createClaimableBalanceLowReserve"
+      | "createClaimableBalanceNoTrust"
+      | "createClaimableBalanceNotAuthorized"
+      | "createClaimableBalanceUnderfunded";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1299,12 +1307,12 @@ export namespace xdr {
 
   class ClaimClaimableBalanceResultCode {
     readonly name:
-      | 'claimClaimableBalanceSuccess'
-      | 'claimClaimableBalanceDoesNotExist'
-      | 'claimClaimableBalanceCannotClaim'
-      | 'claimClaimableBalanceLineFull'
-      | 'claimClaimableBalanceNoTrust'
-      | 'claimClaimableBalanceNotAuthorized';
+      | "claimClaimableBalanceSuccess"
+      | "claimClaimableBalanceDoesNotExist"
+      | "claimClaimableBalanceCannotClaim"
+      | "claimClaimableBalanceLineFull"
+      | "claimClaimableBalanceNoTrust"
+      | "claimClaimableBalanceNotAuthorized";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1323,10 +1331,10 @@ export namespace xdr {
 
   class BeginSponsoringFutureReservesResultCode {
     readonly name:
-      | 'beginSponsoringFutureReservesSuccess'
-      | 'beginSponsoringFutureReservesMalformed'
-      | 'beginSponsoringFutureReservesAlreadySponsored'
-      | 'beginSponsoringFutureReservesRecursive';
+      | "beginSponsoringFutureReservesSuccess"
+      | "beginSponsoringFutureReservesMalformed"
+      | "beginSponsoringFutureReservesAlreadySponsored"
+      | "beginSponsoringFutureReservesRecursive";
 
     readonly value: 0 | -1 | -2 | -3;
 
@@ -1341,8 +1349,8 @@ export namespace xdr {
 
   class EndSponsoringFutureReservesResultCode {
     readonly name:
-      | 'endSponsoringFutureReservesSuccess'
-      | 'endSponsoringFutureReservesNotSponsored';
+      | "endSponsoringFutureReservesSuccess"
+      | "endSponsoringFutureReservesNotSponsored";
 
     readonly value: 0 | -1;
 
@@ -1353,12 +1361,12 @@ export namespace xdr {
 
   class RevokeSponsorshipResultCode {
     readonly name:
-      | 'revokeSponsorshipSuccess'
-      | 'revokeSponsorshipDoesNotExist'
-      | 'revokeSponsorshipNotSponsor'
-      | 'revokeSponsorshipLowReserve'
-      | 'revokeSponsorshipOnlyTransferable'
-      | 'revokeSponsorshipMalformed';
+      | "revokeSponsorshipSuccess"
+      | "revokeSponsorshipDoesNotExist"
+      | "revokeSponsorshipNotSponsor"
+      | "revokeSponsorshipLowReserve"
+      | "revokeSponsorshipOnlyTransferable"
+      | "revokeSponsorshipMalformed";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1377,11 +1385,11 @@ export namespace xdr {
 
   class ClawbackResultCode {
     readonly name:
-      | 'clawbackSuccess'
-      | 'clawbackMalformed'
-      | 'clawbackNotClawbackEnabled'
-      | 'clawbackNoTrust'
-      | 'clawbackUnderfunded';
+      | "clawbackSuccess"
+      | "clawbackMalformed"
+      | "clawbackNotClawbackEnabled"
+      | "clawbackNoTrust"
+      | "clawbackUnderfunded";
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -1398,10 +1406,10 @@ export namespace xdr {
 
   class ClawbackClaimableBalanceResultCode {
     readonly name:
-      | 'clawbackClaimableBalanceSuccess'
-      | 'clawbackClaimableBalanceDoesNotExist'
-      | 'clawbackClaimableBalanceNotIssuer'
-      | 'clawbackClaimableBalanceNotClawbackEnabled';
+      | "clawbackClaimableBalanceSuccess"
+      | "clawbackClaimableBalanceDoesNotExist"
+      | "clawbackClaimableBalanceNotIssuer"
+      | "clawbackClaimableBalanceNotClawbackEnabled";
 
     readonly value: 0 | -1 | -2 | -3;
 
@@ -1416,12 +1424,12 @@ export namespace xdr {
 
   class SetTrustLineFlagsResultCode {
     readonly name:
-      | 'setTrustLineFlagsSuccess'
-      | 'setTrustLineFlagsMalformed'
-      | 'setTrustLineFlagsNoTrustLine'
-      | 'setTrustLineFlagsCantRevoke'
-      | 'setTrustLineFlagsInvalidState'
-      | 'setTrustLineFlagsLowReserve';
+      | "setTrustLineFlagsSuccess"
+      | "setTrustLineFlagsMalformed"
+      | "setTrustLineFlagsNoTrustLine"
+      | "setTrustLineFlagsCantRevoke"
+      | "setTrustLineFlagsInvalidState"
+      | "setTrustLineFlagsLowReserve";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1440,14 +1448,14 @@ export namespace xdr {
 
   class LiquidityPoolDepositResultCode {
     readonly name:
-      | 'liquidityPoolDepositSuccess'
-      | 'liquidityPoolDepositMalformed'
-      | 'liquidityPoolDepositNoTrust'
-      | 'liquidityPoolDepositNotAuthorized'
-      | 'liquidityPoolDepositUnderfunded'
-      | 'liquidityPoolDepositLineFull'
-      | 'liquidityPoolDepositBadPrice'
-      | 'liquidityPoolDepositPoolFull';
+      | "liquidityPoolDepositSuccess"
+      | "liquidityPoolDepositMalformed"
+      | "liquidityPoolDepositNoTrust"
+      | "liquidityPoolDepositNotAuthorized"
+      | "liquidityPoolDepositUnderfunded"
+      | "liquidityPoolDepositLineFull"
+      | "liquidityPoolDepositBadPrice"
+      | "liquidityPoolDepositPoolFull";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7;
 
@@ -1470,12 +1478,12 @@ export namespace xdr {
 
   class LiquidityPoolWithdrawResultCode {
     readonly name:
-      | 'liquidityPoolWithdrawSuccess'
-      | 'liquidityPoolWithdrawMalformed'
-      | 'liquidityPoolWithdrawNoTrust'
-      | 'liquidityPoolWithdrawUnderfunded'
-      | 'liquidityPoolWithdrawLineFull'
-      | 'liquidityPoolWithdrawUnderMinimum';
+      | "liquidityPoolWithdrawSuccess"
+      | "liquidityPoolWithdrawMalformed"
+      | "liquidityPoolWithdrawNoTrust"
+      | "liquidityPoolWithdrawUnderfunded"
+      | "liquidityPoolWithdrawLineFull"
+      | "liquidityPoolWithdrawUnderMinimum";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1494,13 +1502,13 @@ export namespace xdr {
 
   class OperationResultCode {
     readonly name:
-      | 'opInner'
-      | 'opBadAuth'
-      | 'opNoAccount'
-      | 'opNotSupported'
-      | 'opTooManySubentries'
-      | 'opExceededWorkLimit'
-      | 'opTooManySponsoring';
+      | "opInner"
+      | "opBadAuth"
+      | "opNoAccount"
+      | "opNotSupported"
+      | "opTooManySubentries"
+      | "opExceededWorkLimit"
+      | "opTooManySponsoring";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6;
 
@@ -1521,24 +1529,24 @@ export namespace xdr {
 
   class TransactionResultCode {
     readonly name:
-      | 'txFeeBumpInnerSuccess'
-      | 'txSuccess'
-      | 'txFailed'
-      | 'txTooEarly'
-      | 'txTooLate'
-      | 'txMissingOperation'
-      | 'txBadSeq'
-      | 'txBadAuth'
-      | 'txInsufficientBalance'
-      | 'txNoAccount'
-      | 'txInsufficientFee'
-      | 'txBadAuthExtra'
-      | 'txInternalError'
-      | 'txNotSupported'
-      | 'txFeeBumpInnerFailed'
-      | 'txBadSponsorship'
-      | 'txBadMinSeqAgeOrGap'
-      | 'txMalformed';
+      | "txFeeBumpInnerSuccess"
+      | "txSuccess"
+      | "txFailed"
+      | "txTooEarly"
+      | "txTooLate"
+      | "txMissingOperation"
+      | "txBadSeq"
+      | "txBadAuth"
+      | "txInsufficientBalance"
+      | "txNoAccount"
+      | "txInsufficientFee"
+      | "txBadAuthExtra"
+      | "txInternalError"
+      | "txNotSupported"
+      | "txFeeBumpInnerFailed"
+      | "txBadSponsorship"
+      | "txBadMinSeqAgeOrGap"
+      | "txMalformed";
 
     readonly value:
       | 1
@@ -1599,11 +1607,11 @@ export namespace xdr {
 
   class CryptoKeyType {
     readonly name:
-      | 'keyTypeEd25519'
-      | 'keyTypePreAuthTx'
-      | 'keyTypeHashX'
-      | 'keyTypeEd25519SignedPayload'
-      | 'keyTypeMuxedEd25519';
+      | "keyTypeEd25519"
+      | "keyTypePreAuthTx"
+      | "keyTypeHashX"
+      | "keyTypeEd25519SignedPayload"
+      | "keyTypeMuxedEd25519";
 
     readonly value: 0 | 1 | 2 | 3 | 256;
 
@@ -1619,7 +1627,7 @@ export namespace xdr {
   }
 
   class PublicKeyType {
-    readonly name: 'publicKeyTypeEd25519';
+    readonly name: "publicKeyTypeEd25519";
 
     readonly value: 0;
 
@@ -1628,10 +1636,10 @@ export namespace xdr {
 
   class SignerKeyType {
     readonly name:
-      | 'signerKeyTypeEd25519'
-      | 'signerKeyTypePreAuthTx'
-      | 'signerKeyTypeHashX'
-      | 'signerKeyTypeEd25519SignedPayload';
+      | "signerKeyTypeEd25519"
+      | "signerKeyTypePreAuthTx"
+      | "signerKeyTypeHashX"
+      | "signerKeyTypeEd25519SignedPayload";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -1662,7 +1670,9 @@ export namespace xdr {
 
   const DataValue: VarOpaque;
 
-  type PoolId = typeof Hash;
+  type Hash = Opaque[];
+
+  type PoolId = Hash;
 
   const AssetCode4: Opaque;
 
@@ -1677,6 +1687,10 @@ export namespace xdr {
   const EncryptedBody: VarOpaque;
 
   const PeerStatList: XDRArray<PeerStats>;
+
+  const TxAdvertVector: XDRArray<Hash>;
+
+  const TxDemandVector: XDRArray<Hash>;
 
   const Hash: Opaque;
 
@@ -1703,9 +1717,9 @@ export namespace xdr {
 
     value(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpBallot;
 
@@ -1715,13 +1729,13 @@ export namespace xdr {
 
     static toXDR(value: ScpBallot): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpBallot;
+    static fromXDR(input: Buffer, format?: "raw"): ScpBallot;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpBallot;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpBallot;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpNomination {
@@ -1737,9 +1751,9 @@ export namespace xdr {
 
     accepted(value?: Buffer[]): Buffer[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpNomination;
 
@@ -1749,13 +1763,13 @@ export namespace xdr {
 
     static toXDR(value: ScpNomination): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpNomination;
+    static fromXDR(input: Buffer, format?: "raw"): ScpNomination;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpNomination;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpNomination;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatementPrepare {
@@ -1780,9 +1794,9 @@ export namespace xdr {
 
     nH(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpStatementPrepare;
 
@@ -1792,16 +1806,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementPrepare): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementPrepare;
+    static fromXDR(input: Buffer, format?: "raw"): ScpStatementPrepare;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScpStatementPrepare;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatementConfirm {
@@ -1823,9 +1837,9 @@ export namespace xdr {
 
     quorumSetHash(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpStatementConfirm;
 
@@ -1835,16 +1849,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementConfirm): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementConfirm;
+    static fromXDR(input: Buffer, format?: "raw"): ScpStatementConfirm;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScpStatementConfirm;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatementExternalize {
@@ -1860,9 +1874,9 @@ export namespace xdr {
 
     commitQuorumSetHash(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpStatementExternalize;
 
@@ -1872,16 +1886,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementExternalize): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementExternalize;
+    static fromXDR(input: Buffer, format?: "raw"): ScpStatementExternalize;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScpStatementExternalize;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatement {
@@ -1897,9 +1911,9 @@ export namespace xdr {
 
     pledges(value?: ScpStatementPledges): ScpStatementPledges;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpStatement;
 
@@ -1909,13 +1923,13 @@ export namespace xdr {
 
     static toXDR(value: ScpStatement): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpStatement;
+    static fromXDR(input: Buffer, format?: "raw"): ScpStatement;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpStatement;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpStatement;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpEnvelope {
@@ -1925,9 +1939,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpEnvelope;
 
@@ -1937,13 +1951,13 @@ export namespace xdr {
 
     static toXDR(value: ScpEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpEnvelope;
+    static fromXDR(input: Buffer, format?: "raw"): ScpEnvelope;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpEnvelope;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpEnvelope;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpQuorumSet {
@@ -1959,9 +1973,9 @@ export namespace xdr {
 
     innerSets(value?: ScpQuorumSet[]): ScpQuorumSet[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpQuorumSet;
 
@@ -1971,13 +1985,13 @@ export namespace xdr {
 
     static toXDR(value: ScpQuorumSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpQuorumSet;
+    static fromXDR(input: Buffer, format?: "raw"): ScpQuorumSet;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpQuorumSet;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpQuorumSet;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AlphaNum4 {
@@ -1987,9 +2001,9 @@ export namespace xdr {
 
     issuer(value?: AccountId): AccountId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AlphaNum4;
 
@@ -1999,13 +2013,13 @@ export namespace xdr {
 
     static toXDR(value: AlphaNum4): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AlphaNum4;
+    static fromXDR(input: Buffer, format?: "raw"): AlphaNum4;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AlphaNum4;
+    static fromXDR(input: string, format: "hex" | "base64"): AlphaNum4;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AlphaNum12 {
@@ -2015,9 +2029,9 @@ export namespace xdr {
 
     issuer(value?: AccountId): AccountId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AlphaNum12;
 
@@ -2027,13 +2041,13 @@ export namespace xdr {
 
     static toXDR(value: AlphaNum12): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AlphaNum12;
+    static fromXDR(input: Buffer, format?: "raw"): AlphaNum12;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AlphaNum12;
+    static fromXDR(input: string, format: "hex" | "base64"): AlphaNum12;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Price {
@@ -2043,9 +2057,9 @@ export namespace xdr {
 
     d(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Price;
 
@@ -2055,13 +2069,13 @@ export namespace xdr {
 
     static toXDR(value: Price): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Price;
+    static fromXDR(input: Buffer, format?: "raw"): Price;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Price;
+    static fromXDR(input: string, format: "hex" | "base64"): Price;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Liabilities {
@@ -2071,9 +2085,9 @@ export namespace xdr {
 
     selling(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Liabilities;
 
@@ -2083,13 +2097,13 @@ export namespace xdr {
 
     static toXDR(value: Liabilities): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Liabilities;
+    static fromXDR(input: Buffer, format?: "raw"): Liabilities;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Liabilities;
+    static fromXDR(input: string, format: "hex" | "base64"): Liabilities;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Signer {
@@ -2099,9 +2113,9 @@ export namespace xdr {
 
     weight(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Signer;
 
@@ -2111,13 +2125,13 @@ export namespace xdr {
 
     static toXDR(value: Signer): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Signer;
+    static fromXDR(input: Buffer, format?: "raw"): Signer;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Signer;
+    static fromXDR(input: string, format: "hex" | "base64"): Signer;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExtensionV3 {
@@ -2133,9 +2147,9 @@ export namespace xdr {
 
     seqTime(value?: TimePoint): TimePoint;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExtensionV3;
 
@@ -2145,16 +2159,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV3): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV3;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV3;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AccountEntryExtensionV3;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExtensionV2 {
@@ -2175,9 +2189,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExtensionV2Ext): AccountEntryExtensionV2Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExtensionV2;
 
@@ -2187,16 +2201,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV2;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV2;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AccountEntryExtensionV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExtensionV1 {
@@ -2209,9 +2223,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExtensionV1Ext): AccountEntryExtensionV1Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExtensionV1;
 
@@ -2221,16 +2235,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV1;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AccountEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntry {
@@ -2267,9 +2281,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExt): AccountEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntry;
 
@@ -2279,13 +2293,13 @@ export namespace xdr {
 
     static toXDR(value: AccountEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntry;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AccountEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): AccountEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntryExtensionV2 {
@@ -2298,9 +2312,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryExtensionV2Ext): TrustLineEntryExtensionV2Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntryExtensionV2;
 
@@ -2310,16 +2324,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExtensionV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExtensionV2;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExtensionV2;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TrustLineEntryExtensionV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntryV1 {
@@ -2332,9 +2346,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryV1Ext): TrustLineEntryV1Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntryV1;
 
@@ -2344,13 +2358,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryV1;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryV1;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntryV1;
+    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntryV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntry {
@@ -2375,9 +2389,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryExt): TrustLineEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntry;
 
@@ -2387,13 +2401,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntry;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OfferEntry {
@@ -2424,9 +2438,9 @@ export namespace xdr {
 
     ext(value?: OfferEntryExt): OfferEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OfferEntry;
 
@@ -2436,13 +2450,13 @@ export namespace xdr {
 
     static toXDR(value: OfferEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OfferEntry;
+    static fromXDR(input: Buffer, format?: "raw"): OfferEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OfferEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): OfferEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class DataEntry {
@@ -2461,9 +2475,9 @@ export namespace xdr {
 
     ext(value?: DataEntryExt): DataEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): DataEntry;
 
@@ -2473,13 +2487,13 @@ export namespace xdr {
 
     static toXDR(value: DataEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): DataEntry;
+    static fromXDR(input: Buffer, format?: "raw"): DataEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): DataEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): DataEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimantV0 {
@@ -2492,9 +2506,9 @@ export namespace xdr {
 
     predicate(value?: ClaimPredicate): ClaimPredicate;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimantV0;
 
@@ -2504,13 +2518,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimantV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimantV0;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimantV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimantV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimantV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimableBalanceEntryExtensionV1 {
@@ -2525,9 +2539,9 @@ export namespace xdr {
 
     flags(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExtensionV1;
 
@@ -2539,17 +2553,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): ClaimableBalanceEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimableBalanceEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimableBalanceEntry {
@@ -2571,9 +2585,9 @@ export namespace xdr {
 
     ext(value?: ClaimableBalanceEntryExt): ClaimableBalanceEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimableBalanceEntry;
 
@@ -2583,16 +2597,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceEntry;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceEntry;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimableBalanceEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolConstantProductParameters {
@@ -2604,9 +2618,9 @@ export namespace xdr {
 
     fee(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolConstantProductParameters;
 
@@ -2621,17 +2635,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): LiquidityPoolConstantProductParameters;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolConstantProductParameters;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolEntryConstantProduct {
@@ -2655,9 +2669,9 @@ export namespace xdr {
 
     poolSharesTrustLineCount(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolEntryConstantProduct;
 
@@ -2669,17 +2683,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): LiquidityPoolEntryConstantProduct;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolEntryConstantProduct;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolEntry {
@@ -2692,9 +2706,9 @@ export namespace xdr {
 
     body(value?: LiquidityPoolEntryBody): LiquidityPoolEntryBody;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolEntry;
 
@@ -2704,13 +2718,13 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolEntry;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LiquidityPoolEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): LiquidityPoolEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntryExtensionV1 {
@@ -2723,9 +2737,9 @@ export namespace xdr {
 
     ext(value?: LedgerEntryExtensionV1Ext): LedgerEntryExtensionV1Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntryExtensionV1;
 
@@ -2735,16 +2749,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExtensionV1;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntry {
@@ -2760,9 +2774,9 @@ export namespace xdr {
 
     ext(value?: LedgerEntryExt): LedgerEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntry;
 
@@ -2772,13 +2786,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntry;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyAccount {
@@ -2786,9 +2800,9 @@ export namespace xdr {
 
     accountId(value?: AccountId): AccountId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyAccount;
 
@@ -2798,13 +2812,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyAccount): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyAccount;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyAccount;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyAccount;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyAccount;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyTrustLine {
@@ -2814,9 +2828,9 @@ export namespace xdr {
 
     asset(value?: TrustLineAsset): TrustLineAsset;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyTrustLine;
 
@@ -2826,13 +2840,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyTrustLine): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyTrustLine;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyTrustLine;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyTrustLine;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyTrustLine;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyOffer {
@@ -2842,9 +2856,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyOffer;
 
@@ -2854,13 +2868,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyOffer): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyOffer;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyOffer;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyOffer;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyOffer;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyData {
@@ -2873,9 +2887,9 @@ export namespace xdr {
 
     dataName(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyData;
 
@@ -2885,13 +2899,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyData): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyData;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyData;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyData;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyData;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyClaimableBalance {
@@ -2899,9 +2913,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyClaimableBalance;
 
@@ -2911,16 +2925,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyClaimableBalance): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyClaimableBalance;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyClaimableBalance;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerKeyClaimableBalance;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyLiquidityPool {
@@ -2928,9 +2942,9 @@ export namespace xdr {
 
     liquidityPoolId(value?: PoolId): PoolId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyLiquidityPool;
 
@@ -2940,16 +2954,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyLiquidityPool): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyLiquidityPool;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyLiquidityPool;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerKeyLiquidityPool;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerCloseValueSignature {
@@ -2959,9 +2973,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerCloseValueSignature;
 
@@ -2971,16 +2985,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseValueSignature): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseValueSignature;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseValueSignature;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerCloseValueSignature;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class StellarValue {
@@ -2999,9 +3013,9 @@ export namespace xdr {
 
     ext(value?: StellarValueExt): StellarValueExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): StellarValue;
 
@@ -3011,13 +3025,13 @@ export namespace xdr {
 
     static toXDR(value: StellarValue): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): StellarValue;
+    static fromXDR(input: Buffer, format?: "raw"): StellarValue;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): StellarValue;
+    static fromXDR(input: string, format: "hex" | "base64"): StellarValue;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeaderExtensionV1 {
@@ -3027,9 +3041,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderExtensionV1Ext): LedgerHeaderExtensionV1Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeaderExtensionV1;
 
@@ -3039,16 +3053,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExtensionV1;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExtensionV1;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerHeaderExtensionV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeader {
@@ -3100,9 +3114,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderExt): LedgerHeaderExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeader;
 
@@ -3112,13 +3126,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeader): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeader;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeader;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerHeader;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerHeader;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BucketMetadata {
@@ -3128,9 +3142,9 @@ export namespace xdr {
 
     ext(value?: BucketMetadataExt): BucketMetadataExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BucketMetadata;
 
@@ -3140,13 +3154,13 @@ export namespace xdr {
 
     static toXDR(value: BucketMetadata): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): BucketMetadata;
+    static fromXDR(input: Buffer, format?: "raw"): BucketMetadata;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): BucketMetadata;
+    static fromXDR(input: string, format: "hex" | "base64"): BucketMetadata;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TxSetComponentTxsMaybeDiscountedFee {
@@ -3159,9 +3173,9 @@ export namespace xdr {
 
     txes(value?: TransactionEnvelope[]): TransactionEnvelope[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TxSetComponentTxsMaybeDiscountedFee;
 
@@ -3173,17 +3187,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): TxSetComponentTxsMaybeDiscountedFee;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TxSetComponentTxsMaybeDiscountedFee;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionSet {
@@ -3196,9 +3210,9 @@ export namespace xdr {
 
     txes(value?: TransactionEnvelope[]): TransactionEnvelope[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionSet;
 
@@ -3208,13 +3222,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionSet;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionSet;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionSet;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionSet;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionSetV1 {
@@ -3227,9 +3241,9 @@ export namespace xdr {
 
     phases(value?: TransactionPhase[]): TransactionPhase[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionSetV1;
 
@@ -3239,13 +3253,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionSetV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionSetV1;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionSetV1;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionSetV1;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionSetV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultPair {
@@ -3258,9 +3272,9 @@ export namespace xdr {
 
     result(value?: TransactionResult): TransactionResult;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultPair;
 
@@ -3270,16 +3284,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultPair): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultPair;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultPair;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultPair;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultSet {
@@ -3287,9 +3301,9 @@ export namespace xdr {
 
     results(value?: TransactionResultPair[]): TransactionResultPair[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultSet;
 
@@ -3299,16 +3313,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultSet;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultSet;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultSet;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionHistoryEntry {
@@ -3324,9 +3338,9 @@ export namespace xdr {
 
     ext(value?: TransactionHistoryEntryExt): TransactionHistoryEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionHistoryEntry;
 
@@ -3336,16 +3350,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionHistoryEntry;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionHistoryEntry;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionHistoryResultEntry {
@@ -3363,9 +3377,9 @@ export namespace xdr {
       value?: TransactionHistoryResultEntryExt
     ): TransactionHistoryResultEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionHistoryResultEntry;
 
@@ -3377,17 +3391,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): TransactionHistoryResultEntry;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionHistoryResultEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeaderHistoryEntry {
@@ -3403,9 +3417,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderHistoryEntryExt): LedgerHeaderHistoryEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeaderHistoryEntry;
 
@@ -3415,16 +3429,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderHistoryEntry;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderHistoryEntry;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerHeaderHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerScpMessages {
@@ -3434,9 +3448,9 @@ export namespace xdr {
 
     messages(value?: ScpEnvelope[]): ScpEnvelope[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerScpMessages;
 
@@ -3446,13 +3460,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerScpMessages): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerScpMessages;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerScpMessages;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerScpMessages;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerScpMessages;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpHistoryEntryV0 {
@@ -3465,9 +3479,9 @@ export namespace xdr {
 
     ledgerMessages(value?: LedgerScpMessages): LedgerScpMessages;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpHistoryEntryV0;
 
@@ -3477,13 +3491,13 @@ export namespace xdr {
 
     static toXDR(value: ScpHistoryEntryV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpHistoryEntryV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScpHistoryEntryV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpHistoryEntryV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpHistoryEntryV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OperationMeta {
@@ -3491,9 +3505,9 @@ export namespace xdr {
 
     changes(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OperationMeta;
 
@@ -3503,13 +3517,13 @@ export namespace xdr {
 
     static toXDR(value: OperationMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OperationMeta;
+    static fromXDR(input: Buffer, format?: "raw"): OperationMeta;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OperationMeta;
+    static fromXDR(input: string, format: "hex" | "base64"): OperationMeta;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionMetaV1 {
@@ -3522,9 +3536,9 @@ export namespace xdr {
 
     operations(value?: OperationMeta[]): OperationMeta[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionMetaV1;
 
@@ -3534,13 +3548,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMetaV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionMetaV1;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionMetaV1;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMetaV1;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionMetaV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionMetaV2 {
@@ -3556,9 +3570,9 @@ export namespace xdr {
 
     txChangesAfter(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionMetaV2;
 
@@ -3568,13 +3582,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMetaV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionMetaV2;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionMetaV2;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMetaV2;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionMetaV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultMeta {
@@ -3590,9 +3604,9 @@ export namespace xdr {
 
     txApplyProcessing(value?: TransactionMeta): TransactionMeta;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultMeta;
 
@@ -3602,16 +3616,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultMeta;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultMeta;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultMeta;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class UpgradeEntryMeta {
@@ -3624,9 +3638,9 @@ export namespace xdr {
 
     changes(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): UpgradeEntryMeta;
 
@@ -3636,13 +3650,13 @@ export namespace xdr {
 
     static toXDR(value: UpgradeEntryMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): UpgradeEntryMeta;
+    static fromXDR(input: Buffer, format?: "raw"): UpgradeEntryMeta;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): UpgradeEntryMeta;
+    static fromXDR(input: string, format: "hex" | "base64"): UpgradeEntryMeta;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerCloseMetaV0 {
@@ -3664,9 +3678,9 @@ export namespace xdr {
 
     scpInfo(value?: ScpHistoryEntry[]): ScpHistoryEntry[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerCloseMetaV0;
 
@@ -3676,13 +3690,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMetaV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMetaV0;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMetaV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMetaV0;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMetaV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerCloseMetaV1 {
@@ -3704,9 +3718,9 @@ export namespace xdr {
 
     scpInfo(value?: ScpHistoryEntry[]): ScpHistoryEntry[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerCloseMetaV1;
 
@@ -3716,13 +3730,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMetaV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMetaV1;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMetaV1;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMetaV1;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMetaV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Error {
@@ -3732,9 +3746,9 @@ export namespace xdr {
 
     msg(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Error;
 
@@ -3744,13 +3758,13 @@ export namespace xdr {
 
     static toXDR(value: Error): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Error;
+    static fromXDR(input: Buffer, format?: "raw"): Error;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Error;
+    static fromXDR(input: string, format: "hex" | "base64"): Error;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SendMore {
@@ -3758,9 +3772,9 @@ export namespace xdr {
 
     numMessages(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SendMore;
 
@@ -3770,13 +3784,13 @@ export namespace xdr {
 
     static toXDR(value: SendMore): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SendMore;
+    static fromXDR(input: Buffer, format?: "raw"): SendMore;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): SendMore;
+    static fromXDR(input: string, format: "hex" | "base64"): SendMore;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AuthCert {
@@ -3792,9 +3806,9 @@ export namespace xdr {
 
     sig(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AuthCert;
 
@@ -3804,13 +3818,13 @@ export namespace xdr {
 
     static toXDR(value: AuthCert): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AuthCert;
+    static fromXDR(input: Buffer, format?: "raw"): AuthCert;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AuthCert;
+    static fromXDR(input: string, format: "hex" | "base64"): AuthCert;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Hello {
@@ -3844,9 +3858,9 @@ export namespace xdr {
 
     nonce(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Hello;
 
@@ -3856,23 +3870,23 @@ export namespace xdr {
 
     static toXDR(value: Hello): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Hello;
+    static fromXDR(input: Buffer, format?: "raw"): Hello;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Hello;
+    static fromXDR(input: string, format: "hex" | "base64"): Hello;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Auth {
-    constructor(attributes: { unused: number });
+    constructor(attributes: { flags: number });
 
-    unused(value?: number): number;
+    flags(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Auth;
 
@@ -3882,13 +3896,13 @@ export namespace xdr {
 
     static toXDR(value: Auth): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Auth;
+    static fromXDR(input: Buffer, format?: "raw"): Auth;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Auth;
+    static fromXDR(input: string, format: "hex" | "base64"): Auth;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PeerAddress {
@@ -3904,9 +3918,9 @@ export namespace xdr {
 
     numFailures(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PeerAddress;
 
@@ -3916,13 +3930,13 @@ export namespace xdr {
 
     static toXDR(value: PeerAddress): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PeerAddress;
+    static fromXDR(input: Buffer, format?: "raw"): PeerAddress;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PeerAddress;
+    static fromXDR(input: string, format: "hex" | "base64"): PeerAddress;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class DontHave {
@@ -3932,9 +3946,9 @@ export namespace xdr {
 
     reqHash(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): DontHave;
 
@@ -3944,13 +3958,13 @@ export namespace xdr {
 
     static toXDR(value: DontHave): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): DontHave;
+    static fromXDR(input: Buffer, format?: "raw"): DontHave;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): DontHave;
+    static fromXDR(input: string, format: "hex" | "base64"): DontHave;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SurveyRequestMessage {
@@ -3972,9 +3986,9 @@ export namespace xdr {
 
     commandType(value?: SurveyMessageCommandType): SurveyMessageCommandType;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SurveyRequestMessage;
 
@@ -3984,16 +3998,16 @@ export namespace xdr {
 
     static toXDR(value: SurveyRequestMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SurveyRequestMessage;
+    static fromXDR(input: Buffer, format?: "raw"): SurveyRequestMessage;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SurveyRequestMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SignedSurveyRequestMessage {
@@ -4006,9 +4020,9 @@ export namespace xdr {
 
     request(value?: SurveyRequestMessage): SurveyRequestMessage;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SignedSurveyRequestMessage;
 
@@ -4018,16 +4032,16 @@ export namespace xdr {
 
     static toXDR(value: SignedSurveyRequestMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SignedSurveyRequestMessage;
+    static fromXDR(input: Buffer, format?: "raw"): SignedSurveyRequestMessage;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SignedSurveyRequestMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SurveyResponseMessage {
@@ -4049,9 +4063,9 @@ export namespace xdr {
 
     encryptedBody(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SurveyResponseMessage;
 
@@ -4061,16 +4075,16 @@ export namespace xdr {
 
     static toXDR(value: SurveyResponseMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SurveyResponseMessage;
+    static fromXDR(input: Buffer, format?: "raw"): SurveyResponseMessage;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SurveyResponseMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SignedSurveyResponseMessage {
@@ -4083,9 +4097,9 @@ export namespace xdr {
 
     response(value?: SurveyResponseMessage): SurveyResponseMessage;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SignedSurveyResponseMessage;
 
@@ -4095,16 +4109,16 @@ export namespace xdr {
 
     static toXDR(value: SignedSurveyResponseMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SignedSurveyResponseMessage;
+    static fromXDR(input: Buffer, format?: "raw"): SignedSurveyResponseMessage;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SignedSurveyResponseMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PeerStats {
@@ -4156,9 +4170,9 @@ export namespace xdr {
 
     duplicateFetchMessageRecv(value?: Uint64): Uint64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PeerStats;
 
@@ -4168,13 +4182,13 @@ export namespace xdr {
 
     static toXDR(value: PeerStats): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PeerStats;
+    static fromXDR(input: Buffer, format?: "raw"): PeerStats;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PeerStats;
+    static fromXDR(input: string, format: "hex" | "base64"): PeerStats;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TopologyResponseBody {
@@ -4193,9 +4207,9 @@ export namespace xdr {
 
     totalOutboundPeerCount(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TopologyResponseBody;
 
@@ -4205,16 +4219,68 @@ export namespace xdr {
 
     static toXDR(value: TopologyResponseBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TopologyResponseBody;
+    static fromXDR(input: Buffer, format?: "raw"): TopologyResponseBody;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TopologyResponseBody;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class FloodAdvert {
+    constructor(attributes: { txHashes: Hash[] });
+
+    txHashes(value?: Hash[]): Hash[];
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): FloodAdvert;
+
+    static write(value: FloodAdvert, io: Buffer): void;
+
+    static isValid(value: FloodAdvert): boolean;
+
+    static toXDR(value: FloodAdvert): Buffer;
+
+    static fromXDR(input: Buffer, format?: "raw"): FloodAdvert;
+
+    static fromXDR(input: string, format: "hex" | "base64"): FloodAdvert;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class FloodDemand {
+    constructor(attributes: { txHashes: Hash[] });
+
+    txHashes(value?: Hash[]): Hash[];
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): FloodDemand;
+
+    static write(value: FloodDemand, io: Buffer): void;
+
+    static isValid(value: FloodDemand): boolean;
+
+    static toXDR(value: FloodDemand): Buffer;
+
+    static fromXDR(input: Buffer, format?: "raw"): FloodDemand;
+
+    static fromXDR(input: string, format: "hex" | "base64"): FloodDemand;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AuthenticatedMessageV0 {
@@ -4230,9 +4296,9 @@ export namespace xdr {
 
     mac(value?: HmacSha256Mac): HmacSha256Mac;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AuthenticatedMessageV0;
 
@@ -4242,16 +4308,16 @@ export namespace xdr {
 
     static toXDR(value: AuthenticatedMessageV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AuthenticatedMessageV0;
+    static fromXDR(input: Buffer, format?: "raw"): AuthenticatedMessageV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AuthenticatedMessageV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class MuxedAccountMed25519 {
@@ -4261,9 +4327,9 @@ export namespace xdr {
 
     ed25519(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): MuxedAccountMed25519;
 
@@ -4273,16 +4339,16 @@ export namespace xdr {
 
     static toXDR(value: MuxedAccountMed25519): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): MuxedAccountMed25519;
+    static fromXDR(input: Buffer, format?: "raw"): MuxedAccountMed25519;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): MuxedAccountMed25519;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class DecoratedSignature {
@@ -4292,9 +4358,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): DecoratedSignature;
 
@@ -4304,13 +4370,13 @@ export namespace xdr {
 
     static toXDR(value: DecoratedSignature): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): DecoratedSignature;
+    static fromXDR(input: Buffer, format?: "raw"): DecoratedSignature;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): DecoratedSignature;
+    static fromXDR(input: string, format: "hex" | "base64"): DecoratedSignature;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreateAccountOp {
@@ -4320,9 +4386,9 @@ export namespace xdr {
 
     startingBalance(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreateAccountOp;
 
@@ -4332,13 +4398,13 @@ export namespace xdr {
 
     static toXDR(value: CreateAccountOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreateAccountOp;
+    static fromXDR(input: Buffer, format?: "raw"): CreateAccountOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): CreateAccountOp;
+    static fromXDR(input: string, format: "hex" | "base64"): CreateAccountOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PaymentOp {
@@ -4354,9 +4420,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PaymentOp;
 
@@ -4366,13 +4432,13 @@ export namespace xdr {
 
     static toXDR(value: PaymentOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PaymentOp;
+    static fromXDR(input: Buffer, format?: "raw"): PaymentOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PaymentOp;
+    static fromXDR(input: string, format: "hex" | "base64"): PaymentOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictReceiveOp {
@@ -4397,9 +4463,9 @@ export namespace xdr {
 
     path(value?: Asset[]): Asset[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveOp;
 
@@ -4409,16 +4475,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictReceiveOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictReceiveOp;
+    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictReceiveOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictReceiveOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictSendOp {
@@ -4443,9 +4509,9 @@ export namespace xdr {
 
     path(value?: Asset[]): Asset[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictSendOp;
 
@@ -4455,16 +4521,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictSendOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictSendOp;
+    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictSendOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictSendOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageSellOfferOp {
@@ -4486,9 +4552,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageSellOfferOp;
 
@@ -4498,13 +4564,13 @@ export namespace xdr {
 
     static toXDR(value: ManageSellOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageSellOfferOp;
+    static fromXDR(input: Buffer, format?: "raw"): ManageSellOfferOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ManageSellOfferOp;
+    static fromXDR(input: string, format: "hex" | "base64"): ManageSellOfferOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageBuyOfferOp {
@@ -4526,9 +4592,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageBuyOfferOp;
 
@@ -4538,13 +4604,13 @@ export namespace xdr {
 
     static toXDR(value: ManageBuyOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageBuyOfferOp;
+    static fromXDR(input: Buffer, format?: "raw"): ManageBuyOfferOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ManageBuyOfferOp;
+    static fromXDR(input: string, format: "hex" | "base64"): ManageBuyOfferOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreatePassiveSellOfferOp {
@@ -4563,9 +4629,9 @@ export namespace xdr {
 
     price(value?: Price): Price;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreatePassiveSellOfferOp;
 
@@ -4575,16 +4641,16 @@ export namespace xdr {
 
     static toXDR(value: CreatePassiveSellOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreatePassiveSellOfferOp;
+    static fromXDR(input: Buffer, format?: "raw"): CreatePassiveSellOfferOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): CreatePassiveSellOfferOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SetOptionsOp {
@@ -4618,9 +4684,9 @@ export namespace xdr {
 
     signer(value?: null | Signer): null | Signer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SetOptionsOp;
 
@@ -4630,13 +4696,13 @@ export namespace xdr {
 
     static toXDR(value: SetOptionsOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SetOptionsOp;
+    static fromXDR(input: Buffer, format?: "raw"): SetOptionsOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): SetOptionsOp;
+    static fromXDR(input: string, format: "hex" | "base64"): SetOptionsOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ChangeTrustOp {
@@ -4646,9 +4712,9 @@ export namespace xdr {
 
     limit(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ChangeTrustOp;
 
@@ -4658,13 +4724,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustOp;
+    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustOp;
+    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AllowTrustOp {
@@ -4680,9 +4746,9 @@ export namespace xdr {
 
     authorize(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AllowTrustOp;
 
@@ -4692,13 +4758,13 @@ export namespace xdr {
 
     static toXDR(value: AllowTrustOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AllowTrustOp;
+    static fromXDR(input: Buffer, format?: "raw"): AllowTrustOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AllowTrustOp;
+    static fromXDR(input: string, format: "hex" | "base64"): AllowTrustOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageDataOp {
@@ -4711,9 +4777,9 @@ export namespace xdr {
 
     dataValue(value?: null | Buffer): null | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageDataOp;
 
@@ -4723,13 +4789,13 @@ export namespace xdr {
 
     static toXDR(value: ManageDataOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageDataOp;
+    static fromXDR(input: Buffer, format?: "raw"): ManageDataOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ManageDataOp;
+    static fromXDR(input: string, format: "hex" | "base64"): ManageDataOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BumpSequenceOp {
@@ -4737,9 +4803,9 @@ export namespace xdr {
 
     bumpTo(value?: SequenceNumber): SequenceNumber;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BumpSequenceOp;
 
@@ -4749,13 +4815,13 @@ export namespace xdr {
 
     static toXDR(value: BumpSequenceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): BumpSequenceOp;
+    static fromXDR(input: Buffer, format?: "raw"): BumpSequenceOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): BumpSequenceOp;
+    static fromXDR(input: string, format: "hex" | "base64"): BumpSequenceOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreateClaimableBalanceOp {
@@ -4771,9 +4837,9 @@ export namespace xdr {
 
     claimants(value?: Claimant[]): Claimant[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreateClaimableBalanceOp;
 
@@ -4783,16 +4849,16 @@ export namespace xdr {
 
     static toXDR(value: CreateClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreateClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: "raw"): CreateClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): CreateClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimClaimableBalanceOp {
@@ -4800,9 +4866,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimClaimableBalanceOp;
 
@@ -4812,16 +4878,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BeginSponsoringFutureReservesOp {
@@ -4829,9 +4895,9 @@ export namespace xdr {
 
     sponsoredId(value?: AccountId): AccountId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BeginSponsoringFutureReservesOp;
 
@@ -4843,17 +4909,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): BeginSponsoringFutureReservesOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): BeginSponsoringFutureReservesOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class RevokeSponsorshipOpSigner {
@@ -4863,9 +4929,9 @@ export namespace xdr {
 
     signerKey(value?: SignerKey): SignerKey;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): RevokeSponsorshipOpSigner;
 
@@ -4875,16 +4941,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipOpSigner): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipOpSigner;
+    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipOpSigner;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): RevokeSponsorshipOpSigner;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClawbackOp {
@@ -4900,9 +4966,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClawbackOp;
 
@@ -4912,13 +4978,13 @@ export namespace xdr {
 
     static toXDR(value: ClawbackOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClawbackOp;
+    static fromXDR(input: Buffer, format?: "raw"): ClawbackOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClawbackOp;
+    static fromXDR(input: string, format: "hex" | "base64"): ClawbackOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClawbackClaimableBalanceOp {
@@ -4926,9 +4992,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClawbackClaimableBalanceOp;
 
@@ -4938,16 +5004,16 @@ export namespace xdr {
 
     static toXDR(value: ClawbackClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClawbackClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: "raw"): ClawbackClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClawbackClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SetTrustLineFlagsOp {
@@ -4966,9 +5032,9 @@ export namespace xdr {
 
     setFlags(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SetTrustLineFlagsOp;
 
@@ -4978,16 +5044,16 @@ export namespace xdr {
 
     static toXDR(value: SetTrustLineFlagsOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SetTrustLineFlagsOp;
+    static fromXDR(input: Buffer, format?: "raw"): SetTrustLineFlagsOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SetTrustLineFlagsOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolDepositOp {
@@ -5009,9 +5075,9 @@ export namespace xdr {
 
     maxPrice(value?: Price): Price;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolDepositOp;
 
@@ -5021,16 +5087,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolDepositOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolDepositOp;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolDepositOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolDepositOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolWithdrawOp {
@@ -5049,9 +5115,9 @@ export namespace xdr {
 
     minAmountB(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolWithdrawOp;
 
@@ -5061,47 +5127,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolWithdrawOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolWithdrawOp;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolWithdrawOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolWithdrawOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
-  }
-
-  class Operation2 {
-    constructor(attributes: {
-      sourceAccount: null | MuxedAccount;
-      body: OperationBody;
-    });
-
-    sourceAccount(value?: null | MuxedAccount): null | MuxedAccount;
-
-    body(value?: OperationBody): OperationBody;
-
-    toXDR(format?: 'raw'): Buffer;
-
-    toXDR(format: 'hex' | 'base64'): string;
-
-    static read(io: Buffer): Operation;
-
-    static write(value: Operation, io: Buffer): void;
-
-    static isValid(value: Operation): boolean;
-
-    static toXDR(value: Operation): Buffer;
-
-    static fromXDR(input: Buffer, format?: 'raw'): Operation;
-
-    static fromXDR(input: string, format: 'hex' | 'base64'): Operation;
-
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
-
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimageOperationId {
@@ -5117,9 +5152,9 @@ export namespace xdr {
 
     opNum(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimageOperationId;
 
@@ -5129,16 +5164,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageOperationId): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageOperationId;
+    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageOperationId;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): HashIdPreimageOperationId;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimageRevokeId {
@@ -5160,9 +5195,9 @@ export namespace xdr {
 
     asset(value?: Asset): Asset;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimageRevokeId;
 
@@ -5172,16 +5207,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageRevokeId): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageRevokeId;
+    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageRevokeId;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): HashIdPreimageRevokeId;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TimeBounds {
@@ -5191,9 +5226,9 @@ export namespace xdr {
 
     maxTime(value?: TimePoint): TimePoint;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TimeBounds;
 
@@ -5203,13 +5238,13 @@ export namespace xdr {
 
     static toXDR(value: TimeBounds): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TimeBounds;
+    static fromXDR(input: Buffer, format?: "raw"): TimeBounds;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TimeBounds;
+    static fromXDR(input: string, format: "hex" | "base64"): TimeBounds;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerBounds {
@@ -5219,9 +5254,9 @@ export namespace xdr {
 
     maxLedger(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerBounds;
 
@@ -5231,13 +5266,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerBounds): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerBounds;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerBounds;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerBounds;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerBounds;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PreconditionsV2 {
@@ -5262,9 +5297,9 @@ export namespace xdr {
 
     extraSigners(value?: SignerKey[]): SignerKey[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PreconditionsV2;
 
@@ -5274,13 +5309,13 @@ export namespace xdr {
 
     static toXDR(value: PreconditionsV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PreconditionsV2;
+    static fromXDR(input: Buffer, format?: "raw"): PreconditionsV2;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PreconditionsV2;
+    static fromXDR(input: string, format: "hex" | "base64"): PreconditionsV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionV0 {
@@ -5308,9 +5343,9 @@ export namespace xdr {
 
     ext(value?: TransactionV0Ext): TransactionV0Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionV0;
 
@@ -5320,13 +5355,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionV0;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionV0Envelope {
@@ -5339,9 +5374,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionV0Envelope;
 
@@ -5351,16 +5386,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0Envelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0Envelope;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionV0Envelope;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionV0Envelope;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Transaction {
@@ -5388,9 +5423,9 @@ export namespace xdr {
 
     ext(value?: TransactionExt): TransactionExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Transaction;
 
@@ -5400,13 +5435,13 @@ export namespace xdr {
 
     static toXDR(value: Transaction): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Transaction;
+    static fromXDR(input: Buffer, format?: "raw"): Transaction;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Transaction;
+    static fromXDR(input: string, format: "hex" | "base64"): Transaction;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionV1Envelope {
@@ -5419,9 +5454,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionV1Envelope;
 
@@ -5431,16 +5466,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionV1Envelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionV1Envelope;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionV1Envelope;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionV1Envelope;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class FeeBumpTransaction {
@@ -5459,9 +5494,9 @@ export namespace xdr {
 
     ext(value?: FeeBumpTransactionExt): FeeBumpTransactionExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): FeeBumpTransaction;
 
@@ -5471,13 +5506,13 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransaction): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransaction;
+    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransaction;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): FeeBumpTransaction;
+    static fromXDR(input: string, format: "hex" | "base64"): FeeBumpTransaction;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class FeeBumpTransactionEnvelope {
@@ -5490,9 +5525,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): FeeBumpTransactionEnvelope;
 
@@ -5502,16 +5537,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionEnvelope;
+    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionEnvelope;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): FeeBumpTransactionEnvelope;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionSignaturePayload {
@@ -5526,9 +5561,9 @@ export namespace xdr {
       value?: TransactionSignaturePayloadTaggedTransaction
     ): TransactionSignaturePayloadTaggedTransaction;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionSignaturePayload;
 
@@ -5538,16 +5573,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionSignaturePayload): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionSignaturePayload;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionSignaturePayload;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionSignaturePayload;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimOfferAtomV0 {
@@ -5572,9 +5607,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimOfferAtomV0;
 
@@ -5584,13 +5619,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimOfferAtomV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimOfferAtomV0;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimOfferAtomV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimOfferAtomV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimOfferAtomV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimOfferAtom {
@@ -5615,9 +5650,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimOfferAtom;
 
@@ -5627,13 +5662,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimOfferAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimOfferAtom;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimOfferAtom;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimOfferAtom;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimOfferAtom;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimLiquidityAtom {
@@ -5655,9 +5690,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimLiquidityAtom;
 
@@ -5667,13 +5702,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimLiquidityAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimLiquidityAtom;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimLiquidityAtom;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimLiquidityAtom;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimLiquidityAtom;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SimplePaymentResult {
@@ -5689,9 +5724,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SimplePaymentResult;
 
@@ -5701,16 +5736,16 @@ export namespace xdr {
 
     static toXDR(value: SimplePaymentResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SimplePaymentResult;
+    static fromXDR(input: Buffer, format?: "raw"): SimplePaymentResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SimplePaymentResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictReceiveResultSuccess {
@@ -5720,9 +5755,9 @@ export namespace xdr {
 
     last(value?: SimplePaymentResult): SimplePaymentResult;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveResultSuccess;
 
@@ -5737,17 +5772,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): PathPaymentStrictReceiveResultSuccess;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictReceiveResultSuccess;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictSendResultSuccess {
@@ -5757,9 +5792,9 @@ export namespace xdr {
 
     last(value?: SimplePaymentResult): SimplePaymentResult;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictSendResultSuccess;
 
@@ -5771,17 +5806,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): PathPaymentStrictSendResultSuccess;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictSendResultSuccess;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageOfferSuccessResult {
@@ -5794,9 +5829,9 @@ export namespace xdr {
 
     offer(value?: ManageOfferSuccessResultOffer): ManageOfferSuccessResultOffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageOfferSuccessResult;
 
@@ -5806,16 +5841,16 @@ export namespace xdr {
 
     static toXDR(value: ManageOfferSuccessResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageOfferSuccessResult;
+    static fromXDR(input: Buffer, format?: "raw"): ManageOfferSuccessResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ManageOfferSuccessResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InflationPayout {
@@ -5825,9 +5860,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InflationPayout;
 
@@ -5837,13 +5872,13 @@ export namespace xdr {
 
     static toXDR(value: InflationPayout): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InflationPayout;
+    static fromXDR(input: Buffer, format?: "raw"): InflationPayout;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): InflationPayout;
+    static fromXDR(input: string, format: "hex" | "base64"): InflationPayout;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InnerTransactionResult {
@@ -5859,9 +5894,9 @@ export namespace xdr {
 
     ext(value?: InnerTransactionResultExt): InnerTransactionResultExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InnerTransactionResult;
 
@@ -5871,16 +5906,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResult;
+    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InnerTransactionResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InnerTransactionResultPair {
@@ -5893,9 +5928,9 @@ export namespace xdr {
 
     result(value?: InnerTransactionResult): InnerTransactionResult;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InnerTransactionResultPair;
 
@@ -5905,16 +5940,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultPair): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultPair;
+    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultPair;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InnerTransactionResultPair;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResult {
@@ -5930,9 +5965,9 @@ export namespace xdr {
 
     ext(value?: TransactionResultExt): TransactionResultExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResult;
 
@@ -5942,13 +5977,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResult;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionResult;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SignerKeyEd25519SignedPayload {
@@ -5958,9 +5993,9 @@ export namespace xdr {
 
     payload(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SignerKeyEd25519SignedPayload;
 
@@ -5972,17 +6007,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): SignerKeyEd25519SignedPayload;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SignerKeyEd25519SignedPayload;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Curve25519Secret {
@@ -5990,9 +6025,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Curve25519Secret;
 
@@ -6002,13 +6037,13 @@ export namespace xdr {
 
     static toXDR(value: Curve25519Secret): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Curve25519Secret;
+    static fromXDR(input: Buffer, format?: "raw"): Curve25519Secret;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Curve25519Secret;
+    static fromXDR(input: string, format: "hex" | "base64"): Curve25519Secret;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Curve25519Public {
@@ -6016,9 +6051,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Curve25519Public;
 
@@ -6028,13 +6063,13 @@ export namespace xdr {
 
     static toXDR(value: Curve25519Public): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Curve25519Public;
+    static fromXDR(input: Buffer, format?: "raw"): Curve25519Public;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Curve25519Public;
+    static fromXDR(input: string, format: "hex" | "base64"): Curve25519Public;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HmacSha256Key {
@@ -6042,9 +6077,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HmacSha256Key;
 
@@ -6054,13 +6089,13 @@ export namespace xdr {
 
     static toXDR(value: HmacSha256Key): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HmacSha256Key;
+    static fromXDR(input: Buffer, format?: "raw"): HmacSha256Key;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): HmacSha256Key;
+    static fromXDR(input: string, format: "hex" | "base64"): HmacSha256Key;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HmacSha256Mac {
@@ -6068,9 +6103,9 @@ export namespace xdr {
 
     mac(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HmacSha256Mac;
 
@@ -6080,13 +6115,13 @@ export namespace xdr {
 
     static toXDR(value: HmacSha256Mac): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HmacSha256Mac;
+    static fromXDR(input: Buffer, format?: "raw"): HmacSha256Mac;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): HmacSha256Mac;
+    static fromXDR(input: string, format: "hex" | "base64"): HmacSha256Mac;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatementPledges {
@@ -6116,9 +6151,9 @@ export namespace xdr {
       | ScpStatementExternalize
       | ScpNomination;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpStatementPledges;
 
@@ -6128,16 +6163,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementPledges): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementPledges;
+    static fromXDR(input: Buffer, format?: "raw"): ScpStatementPledges;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScpStatementPledges;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AssetCode {
@@ -6153,9 +6188,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AssetCode;
 
@@ -6165,13 +6200,13 @@ export namespace xdr {
 
     static toXDR(value: AssetCode): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AssetCode;
+    static fromXDR(input: Buffer, format?: "raw"): AssetCode;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AssetCode;
+    static fromXDR(input: string, format: "hex" | "base64"): AssetCode;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Asset {
@@ -6189,9 +6224,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Asset;
 
@@ -6201,13 +6236,13 @@ export namespace xdr {
 
     static toXDR(value: Asset): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Asset;
+    static fromXDR(input: Buffer, format?: "raw"): Asset;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Asset;
+    static fromXDR(input: string, format: "hex" | "base64"): Asset;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExtensionV2Ext {
@@ -6221,9 +6256,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV3 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExtensionV2Ext;
 
@@ -6233,16 +6268,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV2Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV2Ext;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV2Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AccountEntryExtensionV2Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExtensionV1Ext {
@@ -6256,9 +6291,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV2 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExtensionV1Ext;
 
@@ -6268,16 +6303,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AccountEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExt {
@@ -6291,9 +6326,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV1 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExt;
 
@@ -6303,13 +6338,13 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AccountEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): AccountEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineAsset {
@@ -6331,9 +6366,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | PoolId | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineAsset;
 
@@ -6343,13 +6378,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineAsset): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineAsset;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineAsset;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineAsset;
+    static fromXDR(input: string, format: "hex" | "base64"): TrustLineAsset;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntryExtensionV2Ext {
@@ -6359,9 +6394,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntryExtensionV2Ext;
 
@@ -6371,16 +6406,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExtensionV2Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExtensionV2Ext;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExtensionV2Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TrustLineEntryExtensionV2Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntryV1Ext {
@@ -6394,9 +6429,9 @@ export namespace xdr {
 
     value(): TrustLineEntryExtensionV2 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntryV1Ext;
 
@@ -6406,16 +6441,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryV1Ext;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryV1Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TrustLineEntryV1Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntryExt {
@@ -6429,9 +6464,9 @@ export namespace xdr {
 
     value(): TrustLineEntryV1 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntryExt;
 
@@ -6441,13 +6476,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OfferEntryExt {
@@ -6457,9 +6492,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OfferEntryExt;
 
@@ -6469,13 +6504,13 @@ export namespace xdr {
 
     static toXDR(value: OfferEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OfferEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): OfferEntryExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OfferEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): OfferEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class DataEntryExt {
@@ -6485,9 +6520,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): DataEntryExt;
 
@@ -6497,13 +6532,13 @@ export namespace xdr {
 
     static toXDR(value: DataEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): DataEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): DataEntryExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): DataEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): DataEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimPredicate {
@@ -6540,9 +6575,9 @@ export namespace xdr {
       | Int64
       | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimPredicate;
 
@@ -6552,13 +6587,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimPredicate): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimPredicate;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimPredicate;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimPredicate;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimPredicate;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Claimant {
@@ -6570,9 +6605,9 @@ export namespace xdr {
 
     value(): ClaimantV0;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Claimant;
 
@@ -6582,13 +6617,13 @@ export namespace xdr {
 
     static toXDR(value: Claimant): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Claimant;
+    static fromXDR(input: Buffer, format?: "raw"): Claimant;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Claimant;
+    static fromXDR(input: string, format: "hex" | "base64"): Claimant;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimableBalanceId {
@@ -6600,9 +6635,9 @@ export namespace xdr {
 
     value(): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimableBalanceId;
 
@@ -6612,13 +6647,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceId): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceId;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceId;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimableBalanceId;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimableBalanceId;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimableBalanceEntryExtensionV1Ext {
@@ -6628,9 +6663,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExtensionV1Ext;
 
@@ -6642,17 +6677,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): ClaimableBalanceEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimableBalanceEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimableBalanceEntryExt {
@@ -6668,9 +6703,9 @@ export namespace xdr {
 
     value(): ClaimableBalanceEntryExtensionV1 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExt;
 
@@ -6680,16 +6715,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceEntryExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimableBalanceEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolEntryBody {
@@ -6705,9 +6740,9 @@ export namespace xdr {
 
     value(): LiquidityPoolEntryConstantProduct;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolEntryBody;
 
@@ -6717,16 +6752,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolEntryBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolEntryBody;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolEntryBody;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolEntryBody;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntryExtensionV1Ext {
@@ -6736,9 +6771,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntryExtensionV1Ext;
 
@@ -6748,16 +6783,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntryData {
@@ -6795,9 +6830,9 @@ export namespace xdr {
       | ClaimableBalanceEntry
       | LiquidityPoolEntry;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntryData;
 
@@ -6807,13 +6842,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryData): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryData;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryData;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryData;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryData;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntryExt {
@@ -6827,9 +6862,9 @@ export namespace xdr {
 
     value(): LedgerEntryExtensionV1 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntryExt;
 
@@ -6839,13 +6874,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKey {
@@ -6885,9 +6920,9 @@ export namespace xdr {
       | LedgerKeyClaimableBalance
       | LedgerKeyLiquidityPool;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKey;
 
@@ -6897,13 +6932,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKey;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKey;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKey;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerKey;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class StellarValueExt {
@@ -6921,9 +6956,9 @@ export namespace xdr {
 
     value(): LedgerCloseValueSignature | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): StellarValueExt;
 
@@ -6933,13 +6968,13 @@ export namespace xdr {
 
     static toXDR(value: StellarValueExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): StellarValueExt;
+    static fromXDR(input: Buffer, format?: "raw"): StellarValueExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): StellarValueExt;
+    static fromXDR(input: string, format: "hex" | "base64"): StellarValueExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeaderExtensionV1Ext {
@@ -6949,9 +6984,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeaderExtensionV1Ext;
 
@@ -6961,16 +6996,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerHeaderExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeaderExt {
@@ -6984,9 +7019,9 @@ export namespace xdr {
 
     value(): LedgerHeaderExtensionV1 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeaderExt;
 
@@ -6996,13 +7031,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExt;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerHeaderExt;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerHeaderExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerUpgrade {
@@ -7030,9 +7065,9 @@ export namespace xdr {
 
     value(): number | number | number | number | number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerUpgrade;
 
@@ -7042,13 +7077,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerUpgrade): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerUpgrade;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerUpgrade;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerUpgrade;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerUpgrade;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BucketMetadataExt {
@@ -7058,9 +7093,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BucketMetadataExt;
 
@@ -7070,13 +7105,13 @@ export namespace xdr {
 
     static toXDR(value: BucketMetadataExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): BucketMetadataExt;
+    static fromXDR(input: Buffer, format?: "raw"): BucketMetadataExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): BucketMetadataExt;
+    static fromXDR(input: string, format: "hex" | "base64"): BucketMetadataExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BucketEntry {
@@ -7098,9 +7133,9 @@ export namespace xdr {
 
     value(): LedgerEntry | LedgerKey | BucketMetadata;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BucketEntry;
 
@@ -7110,13 +7145,13 @@ export namespace xdr {
 
     static toXDR(value: BucketEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): BucketEntry;
+    static fromXDR(input: Buffer, format?: "raw"): BucketEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): BucketEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): BucketEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TxSetComponent {
@@ -7132,9 +7167,9 @@ export namespace xdr {
 
     value(): TxSetComponentTxsMaybeDiscountedFee;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TxSetComponent;
 
@@ -7144,13 +7179,13 @@ export namespace xdr {
 
     static toXDR(value: TxSetComponent): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TxSetComponent;
+    static fromXDR(input: Buffer, format?: "raw"): TxSetComponent;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TxSetComponent;
+    static fromXDR(input: string, format: "hex" | "base64"): TxSetComponent;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionPhase {
@@ -7162,9 +7197,9 @@ export namespace xdr {
 
     value(): TxSetComponent[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionPhase;
 
@@ -7174,13 +7209,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionPhase): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionPhase;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionPhase;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionPhase;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionPhase;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class GeneralizedTransactionSet {
@@ -7192,9 +7227,9 @@ export namespace xdr {
 
     value(): TransactionSetV1;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): GeneralizedTransactionSet;
 
@@ -7204,16 +7239,16 @@ export namespace xdr {
 
     static toXDR(value: GeneralizedTransactionSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): GeneralizedTransactionSet;
+    static fromXDR(input: Buffer, format?: "raw"): GeneralizedTransactionSet;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): GeneralizedTransactionSet;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionHistoryEntryExt {
@@ -7229,9 +7264,9 @@ export namespace xdr {
 
     value(): GeneralizedTransactionSet | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionHistoryEntryExt;
 
@@ -7241,16 +7276,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionHistoryEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionHistoryEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionHistoryEntryExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionHistoryEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionHistoryResultEntryExt {
@@ -7260,9 +7295,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionHistoryResultEntryExt;
 
@@ -7274,17 +7309,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): TransactionHistoryResultEntryExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionHistoryResultEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeaderHistoryEntryExt {
@@ -7294,9 +7329,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeaderHistoryEntryExt;
 
@@ -7306,16 +7341,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderHistoryEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderHistoryEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderHistoryEntryExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerHeaderHistoryEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpHistoryEntry {
@@ -7327,9 +7362,9 @@ export namespace xdr {
 
     value(): ScpHistoryEntryV0;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpHistoryEntry;
 
@@ -7339,13 +7374,13 @@ export namespace xdr {
 
     static toXDR(value: ScpHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpHistoryEntry;
+    static fromXDR(input: Buffer, format?: "raw"): ScpHistoryEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpHistoryEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntryChange {
@@ -7369,9 +7404,9 @@ export namespace xdr {
 
     value(): LedgerEntry | LedgerEntry | LedgerKey | LedgerEntry;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntryChange;
 
@@ -7381,13 +7416,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryChange): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryChange;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryChange;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryChange;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryChange;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionMeta {
@@ -7407,9 +7442,9 @@ export namespace xdr {
 
     value(): OperationMeta[] | TransactionMetaV1 | TransactionMetaV2;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionMeta;
 
@@ -7419,13 +7454,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionMeta;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionMeta;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMeta;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionMeta;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerCloseMeta {
@@ -7441,9 +7476,9 @@ export namespace xdr {
 
     value(): LedgerCloseMetaV0 | LedgerCloseMetaV1;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerCloseMeta;
 
@@ -7453,13 +7488,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMeta;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMeta;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMeta;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMeta;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PeerAddressIp {
@@ -7475,9 +7510,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PeerAddressIp;
 
@@ -7487,13 +7522,13 @@ export namespace xdr {
 
     static toXDR(value: PeerAddressIp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PeerAddressIp;
+    static fromXDR(input: Buffer, format?: "raw"): PeerAddressIp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PeerAddressIp;
+    static fromXDR(input: string, format: "hex" | "base64"): PeerAddressIp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SurveyResponseBody {
@@ -7505,9 +7540,9 @@ export namespace xdr {
 
     value(): TopologyResponseBody;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SurveyResponseBody;
 
@@ -7517,13 +7552,13 @@ export namespace xdr {
 
     static toXDR(value: SurveyResponseBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SurveyResponseBody;
+    static fromXDR(input: Buffer, format?: "raw"): SurveyResponseBody;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): SurveyResponseBody;
+    static fromXDR(input: string, format: "hex" | "base64"): SurveyResponseBody;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class StellarMessage {
@@ -7567,6 +7602,10 @@ export namespace xdr {
 
     sendMoreMessage(value?: SendMore): SendMore;
 
+    floodAdvert(value?: FloodAdvert): FloodAdvert;
+
+    floodDemand(value?: FloodDemand): FloodDemand;
+
     static errorMsg(value: Error): StellarMessage;
 
     static hello(value: Hello): StellarMessage;
@@ -7601,6 +7640,10 @@ export namespace xdr {
 
     static sendMore(value: SendMore): StellarMessage;
 
+    static floodAdvert(value: FloodAdvert): StellarMessage;
+
+    static floodDemand(value: FloodDemand): StellarMessage;
+
     value():
       | Error
       | Hello
@@ -7618,11 +7661,13 @@ export namespace xdr {
       | ScpEnvelope
       | number
       | SendMore
+      | FloodAdvert
+      | FloodDemand
       | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): StellarMessage;
 
@@ -7632,13 +7677,13 @@ export namespace xdr {
 
     static toXDR(value: StellarMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): StellarMessage;
+    static fromXDR(input: Buffer, format?: "raw"): StellarMessage;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): StellarMessage;
+    static fromXDR(input: string, format: "hex" | "base64"): StellarMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AuthenticatedMessage {
@@ -7650,9 +7695,9 @@ export namespace xdr {
 
     value(): AuthenticatedMessageV0;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AuthenticatedMessage;
 
@@ -7662,16 +7707,16 @@ export namespace xdr {
 
     static toXDR(value: AuthenticatedMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AuthenticatedMessage;
+    static fromXDR(input: Buffer, format?: "raw"): AuthenticatedMessage;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AuthenticatedMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolParameters {
@@ -7687,9 +7732,9 @@ export namespace xdr {
 
     value(): LiquidityPoolConstantProductParameters;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolParameters;
 
@@ -7699,16 +7744,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolParameters): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolParameters;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolParameters;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolParameters;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class MuxedAccount {
@@ -7724,9 +7769,9 @@ export namespace xdr {
 
     value(): Buffer | MuxedAccountMed25519;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): MuxedAccount;
 
@@ -7736,13 +7781,13 @@ export namespace xdr {
 
     static toXDR(value: MuxedAccount): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): MuxedAccount;
+    static fromXDR(input: Buffer, format?: "raw"): MuxedAccount;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): MuxedAccount;
+    static fromXDR(input: string, format: "hex" | "base64"): MuxedAccount;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ChangeTrustAsset {
@@ -7764,9 +7809,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | LiquidityPoolParameters | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ChangeTrustAsset;
 
@@ -7776,13 +7821,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustAsset): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustAsset;
+    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustAsset;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustAsset;
+    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustAsset;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class RevokeSponsorshipOp {
@@ -7800,9 +7845,9 @@ export namespace xdr {
 
     value(): LedgerKey | RevokeSponsorshipOpSigner;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): RevokeSponsorshipOp;
 
@@ -7812,16 +7857,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipOp;
+    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): RevokeSponsorshipOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OperationBody {
@@ -7972,9 +8017,9 @@ export namespace xdr {
       | LiquidityPoolWithdrawOp
       | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OperationBody;
 
@@ -7984,13 +8029,13 @@ export namespace xdr {
 
     static toXDR(value: OperationBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OperationBody;
+    static fromXDR(input: Buffer, format?: "raw"): OperationBody;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OperationBody;
+    static fromXDR(input: string, format: "hex" | "base64"): OperationBody;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimage {
@@ -8008,9 +8053,9 @@ export namespace xdr {
 
     value(): HashIdPreimageOperationId | HashIdPreimageRevokeId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimage;
 
@@ -8020,13 +8065,13 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimage;
+    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimage;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): HashIdPreimage;
+    static fromXDR(input: string, format: "hex" | "base64"): HashIdPreimage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Memo {
@@ -8052,9 +8097,9 @@ export namespace xdr {
 
     value(): string | Buffer | Uint64 | Buffer | Buffer | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Memo;
 
@@ -8064,13 +8109,13 @@ export namespace xdr {
 
     static toXDR(value: Memo): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Memo;
+    static fromXDR(input: Buffer, format?: "raw"): Memo;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Memo;
+    static fromXDR(input: string, format: "hex" | "base64"): Memo;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Preconditions {
@@ -8088,9 +8133,9 @@ export namespace xdr {
 
     value(): TimeBounds | PreconditionsV2 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Preconditions;
 
@@ -8100,13 +8145,13 @@ export namespace xdr {
 
     static toXDR(value: Preconditions): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Preconditions;
+    static fromXDR(input: Buffer, format?: "raw"): Preconditions;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Preconditions;
+    static fromXDR(input: string, format: "hex" | "base64"): Preconditions;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionV0Ext {
@@ -8116,9 +8161,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionV0Ext;
 
@@ -8128,13 +8173,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0Ext;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionV0Ext;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionV0Ext;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionV0Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionExt {
@@ -8144,9 +8189,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionExt;
 
@@ -8156,13 +8201,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionExt;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionExt;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class FeeBumpTransactionInnerTx {
@@ -8176,9 +8221,9 @@ export namespace xdr {
 
     value(): TransactionV1Envelope;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): FeeBumpTransactionInnerTx;
 
@@ -8188,16 +8233,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionInnerTx): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionInnerTx;
+    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionInnerTx;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): FeeBumpTransactionInnerTx;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class FeeBumpTransactionExt {
@@ -8207,9 +8252,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): FeeBumpTransactionExt;
 
@@ -8219,16 +8264,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionExt;
+    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): FeeBumpTransactionExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionEnvelope {
@@ -8253,9 +8298,9 @@ export namespace xdr {
       | TransactionV1Envelope
       | FeeBumpTransactionEnvelope;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionEnvelope;
 
@@ -8265,16 +8310,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionEnvelope;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionEnvelope;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionEnvelope;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionSignaturePayloadTaggedTransaction {
@@ -8294,9 +8339,9 @@ export namespace xdr {
 
     value(): Transaction | FeeBumpTransaction;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionSignaturePayloadTaggedTransaction;
 
@@ -8313,17 +8358,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): TransactionSignaturePayloadTaggedTransaction;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionSignaturePayloadTaggedTransaction;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimAtom {
@@ -8343,9 +8388,9 @@ export namespace xdr {
 
     value(): ClaimOfferAtomV0 | ClaimOfferAtom | ClaimLiquidityAtom;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimAtom;
 
@@ -8355,13 +8400,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimAtom;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimAtom;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimAtom;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimAtom;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreateAccountResult {
@@ -8379,9 +8424,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreateAccountResult;
 
@@ -8391,16 +8436,16 @@ export namespace xdr {
 
     static toXDR(value: CreateAccountResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreateAccountResult;
+    static fromXDR(input: Buffer, format?: "raw"): CreateAccountResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): CreateAccountResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PaymentResult {
@@ -8428,9 +8473,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PaymentResult;
 
@@ -8440,13 +8485,13 @@ export namespace xdr {
 
     static toXDR(value: PaymentResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PaymentResult;
+    static fromXDR(input: Buffer, format?: "raw"): PaymentResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PaymentResult;
+    static fromXDR(input: string, format: "hex" | "base64"): PaymentResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictReceiveResult {
@@ -8490,9 +8535,9 @@ export namespace xdr {
 
     value(): PathPaymentStrictReceiveResultSuccess | Asset | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveResult;
 
@@ -8504,17 +8549,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): PathPaymentStrictReceiveResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictReceiveResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictSendResult {
@@ -8558,9 +8603,9 @@ export namespace xdr {
 
     value(): PathPaymentStrictSendResultSuccess | Asset | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictSendResult;
 
@@ -8570,16 +8615,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictSendResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictSendResult;
+    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictSendResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictSendResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageOfferSuccessResultOffer {
@@ -8595,9 +8640,9 @@ export namespace xdr {
 
     value(): OfferEntry | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageOfferSuccessResultOffer;
 
@@ -8609,17 +8654,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): ManageOfferSuccessResultOffer;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ManageOfferSuccessResultOffer;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageSellOfferResult {
@@ -8657,9 +8702,9 @@ export namespace xdr {
 
     value(): ManageOfferSuccessResult | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageSellOfferResult;
 
@@ -8669,16 +8714,16 @@ export namespace xdr {
 
     static toXDR(value: ManageSellOfferResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageSellOfferResult;
+    static fromXDR(input: Buffer, format?: "raw"): ManageSellOfferResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ManageSellOfferResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageBuyOfferResult {
@@ -8716,9 +8761,9 @@ export namespace xdr {
 
     value(): ManageOfferSuccessResult | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageBuyOfferResult;
 
@@ -8728,16 +8773,16 @@ export namespace xdr {
 
     static toXDR(value: ManageBuyOfferResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageBuyOfferResult;
+    static fromXDR(input: Buffer, format?: "raw"): ManageBuyOfferResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ManageBuyOfferResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SetOptionsResult {
@@ -8767,9 +8812,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SetOptionsResult;
 
@@ -8779,13 +8824,13 @@ export namespace xdr {
 
     static toXDR(value: SetOptionsResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SetOptionsResult;
+    static fromXDR(input: Buffer, format?: "raw"): SetOptionsResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): SetOptionsResult;
+    static fromXDR(input: string, format: "hex" | "base64"): SetOptionsResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ChangeTrustResult {
@@ -8811,9 +8856,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ChangeTrustResult;
 
@@ -8823,13 +8868,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustResult;
+    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustResult;
+    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AllowTrustResult {
@@ -8851,9 +8896,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AllowTrustResult;
 
@@ -8863,13 +8908,13 @@ export namespace xdr {
 
     static toXDR(value: AllowTrustResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AllowTrustResult;
+    static fromXDR(input: Buffer, format?: "raw"): AllowTrustResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AllowTrustResult;
+    static fromXDR(input: string, format: "hex" | "base64"): AllowTrustResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountMergeResult {
@@ -8895,9 +8940,9 @@ export namespace xdr {
 
     value(): Int64 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountMergeResult;
 
@@ -8907,13 +8952,13 @@ export namespace xdr {
 
     static toXDR(value: AccountMergeResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountMergeResult;
+    static fromXDR(input: Buffer, format?: "raw"): AccountMergeResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AccountMergeResult;
+    static fromXDR(input: string, format: "hex" | "base64"): AccountMergeResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InflationResult {
@@ -8927,9 +8972,9 @@ export namespace xdr {
 
     value(): InflationPayout[] | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InflationResult;
 
@@ -8939,13 +8984,13 @@ export namespace xdr {
 
     static toXDR(value: InflationResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InflationResult;
+    static fromXDR(input: Buffer, format?: "raw"): InflationResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): InflationResult;
+    static fromXDR(input: string, format: "hex" | "base64"): InflationResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageDataResult {
@@ -8963,9 +9008,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageDataResult;
 
@@ -8975,13 +9020,13 @@ export namespace xdr {
 
     static toXDR(value: ManageDataResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageDataResult;
+    static fromXDR(input: Buffer, format?: "raw"): ManageDataResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ManageDataResult;
+    static fromXDR(input: string, format: "hex" | "base64"): ManageDataResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BumpSequenceResult {
@@ -8993,9 +9038,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BumpSequenceResult;
 
@@ -9005,13 +9050,13 @@ export namespace xdr {
 
     static toXDR(value: BumpSequenceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): BumpSequenceResult;
+    static fromXDR(input: Buffer, format?: "raw"): BumpSequenceResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): BumpSequenceResult;
+    static fromXDR(input: string, format: "hex" | "base64"): BumpSequenceResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreateClaimableBalanceResult {
@@ -9035,9 +9080,9 @@ export namespace xdr {
 
     value(): ClaimableBalanceId | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreateClaimableBalanceResult;
 
@@ -9047,16 +9092,16 @@ export namespace xdr {
 
     static toXDR(value: CreateClaimableBalanceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreateClaimableBalanceResult;
+    static fromXDR(input: Buffer, format?: "raw"): CreateClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): CreateClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimClaimableBalanceResult {
@@ -9076,9 +9121,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimClaimableBalanceResult;
 
@@ -9088,16 +9133,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimClaimableBalanceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimClaimableBalanceResult;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BeginSponsoringFutureReservesResult {
@@ -9113,9 +9158,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BeginSponsoringFutureReservesResult;
 
@@ -9127,17 +9172,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): BeginSponsoringFutureReservesResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): BeginSponsoringFutureReservesResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class EndSponsoringFutureReservesResult {
@@ -9149,9 +9194,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): EndSponsoringFutureReservesResult;
 
@@ -9163,17 +9208,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): EndSponsoringFutureReservesResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): EndSponsoringFutureReservesResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class RevokeSponsorshipResult {
@@ -9193,9 +9238,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): RevokeSponsorshipResult;
 
@@ -9205,16 +9250,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipResult;
+    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): RevokeSponsorshipResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClawbackResult {
@@ -9232,9 +9277,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClawbackResult;
 
@@ -9244,13 +9289,13 @@ export namespace xdr {
 
     static toXDR(value: ClawbackResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClawbackResult;
+    static fromXDR(input: Buffer, format?: "raw"): ClawbackResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClawbackResult;
+    static fromXDR(input: string, format: "hex" | "base64"): ClawbackResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClawbackClaimableBalanceResult {
@@ -9266,9 +9311,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClawbackClaimableBalanceResult;
 
@@ -9280,17 +9325,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): ClawbackClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClawbackClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SetTrustLineFlagsResult {
@@ -9310,9 +9355,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SetTrustLineFlagsResult;
 
@@ -9322,16 +9367,16 @@ export namespace xdr {
 
     static toXDR(value: SetTrustLineFlagsResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SetTrustLineFlagsResult;
+    static fromXDR(input: Buffer, format?: "raw"): SetTrustLineFlagsResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SetTrustLineFlagsResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolDepositResult {
@@ -9355,9 +9400,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolDepositResult;
 
@@ -9367,16 +9412,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolDepositResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolDepositResult;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolDepositResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolDepositResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolWithdrawResult {
@@ -9396,9 +9441,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolWithdrawResult;
 
@@ -9408,16 +9453,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolWithdrawResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolWithdrawResult;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolWithdrawResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolWithdrawResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OperationResultTr {
@@ -9589,9 +9634,9 @@ export namespace xdr {
       | LiquidityPoolDepositResult
       | LiquidityPoolWithdrawResult;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OperationResultTr;
 
@@ -9601,13 +9646,13 @@ export namespace xdr {
 
     static toXDR(value: OperationResultTr): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OperationResultTr;
+    static fromXDR(input: Buffer, format?: "raw"): OperationResultTr;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OperationResultTr;
+    static fromXDR(input: string, format: "hex" | "base64"): OperationResultTr;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OperationResult {
@@ -9631,9 +9676,9 @@ export namespace xdr {
 
     value(): OperationResultTr | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OperationResult;
 
@@ -9643,13 +9688,13 @@ export namespace xdr {
 
     static toXDR(value: OperationResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OperationResult;
+    static fromXDR(input: Buffer, format?: "raw"): OperationResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OperationResult;
+    static fromXDR(input: string, format: "hex" | "base64"): OperationResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InnerTransactionResultResult {
@@ -9691,9 +9736,9 @@ export namespace xdr {
 
     value(): OperationResult[] | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InnerTransactionResultResult;
 
@@ -9703,16 +9748,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultResult;
+    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InnerTransactionResultResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InnerTransactionResultExt {
@@ -9722,9 +9767,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InnerTransactionResultExt;
 
@@ -9734,16 +9779,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultExt;
+    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InnerTransactionResultExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultResult {
@@ -9797,9 +9842,9 @@ export namespace xdr {
 
     value(): InnerTransactionResultPair | OperationResult[] | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultResult;
 
@@ -9809,16 +9854,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultResult;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultExt {
@@ -9828,9 +9873,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultExt;
 
@@ -9840,16 +9885,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultExt;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ExtensionPoint {
@@ -9859,9 +9904,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ExtensionPoint;
 
@@ -9871,13 +9916,13 @@ export namespace xdr {
 
     static toXDR(value: ExtensionPoint): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ExtensionPoint;
+    static fromXDR(input: Buffer, format?: "raw"): ExtensionPoint;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ExtensionPoint;
+    static fromXDR(input: string, format: "hex" | "base64"): ExtensionPoint;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PublicKey {
@@ -9889,9 +9934,9 @@ export namespace xdr {
 
     value(): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PublicKey;
 
@@ -9901,13 +9946,13 @@ export namespace xdr {
 
     static toXDR(value: PublicKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PublicKey;
+    static fromXDR(input: Buffer, format?: "raw"): PublicKey;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PublicKey;
+    static fromXDR(input: string, format: "hex" | "base64"): PublicKey;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SignerKey {
@@ -9935,9 +9980,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer | Buffer | SignerKeyEd25519SignedPayload;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SignerKey;
 
@@ -9947,12 +9992,12 @@ export namespace xdr {
 
     static toXDR(value: SignerKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SignerKey;
+    static fromXDR(input: Buffer, format?: "raw"): SignerKey;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): SignerKey;
+    static fromXDR(input: string, format: "hex" | "base64"): SignerKey;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 }

--- a/types/curr.d.ts
+++ b/types/curr.d.ts
@@ -1,4 +1,4 @@
-// Automatically generated on 2022-08-12T12:40:00+01:00
+// Automatically generated on 2023-04-20T14:53:00-08:00
 import { Operation } from './index';
 
 export {};
@@ -16,25 +16,25 @@ declare namespace xdrHidden {
 
     body(value?: xdr.OperationBody): xdr.OperationBody;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
-    static read(io: Buffer): Operation;
+    static read(io: Buffer): xdr.Operation;
 
-    static write(value: Operation, io: Buffer): void;
+    static write(value: xdr.Operation, io: Buffer): void;
 
-    static isValid(value: Operation): boolean;
+    static isValid(value: xdr.Operation): boolean;
 
-    static toXDR(value: Operation): Buffer;
+    static toXDR(value: xdr.Operation): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Operation;
+    static fromXDR(input: Buffer, format?: 'raw'): xdr.Operation;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Operation;
+    static fromXDR(input: string, format: 'hex' | 'base64'): xdr.Operation;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 }
 
@@ -48,10 +48,10 @@ export namespace xdr {
     write(value: number, io: Buffer): void;
     isValid(value: number): boolean;
     toXDR(value: number): Buffer;
-    fromXDR(input: Buffer, format?: "raw"): number;
-    fromXDR(input: string, format: "hex" | "base64"): number;
-    validateXDR(input: Buffer, format?: "raw"): boolean;
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    fromXDR(input: Buffer, format?: 'raw'): number;
+    fromXDR(input: string, format: 'hex' | 'base64'): number;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   interface UnsignedInt {
@@ -61,10 +61,10 @@ export namespace xdr {
     write(value: number, io: Buffer): void;
     isValid(value: number): boolean;
     toXDR(value: number): Buffer;
-    fromXDR(input: Buffer, format?: "raw"): number;
-    fromXDR(input: string, format: "hex" | "base64"): number;
-    validateXDR(input: Buffer, format?: "raw"): boolean;
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    fromXDR(input: Buffer, format?: 'raw'): number;
+    fromXDR(input: string, format: 'hex' | 'base64'): number;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   interface Bool {
@@ -72,10 +72,10 @@ export namespace xdr {
     write(value: boolean, io: Buffer): void;
     isValid(value: boolean): boolean;
     toXDR(value: boolean): Buffer;
-    fromXDR(input: Buffer, format?: "raw"): boolean;
-    fromXDR(input: string, format: "hex" | "base64"): boolean;
-    validateXDR(input: Buffer, format?: "raw"): boolean;
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    fromXDR(input: Buffer, format?: 'raw'): boolean;
+    fromXDR(input: string, format: 'hex' | 'base64'): boolean;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Hyper {
@@ -87,19 +87,19 @@ export namespace xdr {
 
     constructor(low: number, high: number);
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static toXDR(value: Hyper): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Hyper;
+    static fromXDR(input: Buffer, format?: 'raw'): Hyper;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Hyper;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Hyper;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
 
     static readonly MAX_VALUE: Hyper;
 
@@ -125,19 +125,19 @@ export namespace xdr {
 
     constructor(low: number, high: number);
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static toXDR(value: UnsignedHyper): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): UnsignedHyper;
+    static fromXDR(input: Buffer, format?: 'raw'): UnsignedHyper;
 
-    static fromXDR(input: string, format: "hex" | "base64"): UnsignedHyper;
+    static fromXDR(input: string, format: 'hex' | 'base64'): UnsignedHyper;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
 
     static readonly MAX_VALUE: UnsignedHyper;
 
@@ -167,13 +167,13 @@ export namespace xdr {
 
     toXDR(value: string | Buffer): Buffer;
 
-    fromXDR(input: Buffer, format?: "raw"): Buffer;
+    fromXDR(input: Buffer, format?: 'raw'): Buffer;
 
-    fromXDR(input: string, format: "hex" | "base64"): Buffer;
+    fromXDR(input: string, format: 'hex' | 'base64'): Buffer;
 
-    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class XDRArray<T> {
@@ -185,13 +185,13 @@ export namespace xdr {
 
     toXDR(value: T[]): Buffer;
 
-    fromXDR(input: Buffer, format?: "raw"): T[];
+    fromXDR(input: Buffer, format?: 'raw'): T[];
 
-    fromXDR(input: string, format: "hex" | "base64"): T[];
+    fromXDR(input: string, format: 'hex' | 'base64'): T[];
 
-    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Opaque {
@@ -205,13 +205,13 @@ export namespace xdr {
 
     toXDR(value: Buffer): Buffer;
 
-    fromXDR(input: Buffer, format?: "raw"): Buffer;
+    fromXDR(input: Buffer, format?: 'raw'): Buffer;
 
-    fromXDR(input: string, format: "hex" | "base64"): Buffer;
+    fromXDR(input: string, format: 'hex' | 'base64'): Buffer;
 
-    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class VarOpaque extends Opaque {}
@@ -231,21 +231,21 @@ export namespace xdr {
 
     toXDR(value: any): Buffer;
 
-    fromXDR(input: Buffer, format?: "raw"): any;
+    fromXDR(input: Buffer, format?: 'raw'): any;
 
-    fromXDR(input: string, format: "hex" | "base64"): any;
+    fromXDR(input: string, format: 'hex' | 'base64'): any;
 
-    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatementType {
     readonly name:
-      | "scpStPrepare"
-      | "scpStConfirm"
-      | "scpStExternalize"
-      | "scpStNominate";
+      | 'scpStPrepare'
+      | 'scpStConfirm'
+      | 'scpStExternalize'
+      | 'scpStNominate';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -260,10 +260,10 @@ export namespace xdr {
 
   class AssetType {
     readonly name:
-      | "assetTypeNative"
-      | "assetTypeCreditAlphanum4"
-      | "assetTypeCreditAlphanum12"
-      | "assetTypePoolShare";
+      | 'assetTypeNative'
+      | 'assetTypeCreditAlphanum4'
+      | 'assetTypeCreditAlphanum12'
+      | 'assetTypePoolShare';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -278,10 +278,10 @@ export namespace xdr {
 
   class ThresholdIndices {
     readonly name:
-      | "thresholdMasterWeight"
-      | "thresholdLow"
-      | "thresholdMed"
-      | "thresholdHigh";
+      | 'thresholdMasterWeight'
+      | 'thresholdLow'
+      | 'thresholdMed'
+      | 'thresholdHigh';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -296,12 +296,12 @@ export namespace xdr {
 
   class LedgerEntryType {
     readonly name:
-      | "account"
-      | "trustline"
-      | "offer"
-      | "data"
-      | "claimableBalance"
-      | "liquidityPool";
+      | 'account'
+      | 'trustline'
+      | 'offer'
+      | 'data'
+      | 'claimableBalance'
+      | 'liquidityPool';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -320,10 +320,10 @@ export namespace xdr {
 
   class AccountFlags {
     readonly name:
-      | "authRequiredFlag"
-      | "authRevocableFlag"
-      | "authImmutableFlag"
-      | "authClawbackEnabledFlag";
+      | 'authRequiredFlag'
+      | 'authRevocableFlag'
+      | 'authImmutableFlag'
+      | 'authClawbackEnabledFlag';
 
     readonly value: 1 | 2 | 4 | 8;
 
@@ -338,9 +338,9 @@ export namespace xdr {
 
   class TrustLineFlags {
     readonly name:
-      | "authorizedFlag"
-      | "authorizedToMaintainLiabilitiesFlag"
-      | "trustlineClawbackEnabledFlag";
+      | 'authorizedFlag'
+      | 'authorizedToMaintainLiabilitiesFlag'
+      | 'trustlineClawbackEnabledFlag';
 
     readonly value: 1 | 2 | 4;
 
@@ -352,7 +352,7 @@ export namespace xdr {
   }
 
   class LiquidityPoolType {
-    readonly name: "liquidityPoolConstantProduct";
+    readonly name: 'liquidityPoolConstantProduct';
 
     readonly value: 0;
 
@@ -360,7 +360,7 @@ export namespace xdr {
   }
 
   class OfferEntryFlags {
-    readonly name: "passiveFlag";
+    readonly name: 'passiveFlag';
 
     readonly value: 1;
 
@@ -369,12 +369,12 @@ export namespace xdr {
 
   class ClaimPredicateType {
     readonly name:
-      | "claimPredicateUnconditional"
-      | "claimPredicateAnd"
-      | "claimPredicateOr"
-      | "claimPredicateNot"
-      | "claimPredicateBeforeAbsoluteTime"
-      | "claimPredicateBeforeRelativeTime";
+      | 'claimPredicateUnconditional'
+      | 'claimPredicateAnd'
+      | 'claimPredicateOr'
+      | 'claimPredicateNot'
+      | 'claimPredicateBeforeAbsoluteTime'
+      | 'claimPredicateBeforeRelativeTime';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -392,7 +392,7 @@ export namespace xdr {
   }
 
   class ClaimantType {
-    readonly name: "claimantTypeV0";
+    readonly name: 'claimantTypeV0';
 
     readonly value: 0;
 
@@ -400,7 +400,7 @@ export namespace xdr {
   }
 
   class ClaimableBalanceIdType {
-    readonly name: "claimableBalanceIdTypeV0";
+    readonly name: 'claimableBalanceIdTypeV0';
 
     readonly value: 0;
 
@@ -408,7 +408,7 @@ export namespace xdr {
   }
 
   class ClaimableBalanceFlags {
-    readonly name: "claimableBalanceClawbackEnabledFlag";
+    readonly name: 'claimableBalanceClawbackEnabledFlag';
 
     readonly value: 1;
 
@@ -417,14 +417,14 @@ export namespace xdr {
 
   class EnvelopeType {
     readonly name:
-      | "envelopeTypeTxV0"
-      | "envelopeTypeScp"
-      | "envelopeTypeTx"
-      | "envelopeTypeAuth"
-      | "envelopeTypeScpvalue"
-      | "envelopeTypeTxFeeBump"
-      | "envelopeTypeOpId"
-      | "envelopeTypePoolRevokeOpId";
+      | 'envelopeTypeTxV0'
+      | 'envelopeTypeScp'
+      | 'envelopeTypeTx'
+      | 'envelopeTypeAuth'
+      | 'envelopeTypeScpvalue'
+      | 'envelopeTypeTxFeeBump'
+      | 'envelopeTypeOpId'
+      | 'envelopeTypePoolRevokeOpId';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
@@ -446,7 +446,7 @@ export namespace xdr {
   }
 
   class StellarValueType {
-    readonly name: "stellarValueBasic" | "stellarValueSigned";
+    readonly name: 'stellarValueBasic' | 'stellarValueSigned';
 
     readonly value: 0 | 1;
 
@@ -457,9 +457,9 @@ export namespace xdr {
 
   class LedgerHeaderFlags {
     readonly name:
-      | "disableLiquidityPoolTradingFlag"
-      | "disableLiquidityPoolDepositFlag"
-      | "disableLiquidityPoolWithdrawalFlag";
+      | 'disableLiquidityPoolTradingFlag'
+      | 'disableLiquidityPoolDepositFlag'
+      | 'disableLiquidityPoolWithdrawalFlag';
 
     readonly value: 1 | 2 | 4;
 
@@ -472,11 +472,11 @@ export namespace xdr {
 
   class LedgerUpgradeType {
     readonly name:
-      | "ledgerUpgradeVersion"
-      | "ledgerUpgradeBaseFee"
-      | "ledgerUpgradeMaxTxSetSize"
-      | "ledgerUpgradeBaseReserve"
-      | "ledgerUpgradeFlags";
+      | 'ledgerUpgradeVersion'
+      | 'ledgerUpgradeBaseFee'
+      | 'ledgerUpgradeMaxTxSetSize'
+      | 'ledgerUpgradeBaseReserve'
+      | 'ledgerUpgradeFlags';
 
     readonly value: 1 | 2 | 3 | 4 | 5;
 
@@ -492,7 +492,7 @@ export namespace xdr {
   }
 
   class BucketEntryType {
-    readonly name: "metaentry" | "liveentry" | "deadentry" | "initentry";
+    readonly name: 'metaentry' | 'liveentry' | 'deadentry' | 'initentry';
 
     readonly value: -1 | 0 | 1 | 2;
 
@@ -506,7 +506,7 @@ export namespace xdr {
   }
 
   class TxSetComponentType {
-    readonly name: "txsetCompTxsMaybeDiscountedFee";
+    readonly name: 'txsetCompTxsMaybeDiscountedFee';
 
     readonly value: 0;
 
@@ -515,10 +515,10 @@ export namespace xdr {
 
   class LedgerEntryChangeType {
     readonly name:
-      | "ledgerEntryCreated"
-      | "ledgerEntryUpdated"
-      | "ledgerEntryRemoved"
-      | "ledgerEntryState";
+      | 'ledgerEntryCreated'
+      | 'ledgerEntryUpdated'
+      | 'ledgerEntryRemoved'
+      | 'ledgerEntryState';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -532,7 +532,7 @@ export namespace xdr {
   }
 
   class ErrorCode {
-    readonly name: "errMisc" | "errData" | "errConf" | "errAuth" | "errLoad";
+    readonly name: 'errMisc' | 'errData' | 'errConf' | 'errAuth' | 'errLoad';
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -548,7 +548,7 @@ export namespace xdr {
   }
 
   class IpAddrType {
-    readonly name: "iPv4" | "iPv6";
+    readonly name: 'iPv4' | 'iPv6';
 
     readonly value: 0 | 1;
 
@@ -559,25 +559,25 @@ export namespace xdr {
 
   class MessageType {
     readonly name:
-      | "errorMsg"
-      | "auth"
-      | "dontHave"
-      | "getPeers"
-      | "peers"
-      | "getTxSet"
-      | "txSet"
-      | "generalizedTxSet"
-      | "transaction"
-      | "getScpQuorumset"
-      | "scpQuorumset"
-      | "scpMessage"
-      | "getScpState"
-      | "hello"
-      | "surveyRequest"
-      | "surveyResponse"
-      | "sendMore"
-      | "floodAdvert"
-      | "floodDemand";
+      | 'errorMsg'
+      | 'auth'
+      | 'dontHave'
+      | 'getPeers'
+      | 'peers'
+      | 'getTxSet'
+      | 'txSet'
+      | 'generalizedTxSet'
+      | 'transaction'
+      | 'getScpQuorumset'
+      | 'scpQuorumset'
+      | 'scpMessage'
+      | 'getScpState'
+      | 'hello'
+      | 'surveyRequest'
+      | 'surveyResponse'
+      | 'sendMore'
+      | 'floodAdvert'
+      | 'floodDemand';
 
     readonly value:
       | 0
@@ -640,7 +640,7 @@ export namespace xdr {
   }
 
   class SurveyMessageCommandType {
-    readonly name: "surveyTopology";
+    readonly name: 'surveyTopology';
 
     readonly value: 0;
 
@@ -649,30 +649,30 @@ export namespace xdr {
 
   class OperationType {
     readonly name:
-      | "createAccount"
-      | "payment"
-      | "pathPaymentStrictReceive"
-      | "manageSellOffer"
-      | "createPassiveSellOffer"
-      | "setOptions"
-      | "changeTrust"
-      | "allowTrust"
-      | "accountMerge"
-      | "inflation"
-      | "manageData"
-      | "bumpSequence"
-      | "manageBuyOffer"
-      | "pathPaymentStrictSend"
-      | "createClaimableBalance"
-      | "claimClaimableBalance"
-      | "beginSponsoringFutureReserves"
-      | "endSponsoringFutureReserves"
-      | "revokeSponsorship"
-      | "clawback"
-      | "clawbackClaimableBalance"
-      | "setTrustLineFlags"
-      | "liquidityPoolDeposit"
-      | "liquidityPoolWithdraw";
+      | 'createAccount'
+      | 'payment'
+      | 'pathPaymentStrictReceive'
+      | 'manageSellOffer'
+      | 'createPassiveSellOffer'
+      | 'setOptions'
+      | 'changeTrust'
+      | 'allowTrust'
+      | 'accountMerge'
+      | 'inflation'
+      | 'manageData'
+      | 'bumpSequence'
+      | 'manageBuyOffer'
+      | 'pathPaymentStrictSend'
+      | 'createClaimableBalance'
+      | 'claimClaimableBalance'
+      | 'beginSponsoringFutureReserves'
+      | 'endSponsoringFutureReserves'
+      | 'revokeSponsorship'
+      | 'clawback'
+      | 'clawbackClaimableBalance'
+      | 'setTrustLineFlags'
+      | 'liquidityPoolDeposit'
+      | 'liquidityPoolWithdraw';
 
     readonly value:
       | 0
@@ -750,7 +750,7 @@ export namespace xdr {
   }
 
   class RevokeSponsorshipType {
-    readonly name: "revokeSponsorshipLedgerEntry" | "revokeSponsorshipSigner";
+    readonly name: 'revokeSponsorshipLedgerEntry' | 'revokeSponsorshipSigner';
 
     readonly value: 0 | 1;
 
@@ -761,11 +761,11 @@ export namespace xdr {
 
   class MemoType {
     readonly name:
-      | "memoNone"
-      | "memoText"
-      | "memoId"
-      | "memoHash"
-      | "memoReturn";
+      | 'memoNone'
+      | 'memoText'
+      | 'memoId'
+      | 'memoHash'
+      | 'memoReturn';
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -781,7 +781,7 @@ export namespace xdr {
   }
 
   class PreconditionType {
-    readonly name: "precondNone" | "precondTime" | "precondV2";
+    readonly name: 'precondNone' | 'precondTime' | 'precondV2';
 
     readonly value: 0 | 1 | 2;
 
@@ -794,9 +794,9 @@ export namespace xdr {
 
   class ClaimAtomType {
     readonly name:
-      | "claimAtomTypeV0"
-      | "claimAtomTypeOrderBook"
-      | "claimAtomTypeLiquidityPool";
+      | 'claimAtomTypeV0'
+      | 'claimAtomTypeOrderBook'
+      | 'claimAtomTypeLiquidityPool';
 
     readonly value: 0 | 1 | 2;
 
@@ -809,11 +809,11 @@ export namespace xdr {
 
   class CreateAccountResultCode {
     readonly name:
-      | "createAccountSuccess"
-      | "createAccountMalformed"
-      | "createAccountUnderfunded"
-      | "createAccountLowReserve"
-      | "createAccountAlreadyExist";
+      | 'createAccountSuccess'
+      | 'createAccountMalformed'
+      | 'createAccountUnderfunded'
+      | 'createAccountLowReserve'
+      | 'createAccountAlreadyExist';
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -830,16 +830,16 @@ export namespace xdr {
 
   class PaymentResultCode {
     readonly name:
-      | "paymentSuccess"
-      | "paymentMalformed"
-      | "paymentUnderfunded"
-      | "paymentSrcNoTrust"
-      | "paymentSrcNotAuthorized"
-      | "paymentNoDestination"
-      | "paymentNoTrust"
-      | "paymentNotAuthorized"
-      | "paymentLineFull"
-      | "paymentNoIssuer";
+      | 'paymentSuccess'
+      | 'paymentMalformed'
+      | 'paymentUnderfunded'
+      | 'paymentSrcNoTrust'
+      | 'paymentSrcNotAuthorized'
+      | 'paymentNoDestination'
+      | 'paymentNoTrust'
+      | 'paymentNotAuthorized'
+      | 'paymentLineFull'
+      | 'paymentNoIssuer';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9;
 
@@ -866,19 +866,19 @@ export namespace xdr {
 
   class PathPaymentStrictReceiveResultCode {
     readonly name:
-      | "pathPaymentStrictReceiveSuccess"
-      | "pathPaymentStrictReceiveMalformed"
-      | "pathPaymentStrictReceiveUnderfunded"
-      | "pathPaymentStrictReceiveSrcNoTrust"
-      | "pathPaymentStrictReceiveSrcNotAuthorized"
-      | "pathPaymentStrictReceiveNoDestination"
-      | "pathPaymentStrictReceiveNoTrust"
-      | "pathPaymentStrictReceiveNotAuthorized"
-      | "pathPaymentStrictReceiveLineFull"
-      | "pathPaymentStrictReceiveNoIssuer"
-      | "pathPaymentStrictReceiveTooFewOffers"
-      | "pathPaymentStrictReceiveOfferCrossSelf"
-      | "pathPaymentStrictReceiveOverSendmax";
+      | 'pathPaymentStrictReceiveSuccess'
+      | 'pathPaymentStrictReceiveMalformed'
+      | 'pathPaymentStrictReceiveUnderfunded'
+      | 'pathPaymentStrictReceiveSrcNoTrust'
+      | 'pathPaymentStrictReceiveSrcNotAuthorized'
+      | 'pathPaymentStrictReceiveNoDestination'
+      | 'pathPaymentStrictReceiveNoTrust'
+      | 'pathPaymentStrictReceiveNotAuthorized'
+      | 'pathPaymentStrictReceiveLineFull'
+      | 'pathPaymentStrictReceiveNoIssuer'
+      | 'pathPaymentStrictReceiveTooFewOffers'
+      | 'pathPaymentStrictReceiveOfferCrossSelf'
+      | 'pathPaymentStrictReceiveOverSendmax';
 
     readonly value:
       | 0
@@ -924,19 +924,19 @@ export namespace xdr {
 
   class PathPaymentStrictSendResultCode {
     readonly name:
-      | "pathPaymentStrictSendSuccess"
-      | "pathPaymentStrictSendMalformed"
-      | "pathPaymentStrictSendUnderfunded"
-      | "pathPaymentStrictSendSrcNoTrust"
-      | "pathPaymentStrictSendSrcNotAuthorized"
-      | "pathPaymentStrictSendNoDestination"
-      | "pathPaymentStrictSendNoTrust"
-      | "pathPaymentStrictSendNotAuthorized"
-      | "pathPaymentStrictSendLineFull"
-      | "pathPaymentStrictSendNoIssuer"
-      | "pathPaymentStrictSendTooFewOffers"
-      | "pathPaymentStrictSendOfferCrossSelf"
-      | "pathPaymentStrictSendUnderDestmin";
+      | 'pathPaymentStrictSendSuccess'
+      | 'pathPaymentStrictSendMalformed'
+      | 'pathPaymentStrictSendUnderfunded'
+      | 'pathPaymentStrictSendSrcNoTrust'
+      | 'pathPaymentStrictSendSrcNotAuthorized'
+      | 'pathPaymentStrictSendNoDestination'
+      | 'pathPaymentStrictSendNoTrust'
+      | 'pathPaymentStrictSendNotAuthorized'
+      | 'pathPaymentStrictSendLineFull'
+      | 'pathPaymentStrictSendNoIssuer'
+      | 'pathPaymentStrictSendTooFewOffers'
+      | 'pathPaymentStrictSendOfferCrossSelf'
+      | 'pathPaymentStrictSendUnderDestmin';
 
     readonly value:
       | 0
@@ -982,19 +982,19 @@ export namespace xdr {
 
   class ManageSellOfferResultCode {
     readonly name:
-      | "manageSellOfferSuccess"
-      | "manageSellOfferMalformed"
-      | "manageSellOfferSellNoTrust"
-      | "manageSellOfferBuyNoTrust"
-      | "manageSellOfferSellNotAuthorized"
-      | "manageSellOfferBuyNotAuthorized"
-      | "manageSellOfferLineFull"
-      | "manageSellOfferUnderfunded"
-      | "manageSellOfferCrossSelf"
-      | "manageSellOfferSellNoIssuer"
-      | "manageSellOfferBuyNoIssuer"
-      | "manageSellOfferNotFound"
-      | "manageSellOfferLowReserve";
+      | 'manageSellOfferSuccess'
+      | 'manageSellOfferMalformed'
+      | 'manageSellOfferSellNoTrust'
+      | 'manageSellOfferBuyNoTrust'
+      | 'manageSellOfferSellNotAuthorized'
+      | 'manageSellOfferBuyNotAuthorized'
+      | 'manageSellOfferLineFull'
+      | 'manageSellOfferUnderfunded'
+      | 'manageSellOfferCrossSelf'
+      | 'manageSellOfferSellNoIssuer'
+      | 'manageSellOfferBuyNoIssuer'
+      | 'manageSellOfferNotFound'
+      | 'manageSellOfferLowReserve';
 
     readonly value:
       | 0
@@ -1040,9 +1040,9 @@ export namespace xdr {
 
   class ManageOfferEffect {
     readonly name:
-      | "manageOfferCreated"
-      | "manageOfferUpdated"
-      | "manageOfferDeleted";
+      | 'manageOfferCreated'
+      | 'manageOfferUpdated'
+      | 'manageOfferDeleted';
 
     readonly value: 0 | 1 | 2;
 
@@ -1055,19 +1055,19 @@ export namespace xdr {
 
   class ManageBuyOfferResultCode {
     readonly name:
-      | "manageBuyOfferSuccess"
-      | "manageBuyOfferMalformed"
-      | "manageBuyOfferSellNoTrust"
-      | "manageBuyOfferBuyNoTrust"
-      | "manageBuyOfferSellNotAuthorized"
-      | "manageBuyOfferBuyNotAuthorized"
-      | "manageBuyOfferLineFull"
-      | "manageBuyOfferUnderfunded"
-      | "manageBuyOfferCrossSelf"
-      | "manageBuyOfferSellNoIssuer"
-      | "manageBuyOfferBuyNoIssuer"
-      | "manageBuyOfferNotFound"
-      | "manageBuyOfferLowReserve";
+      | 'manageBuyOfferSuccess'
+      | 'manageBuyOfferMalformed'
+      | 'manageBuyOfferSellNoTrust'
+      | 'manageBuyOfferBuyNoTrust'
+      | 'manageBuyOfferSellNotAuthorized'
+      | 'manageBuyOfferBuyNotAuthorized'
+      | 'manageBuyOfferLineFull'
+      | 'manageBuyOfferUnderfunded'
+      | 'manageBuyOfferCrossSelf'
+      | 'manageBuyOfferSellNoIssuer'
+      | 'manageBuyOfferBuyNoIssuer'
+      | 'manageBuyOfferNotFound'
+      | 'manageBuyOfferLowReserve';
 
     readonly value:
       | 0
@@ -1113,17 +1113,17 @@ export namespace xdr {
 
   class SetOptionsResultCode {
     readonly name:
-      | "setOptionsSuccess"
-      | "setOptionsLowReserve"
-      | "setOptionsTooManySigners"
-      | "setOptionsBadFlags"
-      | "setOptionsInvalidInflation"
-      | "setOptionsCantChange"
-      | "setOptionsUnknownFlag"
-      | "setOptionsThresholdOutOfRange"
-      | "setOptionsBadSigner"
-      | "setOptionsInvalidHomeDomain"
-      | "setOptionsAuthRevocableRequired";
+      | 'setOptionsSuccess'
+      | 'setOptionsLowReserve'
+      | 'setOptionsTooManySigners'
+      | 'setOptionsBadFlags'
+      | 'setOptionsInvalidInflation'
+      | 'setOptionsCantChange'
+      | 'setOptionsUnknownFlag'
+      | 'setOptionsThresholdOutOfRange'
+      | 'setOptionsBadSigner'
+      | 'setOptionsInvalidHomeDomain'
+      | 'setOptionsAuthRevocableRequired';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9 | -10;
 
@@ -1152,15 +1152,15 @@ export namespace xdr {
 
   class ChangeTrustResultCode {
     readonly name:
-      | "changeTrustSuccess"
-      | "changeTrustMalformed"
-      | "changeTrustNoIssuer"
-      | "changeTrustInvalidLimit"
-      | "changeTrustLowReserve"
-      | "changeTrustSelfNotAllowed"
-      | "changeTrustTrustLineMissing"
-      | "changeTrustCannotDelete"
-      | "changeTrustNotAuthMaintainLiabilities";
+      | 'changeTrustSuccess'
+      | 'changeTrustMalformed'
+      | 'changeTrustNoIssuer'
+      | 'changeTrustInvalidLimit'
+      | 'changeTrustLowReserve'
+      | 'changeTrustSelfNotAllowed'
+      | 'changeTrustTrustLineMissing'
+      | 'changeTrustCannotDelete'
+      | 'changeTrustNotAuthMaintainLiabilities';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8;
 
@@ -1185,13 +1185,13 @@ export namespace xdr {
 
   class AllowTrustResultCode {
     readonly name:
-      | "allowTrustSuccess"
-      | "allowTrustMalformed"
-      | "allowTrustNoTrustLine"
-      | "allowTrustTrustNotRequired"
-      | "allowTrustCantRevoke"
-      | "allowTrustSelfNotAllowed"
-      | "allowTrustLowReserve";
+      | 'allowTrustSuccess'
+      | 'allowTrustMalformed'
+      | 'allowTrustNoTrustLine'
+      | 'allowTrustTrustNotRequired'
+      | 'allowTrustCantRevoke'
+      | 'allowTrustSelfNotAllowed'
+      | 'allowTrustLowReserve';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6;
 
@@ -1212,14 +1212,14 @@ export namespace xdr {
 
   class AccountMergeResultCode {
     readonly name:
-      | "accountMergeSuccess"
-      | "accountMergeMalformed"
-      | "accountMergeNoAccount"
-      | "accountMergeImmutableSet"
-      | "accountMergeHasSubEntries"
-      | "accountMergeSeqnumTooFar"
-      | "accountMergeDestFull"
-      | "accountMergeIsSponsor";
+      | 'accountMergeSuccess'
+      | 'accountMergeMalformed'
+      | 'accountMergeNoAccount'
+      | 'accountMergeImmutableSet'
+      | 'accountMergeHasSubEntries'
+      | 'accountMergeSeqnumTooFar'
+      | 'accountMergeDestFull'
+      | 'accountMergeIsSponsor';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7;
 
@@ -1241,7 +1241,7 @@ export namespace xdr {
   }
 
   class InflationResultCode {
-    readonly name: "inflationSuccess" | "inflationNotTime";
+    readonly name: 'inflationSuccess' | 'inflationNotTime';
 
     readonly value: 0 | -1;
 
@@ -1252,11 +1252,11 @@ export namespace xdr {
 
   class ManageDataResultCode {
     readonly name:
-      | "manageDataSuccess"
-      | "manageDataNotSupportedYet"
-      | "manageDataNameNotFound"
-      | "manageDataLowReserve"
-      | "manageDataInvalidName";
+      | 'manageDataSuccess'
+      | 'manageDataNotSupportedYet'
+      | 'manageDataNameNotFound'
+      | 'manageDataLowReserve'
+      | 'manageDataInvalidName';
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -1272,7 +1272,7 @@ export namespace xdr {
   }
 
   class BumpSequenceResultCode {
-    readonly name: "bumpSequenceSuccess" | "bumpSequenceBadSeq";
+    readonly name: 'bumpSequenceSuccess' | 'bumpSequenceBadSeq';
 
     readonly value: 0 | -1;
 
@@ -1283,12 +1283,12 @@ export namespace xdr {
 
   class CreateClaimableBalanceResultCode {
     readonly name:
-      | "createClaimableBalanceSuccess"
-      | "createClaimableBalanceMalformed"
-      | "createClaimableBalanceLowReserve"
-      | "createClaimableBalanceNoTrust"
-      | "createClaimableBalanceNotAuthorized"
-      | "createClaimableBalanceUnderfunded";
+      | 'createClaimableBalanceSuccess'
+      | 'createClaimableBalanceMalformed'
+      | 'createClaimableBalanceLowReserve'
+      | 'createClaimableBalanceNoTrust'
+      | 'createClaimableBalanceNotAuthorized'
+      | 'createClaimableBalanceUnderfunded';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1307,12 +1307,12 @@ export namespace xdr {
 
   class ClaimClaimableBalanceResultCode {
     readonly name:
-      | "claimClaimableBalanceSuccess"
-      | "claimClaimableBalanceDoesNotExist"
-      | "claimClaimableBalanceCannotClaim"
-      | "claimClaimableBalanceLineFull"
-      | "claimClaimableBalanceNoTrust"
-      | "claimClaimableBalanceNotAuthorized";
+      | 'claimClaimableBalanceSuccess'
+      | 'claimClaimableBalanceDoesNotExist'
+      | 'claimClaimableBalanceCannotClaim'
+      | 'claimClaimableBalanceLineFull'
+      | 'claimClaimableBalanceNoTrust'
+      | 'claimClaimableBalanceNotAuthorized';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1331,10 +1331,10 @@ export namespace xdr {
 
   class BeginSponsoringFutureReservesResultCode {
     readonly name:
-      | "beginSponsoringFutureReservesSuccess"
-      | "beginSponsoringFutureReservesMalformed"
-      | "beginSponsoringFutureReservesAlreadySponsored"
-      | "beginSponsoringFutureReservesRecursive";
+      | 'beginSponsoringFutureReservesSuccess'
+      | 'beginSponsoringFutureReservesMalformed'
+      | 'beginSponsoringFutureReservesAlreadySponsored'
+      | 'beginSponsoringFutureReservesRecursive';
 
     readonly value: 0 | -1 | -2 | -3;
 
@@ -1349,8 +1349,8 @@ export namespace xdr {
 
   class EndSponsoringFutureReservesResultCode {
     readonly name:
-      | "endSponsoringFutureReservesSuccess"
-      | "endSponsoringFutureReservesNotSponsored";
+      | 'endSponsoringFutureReservesSuccess'
+      | 'endSponsoringFutureReservesNotSponsored';
 
     readonly value: 0 | -1;
 
@@ -1361,12 +1361,12 @@ export namespace xdr {
 
   class RevokeSponsorshipResultCode {
     readonly name:
-      | "revokeSponsorshipSuccess"
-      | "revokeSponsorshipDoesNotExist"
-      | "revokeSponsorshipNotSponsor"
-      | "revokeSponsorshipLowReserve"
-      | "revokeSponsorshipOnlyTransferable"
-      | "revokeSponsorshipMalformed";
+      | 'revokeSponsorshipSuccess'
+      | 'revokeSponsorshipDoesNotExist'
+      | 'revokeSponsorshipNotSponsor'
+      | 'revokeSponsorshipLowReserve'
+      | 'revokeSponsorshipOnlyTransferable'
+      | 'revokeSponsorshipMalformed';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1385,11 +1385,11 @@ export namespace xdr {
 
   class ClawbackResultCode {
     readonly name:
-      | "clawbackSuccess"
-      | "clawbackMalformed"
-      | "clawbackNotClawbackEnabled"
-      | "clawbackNoTrust"
-      | "clawbackUnderfunded";
+      | 'clawbackSuccess'
+      | 'clawbackMalformed'
+      | 'clawbackNotClawbackEnabled'
+      | 'clawbackNoTrust'
+      | 'clawbackUnderfunded';
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -1406,10 +1406,10 @@ export namespace xdr {
 
   class ClawbackClaimableBalanceResultCode {
     readonly name:
-      | "clawbackClaimableBalanceSuccess"
-      | "clawbackClaimableBalanceDoesNotExist"
-      | "clawbackClaimableBalanceNotIssuer"
-      | "clawbackClaimableBalanceNotClawbackEnabled";
+      | 'clawbackClaimableBalanceSuccess'
+      | 'clawbackClaimableBalanceDoesNotExist'
+      | 'clawbackClaimableBalanceNotIssuer'
+      | 'clawbackClaimableBalanceNotClawbackEnabled';
 
     readonly value: 0 | -1 | -2 | -3;
 
@@ -1424,12 +1424,12 @@ export namespace xdr {
 
   class SetTrustLineFlagsResultCode {
     readonly name:
-      | "setTrustLineFlagsSuccess"
-      | "setTrustLineFlagsMalformed"
-      | "setTrustLineFlagsNoTrustLine"
-      | "setTrustLineFlagsCantRevoke"
-      | "setTrustLineFlagsInvalidState"
-      | "setTrustLineFlagsLowReserve";
+      | 'setTrustLineFlagsSuccess'
+      | 'setTrustLineFlagsMalformed'
+      | 'setTrustLineFlagsNoTrustLine'
+      | 'setTrustLineFlagsCantRevoke'
+      | 'setTrustLineFlagsInvalidState'
+      | 'setTrustLineFlagsLowReserve';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1448,14 +1448,14 @@ export namespace xdr {
 
   class LiquidityPoolDepositResultCode {
     readonly name:
-      | "liquidityPoolDepositSuccess"
-      | "liquidityPoolDepositMalformed"
-      | "liquidityPoolDepositNoTrust"
-      | "liquidityPoolDepositNotAuthorized"
-      | "liquidityPoolDepositUnderfunded"
-      | "liquidityPoolDepositLineFull"
-      | "liquidityPoolDepositBadPrice"
-      | "liquidityPoolDepositPoolFull";
+      | 'liquidityPoolDepositSuccess'
+      | 'liquidityPoolDepositMalformed'
+      | 'liquidityPoolDepositNoTrust'
+      | 'liquidityPoolDepositNotAuthorized'
+      | 'liquidityPoolDepositUnderfunded'
+      | 'liquidityPoolDepositLineFull'
+      | 'liquidityPoolDepositBadPrice'
+      | 'liquidityPoolDepositPoolFull';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7;
 
@@ -1478,12 +1478,12 @@ export namespace xdr {
 
   class LiquidityPoolWithdrawResultCode {
     readonly name:
-      | "liquidityPoolWithdrawSuccess"
-      | "liquidityPoolWithdrawMalformed"
-      | "liquidityPoolWithdrawNoTrust"
-      | "liquidityPoolWithdrawUnderfunded"
-      | "liquidityPoolWithdrawLineFull"
-      | "liquidityPoolWithdrawUnderMinimum";
+      | 'liquidityPoolWithdrawSuccess'
+      | 'liquidityPoolWithdrawMalformed'
+      | 'liquidityPoolWithdrawNoTrust'
+      | 'liquidityPoolWithdrawUnderfunded'
+      | 'liquidityPoolWithdrawLineFull'
+      | 'liquidityPoolWithdrawUnderMinimum';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1502,13 +1502,13 @@ export namespace xdr {
 
   class OperationResultCode {
     readonly name:
-      | "opInner"
-      | "opBadAuth"
-      | "opNoAccount"
-      | "opNotSupported"
-      | "opTooManySubentries"
-      | "opExceededWorkLimit"
-      | "opTooManySponsoring";
+      | 'opInner'
+      | 'opBadAuth'
+      | 'opNoAccount'
+      | 'opNotSupported'
+      | 'opTooManySubentries'
+      | 'opExceededWorkLimit'
+      | 'opTooManySponsoring';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6;
 
@@ -1529,24 +1529,24 @@ export namespace xdr {
 
   class TransactionResultCode {
     readonly name:
-      | "txFeeBumpInnerSuccess"
-      | "txSuccess"
-      | "txFailed"
-      | "txTooEarly"
-      | "txTooLate"
-      | "txMissingOperation"
-      | "txBadSeq"
-      | "txBadAuth"
-      | "txInsufficientBalance"
-      | "txNoAccount"
-      | "txInsufficientFee"
-      | "txBadAuthExtra"
-      | "txInternalError"
-      | "txNotSupported"
-      | "txFeeBumpInnerFailed"
-      | "txBadSponsorship"
-      | "txBadMinSeqAgeOrGap"
-      | "txMalformed";
+      | 'txFeeBumpInnerSuccess'
+      | 'txSuccess'
+      | 'txFailed'
+      | 'txTooEarly'
+      | 'txTooLate'
+      | 'txMissingOperation'
+      | 'txBadSeq'
+      | 'txBadAuth'
+      | 'txInsufficientBalance'
+      | 'txNoAccount'
+      | 'txInsufficientFee'
+      | 'txBadAuthExtra'
+      | 'txInternalError'
+      | 'txNotSupported'
+      | 'txFeeBumpInnerFailed'
+      | 'txBadSponsorship'
+      | 'txBadMinSeqAgeOrGap'
+      | 'txMalformed';
 
     readonly value:
       | 1
@@ -1607,11 +1607,11 @@ export namespace xdr {
 
   class CryptoKeyType {
     readonly name:
-      | "keyTypeEd25519"
-      | "keyTypePreAuthTx"
-      | "keyTypeHashX"
-      | "keyTypeEd25519SignedPayload"
-      | "keyTypeMuxedEd25519";
+      | 'keyTypeEd25519'
+      | 'keyTypePreAuthTx'
+      | 'keyTypeHashX'
+      | 'keyTypeEd25519SignedPayload'
+      | 'keyTypeMuxedEd25519';
 
     readonly value: 0 | 1 | 2 | 3 | 256;
 
@@ -1627,7 +1627,7 @@ export namespace xdr {
   }
 
   class PublicKeyType {
-    readonly name: "publicKeyTypeEd25519";
+    readonly name: 'publicKeyTypeEd25519';
 
     readonly value: 0;
 
@@ -1636,10 +1636,10 @@ export namespace xdr {
 
   class SignerKeyType {
     readonly name:
-      | "signerKeyTypeEd25519"
-      | "signerKeyTypePreAuthTx"
-      | "signerKeyTypeHashX"
-      | "signerKeyTypeEd25519SignedPayload";
+      | 'signerKeyTypeEd25519'
+      | 'signerKeyTypePreAuthTx'
+      | 'signerKeyTypeHashX'
+      | 'signerKeyTypeEd25519SignedPayload';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -1717,9 +1717,9 @@ export namespace xdr {
 
     value(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpBallot;
 
@@ -1729,13 +1729,13 @@ export namespace xdr {
 
     static toXDR(value: ScpBallot): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpBallot;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpBallot;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpBallot;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpBallot;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpNomination {
@@ -1751,9 +1751,9 @@ export namespace xdr {
 
     accepted(value?: Buffer[]): Buffer[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpNomination;
 
@@ -1763,13 +1763,13 @@ export namespace xdr {
 
     static toXDR(value: ScpNomination): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpNomination;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpNomination;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpNomination;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpNomination;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatementPrepare {
@@ -1794,9 +1794,9 @@ export namespace xdr {
 
     nH(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpStatementPrepare;
 
@@ -1806,16 +1806,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementPrepare): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpStatementPrepare;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementPrepare;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScpStatementPrepare;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatementConfirm {
@@ -1837,9 +1837,9 @@ export namespace xdr {
 
     quorumSetHash(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpStatementConfirm;
 
@@ -1849,16 +1849,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementConfirm): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpStatementConfirm;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementConfirm;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScpStatementConfirm;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatementExternalize {
@@ -1874,9 +1874,9 @@ export namespace xdr {
 
     commitQuorumSetHash(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpStatementExternalize;
 
@@ -1886,16 +1886,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementExternalize): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpStatementExternalize;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementExternalize;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScpStatementExternalize;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatement {
@@ -1911,9 +1911,9 @@ export namespace xdr {
 
     pledges(value?: ScpStatementPledges): ScpStatementPledges;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpStatement;
 
@@ -1923,13 +1923,13 @@ export namespace xdr {
 
     static toXDR(value: ScpStatement): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpStatement;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpStatement;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpStatement;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpStatement;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpEnvelope {
@@ -1939,9 +1939,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpEnvelope;
 
@@ -1951,13 +1951,13 @@ export namespace xdr {
 
     static toXDR(value: ScpEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpEnvelope;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpEnvelope;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpEnvelope;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpEnvelope;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpQuorumSet {
@@ -1973,9 +1973,9 @@ export namespace xdr {
 
     innerSets(value?: ScpQuorumSet[]): ScpQuorumSet[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpQuorumSet;
 
@@ -1985,13 +1985,13 @@ export namespace xdr {
 
     static toXDR(value: ScpQuorumSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpQuorumSet;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpQuorumSet;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpQuorumSet;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpQuorumSet;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AlphaNum4 {
@@ -2001,9 +2001,9 @@ export namespace xdr {
 
     issuer(value?: AccountId): AccountId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AlphaNum4;
 
@@ -2013,13 +2013,13 @@ export namespace xdr {
 
     static toXDR(value: AlphaNum4): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AlphaNum4;
+    static fromXDR(input: Buffer, format?: 'raw'): AlphaNum4;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AlphaNum4;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AlphaNum4;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AlphaNum12 {
@@ -2029,9 +2029,9 @@ export namespace xdr {
 
     issuer(value?: AccountId): AccountId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AlphaNum12;
 
@@ -2041,13 +2041,13 @@ export namespace xdr {
 
     static toXDR(value: AlphaNum12): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AlphaNum12;
+    static fromXDR(input: Buffer, format?: 'raw'): AlphaNum12;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AlphaNum12;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AlphaNum12;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Price {
@@ -2057,9 +2057,9 @@ export namespace xdr {
 
     d(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Price;
 
@@ -2069,13 +2069,13 @@ export namespace xdr {
 
     static toXDR(value: Price): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Price;
+    static fromXDR(input: Buffer, format?: 'raw'): Price;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Price;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Price;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Liabilities {
@@ -2085,9 +2085,9 @@ export namespace xdr {
 
     selling(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Liabilities;
 
@@ -2097,13 +2097,13 @@ export namespace xdr {
 
     static toXDR(value: Liabilities): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Liabilities;
+    static fromXDR(input: Buffer, format?: 'raw'): Liabilities;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Liabilities;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Liabilities;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Signer {
@@ -2113,9 +2113,9 @@ export namespace xdr {
 
     weight(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Signer;
 
@@ -2125,13 +2125,13 @@ export namespace xdr {
 
     static toXDR(value: Signer): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Signer;
+    static fromXDR(input: Buffer, format?: 'raw'): Signer;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Signer;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Signer;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExtensionV3 {
@@ -2147,9 +2147,9 @@ export namespace xdr {
 
     seqTime(value?: TimePoint): TimePoint;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExtensionV3;
 
@@ -2159,16 +2159,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV3): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV3;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV3;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AccountEntryExtensionV3;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExtensionV2 {
@@ -2189,9 +2189,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExtensionV2Ext): AccountEntryExtensionV2Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExtensionV2;
 
@@ -2201,16 +2201,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV2;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV2;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AccountEntryExtensionV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExtensionV1 {
@@ -2223,9 +2223,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExtensionV1Ext): AccountEntryExtensionV1Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExtensionV1;
 
@@ -2235,16 +2235,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV1;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AccountEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntry {
@@ -2281,9 +2281,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExt): AccountEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntry;
 
@@ -2293,13 +2293,13 @@ export namespace xdr {
 
     static toXDR(value: AccountEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AccountEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AccountEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntryExtensionV2 {
@@ -2312,9 +2312,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryExtensionV2Ext): TrustLineEntryExtensionV2Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntryExtensionV2;
 
@@ -2324,16 +2324,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExtensionV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExtensionV2;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExtensionV2;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TrustLineEntryExtensionV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntryV1 {
@@ -2346,9 +2346,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryV1Ext): TrustLineEntryV1Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntryV1;
 
@@ -2358,13 +2358,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryV1;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryV1;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntryV1;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntryV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntry {
@@ -2389,9 +2389,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryExt): TrustLineEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntry;
 
@@ -2401,13 +2401,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OfferEntry {
@@ -2438,9 +2438,9 @@ export namespace xdr {
 
     ext(value?: OfferEntryExt): OfferEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OfferEntry;
 
@@ -2450,13 +2450,13 @@ export namespace xdr {
 
     static toXDR(value: OfferEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OfferEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): OfferEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OfferEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OfferEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class DataEntry {
@@ -2475,9 +2475,9 @@ export namespace xdr {
 
     ext(value?: DataEntryExt): DataEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): DataEntry;
 
@@ -2487,13 +2487,13 @@ export namespace xdr {
 
     static toXDR(value: DataEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): DataEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): DataEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): DataEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): DataEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimantV0 {
@@ -2506,9 +2506,9 @@ export namespace xdr {
 
     predicate(value?: ClaimPredicate): ClaimPredicate;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimantV0;
 
@@ -2518,13 +2518,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimantV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimantV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimantV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimantV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimantV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimableBalanceEntryExtensionV1 {
@@ -2539,9 +2539,9 @@ export namespace xdr {
 
     flags(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExtensionV1;
 
@@ -2553,17 +2553,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ClaimableBalanceEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimableBalanceEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimableBalanceEntry {
@@ -2585,9 +2585,9 @@ export namespace xdr {
 
     ext(value?: ClaimableBalanceEntryExt): ClaimableBalanceEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimableBalanceEntry;
 
@@ -2597,16 +2597,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceEntry;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimableBalanceEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolConstantProductParameters {
@@ -2618,9 +2618,9 @@ export namespace xdr {
 
     fee(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolConstantProductParameters;
 
@@ -2635,17 +2635,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): LiquidityPoolConstantProductParameters;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolConstantProductParameters;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolEntryConstantProduct {
@@ -2669,9 +2669,9 @@ export namespace xdr {
 
     poolSharesTrustLineCount(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolEntryConstantProduct;
 
@@ -2683,17 +2683,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): LiquidityPoolEntryConstantProduct;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolEntryConstantProduct;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolEntry {
@@ -2706,9 +2706,9 @@ export namespace xdr {
 
     body(value?: LiquidityPoolEntryBody): LiquidityPoolEntryBody;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolEntry;
 
@@ -2718,13 +2718,13 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LiquidityPoolEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LiquidityPoolEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntryExtensionV1 {
@@ -2737,9 +2737,9 @@ export namespace xdr {
 
     ext(value?: LedgerEntryExtensionV1Ext): LedgerEntryExtensionV1Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntryExtensionV1;
 
@@ -2749,16 +2749,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExtensionV1;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntry {
@@ -2774,9 +2774,9 @@ export namespace xdr {
 
     ext(value?: LedgerEntryExt): LedgerEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntry;
 
@@ -2786,13 +2786,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyAccount {
@@ -2800,9 +2800,9 @@ export namespace xdr {
 
     accountId(value?: AccountId): AccountId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyAccount;
 
@@ -2812,13 +2812,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyAccount): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyAccount;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyAccount;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyAccount;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyAccount;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyTrustLine {
@@ -2828,9 +2828,9 @@ export namespace xdr {
 
     asset(value?: TrustLineAsset): TrustLineAsset;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyTrustLine;
 
@@ -2840,13 +2840,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyTrustLine): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyTrustLine;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyTrustLine;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyTrustLine;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyTrustLine;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyOffer {
@@ -2856,9 +2856,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyOffer;
 
@@ -2868,13 +2868,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyOffer): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyOffer;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyOffer;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyOffer;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyOffer;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyData {
@@ -2887,9 +2887,9 @@ export namespace xdr {
 
     dataName(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyData;
 
@@ -2899,13 +2899,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyData): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyData;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyData;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyData;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyData;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyClaimableBalance {
@@ -2913,9 +2913,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyClaimableBalance;
 
@@ -2925,16 +2925,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyClaimableBalance): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyClaimableBalance;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyClaimableBalance;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerKeyClaimableBalance;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyLiquidityPool {
@@ -2942,9 +2942,9 @@ export namespace xdr {
 
     liquidityPoolId(value?: PoolId): PoolId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyLiquidityPool;
 
@@ -2954,16 +2954,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyLiquidityPool): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyLiquidityPool;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyLiquidityPool;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerKeyLiquidityPool;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerCloseValueSignature {
@@ -2973,9 +2973,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerCloseValueSignature;
 
@@ -2985,16 +2985,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseValueSignature): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseValueSignature;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseValueSignature;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerCloseValueSignature;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class StellarValue {
@@ -3013,9 +3013,9 @@ export namespace xdr {
 
     ext(value?: StellarValueExt): StellarValueExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): StellarValue;
 
@@ -3025,13 +3025,13 @@ export namespace xdr {
 
     static toXDR(value: StellarValue): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): StellarValue;
+    static fromXDR(input: Buffer, format?: 'raw'): StellarValue;
 
-    static fromXDR(input: string, format: "hex" | "base64"): StellarValue;
+    static fromXDR(input: string, format: 'hex' | 'base64'): StellarValue;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeaderExtensionV1 {
@@ -3041,9 +3041,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderExtensionV1Ext): LedgerHeaderExtensionV1Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeaderExtensionV1;
 
@@ -3053,16 +3053,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExtensionV1;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExtensionV1;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerHeaderExtensionV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeader {
@@ -3114,9 +3114,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderExt): LedgerHeaderExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeader;
 
@@ -3126,13 +3126,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeader): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeader;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeader;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerHeader;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerHeader;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BucketMetadata {
@@ -3142,9 +3142,9 @@ export namespace xdr {
 
     ext(value?: BucketMetadataExt): BucketMetadataExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BucketMetadata;
 
@@ -3154,13 +3154,13 @@ export namespace xdr {
 
     static toXDR(value: BucketMetadata): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): BucketMetadata;
+    static fromXDR(input: Buffer, format?: 'raw'): BucketMetadata;
 
-    static fromXDR(input: string, format: "hex" | "base64"): BucketMetadata;
+    static fromXDR(input: string, format: 'hex' | 'base64'): BucketMetadata;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TxSetComponentTxsMaybeDiscountedFee {
@@ -3173,9 +3173,9 @@ export namespace xdr {
 
     txes(value?: TransactionEnvelope[]): TransactionEnvelope[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TxSetComponentTxsMaybeDiscountedFee;
 
@@ -3187,17 +3187,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): TxSetComponentTxsMaybeDiscountedFee;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TxSetComponentTxsMaybeDiscountedFee;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionSet {
@@ -3210,9 +3210,9 @@ export namespace xdr {
 
     txes(value?: TransactionEnvelope[]): TransactionEnvelope[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionSet;
 
@@ -3222,13 +3222,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionSet;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionSet;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionSet;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionSet;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionSetV1 {
@@ -3241,9 +3241,9 @@ export namespace xdr {
 
     phases(value?: TransactionPhase[]): TransactionPhase[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionSetV1;
 
@@ -3253,13 +3253,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionSetV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionSetV1;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionSetV1;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionSetV1;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionSetV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultPair {
@@ -3272,9 +3272,9 @@ export namespace xdr {
 
     result(value?: TransactionResult): TransactionResult;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultPair;
 
@@ -3284,16 +3284,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultPair): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultPair;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultPair;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultPair;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultSet {
@@ -3301,9 +3301,9 @@ export namespace xdr {
 
     results(value?: TransactionResultPair[]): TransactionResultPair[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultSet;
 
@@ -3313,16 +3313,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultSet;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultSet;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultSet;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionHistoryEntry {
@@ -3338,9 +3338,9 @@ export namespace xdr {
 
     ext(value?: TransactionHistoryEntryExt): TransactionHistoryEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionHistoryEntry;
 
@@ -3350,16 +3350,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionHistoryEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionHistoryEntry;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionHistoryResultEntry {
@@ -3377,9 +3377,9 @@ export namespace xdr {
       value?: TransactionHistoryResultEntryExt
     ): TransactionHistoryResultEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionHistoryResultEntry;
 
@@ -3391,17 +3391,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): TransactionHistoryResultEntry;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionHistoryResultEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeaderHistoryEntry {
@@ -3417,9 +3417,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderHistoryEntryExt): LedgerHeaderHistoryEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeaderHistoryEntry;
 
@@ -3429,16 +3429,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderHistoryEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderHistoryEntry;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerHeaderHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerScpMessages {
@@ -3448,9 +3448,9 @@ export namespace xdr {
 
     messages(value?: ScpEnvelope[]): ScpEnvelope[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerScpMessages;
 
@@ -3460,13 +3460,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerScpMessages): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerScpMessages;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerScpMessages;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerScpMessages;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerScpMessages;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpHistoryEntryV0 {
@@ -3479,9 +3479,9 @@ export namespace xdr {
 
     ledgerMessages(value?: LedgerScpMessages): LedgerScpMessages;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpHistoryEntryV0;
 
@@ -3491,13 +3491,13 @@ export namespace xdr {
 
     static toXDR(value: ScpHistoryEntryV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpHistoryEntryV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpHistoryEntryV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpHistoryEntryV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpHistoryEntryV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OperationMeta {
@@ -3505,9 +3505,9 @@ export namespace xdr {
 
     changes(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OperationMeta;
 
@@ -3517,13 +3517,13 @@ export namespace xdr {
 
     static toXDR(value: OperationMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OperationMeta;
+    static fromXDR(input: Buffer, format?: 'raw'): OperationMeta;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OperationMeta;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OperationMeta;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionMetaV1 {
@@ -3536,9 +3536,9 @@ export namespace xdr {
 
     operations(value?: OperationMeta[]): OperationMeta[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionMetaV1;
 
@@ -3548,13 +3548,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMetaV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionMetaV1;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionMetaV1;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionMetaV1;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMetaV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionMetaV2 {
@@ -3570,9 +3570,9 @@ export namespace xdr {
 
     txChangesAfter(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionMetaV2;
 
@@ -3582,13 +3582,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMetaV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionMetaV2;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionMetaV2;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionMetaV2;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMetaV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultMeta {
@@ -3604,9 +3604,9 @@ export namespace xdr {
 
     txApplyProcessing(value?: TransactionMeta): TransactionMeta;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultMeta;
 
@@ -3616,16 +3616,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultMeta;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultMeta;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultMeta;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class UpgradeEntryMeta {
@@ -3638,9 +3638,9 @@ export namespace xdr {
 
     changes(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): UpgradeEntryMeta;
 
@@ -3650,13 +3650,13 @@ export namespace xdr {
 
     static toXDR(value: UpgradeEntryMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): UpgradeEntryMeta;
+    static fromXDR(input: Buffer, format?: 'raw'): UpgradeEntryMeta;
 
-    static fromXDR(input: string, format: "hex" | "base64"): UpgradeEntryMeta;
+    static fromXDR(input: string, format: 'hex' | 'base64'): UpgradeEntryMeta;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerCloseMetaV0 {
@@ -3678,9 +3678,9 @@ export namespace xdr {
 
     scpInfo(value?: ScpHistoryEntry[]): ScpHistoryEntry[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerCloseMetaV0;
 
@@ -3690,13 +3690,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMetaV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMetaV0;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMetaV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMetaV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMetaV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerCloseMetaV1 {
@@ -3718,9 +3718,9 @@ export namespace xdr {
 
     scpInfo(value?: ScpHistoryEntry[]): ScpHistoryEntry[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerCloseMetaV1;
 
@@ -3730,13 +3730,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMetaV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMetaV1;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMetaV1;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMetaV1;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMetaV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Error {
@@ -3746,9 +3746,9 @@ export namespace xdr {
 
     msg(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Error;
 
@@ -3758,13 +3758,13 @@ export namespace xdr {
 
     static toXDR(value: Error): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Error;
+    static fromXDR(input: Buffer, format?: 'raw'): Error;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Error;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Error;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SendMore {
@@ -3772,9 +3772,9 @@ export namespace xdr {
 
     numMessages(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SendMore;
 
@@ -3784,13 +3784,13 @@ export namespace xdr {
 
     static toXDR(value: SendMore): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SendMore;
+    static fromXDR(input: Buffer, format?: 'raw'): SendMore;
 
-    static fromXDR(input: string, format: "hex" | "base64"): SendMore;
+    static fromXDR(input: string, format: 'hex' | 'base64'): SendMore;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AuthCert {
@@ -3806,9 +3806,9 @@ export namespace xdr {
 
     sig(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AuthCert;
 
@@ -3818,13 +3818,13 @@ export namespace xdr {
 
     static toXDR(value: AuthCert): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AuthCert;
+    static fromXDR(input: Buffer, format?: 'raw'): AuthCert;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AuthCert;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AuthCert;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Hello {
@@ -3858,9 +3858,9 @@ export namespace xdr {
 
     nonce(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Hello;
 
@@ -3870,13 +3870,13 @@ export namespace xdr {
 
     static toXDR(value: Hello): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Hello;
+    static fromXDR(input: Buffer, format?: 'raw'): Hello;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Hello;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Hello;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Auth {
@@ -3884,9 +3884,9 @@ export namespace xdr {
 
     flags(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Auth;
 
@@ -3896,13 +3896,13 @@ export namespace xdr {
 
     static toXDR(value: Auth): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Auth;
+    static fromXDR(input: Buffer, format?: 'raw'): Auth;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Auth;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Auth;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PeerAddress {
@@ -3918,9 +3918,9 @@ export namespace xdr {
 
     numFailures(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PeerAddress;
 
@@ -3930,13 +3930,13 @@ export namespace xdr {
 
     static toXDR(value: PeerAddress): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PeerAddress;
+    static fromXDR(input: Buffer, format?: 'raw'): PeerAddress;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PeerAddress;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PeerAddress;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class DontHave {
@@ -3946,9 +3946,9 @@ export namespace xdr {
 
     reqHash(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): DontHave;
 
@@ -3958,13 +3958,13 @@ export namespace xdr {
 
     static toXDR(value: DontHave): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): DontHave;
+    static fromXDR(input: Buffer, format?: 'raw'): DontHave;
 
-    static fromXDR(input: string, format: "hex" | "base64"): DontHave;
+    static fromXDR(input: string, format: 'hex' | 'base64'): DontHave;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SurveyRequestMessage {
@@ -3986,9 +3986,9 @@ export namespace xdr {
 
     commandType(value?: SurveyMessageCommandType): SurveyMessageCommandType;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SurveyRequestMessage;
 
@@ -3998,16 +3998,16 @@ export namespace xdr {
 
     static toXDR(value: SurveyRequestMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SurveyRequestMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): SurveyRequestMessage;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SurveyRequestMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SignedSurveyRequestMessage {
@@ -4020,9 +4020,9 @@ export namespace xdr {
 
     request(value?: SurveyRequestMessage): SurveyRequestMessage;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SignedSurveyRequestMessage;
 
@@ -4032,16 +4032,16 @@ export namespace xdr {
 
     static toXDR(value: SignedSurveyRequestMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SignedSurveyRequestMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): SignedSurveyRequestMessage;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SignedSurveyRequestMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SurveyResponseMessage {
@@ -4063,9 +4063,9 @@ export namespace xdr {
 
     encryptedBody(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SurveyResponseMessage;
 
@@ -4075,16 +4075,16 @@ export namespace xdr {
 
     static toXDR(value: SurveyResponseMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SurveyResponseMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): SurveyResponseMessage;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SurveyResponseMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SignedSurveyResponseMessage {
@@ -4097,9 +4097,9 @@ export namespace xdr {
 
     response(value?: SurveyResponseMessage): SurveyResponseMessage;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SignedSurveyResponseMessage;
 
@@ -4109,16 +4109,16 @@ export namespace xdr {
 
     static toXDR(value: SignedSurveyResponseMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SignedSurveyResponseMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): SignedSurveyResponseMessage;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SignedSurveyResponseMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PeerStats {
@@ -4170,9 +4170,9 @@ export namespace xdr {
 
     duplicateFetchMessageRecv(value?: Uint64): Uint64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PeerStats;
 
@@ -4182,13 +4182,13 @@ export namespace xdr {
 
     static toXDR(value: PeerStats): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PeerStats;
+    static fromXDR(input: Buffer, format?: 'raw'): PeerStats;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PeerStats;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PeerStats;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TopologyResponseBody {
@@ -4207,9 +4207,9 @@ export namespace xdr {
 
     totalOutboundPeerCount(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TopologyResponseBody;
 
@@ -4219,16 +4219,16 @@ export namespace xdr {
 
     static toXDR(value: TopologyResponseBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TopologyResponseBody;
+    static fromXDR(input: Buffer, format?: 'raw'): TopologyResponseBody;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TopologyResponseBody;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FloodAdvert {
@@ -4236,9 +4236,9 @@ export namespace xdr {
 
     txHashes(value?: Hash[]): Hash[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FloodAdvert;
 
@@ -4248,13 +4248,13 @@ export namespace xdr {
 
     static toXDR(value: FloodAdvert): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FloodAdvert;
+    static fromXDR(input: Buffer, format?: 'raw'): FloodAdvert;
 
-    static fromXDR(input: string, format: "hex" | "base64"): FloodAdvert;
+    static fromXDR(input: string, format: 'hex' | 'base64'): FloodAdvert;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FloodDemand {
@@ -4262,9 +4262,9 @@ export namespace xdr {
 
     txHashes(value?: Hash[]): Hash[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FloodDemand;
 
@@ -4274,13 +4274,13 @@ export namespace xdr {
 
     static toXDR(value: FloodDemand): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FloodDemand;
+    static fromXDR(input: Buffer, format?: 'raw'): FloodDemand;
 
-    static fromXDR(input: string, format: "hex" | "base64"): FloodDemand;
+    static fromXDR(input: string, format: 'hex' | 'base64'): FloodDemand;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AuthenticatedMessageV0 {
@@ -4296,9 +4296,9 @@ export namespace xdr {
 
     mac(value?: HmacSha256Mac): HmacSha256Mac;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AuthenticatedMessageV0;
 
@@ -4308,16 +4308,16 @@ export namespace xdr {
 
     static toXDR(value: AuthenticatedMessageV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AuthenticatedMessageV0;
+    static fromXDR(input: Buffer, format?: 'raw'): AuthenticatedMessageV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AuthenticatedMessageV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class MuxedAccountMed25519 {
@@ -4327,9 +4327,9 @@ export namespace xdr {
 
     ed25519(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): MuxedAccountMed25519;
 
@@ -4339,16 +4339,16 @@ export namespace xdr {
 
     static toXDR(value: MuxedAccountMed25519): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): MuxedAccountMed25519;
+    static fromXDR(input: Buffer, format?: 'raw'): MuxedAccountMed25519;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): MuxedAccountMed25519;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class DecoratedSignature {
@@ -4358,9 +4358,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): DecoratedSignature;
 
@@ -4370,13 +4370,13 @@ export namespace xdr {
 
     static toXDR(value: DecoratedSignature): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): DecoratedSignature;
+    static fromXDR(input: Buffer, format?: 'raw'): DecoratedSignature;
 
-    static fromXDR(input: string, format: "hex" | "base64"): DecoratedSignature;
+    static fromXDR(input: string, format: 'hex' | 'base64'): DecoratedSignature;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreateAccountOp {
@@ -4386,9 +4386,9 @@ export namespace xdr {
 
     startingBalance(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreateAccountOp;
 
@@ -4398,13 +4398,13 @@ export namespace xdr {
 
     static toXDR(value: CreateAccountOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreateAccountOp;
+    static fromXDR(input: Buffer, format?: 'raw'): CreateAccountOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): CreateAccountOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): CreateAccountOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PaymentOp {
@@ -4420,9 +4420,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PaymentOp;
 
@@ -4432,13 +4432,13 @@ export namespace xdr {
 
     static toXDR(value: PaymentOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PaymentOp;
+    static fromXDR(input: Buffer, format?: 'raw'): PaymentOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PaymentOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PaymentOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictReceiveOp {
@@ -4463,9 +4463,9 @@ export namespace xdr {
 
     path(value?: Asset[]): Asset[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveOp;
 
@@ -4475,16 +4475,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictReceiveOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictReceiveOp;
+    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictReceiveOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictReceiveOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictSendOp {
@@ -4509,9 +4509,9 @@ export namespace xdr {
 
     path(value?: Asset[]): Asset[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictSendOp;
 
@@ -4521,16 +4521,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictSendOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictSendOp;
+    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictSendOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictSendOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageSellOfferOp {
@@ -4552,9 +4552,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageSellOfferOp;
 
@@ -4564,13 +4564,13 @@ export namespace xdr {
 
     static toXDR(value: ManageSellOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageSellOfferOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageSellOfferOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ManageSellOfferOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ManageSellOfferOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageBuyOfferOp {
@@ -4592,9 +4592,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageBuyOfferOp;
 
@@ -4604,13 +4604,13 @@ export namespace xdr {
 
     static toXDR(value: ManageBuyOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageBuyOfferOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageBuyOfferOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ManageBuyOfferOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ManageBuyOfferOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreatePassiveSellOfferOp {
@@ -4629,9 +4629,9 @@ export namespace xdr {
 
     price(value?: Price): Price;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreatePassiveSellOfferOp;
 
@@ -4641,16 +4641,16 @@ export namespace xdr {
 
     static toXDR(value: CreatePassiveSellOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreatePassiveSellOfferOp;
+    static fromXDR(input: Buffer, format?: 'raw'): CreatePassiveSellOfferOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): CreatePassiveSellOfferOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SetOptionsOp {
@@ -4684,9 +4684,9 @@ export namespace xdr {
 
     signer(value?: null | Signer): null | Signer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SetOptionsOp;
 
@@ -4696,13 +4696,13 @@ export namespace xdr {
 
     static toXDR(value: SetOptionsOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SetOptionsOp;
+    static fromXDR(input: Buffer, format?: 'raw'): SetOptionsOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): SetOptionsOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): SetOptionsOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ChangeTrustOp {
@@ -4712,9 +4712,9 @@ export namespace xdr {
 
     limit(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ChangeTrustOp;
 
@@ -4724,13 +4724,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AllowTrustOp {
@@ -4746,9 +4746,9 @@ export namespace xdr {
 
     authorize(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AllowTrustOp;
 
@@ -4758,13 +4758,13 @@ export namespace xdr {
 
     static toXDR(value: AllowTrustOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AllowTrustOp;
+    static fromXDR(input: Buffer, format?: 'raw'): AllowTrustOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AllowTrustOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AllowTrustOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageDataOp {
@@ -4777,9 +4777,9 @@ export namespace xdr {
 
     dataValue(value?: null | Buffer): null | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageDataOp;
 
@@ -4789,13 +4789,13 @@ export namespace xdr {
 
     static toXDR(value: ManageDataOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageDataOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageDataOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ManageDataOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ManageDataOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BumpSequenceOp {
@@ -4803,9 +4803,9 @@ export namespace xdr {
 
     bumpTo(value?: SequenceNumber): SequenceNumber;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BumpSequenceOp;
 
@@ -4815,13 +4815,13 @@ export namespace xdr {
 
     static toXDR(value: BumpSequenceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): BumpSequenceOp;
+    static fromXDR(input: Buffer, format?: 'raw'): BumpSequenceOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): BumpSequenceOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): BumpSequenceOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreateClaimableBalanceOp {
@@ -4837,9 +4837,9 @@ export namespace xdr {
 
     claimants(value?: Claimant[]): Claimant[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreateClaimableBalanceOp;
 
@@ -4849,16 +4849,16 @@ export namespace xdr {
 
     static toXDR(value: CreateClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreateClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: 'raw'): CreateClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): CreateClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimClaimableBalanceOp {
@@ -4866,9 +4866,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimClaimableBalanceOp;
 
@@ -4878,16 +4878,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BeginSponsoringFutureReservesOp {
@@ -4895,9 +4895,9 @@ export namespace xdr {
 
     sponsoredId(value?: AccountId): AccountId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BeginSponsoringFutureReservesOp;
 
@@ -4909,17 +4909,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): BeginSponsoringFutureReservesOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): BeginSponsoringFutureReservesOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class RevokeSponsorshipOpSigner {
@@ -4929,9 +4929,9 @@ export namespace xdr {
 
     signerKey(value?: SignerKey): SignerKey;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): RevokeSponsorshipOpSigner;
 
@@ -4941,16 +4941,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipOpSigner): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipOpSigner;
+    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipOpSigner;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): RevokeSponsorshipOpSigner;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClawbackOp {
@@ -4966,9 +4966,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClawbackOp;
 
@@ -4978,13 +4978,13 @@ export namespace xdr {
 
     static toXDR(value: ClawbackOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClawbackOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ClawbackOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClawbackOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClawbackOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClawbackClaimableBalanceOp {
@@ -4992,9 +4992,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClawbackClaimableBalanceOp;
 
@@ -5004,16 +5004,16 @@ export namespace xdr {
 
     static toXDR(value: ClawbackClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClawbackClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ClawbackClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClawbackClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SetTrustLineFlagsOp {
@@ -5032,9 +5032,9 @@ export namespace xdr {
 
     setFlags(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SetTrustLineFlagsOp;
 
@@ -5044,16 +5044,16 @@ export namespace xdr {
 
     static toXDR(value: SetTrustLineFlagsOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SetTrustLineFlagsOp;
+    static fromXDR(input: Buffer, format?: 'raw'): SetTrustLineFlagsOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SetTrustLineFlagsOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolDepositOp {
@@ -5075,9 +5075,9 @@ export namespace xdr {
 
     maxPrice(value?: Price): Price;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolDepositOp;
 
@@ -5087,16 +5087,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolDepositOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolDepositOp;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolDepositOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolDepositOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolWithdrawOp {
@@ -5115,9 +5115,9 @@ export namespace xdr {
 
     minAmountB(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolWithdrawOp;
 
@@ -5127,16 +5127,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolWithdrawOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolWithdrawOp;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolWithdrawOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolWithdrawOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimageOperationId {
@@ -5152,9 +5152,9 @@ export namespace xdr {
 
     opNum(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimageOperationId;
 
@@ -5164,16 +5164,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageOperationId): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageOperationId;
+    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageOperationId;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): HashIdPreimageOperationId;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimageRevokeId {
@@ -5195,9 +5195,9 @@ export namespace xdr {
 
     asset(value?: Asset): Asset;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimageRevokeId;
 
@@ -5207,16 +5207,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageRevokeId): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageRevokeId;
+    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageRevokeId;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): HashIdPreimageRevokeId;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TimeBounds {
@@ -5226,9 +5226,9 @@ export namespace xdr {
 
     maxTime(value?: TimePoint): TimePoint;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TimeBounds;
 
@@ -5238,13 +5238,13 @@ export namespace xdr {
 
     static toXDR(value: TimeBounds): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TimeBounds;
+    static fromXDR(input: Buffer, format?: 'raw'): TimeBounds;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TimeBounds;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TimeBounds;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerBounds {
@@ -5254,9 +5254,9 @@ export namespace xdr {
 
     maxLedger(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerBounds;
 
@@ -5266,13 +5266,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerBounds): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerBounds;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerBounds;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerBounds;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerBounds;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PreconditionsV2 {
@@ -5297,9 +5297,9 @@ export namespace xdr {
 
     extraSigners(value?: SignerKey[]): SignerKey[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PreconditionsV2;
 
@@ -5309,13 +5309,13 @@ export namespace xdr {
 
     static toXDR(value: PreconditionsV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PreconditionsV2;
+    static fromXDR(input: Buffer, format?: 'raw'): PreconditionsV2;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PreconditionsV2;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PreconditionsV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionV0 {
@@ -5343,9 +5343,9 @@ export namespace xdr {
 
     ext(value?: TransactionV0Ext): TransactionV0Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionV0;
 
@@ -5355,13 +5355,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionV0;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionV0Envelope {
@@ -5374,9 +5374,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionV0Envelope;
 
@@ -5386,16 +5386,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0Envelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionV0Envelope;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0Envelope;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionV0Envelope;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Transaction {
@@ -5423,9 +5423,9 @@ export namespace xdr {
 
     ext(value?: TransactionExt): TransactionExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Transaction;
 
@@ -5435,13 +5435,13 @@ export namespace xdr {
 
     static toXDR(value: Transaction): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Transaction;
+    static fromXDR(input: Buffer, format?: 'raw'): Transaction;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Transaction;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Transaction;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionV1Envelope {
@@ -5454,9 +5454,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionV1Envelope;
 
@@ -5466,16 +5466,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionV1Envelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionV1Envelope;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionV1Envelope;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionV1Envelope;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FeeBumpTransaction {
@@ -5494,9 +5494,9 @@ export namespace xdr {
 
     ext(value?: FeeBumpTransactionExt): FeeBumpTransactionExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FeeBumpTransaction;
 
@@ -5506,13 +5506,13 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransaction): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransaction;
+    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransaction;
 
-    static fromXDR(input: string, format: "hex" | "base64"): FeeBumpTransaction;
+    static fromXDR(input: string, format: 'hex' | 'base64'): FeeBumpTransaction;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FeeBumpTransactionEnvelope {
@@ -5525,9 +5525,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FeeBumpTransactionEnvelope;
 
@@ -5537,16 +5537,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionEnvelope;
+    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionEnvelope;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): FeeBumpTransactionEnvelope;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionSignaturePayload {
@@ -5561,9 +5561,9 @@ export namespace xdr {
       value?: TransactionSignaturePayloadTaggedTransaction
     ): TransactionSignaturePayloadTaggedTransaction;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionSignaturePayload;
 
@@ -5573,16 +5573,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionSignaturePayload): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionSignaturePayload;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionSignaturePayload;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionSignaturePayload;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimOfferAtomV0 {
@@ -5607,9 +5607,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimOfferAtomV0;
 
@@ -5619,13 +5619,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimOfferAtomV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimOfferAtomV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimOfferAtomV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimOfferAtomV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimOfferAtomV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimOfferAtom {
@@ -5650,9 +5650,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimOfferAtom;
 
@@ -5662,13 +5662,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimOfferAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimOfferAtom;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimOfferAtom;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimOfferAtom;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimOfferAtom;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimLiquidityAtom {
@@ -5690,9 +5690,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimLiquidityAtom;
 
@@ -5702,13 +5702,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimLiquidityAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimLiquidityAtom;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimLiquidityAtom;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimLiquidityAtom;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimLiquidityAtom;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SimplePaymentResult {
@@ -5724,9 +5724,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SimplePaymentResult;
 
@@ -5736,16 +5736,16 @@ export namespace xdr {
 
     static toXDR(value: SimplePaymentResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SimplePaymentResult;
+    static fromXDR(input: Buffer, format?: 'raw'): SimplePaymentResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SimplePaymentResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictReceiveResultSuccess {
@@ -5755,9 +5755,9 @@ export namespace xdr {
 
     last(value?: SimplePaymentResult): SimplePaymentResult;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveResultSuccess;
 
@@ -5772,17 +5772,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): PathPaymentStrictReceiveResultSuccess;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictReceiveResultSuccess;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictSendResultSuccess {
@@ -5792,9 +5792,9 @@ export namespace xdr {
 
     last(value?: SimplePaymentResult): SimplePaymentResult;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictSendResultSuccess;
 
@@ -5806,17 +5806,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): PathPaymentStrictSendResultSuccess;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictSendResultSuccess;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageOfferSuccessResult {
@@ -5829,9 +5829,9 @@ export namespace xdr {
 
     offer(value?: ManageOfferSuccessResultOffer): ManageOfferSuccessResultOffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageOfferSuccessResult;
 
@@ -5841,16 +5841,16 @@ export namespace xdr {
 
     static toXDR(value: ManageOfferSuccessResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageOfferSuccessResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageOfferSuccessResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ManageOfferSuccessResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InflationPayout {
@@ -5860,9 +5860,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InflationPayout;
 
@@ -5872,13 +5872,13 @@ export namespace xdr {
 
     static toXDR(value: InflationPayout): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InflationPayout;
+    static fromXDR(input: Buffer, format?: 'raw'): InflationPayout;
 
-    static fromXDR(input: string, format: "hex" | "base64"): InflationPayout;
+    static fromXDR(input: string, format: 'hex' | 'base64'): InflationPayout;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InnerTransactionResult {
@@ -5894,9 +5894,9 @@ export namespace xdr {
 
     ext(value?: InnerTransactionResultExt): InnerTransactionResultExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InnerTransactionResult;
 
@@ -5906,16 +5906,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResult;
+    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InnerTransactionResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InnerTransactionResultPair {
@@ -5928,9 +5928,9 @@ export namespace xdr {
 
     result(value?: InnerTransactionResult): InnerTransactionResult;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InnerTransactionResultPair;
 
@@ -5940,16 +5940,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultPair): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultPair;
+    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultPair;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InnerTransactionResultPair;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResult {
@@ -5965,9 +5965,9 @@ export namespace xdr {
 
     ext(value?: TransactionResultExt): TransactionResultExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResult;
 
@@ -5977,13 +5977,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResult;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SignerKeyEd25519SignedPayload {
@@ -5993,9 +5993,9 @@ export namespace xdr {
 
     payload(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SignerKeyEd25519SignedPayload;
 
@@ -6007,17 +6007,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): SignerKeyEd25519SignedPayload;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SignerKeyEd25519SignedPayload;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Curve25519Secret {
@@ -6025,9 +6025,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Curve25519Secret;
 
@@ -6037,13 +6037,13 @@ export namespace xdr {
 
     static toXDR(value: Curve25519Secret): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Curve25519Secret;
+    static fromXDR(input: Buffer, format?: 'raw'): Curve25519Secret;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Curve25519Secret;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Curve25519Secret;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Curve25519Public {
@@ -6051,9 +6051,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Curve25519Public;
 
@@ -6063,13 +6063,13 @@ export namespace xdr {
 
     static toXDR(value: Curve25519Public): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Curve25519Public;
+    static fromXDR(input: Buffer, format?: 'raw'): Curve25519Public;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Curve25519Public;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Curve25519Public;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HmacSha256Key {
@@ -6077,9 +6077,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HmacSha256Key;
 
@@ -6089,13 +6089,13 @@ export namespace xdr {
 
     static toXDR(value: HmacSha256Key): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HmacSha256Key;
+    static fromXDR(input: Buffer, format?: 'raw'): HmacSha256Key;
 
-    static fromXDR(input: string, format: "hex" | "base64"): HmacSha256Key;
+    static fromXDR(input: string, format: 'hex' | 'base64'): HmacSha256Key;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HmacSha256Mac {
@@ -6103,9 +6103,9 @@ export namespace xdr {
 
     mac(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HmacSha256Mac;
 
@@ -6115,13 +6115,13 @@ export namespace xdr {
 
     static toXDR(value: HmacSha256Mac): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HmacSha256Mac;
+    static fromXDR(input: Buffer, format?: 'raw'): HmacSha256Mac;
 
-    static fromXDR(input: string, format: "hex" | "base64"): HmacSha256Mac;
+    static fromXDR(input: string, format: 'hex' | 'base64'): HmacSha256Mac;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatementPledges {
@@ -6151,9 +6151,9 @@ export namespace xdr {
       | ScpStatementExternalize
       | ScpNomination;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpStatementPledges;
 
@@ -6163,16 +6163,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementPledges): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpStatementPledges;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementPledges;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScpStatementPledges;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AssetCode {
@@ -6188,9 +6188,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AssetCode;
 
@@ -6200,13 +6200,13 @@ export namespace xdr {
 
     static toXDR(value: AssetCode): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AssetCode;
+    static fromXDR(input: Buffer, format?: 'raw'): AssetCode;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AssetCode;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AssetCode;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Asset {
@@ -6224,9 +6224,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Asset;
 
@@ -6236,13 +6236,13 @@ export namespace xdr {
 
     static toXDR(value: Asset): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Asset;
+    static fromXDR(input: Buffer, format?: 'raw'): Asset;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Asset;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Asset;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExtensionV2Ext {
@@ -6256,9 +6256,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV3 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExtensionV2Ext;
 
@@ -6268,16 +6268,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV2Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV2Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV2Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AccountEntryExtensionV2Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExtensionV1Ext {
@@ -6291,9 +6291,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV2 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExtensionV1Ext;
 
@@ -6303,16 +6303,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AccountEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExt {
@@ -6326,9 +6326,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV1 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExt;
 
@@ -6338,13 +6338,13 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AccountEntryExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AccountEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineAsset {
@@ -6366,9 +6366,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | PoolId | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineAsset;
 
@@ -6378,13 +6378,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineAsset): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineAsset;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineAsset;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TrustLineAsset;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineAsset;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntryExtensionV2Ext {
@@ -6394,9 +6394,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntryExtensionV2Ext;
 
@@ -6406,16 +6406,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExtensionV2Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExtensionV2Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExtensionV2Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TrustLineEntryExtensionV2Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntryV1Ext {
@@ -6429,9 +6429,9 @@ export namespace xdr {
 
     value(): TrustLineEntryExtensionV2 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntryV1Ext;
 
@@ -6441,16 +6441,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryV1Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryV1Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TrustLineEntryV1Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntryExt {
@@ -6464,9 +6464,9 @@ export namespace xdr {
 
     value(): TrustLineEntryV1 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntryExt;
 
@@ -6476,13 +6476,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntryExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OfferEntryExt {
@@ -6492,9 +6492,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OfferEntryExt;
 
@@ -6504,13 +6504,13 @@ export namespace xdr {
 
     static toXDR(value: OfferEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OfferEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): OfferEntryExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OfferEntryExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OfferEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class DataEntryExt {
@@ -6520,9 +6520,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): DataEntryExt;
 
@@ -6532,13 +6532,13 @@ export namespace xdr {
 
     static toXDR(value: DataEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): DataEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): DataEntryExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): DataEntryExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): DataEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimPredicate {
@@ -6575,9 +6575,9 @@ export namespace xdr {
       | Int64
       | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimPredicate;
 
@@ -6587,13 +6587,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimPredicate): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimPredicate;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimPredicate;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimPredicate;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimPredicate;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Claimant {
@@ -6605,9 +6605,9 @@ export namespace xdr {
 
     value(): ClaimantV0;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Claimant;
 
@@ -6617,13 +6617,13 @@ export namespace xdr {
 
     static toXDR(value: Claimant): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Claimant;
+    static fromXDR(input: Buffer, format?: 'raw'): Claimant;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Claimant;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Claimant;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimableBalanceId {
@@ -6635,9 +6635,9 @@ export namespace xdr {
 
     value(): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimableBalanceId;
 
@@ -6647,13 +6647,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceId): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceId;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceId;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimableBalanceId;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimableBalanceId;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimableBalanceEntryExtensionV1Ext {
@@ -6663,9 +6663,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExtensionV1Ext;
 
@@ -6677,17 +6677,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ClaimableBalanceEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimableBalanceEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimableBalanceEntryExt {
@@ -6703,9 +6703,9 @@ export namespace xdr {
 
     value(): ClaimableBalanceEntryExtensionV1 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExt;
 
@@ -6715,16 +6715,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceEntryExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimableBalanceEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolEntryBody {
@@ -6740,9 +6740,9 @@ export namespace xdr {
 
     value(): LiquidityPoolEntryConstantProduct;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolEntryBody;
 
@@ -6752,16 +6752,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolEntryBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolEntryBody;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolEntryBody;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolEntryBody;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntryExtensionV1Ext {
@@ -6771,9 +6771,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntryExtensionV1Ext;
 
@@ -6783,16 +6783,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntryData {
@@ -6830,9 +6830,9 @@ export namespace xdr {
       | ClaimableBalanceEntry
       | LiquidityPoolEntry;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntryData;
 
@@ -6842,13 +6842,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryData): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryData;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryData;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryData;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryData;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntryExt {
@@ -6862,9 +6862,9 @@ export namespace xdr {
 
     value(): LedgerEntryExtensionV1 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntryExt;
 
@@ -6874,13 +6874,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKey {
@@ -6920,9 +6920,9 @@ export namespace xdr {
       | LedgerKeyClaimableBalance
       | LedgerKeyLiquidityPool;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKey;
 
@@ -6932,13 +6932,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKey;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKey;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerKey;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKey;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class StellarValueExt {
@@ -6956,9 +6956,9 @@ export namespace xdr {
 
     value(): LedgerCloseValueSignature | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): StellarValueExt;
 
@@ -6968,13 +6968,13 @@ export namespace xdr {
 
     static toXDR(value: StellarValueExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): StellarValueExt;
+    static fromXDR(input: Buffer, format?: 'raw'): StellarValueExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): StellarValueExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): StellarValueExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeaderExtensionV1Ext {
@@ -6984,9 +6984,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeaderExtensionV1Ext;
 
@@ -6996,16 +6996,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerHeaderExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeaderExt {
@@ -7019,9 +7019,9 @@ export namespace xdr {
 
     value(): LedgerHeaderExtensionV1 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeaderExt;
 
@@ -7031,13 +7031,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExt;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerHeaderExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerHeaderExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerUpgrade {
@@ -7065,9 +7065,9 @@ export namespace xdr {
 
     value(): number | number | number | number | number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerUpgrade;
 
@@ -7077,13 +7077,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerUpgrade): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerUpgrade;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerUpgrade;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerUpgrade;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerUpgrade;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BucketMetadataExt {
@@ -7093,9 +7093,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BucketMetadataExt;
 
@@ -7105,13 +7105,13 @@ export namespace xdr {
 
     static toXDR(value: BucketMetadataExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): BucketMetadataExt;
+    static fromXDR(input: Buffer, format?: 'raw'): BucketMetadataExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): BucketMetadataExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): BucketMetadataExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BucketEntry {
@@ -7133,9 +7133,9 @@ export namespace xdr {
 
     value(): LedgerEntry | LedgerKey | BucketMetadata;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BucketEntry;
 
@@ -7145,13 +7145,13 @@ export namespace xdr {
 
     static toXDR(value: BucketEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): BucketEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): BucketEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): BucketEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): BucketEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TxSetComponent {
@@ -7167,9 +7167,9 @@ export namespace xdr {
 
     value(): TxSetComponentTxsMaybeDiscountedFee;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TxSetComponent;
 
@@ -7179,13 +7179,13 @@ export namespace xdr {
 
     static toXDR(value: TxSetComponent): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TxSetComponent;
+    static fromXDR(input: Buffer, format?: 'raw'): TxSetComponent;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TxSetComponent;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TxSetComponent;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionPhase {
@@ -7197,9 +7197,9 @@ export namespace xdr {
 
     value(): TxSetComponent[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionPhase;
 
@@ -7209,13 +7209,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionPhase): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionPhase;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionPhase;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionPhase;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionPhase;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class GeneralizedTransactionSet {
@@ -7227,9 +7227,9 @@ export namespace xdr {
 
     value(): TransactionSetV1;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): GeneralizedTransactionSet;
 
@@ -7239,16 +7239,16 @@ export namespace xdr {
 
     static toXDR(value: GeneralizedTransactionSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): GeneralizedTransactionSet;
+    static fromXDR(input: Buffer, format?: 'raw'): GeneralizedTransactionSet;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): GeneralizedTransactionSet;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionHistoryEntryExt {
@@ -7264,9 +7264,9 @@ export namespace xdr {
 
     value(): GeneralizedTransactionSet | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionHistoryEntryExt;
 
@@ -7276,16 +7276,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionHistoryEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionHistoryEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionHistoryEntryExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionHistoryEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionHistoryResultEntryExt {
@@ -7295,9 +7295,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionHistoryResultEntryExt;
 
@@ -7309,17 +7309,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): TransactionHistoryResultEntryExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionHistoryResultEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeaderHistoryEntryExt {
@@ -7329,9 +7329,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeaderHistoryEntryExt;
 
@@ -7341,16 +7341,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderHistoryEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderHistoryEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderHistoryEntryExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerHeaderHistoryEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpHistoryEntry {
@@ -7362,9 +7362,9 @@ export namespace xdr {
 
     value(): ScpHistoryEntryV0;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpHistoryEntry;
 
@@ -7374,13 +7374,13 @@ export namespace xdr {
 
     static toXDR(value: ScpHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpHistoryEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpHistoryEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpHistoryEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntryChange {
@@ -7404,9 +7404,9 @@ export namespace xdr {
 
     value(): LedgerEntry | LedgerEntry | LedgerKey | LedgerEntry;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntryChange;
 
@@ -7416,13 +7416,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryChange): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryChange;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryChange;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryChange;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryChange;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionMeta {
@@ -7442,9 +7442,9 @@ export namespace xdr {
 
     value(): OperationMeta[] | TransactionMetaV1 | TransactionMetaV2;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionMeta;
 
@@ -7454,13 +7454,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionMeta;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionMeta;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionMeta;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMeta;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerCloseMeta {
@@ -7476,9 +7476,9 @@ export namespace xdr {
 
     value(): LedgerCloseMetaV0 | LedgerCloseMetaV1;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerCloseMeta;
 
@@ -7488,13 +7488,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMeta;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMeta;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMeta;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMeta;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PeerAddressIp {
@@ -7510,9 +7510,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PeerAddressIp;
 
@@ -7522,13 +7522,13 @@ export namespace xdr {
 
     static toXDR(value: PeerAddressIp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PeerAddressIp;
+    static fromXDR(input: Buffer, format?: 'raw'): PeerAddressIp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PeerAddressIp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PeerAddressIp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SurveyResponseBody {
@@ -7540,9 +7540,9 @@ export namespace xdr {
 
     value(): TopologyResponseBody;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SurveyResponseBody;
 
@@ -7552,13 +7552,13 @@ export namespace xdr {
 
     static toXDR(value: SurveyResponseBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SurveyResponseBody;
+    static fromXDR(input: Buffer, format?: 'raw'): SurveyResponseBody;
 
-    static fromXDR(input: string, format: "hex" | "base64"): SurveyResponseBody;
+    static fromXDR(input: string, format: 'hex' | 'base64'): SurveyResponseBody;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class StellarMessage {
@@ -7665,9 +7665,9 @@ export namespace xdr {
       | FloodDemand
       | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): StellarMessage;
 
@@ -7677,13 +7677,13 @@ export namespace xdr {
 
     static toXDR(value: StellarMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): StellarMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): StellarMessage;
 
-    static fromXDR(input: string, format: "hex" | "base64"): StellarMessage;
+    static fromXDR(input: string, format: 'hex' | 'base64'): StellarMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AuthenticatedMessage {
@@ -7695,9 +7695,9 @@ export namespace xdr {
 
     value(): AuthenticatedMessageV0;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AuthenticatedMessage;
 
@@ -7707,16 +7707,16 @@ export namespace xdr {
 
     static toXDR(value: AuthenticatedMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AuthenticatedMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): AuthenticatedMessage;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AuthenticatedMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolParameters {
@@ -7732,9 +7732,9 @@ export namespace xdr {
 
     value(): LiquidityPoolConstantProductParameters;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolParameters;
 
@@ -7744,16 +7744,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolParameters): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolParameters;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolParameters;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolParameters;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class MuxedAccount {
@@ -7769,9 +7769,9 @@ export namespace xdr {
 
     value(): Buffer | MuxedAccountMed25519;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): MuxedAccount;
 
@@ -7781,13 +7781,13 @@ export namespace xdr {
 
     static toXDR(value: MuxedAccount): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): MuxedAccount;
+    static fromXDR(input: Buffer, format?: 'raw'): MuxedAccount;
 
-    static fromXDR(input: string, format: "hex" | "base64"): MuxedAccount;
+    static fromXDR(input: string, format: 'hex' | 'base64'): MuxedAccount;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ChangeTrustAsset {
@@ -7809,9 +7809,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | LiquidityPoolParameters | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ChangeTrustAsset;
 
@@ -7821,13 +7821,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustAsset): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustAsset;
+    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustAsset;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustAsset;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustAsset;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class RevokeSponsorshipOp {
@@ -7845,9 +7845,9 @@ export namespace xdr {
 
     value(): LedgerKey | RevokeSponsorshipOpSigner;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): RevokeSponsorshipOp;
 
@@ -7857,16 +7857,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipOp;
+    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): RevokeSponsorshipOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OperationBody {
@@ -8017,9 +8017,9 @@ export namespace xdr {
       | LiquidityPoolWithdrawOp
       | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OperationBody;
 
@@ -8029,13 +8029,13 @@ export namespace xdr {
 
     static toXDR(value: OperationBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OperationBody;
+    static fromXDR(input: Buffer, format?: 'raw'): OperationBody;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OperationBody;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OperationBody;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimage {
@@ -8053,9 +8053,9 @@ export namespace xdr {
 
     value(): HashIdPreimageOperationId | HashIdPreimageRevokeId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimage;
 
@@ -8065,13 +8065,13 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimage;
+    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimage;
 
-    static fromXDR(input: string, format: "hex" | "base64"): HashIdPreimage;
+    static fromXDR(input: string, format: 'hex' | 'base64'): HashIdPreimage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Memo {
@@ -8097,9 +8097,9 @@ export namespace xdr {
 
     value(): string | Buffer | Uint64 | Buffer | Buffer | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Memo;
 
@@ -8109,13 +8109,13 @@ export namespace xdr {
 
     static toXDR(value: Memo): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Memo;
+    static fromXDR(input: Buffer, format?: 'raw'): Memo;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Memo;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Memo;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Preconditions {
@@ -8133,9 +8133,9 @@ export namespace xdr {
 
     value(): TimeBounds | PreconditionsV2 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Preconditions;
 
@@ -8145,13 +8145,13 @@ export namespace xdr {
 
     static toXDR(value: Preconditions): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Preconditions;
+    static fromXDR(input: Buffer, format?: 'raw'): Preconditions;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Preconditions;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Preconditions;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionV0Ext {
@@ -8161,9 +8161,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionV0Ext;
 
@@ -8173,13 +8173,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionV0Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0Ext;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionV0Ext;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionV0Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionExt {
@@ -8189,9 +8189,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionExt;
 
@@ -8201,13 +8201,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionExt;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FeeBumpTransactionInnerTx {
@@ -8221,9 +8221,9 @@ export namespace xdr {
 
     value(): TransactionV1Envelope;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FeeBumpTransactionInnerTx;
 
@@ -8233,16 +8233,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionInnerTx): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionInnerTx;
+    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionInnerTx;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): FeeBumpTransactionInnerTx;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FeeBumpTransactionExt {
@@ -8252,9 +8252,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FeeBumpTransactionExt;
 
@@ -8264,16 +8264,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionExt;
+    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): FeeBumpTransactionExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionEnvelope {
@@ -8298,9 +8298,9 @@ export namespace xdr {
       | TransactionV1Envelope
       | FeeBumpTransactionEnvelope;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionEnvelope;
 
@@ -8310,16 +8310,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionEnvelope;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionEnvelope;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionEnvelope;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionSignaturePayloadTaggedTransaction {
@@ -8339,9 +8339,9 @@ export namespace xdr {
 
     value(): Transaction | FeeBumpTransaction;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionSignaturePayloadTaggedTransaction;
 
@@ -8358,17 +8358,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): TransactionSignaturePayloadTaggedTransaction;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionSignaturePayloadTaggedTransaction;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimAtom {
@@ -8388,9 +8388,9 @@ export namespace xdr {
 
     value(): ClaimOfferAtomV0 | ClaimOfferAtom | ClaimLiquidityAtom;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimAtom;
 
@@ -8400,13 +8400,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimAtom;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimAtom;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimAtom;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimAtom;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreateAccountResult {
@@ -8424,9 +8424,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreateAccountResult;
 
@@ -8436,16 +8436,16 @@ export namespace xdr {
 
     static toXDR(value: CreateAccountResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreateAccountResult;
+    static fromXDR(input: Buffer, format?: 'raw'): CreateAccountResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): CreateAccountResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PaymentResult {
@@ -8473,9 +8473,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PaymentResult;
 
@@ -8485,13 +8485,13 @@ export namespace xdr {
 
     static toXDR(value: PaymentResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PaymentResult;
+    static fromXDR(input: Buffer, format?: 'raw'): PaymentResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PaymentResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PaymentResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictReceiveResult {
@@ -8535,9 +8535,9 @@ export namespace xdr {
 
     value(): PathPaymentStrictReceiveResultSuccess | Asset | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveResult;
 
@@ -8549,17 +8549,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): PathPaymentStrictReceiveResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictReceiveResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictSendResult {
@@ -8603,9 +8603,9 @@ export namespace xdr {
 
     value(): PathPaymentStrictSendResultSuccess | Asset | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictSendResult;
 
@@ -8615,16 +8615,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictSendResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictSendResult;
+    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictSendResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictSendResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageOfferSuccessResultOffer {
@@ -8640,9 +8640,9 @@ export namespace xdr {
 
     value(): OfferEntry | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageOfferSuccessResultOffer;
 
@@ -8654,17 +8654,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ManageOfferSuccessResultOffer;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ManageOfferSuccessResultOffer;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageSellOfferResult {
@@ -8702,9 +8702,9 @@ export namespace xdr {
 
     value(): ManageOfferSuccessResult | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageSellOfferResult;
 
@@ -8714,16 +8714,16 @@ export namespace xdr {
 
     static toXDR(value: ManageSellOfferResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageSellOfferResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageSellOfferResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ManageSellOfferResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageBuyOfferResult {
@@ -8761,9 +8761,9 @@ export namespace xdr {
 
     value(): ManageOfferSuccessResult | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageBuyOfferResult;
 
@@ -8773,16 +8773,16 @@ export namespace xdr {
 
     static toXDR(value: ManageBuyOfferResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageBuyOfferResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageBuyOfferResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ManageBuyOfferResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SetOptionsResult {
@@ -8812,9 +8812,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SetOptionsResult;
 
@@ -8824,13 +8824,13 @@ export namespace xdr {
 
     static toXDR(value: SetOptionsResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SetOptionsResult;
+    static fromXDR(input: Buffer, format?: 'raw'): SetOptionsResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): SetOptionsResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): SetOptionsResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ChangeTrustResult {
@@ -8856,9 +8856,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ChangeTrustResult;
 
@@ -8868,13 +8868,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AllowTrustResult {
@@ -8896,9 +8896,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AllowTrustResult;
 
@@ -8908,13 +8908,13 @@ export namespace xdr {
 
     static toXDR(value: AllowTrustResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AllowTrustResult;
+    static fromXDR(input: Buffer, format?: 'raw'): AllowTrustResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AllowTrustResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AllowTrustResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountMergeResult {
@@ -8940,9 +8940,9 @@ export namespace xdr {
 
     value(): Int64 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountMergeResult;
 
@@ -8952,13 +8952,13 @@ export namespace xdr {
 
     static toXDR(value: AccountMergeResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountMergeResult;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountMergeResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AccountMergeResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AccountMergeResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InflationResult {
@@ -8972,9 +8972,9 @@ export namespace xdr {
 
     value(): InflationPayout[] | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InflationResult;
 
@@ -8984,13 +8984,13 @@ export namespace xdr {
 
     static toXDR(value: InflationResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InflationResult;
+    static fromXDR(input: Buffer, format?: 'raw'): InflationResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): InflationResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): InflationResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageDataResult {
@@ -9008,9 +9008,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageDataResult;
 
@@ -9020,13 +9020,13 @@ export namespace xdr {
 
     static toXDR(value: ManageDataResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageDataResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageDataResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ManageDataResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ManageDataResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BumpSequenceResult {
@@ -9038,9 +9038,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BumpSequenceResult;
 
@@ -9050,13 +9050,13 @@ export namespace xdr {
 
     static toXDR(value: BumpSequenceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): BumpSequenceResult;
+    static fromXDR(input: Buffer, format?: 'raw'): BumpSequenceResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): BumpSequenceResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): BumpSequenceResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreateClaimableBalanceResult {
@@ -9080,9 +9080,9 @@ export namespace xdr {
 
     value(): ClaimableBalanceId | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreateClaimableBalanceResult;
 
@@ -9092,16 +9092,16 @@ export namespace xdr {
 
     static toXDR(value: CreateClaimableBalanceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreateClaimableBalanceResult;
+    static fromXDR(input: Buffer, format?: 'raw'): CreateClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): CreateClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimClaimableBalanceResult {
@@ -9121,9 +9121,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimClaimableBalanceResult;
 
@@ -9133,16 +9133,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimClaimableBalanceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimClaimableBalanceResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BeginSponsoringFutureReservesResult {
@@ -9158,9 +9158,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BeginSponsoringFutureReservesResult;
 
@@ -9172,17 +9172,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): BeginSponsoringFutureReservesResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): BeginSponsoringFutureReservesResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class EndSponsoringFutureReservesResult {
@@ -9194,9 +9194,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): EndSponsoringFutureReservesResult;
 
@@ -9208,17 +9208,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): EndSponsoringFutureReservesResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): EndSponsoringFutureReservesResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class RevokeSponsorshipResult {
@@ -9238,9 +9238,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): RevokeSponsorshipResult;
 
@@ -9250,16 +9250,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipResult;
+    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): RevokeSponsorshipResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClawbackResult {
@@ -9277,9 +9277,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClawbackResult;
 
@@ -9289,13 +9289,13 @@ export namespace xdr {
 
     static toXDR(value: ClawbackResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClawbackResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ClawbackResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClawbackResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClawbackResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClawbackClaimableBalanceResult {
@@ -9311,9 +9311,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClawbackClaimableBalanceResult;
 
@@ -9325,17 +9325,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ClawbackClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClawbackClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SetTrustLineFlagsResult {
@@ -9355,9 +9355,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SetTrustLineFlagsResult;
 
@@ -9367,16 +9367,16 @@ export namespace xdr {
 
     static toXDR(value: SetTrustLineFlagsResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SetTrustLineFlagsResult;
+    static fromXDR(input: Buffer, format?: 'raw'): SetTrustLineFlagsResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SetTrustLineFlagsResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolDepositResult {
@@ -9400,9 +9400,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolDepositResult;
 
@@ -9412,16 +9412,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolDepositResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolDepositResult;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolDepositResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolDepositResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolWithdrawResult {
@@ -9441,9 +9441,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolWithdrawResult;
 
@@ -9453,16 +9453,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolWithdrawResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolWithdrawResult;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolWithdrawResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolWithdrawResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OperationResultTr {
@@ -9634,9 +9634,9 @@ export namespace xdr {
       | LiquidityPoolDepositResult
       | LiquidityPoolWithdrawResult;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OperationResultTr;
 
@@ -9646,13 +9646,13 @@ export namespace xdr {
 
     static toXDR(value: OperationResultTr): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OperationResultTr;
+    static fromXDR(input: Buffer, format?: 'raw'): OperationResultTr;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OperationResultTr;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OperationResultTr;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OperationResult {
@@ -9676,9 +9676,9 @@ export namespace xdr {
 
     value(): OperationResultTr | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OperationResult;
 
@@ -9688,13 +9688,13 @@ export namespace xdr {
 
     static toXDR(value: OperationResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OperationResult;
+    static fromXDR(input: Buffer, format?: 'raw'): OperationResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OperationResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OperationResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InnerTransactionResultResult {
@@ -9736,9 +9736,9 @@ export namespace xdr {
 
     value(): OperationResult[] | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InnerTransactionResultResult;
 
@@ -9748,16 +9748,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultResult;
+    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InnerTransactionResultResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InnerTransactionResultExt {
@@ -9767,9 +9767,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InnerTransactionResultExt;
 
@@ -9779,16 +9779,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultExt;
+    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InnerTransactionResultExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultResult {
@@ -9842,9 +9842,9 @@ export namespace xdr {
 
     value(): InnerTransactionResultPair | OperationResult[] | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultResult;
 
@@ -9854,16 +9854,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultResult;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultExt {
@@ -9873,9 +9873,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultExt;
 
@@ -9885,16 +9885,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultExt;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ExtensionPoint {
@@ -9904,9 +9904,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ExtensionPoint;
 
@@ -9916,13 +9916,13 @@ export namespace xdr {
 
     static toXDR(value: ExtensionPoint): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ExtensionPoint;
+    static fromXDR(input: Buffer, format?: 'raw'): ExtensionPoint;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ExtensionPoint;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ExtensionPoint;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PublicKey {
@@ -9934,9 +9934,9 @@ export namespace xdr {
 
     value(): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PublicKey;
 
@@ -9946,13 +9946,13 @@ export namespace xdr {
 
     static toXDR(value: PublicKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PublicKey;
+    static fromXDR(input: Buffer, format?: 'raw'): PublicKey;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PublicKey;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PublicKey;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SignerKey {
@@ -9980,9 +9980,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer | Buffer | SignerKeyEd25519SignedPayload;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SignerKey;
 
@@ -9992,12 +9992,12 @@ export namespace xdr {
 
     static toXDR(value: SignerKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SignerKey;
+    static fromXDR(input: Buffer, format?: 'raw'): SignerKey;
 
-    static fromXDR(input: string, format: "hex" | "base64"): SignerKey;
+    static fromXDR(input: string, format: 'hex' | 'base64'): SignerKey;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 }

--- a/types/next.d.ts
+++ b/types/next.d.ts
@@ -1,4 +1,4 @@
-// Automatically generated on 2023-02-15T10:28:00Z
+// Automatically generated on 2022-08-12T12:40:00+01:00
 import { Operation } from './index';
 
 export {};
@@ -16,31 +16,30 @@ declare namespace xdrHidden {
 
     body(value?: xdr.OperationBody): xdr.OperationBody;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
-    static read(io: Buffer): xdr.Operation;
+    static read(io: Buffer): Operation;
 
-    static write(value: xdr.Operation, io: Buffer): void;
+    static write(value: Operation, io: Buffer): void;
 
-    static isValid(value: xdr.Operation): boolean;
+    static isValid(value: Operation): boolean;
 
-    static toXDR(value: xdr.Operation): Buffer;
+    static toXDR(value: Operation): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): xdr.Operation;
+    static fromXDR(input: Buffer, format?: "raw"): Operation;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): xdr.Operation;
+    static fromXDR(input: string, format: "hex" | "base64"): Operation;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 }
 
 export namespace xdr {
   export import Operation = xdrHidden.Operation2; // tslint:disable-line:strict-export-declare-modifiers
-  const SCVAL_LIMIT = 256000;
 
   interface SignedInt {
     readonly MAX_VALUE: 2147483647;
@@ -49,10 +48,10 @@ export namespace xdr {
     write(value: number, io: Buffer): void;
     isValid(value: number): boolean;
     toXDR(value: number): Buffer;
-    fromXDR(input: Buffer, format?: 'raw'): number;
-    fromXDR(input: string, format: 'hex' | 'base64'): number;
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    fromXDR(input: Buffer, format?: "raw"): number;
+    fromXDR(input: string, format: "hex" | "base64"): number;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   interface UnsignedInt {
@@ -62,10 +61,10 @@ export namespace xdr {
     write(value: number, io: Buffer): void;
     isValid(value: number): boolean;
     toXDR(value: number): Buffer;
-    fromXDR(input: Buffer, format?: 'raw'): number;
-    fromXDR(input: string, format: 'hex' | 'base64'): number;
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    fromXDR(input: Buffer, format?: "raw"): number;
+    fromXDR(input: string, format: "hex" | "base64"): number;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   interface Bool {
@@ -73,10 +72,10 @@ export namespace xdr {
     write(value: boolean, io: Buffer): void;
     isValid(value: boolean): boolean;
     toXDR(value: boolean): Buffer;
-    fromXDR(input: Buffer, format?: 'raw'): boolean;
-    fromXDR(input: string, format: 'hex' | 'base64'): boolean;
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    fromXDR(input: Buffer, format?: "raw"): boolean;
+    fromXDR(input: string, format: "hex" | "base64"): boolean;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Hyper {
@@ -88,19 +87,19 @@ export namespace xdr {
 
     constructor(low: number, high: number);
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static toXDR(value: Hyper): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Hyper;
+    static fromXDR(input: Buffer, format?: "raw"): Hyper;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Hyper;
+    static fromXDR(input: string, format: "hex" | "base64"): Hyper;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
 
     static readonly MAX_VALUE: Hyper;
 
@@ -126,19 +125,19 @@ export namespace xdr {
 
     constructor(low: number, high: number);
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static toXDR(value: UnsignedHyper): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): UnsignedHyper;
+    static fromXDR(input: Buffer, format?: "raw"): UnsignedHyper;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): UnsignedHyper;
+    static fromXDR(input: string, format: "hex" | "base64"): UnsignedHyper;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
 
     static readonly MAX_VALUE: UnsignedHyper;
 
@@ -168,13 +167,13 @@ export namespace xdr {
 
     toXDR(value: string | Buffer): Buffer;
 
-    fromXDR(input: Buffer, format?: 'raw'): Buffer;
+    fromXDR(input: Buffer, format?: "raw"): Buffer;
 
-    fromXDR(input: string, format: 'hex' | 'base64'): Buffer;
+    fromXDR(input: string, format: "hex" | "base64"): Buffer;
 
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class XDRArray<T> {
@@ -186,13 +185,13 @@ export namespace xdr {
 
     toXDR(value: T[]): Buffer;
 
-    fromXDR(input: Buffer, format?: 'raw'): T[];
+    fromXDR(input: Buffer, format?: "raw"): T[];
 
-    fromXDR(input: string, format: 'hex' | 'base64'): T[];
+    fromXDR(input: string, format: "hex" | "base64"): T[];
 
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Opaque {
@@ -206,13 +205,13 @@ export namespace xdr {
 
     toXDR(value: Buffer): Buffer;
 
-    fromXDR(input: Buffer, format?: 'raw'): Buffer;
+    fromXDR(input: Buffer, format?: "raw"): Buffer;
 
-    fromXDR(input: string, format: 'hex' | 'base64'): Buffer;
+    fromXDR(input: string, format: "hex" | "base64"): Buffer;
 
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class VarOpaque extends Opaque {}
@@ -232,21 +231,21 @@ export namespace xdr {
 
     toXDR(value: any): Buffer;
 
-    fromXDR(input: Buffer, format?: 'raw'): any;
+    fromXDR(input: Buffer, format?: "raw"): any;
 
-    fromXDR(input: string, format: 'hex' | 'base64'): any;
+    fromXDR(input: string, format: "hex" | "base64"): any;
 
-    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatementType {
     readonly name:
-      | 'scpStPrepare'
-      | 'scpStConfirm'
-      | 'scpStExternalize'
-      | 'scpStNominate';
+      | "scpStPrepare"
+      | "scpStConfirm"
+      | "scpStExternalize"
+      | "scpStNominate";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -261,10 +260,10 @@ export namespace xdr {
 
   class AssetType {
     readonly name:
-      | 'assetTypeNative'
-      | 'assetTypeCreditAlphanum4'
-      | 'assetTypeCreditAlphanum12'
-      | 'assetTypePoolShare';
+      | "assetTypeNative"
+      | "assetTypeCreditAlphanum4"
+      | "assetTypeCreditAlphanum12"
+      | "assetTypePoolShare";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -279,10 +278,10 @@ export namespace xdr {
 
   class ThresholdIndices {
     readonly name:
-      | 'thresholdMasterWeight'
-      | 'thresholdLow'
-      | 'thresholdMed'
-      | 'thresholdHigh';
+      | "thresholdMasterWeight"
+      | "thresholdLow"
+      | "thresholdMed"
+      | "thresholdHigh";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -297,15 +296,15 @@ export namespace xdr {
 
   class LedgerEntryType {
     readonly name:
-      | 'account'
-      | 'trustline'
-      | 'offer'
-      | 'data'
-      | 'claimableBalance'
-      | 'liquidityPool'
-      | 'contractData'
-      | 'contractCode'
-      | 'configSetting';
+      | "account"
+      | "trustline"
+      | "offer"
+      | "data"
+      | "claimableBalance"
+      | "liquidityPool"
+      | "contractData"
+      | "contractCode"
+      | "configSetting";
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
@@ -330,10 +329,10 @@ export namespace xdr {
 
   class AccountFlags {
     readonly name:
-      | 'authRequiredFlag'
-      | 'authRevocableFlag'
-      | 'authImmutableFlag'
-      | 'authClawbackEnabledFlag';
+      | "authRequiredFlag"
+      | "authRevocableFlag"
+      | "authImmutableFlag"
+      | "authClawbackEnabledFlag";
 
     readonly value: 1 | 2 | 4 | 8;
 
@@ -348,9 +347,9 @@ export namespace xdr {
 
   class TrustLineFlags {
     readonly name:
-      | 'authorizedFlag'
-      | 'authorizedToMaintainLiabilitiesFlag'
-      | 'trustlineClawbackEnabledFlag';
+      | "authorizedFlag"
+      | "authorizedToMaintainLiabilitiesFlag"
+      | "trustlineClawbackEnabledFlag";
 
     readonly value: 1 | 2 | 4;
 
@@ -362,7 +361,7 @@ export namespace xdr {
   }
 
   class LiquidityPoolType {
-    readonly name: 'liquidityPoolConstantProduct';
+    readonly name: "liquidityPoolConstantProduct";
 
     readonly value: 0;
 
@@ -370,7 +369,7 @@ export namespace xdr {
   }
 
   class OfferEntryFlags {
-    readonly name: 'passiveFlag';
+    readonly name: "passiveFlag";
 
     readonly value: 1;
 
@@ -379,12 +378,12 @@ export namespace xdr {
 
   class ClaimPredicateType {
     readonly name:
-      | 'claimPredicateUnconditional'
-      | 'claimPredicateAnd'
-      | 'claimPredicateOr'
-      | 'claimPredicateNot'
-      | 'claimPredicateBeforeAbsoluteTime'
-      | 'claimPredicateBeforeRelativeTime';
+      | "claimPredicateUnconditional"
+      | "claimPredicateAnd"
+      | "claimPredicateOr"
+      | "claimPredicateNot"
+      | "claimPredicateBeforeAbsoluteTime"
+      | "claimPredicateBeforeRelativeTime";
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -402,7 +401,7 @@ export namespace xdr {
   }
 
   class ClaimantType {
-    readonly name: 'claimantTypeV0';
+    readonly name: "claimantTypeV0";
 
     readonly value: 0;
 
@@ -410,7 +409,7 @@ export namespace xdr {
   }
 
   class ClaimableBalanceIdType {
-    readonly name: 'claimableBalanceIdTypeV0';
+    readonly name: "claimableBalanceIdTypeV0";
 
     readonly value: 0;
 
@@ -418,45 +417,56 @@ export namespace xdr {
   }
 
   class ClaimableBalanceFlags {
-    readonly name: 'claimableBalanceClawbackEnabledFlag';
+    readonly name: "claimableBalanceClawbackEnabledFlag";
 
     readonly value: 1;
 
     static claimableBalanceClawbackEnabledFlag(): ClaimableBalanceFlags;
   }
 
-  class ConfigSettingType {
-    readonly name: 'configSettingTypeUint32';
-
-    readonly value: 0;
-
-    static configSettingTypeUint32(): ConfigSettingType;
-  }
-
   class ConfigSettingId {
-    readonly name: 'configSettingContractMaxSize';
+    readonly name:
+      | "configSettingContractMaxSizeBytes"
+      | "configSettingContractComputeV0"
+      | "configSettingContractLedgerCostV0"
+      | "configSettingContractHistoricalDataV0"
+      | "configSettingContractMetaDataV0"
+      | "configSettingContractBandwidthV0"
+      | "configSettingContractHostLogicVersion";
 
-    readonly value: 0;
+    readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-    static configSettingContractMaxSize(): ConfigSettingId;
+    static configSettingContractMaxSizeBytes(): ConfigSettingId;
+
+    static configSettingContractComputeV0(): ConfigSettingId;
+
+    static configSettingContractLedgerCostV0(): ConfigSettingId;
+
+    static configSettingContractHistoricalDataV0(): ConfigSettingId;
+
+    static configSettingContractMetaDataV0(): ConfigSettingId;
+
+    static configSettingContractBandwidthV0(): ConfigSettingId;
+
+    static configSettingContractHostLogicVersion(): ConfigSettingId;
   }
 
   class EnvelopeType {
     readonly name:
-      | 'envelopeTypeTxV0'
-      | 'envelopeTypeScp'
-      | 'envelopeTypeTx'
-      | 'envelopeTypeAuth'
-      | 'envelopeTypeScpvalue'
-      | 'envelopeTypeTxFeeBump'
-      | 'envelopeTypeOpId'
-      | 'envelopeTypePoolRevokeOpId'
-      | 'envelopeTypeContractIdFromEd25519'
-      | 'envelopeTypeContractIdFromContract'
-      | 'envelopeTypeContractIdFromAsset'
-      | 'envelopeTypeContractIdFromSourceAccount'
-      | 'envelopeTypeCreateContractArgs'
-      | 'envelopeTypeContractAuth';
+      | "envelopeTypeTxV0"
+      | "envelopeTypeScp"
+      | "envelopeTypeTx"
+      | "envelopeTypeAuth"
+      | "envelopeTypeScpvalue"
+      | "envelopeTypeTxFeeBump"
+      | "envelopeTypeOpId"
+      | "envelopeTypePoolRevokeOpId"
+      | "envelopeTypeContractIdFromEd25519"
+      | "envelopeTypeContractIdFromContract"
+      | "envelopeTypeContractIdFromAsset"
+      | "envelopeTypeContractIdFromSourceAccount"
+      | "envelopeTypeCreateContractArgs"
+      | "envelopeTypeContractAuth";
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;
 
@@ -490,7 +500,7 @@ export namespace xdr {
   }
 
   class StellarValueType {
-    readonly name: 'stellarValueBasic' | 'stellarValueSigned';
+    readonly name: "stellarValueBasic" | "stellarValueSigned";
 
     readonly value: 0 | 1;
 
@@ -501,13 +511,13 @@ export namespace xdr {
 
   class LedgerHeaderFlags {
     readonly name:
-      | 'disableLiquidityPoolTradingFlag'
-      | 'disableLiquidityPoolDepositFlag'
-      | 'disableLiquidityPoolWithdrawalFlag'
-      | 'disableContractCreate'
-      | 'disableContractUpdate'
-      | 'disableContractRemove'
-      | 'disableContractInvoke';
+      | "disableLiquidityPoolTradingFlag"
+      | "disableLiquidityPoolDepositFlag"
+      | "disableLiquidityPoolWithdrawalFlag"
+      | "disableContractCreate"
+      | "disableContractUpdate"
+      | "disableContractRemove"
+      | "disableContractInvoke";
 
     readonly value: 1 | 2 | 4 | 8 | 16 | 32 | 64;
 
@@ -528,12 +538,12 @@ export namespace xdr {
 
   class LedgerUpgradeType {
     readonly name:
-      | 'ledgerUpgradeVersion'
-      | 'ledgerUpgradeBaseFee'
-      | 'ledgerUpgradeMaxTxSetSize'
-      | 'ledgerUpgradeBaseReserve'
-      | 'ledgerUpgradeFlags'
-      | 'ledgerUpgradeConfig';
+      | "ledgerUpgradeVersion"
+      | "ledgerUpgradeBaseFee"
+      | "ledgerUpgradeMaxTxSetSize"
+      | "ledgerUpgradeBaseReserve"
+      | "ledgerUpgradeFlags"
+      | "ledgerUpgradeConfig";
 
     readonly value: 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -551,7 +561,7 @@ export namespace xdr {
   }
 
   class BucketEntryType {
-    readonly name: 'metaentry' | 'liveentry' | 'deadentry' | 'initentry';
+    readonly name: "metaentry" | "liveentry" | "deadentry" | "initentry";
 
     readonly value: -1 | 0 | 1 | 2;
 
@@ -565,7 +575,7 @@ export namespace xdr {
   }
 
   class TxSetComponentType {
-    readonly name: 'txsetCompTxsMaybeDiscountedFee';
+    readonly name: "txsetCompTxsMaybeDiscountedFee";
 
     readonly value: 0;
 
@@ -574,10 +584,10 @@ export namespace xdr {
 
   class LedgerEntryChangeType {
     readonly name:
-      | 'ledgerEntryCreated'
-      | 'ledgerEntryUpdated'
-      | 'ledgerEntryRemoved'
-      | 'ledgerEntryState';
+      | "ledgerEntryCreated"
+      | "ledgerEntryUpdated"
+      | "ledgerEntryRemoved"
+      | "ledgerEntryState";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -591,17 +601,19 @@ export namespace xdr {
   }
 
   class ContractEventType {
-    readonly name: 'system' | 'contract';
+    readonly name: "system" | "contract" | "diagnostic";
 
-    readonly value: 0 | 1;
+    readonly value: 0 | 1 | 2;
 
     static system(): ContractEventType;
 
     static contract(): ContractEventType;
+
+    static diagnostic(): ContractEventType;
   }
 
   class ErrorCode {
-    readonly name: 'errMisc' | 'errData' | 'errConf' | 'errAuth' | 'errLoad';
+    readonly name: "errMisc" | "errData" | "errConf" | "errAuth" | "errLoad";
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -617,7 +629,7 @@ export namespace xdr {
   }
 
   class IpAddrType {
-    readonly name: 'iPv4' | 'iPv6';
+    readonly name: "iPv4" | "iPv6";
 
     readonly value: 0 | 1;
 
@@ -628,25 +640,25 @@ export namespace xdr {
 
   class MessageType {
     readonly name:
-      | 'errorMsg'
-      | 'auth'
-      | 'dontHave'
-      | 'getPeers'
-      | 'peers'
-      | 'getTxSet'
-      | 'txSet'
-      | 'generalizedTxSet'
-      | 'transaction'
-      | 'getScpQuorumset'
-      | 'scpQuorumset'
-      | 'scpMessage'
-      | 'getScpState'
-      | 'hello'
-      | 'surveyRequest'
-      | 'surveyResponse'
-      | 'sendMore'
-      | 'floodAdvert'
-      | 'floodDemand';
+      | "errorMsg"
+      | "auth"
+      | "dontHave"
+      | "getPeers"
+      | "peers"
+      | "getTxSet"
+      | "txSet"
+      | "generalizedTxSet"
+      | "transaction"
+      | "getScpQuorumset"
+      | "scpQuorumset"
+      | "scpMessage"
+      | "getScpState"
+      | "hello"
+      | "surveyRequest"
+      | "surveyResponse"
+      | "sendMore"
+      | "floodAdvert"
+      | "floodDemand";
 
     readonly value:
       | 0
@@ -709,7 +721,7 @@ export namespace xdr {
   }
 
   class SurveyMessageCommandType {
-    readonly name: 'surveyTopology';
+    readonly name: "surveyTopology";
 
     readonly value: 0;
 
@@ -717,7 +729,7 @@ export namespace xdr {
   }
 
   class SurveyMessageResponseType {
-    readonly name: 'surveyTopologyResponseV0' | 'surveyTopologyResponseV1';
+    readonly name: "surveyTopologyResponseV0" | "surveyTopologyResponseV1";
 
     readonly value: 0 | 1;
 
@@ -728,31 +740,31 @@ export namespace xdr {
 
   class OperationType {
     readonly name:
-      | 'createAccount'
-      | 'payment'
-      | 'pathPaymentStrictReceive'
-      | 'manageSellOffer'
-      | 'createPassiveSellOffer'
-      | 'setOptions'
-      | 'changeTrust'
-      | 'allowTrust'
-      | 'accountMerge'
-      | 'inflation'
-      | 'manageData'
-      | 'bumpSequence'
-      | 'manageBuyOffer'
-      | 'pathPaymentStrictSend'
-      | 'createClaimableBalance'
-      | 'claimClaimableBalance'
-      | 'beginSponsoringFutureReserves'
-      | 'endSponsoringFutureReserves'
-      | 'revokeSponsorship'
-      | 'clawback'
-      | 'clawbackClaimableBalance'
-      | 'setTrustLineFlags'
-      | 'liquidityPoolDeposit'
-      | 'liquidityPoolWithdraw'
-      | 'invokeHostFunction';
+      | "createAccount"
+      | "payment"
+      | "pathPaymentStrictReceive"
+      | "manageSellOffer"
+      | "createPassiveSellOffer"
+      | "setOptions"
+      | "changeTrust"
+      | "allowTrust"
+      | "accountMerge"
+      | "inflation"
+      | "manageData"
+      | "bumpSequence"
+      | "manageBuyOffer"
+      | "pathPaymentStrictSend"
+      | "createClaimableBalance"
+      | "claimClaimableBalance"
+      | "beginSponsoringFutureReserves"
+      | "endSponsoringFutureReserves"
+      | "revokeSponsorship"
+      | "clawback"
+      | "clawbackClaimableBalance"
+      | "setTrustLineFlags"
+      | "liquidityPoolDeposit"
+      | "liquidityPoolWithdraw"
+      | "invokeHostFunction";
 
     readonly value:
       | 0
@@ -833,7 +845,7 @@ export namespace xdr {
   }
 
   class RevokeSponsorshipType {
-    readonly name: 'revokeSponsorshipLedgerEntry' | 'revokeSponsorshipSigner';
+    readonly name: "revokeSponsorshipLedgerEntry" | "revokeSponsorshipSigner";
 
     readonly value: 0 | 1;
 
@@ -844,9 +856,9 @@ export namespace xdr {
 
   class HostFunctionType {
     readonly name:
-      | 'hostFunctionTypeInvokeContract'
-      | 'hostFunctionTypeCreateContract'
-      | 'hostFunctionTypeInstallContractCode';
+      | "hostFunctionTypeInvokeContract"
+      | "hostFunctionTypeCreateContract"
+      | "hostFunctionTypeInstallContractCode";
 
     readonly value: 0 | 1 | 2;
 
@@ -859,9 +871,9 @@ export namespace xdr {
 
   class ContractIdType {
     readonly name:
-      | 'contractIdFromSourceAccount'
-      | 'contractIdFromEd25519PublicKey'
-      | 'contractIdFromAsset';
+      | "contractIdFromSourceAccount"
+      | "contractIdFromEd25519PublicKey"
+      | "contractIdFromAsset";
 
     readonly value: 0 | 1 | 2;
 
@@ -874,8 +886,8 @@ export namespace xdr {
 
   class ContractIdPublicKeyType {
     readonly name:
-      | 'contractIdPublicKeySourceAccount'
-      | 'contractIdPublicKeyEd25519';
+      | "contractIdPublicKeySourceAccount"
+      | "contractIdPublicKeyEd25519";
 
     readonly value: 0 | 1;
 
@@ -886,11 +898,11 @@ export namespace xdr {
 
   class MemoType {
     readonly name:
-      | 'memoNone'
-      | 'memoText'
-      | 'memoId'
-      | 'memoHash'
-      | 'memoReturn';
+      | "memoNone"
+      | "memoText"
+      | "memoId"
+      | "memoHash"
+      | "memoReturn";
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -906,7 +918,7 @@ export namespace xdr {
   }
 
   class PreconditionType {
-    readonly name: 'precondNone' | 'precondTime' | 'precondV2';
+    readonly name: "precondNone" | "precondTime" | "precondV2";
 
     readonly value: 0 | 1 | 2;
 
@@ -919,9 +931,9 @@ export namespace xdr {
 
   class ClaimAtomType {
     readonly name:
-      | 'claimAtomTypeV0'
-      | 'claimAtomTypeOrderBook'
-      | 'claimAtomTypeLiquidityPool';
+      | "claimAtomTypeV0"
+      | "claimAtomTypeOrderBook"
+      | "claimAtomTypeLiquidityPool";
 
     readonly value: 0 | 1 | 2;
 
@@ -934,11 +946,11 @@ export namespace xdr {
 
   class CreateAccountResultCode {
     readonly name:
-      | 'createAccountSuccess'
-      | 'createAccountMalformed'
-      | 'createAccountUnderfunded'
-      | 'createAccountLowReserve'
-      | 'createAccountAlreadyExist';
+      | "createAccountSuccess"
+      | "createAccountMalformed"
+      | "createAccountUnderfunded"
+      | "createAccountLowReserve"
+      | "createAccountAlreadyExist";
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -955,16 +967,16 @@ export namespace xdr {
 
   class PaymentResultCode {
     readonly name:
-      | 'paymentSuccess'
-      | 'paymentMalformed'
-      | 'paymentUnderfunded'
-      | 'paymentSrcNoTrust'
-      | 'paymentSrcNotAuthorized'
-      | 'paymentNoDestination'
-      | 'paymentNoTrust'
-      | 'paymentNotAuthorized'
-      | 'paymentLineFull'
-      | 'paymentNoIssuer';
+      | "paymentSuccess"
+      | "paymentMalformed"
+      | "paymentUnderfunded"
+      | "paymentSrcNoTrust"
+      | "paymentSrcNotAuthorized"
+      | "paymentNoDestination"
+      | "paymentNoTrust"
+      | "paymentNotAuthorized"
+      | "paymentLineFull"
+      | "paymentNoIssuer";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9;
 
@@ -991,19 +1003,19 @@ export namespace xdr {
 
   class PathPaymentStrictReceiveResultCode {
     readonly name:
-      | 'pathPaymentStrictReceiveSuccess'
-      | 'pathPaymentStrictReceiveMalformed'
-      | 'pathPaymentStrictReceiveUnderfunded'
-      | 'pathPaymentStrictReceiveSrcNoTrust'
-      | 'pathPaymentStrictReceiveSrcNotAuthorized'
-      | 'pathPaymentStrictReceiveNoDestination'
-      | 'pathPaymentStrictReceiveNoTrust'
-      | 'pathPaymentStrictReceiveNotAuthorized'
-      | 'pathPaymentStrictReceiveLineFull'
-      | 'pathPaymentStrictReceiveNoIssuer'
-      | 'pathPaymentStrictReceiveTooFewOffers'
-      | 'pathPaymentStrictReceiveOfferCrossSelf'
-      | 'pathPaymentStrictReceiveOverSendmax';
+      | "pathPaymentStrictReceiveSuccess"
+      | "pathPaymentStrictReceiveMalformed"
+      | "pathPaymentStrictReceiveUnderfunded"
+      | "pathPaymentStrictReceiveSrcNoTrust"
+      | "pathPaymentStrictReceiveSrcNotAuthorized"
+      | "pathPaymentStrictReceiveNoDestination"
+      | "pathPaymentStrictReceiveNoTrust"
+      | "pathPaymentStrictReceiveNotAuthorized"
+      | "pathPaymentStrictReceiveLineFull"
+      | "pathPaymentStrictReceiveNoIssuer"
+      | "pathPaymentStrictReceiveTooFewOffers"
+      | "pathPaymentStrictReceiveOfferCrossSelf"
+      | "pathPaymentStrictReceiveOverSendmax";
 
     readonly value:
       | 0
@@ -1049,19 +1061,19 @@ export namespace xdr {
 
   class PathPaymentStrictSendResultCode {
     readonly name:
-      | 'pathPaymentStrictSendSuccess'
-      | 'pathPaymentStrictSendMalformed'
-      | 'pathPaymentStrictSendUnderfunded'
-      | 'pathPaymentStrictSendSrcNoTrust'
-      | 'pathPaymentStrictSendSrcNotAuthorized'
-      | 'pathPaymentStrictSendNoDestination'
-      | 'pathPaymentStrictSendNoTrust'
-      | 'pathPaymentStrictSendNotAuthorized'
-      | 'pathPaymentStrictSendLineFull'
-      | 'pathPaymentStrictSendNoIssuer'
-      | 'pathPaymentStrictSendTooFewOffers'
-      | 'pathPaymentStrictSendOfferCrossSelf'
-      | 'pathPaymentStrictSendUnderDestmin';
+      | "pathPaymentStrictSendSuccess"
+      | "pathPaymentStrictSendMalformed"
+      | "pathPaymentStrictSendUnderfunded"
+      | "pathPaymentStrictSendSrcNoTrust"
+      | "pathPaymentStrictSendSrcNotAuthorized"
+      | "pathPaymentStrictSendNoDestination"
+      | "pathPaymentStrictSendNoTrust"
+      | "pathPaymentStrictSendNotAuthorized"
+      | "pathPaymentStrictSendLineFull"
+      | "pathPaymentStrictSendNoIssuer"
+      | "pathPaymentStrictSendTooFewOffers"
+      | "pathPaymentStrictSendOfferCrossSelf"
+      | "pathPaymentStrictSendUnderDestmin";
 
     readonly value:
       | 0
@@ -1107,19 +1119,19 @@ export namespace xdr {
 
   class ManageSellOfferResultCode {
     readonly name:
-      | 'manageSellOfferSuccess'
-      | 'manageSellOfferMalformed'
-      | 'manageSellOfferSellNoTrust'
-      | 'manageSellOfferBuyNoTrust'
-      | 'manageSellOfferSellNotAuthorized'
-      | 'manageSellOfferBuyNotAuthorized'
-      | 'manageSellOfferLineFull'
-      | 'manageSellOfferUnderfunded'
-      | 'manageSellOfferCrossSelf'
-      | 'manageSellOfferSellNoIssuer'
-      | 'manageSellOfferBuyNoIssuer'
-      | 'manageSellOfferNotFound'
-      | 'manageSellOfferLowReserve';
+      | "manageSellOfferSuccess"
+      | "manageSellOfferMalformed"
+      | "manageSellOfferSellNoTrust"
+      | "manageSellOfferBuyNoTrust"
+      | "manageSellOfferSellNotAuthorized"
+      | "manageSellOfferBuyNotAuthorized"
+      | "manageSellOfferLineFull"
+      | "manageSellOfferUnderfunded"
+      | "manageSellOfferCrossSelf"
+      | "manageSellOfferSellNoIssuer"
+      | "manageSellOfferBuyNoIssuer"
+      | "manageSellOfferNotFound"
+      | "manageSellOfferLowReserve";
 
     readonly value:
       | 0
@@ -1165,9 +1177,9 @@ export namespace xdr {
 
   class ManageOfferEffect {
     readonly name:
-      | 'manageOfferCreated'
-      | 'manageOfferUpdated'
-      | 'manageOfferDeleted';
+      | "manageOfferCreated"
+      | "manageOfferUpdated"
+      | "manageOfferDeleted";
 
     readonly value: 0 | 1 | 2;
 
@@ -1180,19 +1192,19 @@ export namespace xdr {
 
   class ManageBuyOfferResultCode {
     readonly name:
-      | 'manageBuyOfferSuccess'
-      | 'manageBuyOfferMalformed'
-      | 'manageBuyOfferSellNoTrust'
-      | 'manageBuyOfferBuyNoTrust'
-      | 'manageBuyOfferSellNotAuthorized'
-      | 'manageBuyOfferBuyNotAuthorized'
-      | 'manageBuyOfferLineFull'
-      | 'manageBuyOfferUnderfunded'
-      | 'manageBuyOfferCrossSelf'
-      | 'manageBuyOfferSellNoIssuer'
-      | 'manageBuyOfferBuyNoIssuer'
-      | 'manageBuyOfferNotFound'
-      | 'manageBuyOfferLowReserve';
+      | "manageBuyOfferSuccess"
+      | "manageBuyOfferMalformed"
+      | "manageBuyOfferSellNoTrust"
+      | "manageBuyOfferBuyNoTrust"
+      | "manageBuyOfferSellNotAuthorized"
+      | "manageBuyOfferBuyNotAuthorized"
+      | "manageBuyOfferLineFull"
+      | "manageBuyOfferUnderfunded"
+      | "manageBuyOfferCrossSelf"
+      | "manageBuyOfferSellNoIssuer"
+      | "manageBuyOfferBuyNoIssuer"
+      | "manageBuyOfferNotFound"
+      | "manageBuyOfferLowReserve";
 
     readonly value:
       | 0
@@ -1238,17 +1250,17 @@ export namespace xdr {
 
   class SetOptionsResultCode {
     readonly name:
-      | 'setOptionsSuccess'
-      | 'setOptionsLowReserve'
-      | 'setOptionsTooManySigners'
-      | 'setOptionsBadFlags'
-      | 'setOptionsInvalidInflation'
-      | 'setOptionsCantChange'
-      | 'setOptionsUnknownFlag'
-      | 'setOptionsThresholdOutOfRange'
-      | 'setOptionsBadSigner'
-      | 'setOptionsInvalidHomeDomain'
-      | 'setOptionsAuthRevocableRequired';
+      | "setOptionsSuccess"
+      | "setOptionsLowReserve"
+      | "setOptionsTooManySigners"
+      | "setOptionsBadFlags"
+      | "setOptionsInvalidInflation"
+      | "setOptionsCantChange"
+      | "setOptionsUnknownFlag"
+      | "setOptionsThresholdOutOfRange"
+      | "setOptionsBadSigner"
+      | "setOptionsInvalidHomeDomain"
+      | "setOptionsAuthRevocableRequired";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9 | -10;
 
@@ -1277,15 +1289,15 @@ export namespace xdr {
 
   class ChangeTrustResultCode {
     readonly name:
-      | 'changeTrustSuccess'
-      | 'changeTrustMalformed'
-      | 'changeTrustNoIssuer'
-      | 'changeTrustInvalidLimit'
-      | 'changeTrustLowReserve'
-      | 'changeTrustSelfNotAllowed'
-      | 'changeTrustTrustLineMissing'
-      | 'changeTrustCannotDelete'
-      | 'changeTrustNotAuthMaintainLiabilities';
+      | "changeTrustSuccess"
+      | "changeTrustMalformed"
+      | "changeTrustNoIssuer"
+      | "changeTrustInvalidLimit"
+      | "changeTrustLowReserve"
+      | "changeTrustSelfNotAllowed"
+      | "changeTrustTrustLineMissing"
+      | "changeTrustCannotDelete"
+      | "changeTrustNotAuthMaintainLiabilities";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8;
 
@@ -1310,13 +1322,13 @@ export namespace xdr {
 
   class AllowTrustResultCode {
     readonly name:
-      | 'allowTrustSuccess'
-      | 'allowTrustMalformed'
-      | 'allowTrustNoTrustLine'
-      | 'allowTrustTrustNotRequired'
-      | 'allowTrustCantRevoke'
-      | 'allowTrustSelfNotAllowed'
-      | 'allowTrustLowReserve';
+      | "allowTrustSuccess"
+      | "allowTrustMalformed"
+      | "allowTrustNoTrustLine"
+      | "allowTrustTrustNotRequired"
+      | "allowTrustCantRevoke"
+      | "allowTrustSelfNotAllowed"
+      | "allowTrustLowReserve";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6;
 
@@ -1337,14 +1349,14 @@ export namespace xdr {
 
   class AccountMergeResultCode {
     readonly name:
-      | 'accountMergeSuccess'
-      | 'accountMergeMalformed'
-      | 'accountMergeNoAccount'
-      | 'accountMergeImmutableSet'
-      | 'accountMergeHasSubEntries'
-      | 'accountMergeSeqnumTooFar'
-      | 'accountMergeDestFull'
-      | 'accountMergeIsSponsor';
+      | "accountMergeSuccess"
+      | "accountMergeMalformed"
+      | "accountMergeNoAccount"
+      | "accountMergeImmutableSet"
+      | "accountMergeHasSubEntries"
+      | "accountMergeSeqnumTooFar"
+      | "accountMergeDestFull"
+      | "accountMergeIsSponsor";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7;
 
@@ -1366,7 +1378,7 @@ export namespace xdr {
   }
 
   class InflationResultCode {
-    readonly name: 'inflationSuccess' | 'inflationNotTime';
+    readonly name: "inflationSuccess" | "inflationNotTime";
 
     readonly value: 0 | -1;
 
@@ -1377,11 +1389,11 @@ export namespace xdr {
 
   class ManageDataResultCode {
     readonly name:
-      | 'manageDataSuccess'
-      | 'manageDataNotSupportedYet'
-      | 'manageDataNameNotFound'
-      | 'manageDataLowReserve'
-      | 'manageDataInvalidName';
+      | "manageDataSuccess"
+      | "manageDataNotSupportedYet"
+      | "manageDataNameNotFound"
+      | "manageDataLowReserve"
+      | "manageDataInvalidName";
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -1397,7 +1409,7 @@ export namespace xdr {
   }
 
   class BumpSequenceResultCode {
-    readonly name: 'bumpSequenceSuccess' | 'bumpSequenceBadSeq';
+    readonly name: "bumpSequenceSuccess" | "bumpSequenceBadSeq";
 
     readonly value: 0 | -1;
 
@@ -1408,12 +1420,12 @@ export namespace xdr {
 
   class CreateClaimableBalanceResultCode {
     readonly name:
-      | 'createClaimableBalanceSuccess'
-      | 'createClaimableBalanceMalformed'
-      | 'createClaimableBalanceLowReserve'
-      | 'createClaimableBalanceNoTrust'
-      | 'createClaimableBalanceNotAuthorized'
-      | 'createClaimableBalanceUnderfunded';
+      | "createClaimableBalanceSuccess"
+      | "createClaimableBalanceMalformed"
+      | "createClaimableBalanceLowReserve"
+      | "createClaimableBalanceNoTrust"
+      | "createClaimableBalanceNotAuthorized"
+      | "createClaimableBalanceUnderfunded";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1432,12 +1444,12 @@ export namespace xdr {
 
   class ClaimClaimableBalanceResultCode {
     readonly name:
-      | 'claimClaimableBalanceSuccess'
-      | 'claimClaimableBalanceDoesNotExist'
-      | 'claimClaimableBalanceCannotClaim'
-      | 'claimClaimableBalanceLineFull'
-      | 'claimClaimableBalanceNoTrust'
-      | 'claimClaimableBalanceNotAuthorized';
+      | "claimClaimableBalanceSuccess"
+      | "claimClaimableBalanceDoesNotExist"
+      | "claimClaimableBalanceCannotClaim"
+      | "claimClaimableBalanceLineFull"
+      | "claimClaimableBalanceNoTrust"
+      | "claimClaimableBalanceNotAuthorized";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1456,10 +1468,10 @@ export namespace xdr {
 
   class BeginSponsoringFutureReservesResultCode {
     readonly name:
-      | 'beginSponsoringFutureReservesSuccess'
-      | 'beginSponsoringFutureReservesMalformed'
-      | 'beginSponsoringFutureReservesAlreadySponsored'
-      | 'beginSponsoringFutureReservesRecursive';
+      | "beginSponsoringFutureReservesSuccess"
+      | "beginSponsoringFutureReservesMalformed"
+      | "beginSponsoringFutureReservesAlreadySponsored"
+      | "beginSponsoringFutureReservesRecursive";
 
     readonly value: 0 | -1 | -2 | -3;
 
@@ -1474,8 +1486,8 @@ export namespace xdr {
 
   class EndSponsoringFutureReservesResultCode {
     readonly name:
-      | 'endSponsoringFutureReservesSuccess'
-      | 'endSponsoringFutureReservesNotSponsored';
+      | "endSponsoringFutureReservesSuccess"
+      | "endSponsoringFutureReservesNotSponsored";
 
     readonly value: 0 | -1;
 
@@ -1486,12 +1498,12 @@ export namespace xdr {
 
   class RevokeSponsorshipResultCode {
     readonly name:
-      | 'revokeSponsorshipSuccess'
-      | 'revokeSponsorshipDoesNotExist'
-      | 'revokeSponsorshipNotSponsor'
-      | 'revokeSponsorshipLowReserve'
-      | 'revokeSponsorshipOnlyTransferable'
-      | 'revokeSponsorshipMalformed';
+      | "revokeSponsorshipSuccess"
+      | "revokeSponsorshipDoesNotExist"
+      | "revokeSponsorshipNotSponsor"
+      | "revokeSponsorshipLowReserve"
+      | "revokeSponsorshipOnlyTransferable"
+      | "revokeSponsorshipMalformed";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1510,11 +1522,11 @@ export namespace xdr {
 
   class ClawbackResultCode {
     readonly name:
-      | 'clawbackSuccess'
-      | 'clawbackMalformed'
-      | 'clawbackNotClawbackEnabled'
-      | 'clawbackNoTrust'
-      | 'clawbackUnderfunded';
+      | "clawbackSuccess"
+      | "clawbackMalformed"
+      | "clawbackNotClawbackEnabled"
+      | "clawbackNoTrust"
+      | "clawbackUnderfunded";
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -1531,10 +1543,10 @@ export namespace xdr {
 
   class ClawbackClaimableBalanceResultCode {
     readonly name:
-      | 'clawbackClaimableBalanceSuccess'
-      | 'clawbackClaimableBalanceDoesNotExist'
-      | 'clawbackClaimableBalanceNotIssuer'
-      | 'clawbackClaimableBalanceNotClawbackEnabled';
+      | "clawbackClaimableBalanceSuccess"
+      | "clawbackClaimableBalanceDoesNotExist"
+      | "clawbackClaimableBalanceNotIssuer"
+      | "clawbackClaimableBalanceNotClawbackEnabled";
 
     readonly value: 0 | -1 | -2 | -3;
 
@@ -1549,12 +1561,12 @@ export namespace xdr {
 
   class SetTrustLineFlagsResultCode {
     readonly name:
-      | 'setTrustLineFlagsSuccess'
-      | 'setTrustLineFlagsMalformed'
-      | 'setTrustLineFlagsNoTrustLine'
-      | 'setTrustLineFlagsCantRevoke'
-      | 'setTrustLineFlagsInvalidState'
-      | 'setTrustLineFlagsLowReserve';
+      | "setTrustLineFlagsSuccess"
+      | "setTrustLineFlagsMalformed"
+      | "setTrustLineFlagsNoTrustLine"
+      | "setTrustLineFlagsCantRevoke"
+      | "setTrustLineFlagsInvalidState"
+      | "setTrustLineFlagsLowReserve";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1573,14 +1585,14 @@ export namespace xdr {
 
   class LiquidityPoolDepositResultCode {
     readonly name:
-      | 'liquidityPoolDepositSuccess'
-      | 'liquidityPoolDepositMalformed'
-      | 'liquidityPoolDepositNoTrust'
-      | 'liquidityPoolDepositNotAuthorized'
-      | 'liquidityPoolDepositUnderfunded'
-      | 'liquidityPoolDepositLineFull'
-      | 'liquidityPoolDepositBadPrice'
-      | 'liquidityPoolDepositPoolFull';
+      | "liquidityPoolDepositSuccess"
+      | "liquidityPoolDepositMalformed"
+      | "liquidityPoolDepositNoTrust"
+      | "liquidityPoolDepositNotAuthorized"
+      | "liquidityPoolDepositUnderfunded"
+      | "liquidityPoolDepositLineFull"
+      | "liquidityPoolDepositBadPrice"
+      | "liquidityPoolDepositPoolFull";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7;
 
@@ -1603,12 +1615,12 @@ export namespace xdr {
 
   class LiquidityPoolWithdrawResultCode {
     readonly name:
-      | 'liquidityPoolWithdrawSuccess'
-      | 'liquidityPoolWithdrawMalformed'
-      | 'liquidityPoolWithdrawNoTrust'
-      | 'liquidityPoolWithdrawUnderfunded'
-      | 'liquidityPoolWithdrawLineFull'
-      | 'liquidityPoolWithdrawUnderMinimum';
+      | "liquidityPoolWithdrawSuccess"
+      | "liquidityPoolWithdrawMalformed"
+      | "liquidityPoolWithdrawNoTrust"
+      | "liquidityPoolWithdrawUnderfunded"
+      | "liquidityPoolWithdrawLineFull"
+      | "liquidityPoolWithdrawUnderMinimum";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1627,9 +1639,9 @@ export namespace xdr {
 
   class InvokeHostFunctionResultCode {
     readonly name:
-      | 'invokeHostFunctionSuccess'
-      | 'invokeHostFunctionMalformed'
-      | 'invokeHostFunctionTrapped';
+      | "invokeHostFunctionSuccess"
+      | "invokeHostFunctionMalformed"
+      | "invokeHostFunctionTrapped";
 
     readonly value: 0 | -1 | -2;
 
@@ -1642,13 +1654,13 @@ export namespace xdr {
 
   class OperationResultCode {
     readonly name:
-      | 'opInner'
-      | 'opBadAuth'
-      | 'opNoAccount'
-      | 'opNotSupported'
-      | 'opTooManySubentries'
-      | 'opExceededWorkLimit'
-      | 'opTooManySponsoring';
+      | "opInner"
+      | "opBadAuth"
+      | "opNoAccount"
+      | "opNotSupported"
+      | "opTooManySubentries"
+      | "opExceededWorkLimit"
+      | "opTooManySponsoring";
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6;
 
@@ -1669,24 +1681,24 @@ export namespace xdr {
 
   class TransactionResultCode {
     readonly name:
-      | 'txFeeBumpInnerSuccess'
-      | 'txSuccess'
-      | 'txFailed'
-      | 'txTooEarly'
-      | 'txTooLate'
-      | 'txMissingOperation'
-      | 'txBadSeq'
-      | 'txBadAuth'
-      | 'txInsufficientBalance'
-      | 'txNoAccount'
-      | 'txInsufficientFee'
-      | 'txBadAuthExtra'
-      | 'txInternalError'
-      | 'txNotSupported'
-      | 'txFeeBumpInnerFailed'
-      | 'txBadSponsorship'
-      | 'txBadMinSeqAgeOrGap'
-      | 'txMalformed';
+      | "txFeeBumpInnerSuccess"
+      | "txSuccess"
+      | "txFailed"
+      | "txTooEarly"
+      | "txTooLate"
+      | "txMissingOperation"
+      | "txBadSeq"
+      | "txBadAuth"
+      | "txInsufficientBalance"
+      | "txNoAccount"
+      | "txInsufficientFee"
+      | "txBadAuthExtra"
+      | "txInternalError"
+      | "txNotSupported"
+      | "txFeeBumpInnerFailed"
+      | "txBadSponsorship"
+      | "txBadMinSeqAgeOrGap"
+      | "txMalformed";
 
     readonly value:
       | 1
@@ -1747,11 +1759,11 @@ export namespace xdr {
 
   class CryptoKeyType {
     readonly name:
-      | 'keyTypeEd25519'
-      | 'keyTypePreAuthTx'
-      | 'keyTypeHashX'
-      | 'keyTypeEd25519SignedPayload'
-      | 'keyTypeMuxedEd25519';
+      | "keyTypeEd25519"
+      | "keyTypePreAuthTx"
+      | "keyTypeHashX"
+      | "keyTypeEd25519SignedPayload"
+      | "keyTypeMuxedEd25519";
 
     readonly value: 0 | 1 | 2 | 3 | 256;
 
@@ -1767,7 +1779,7 @@ export namespace xdr {
   }
 
   class PublicKeyType {
-    readonly name: 'publicKeyTypeEd25519';
+    readonly name: "publicKeyTypeEd25519";
 
     readonly value: 0;
 
@@ -1776,10 +1788,10 @@ export namespace xdr {
 
   class SignerKeyType {
     readonly name:
-      | 'signerKeyTypeEd25519'
-      | 'signerKeyTypePreAuthTx'
-      | 'signerKeyTypeHashX'
-      | 'signerKeyTypeEd25519SignedPayload';
+      | "signerKeyTypeEd25519"
+      | "signerKeyTypePreAuthTx"
+      | "signerKeyTypeHashX"
+      | "signerKeyTypeEd25519SignedPayload";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -1794,28 +1806,28 @@ export namespace xdr {
 
   class ScValType {
     readonly name:
-      | 'scvBool'
-      | 'scvVoid'
-      | 'scvStatus'
-      | 'scvU32'
-      | 'scvI32'
-      | 'scvU64'
-      | 'scvI64'
-      | 'scvTimepoint'
-      | 'scvDuration'
-      | 'scvU128'
-      | 'scvI128'
-      | 'scvU256'
-      | 'scvI256'
-      | 'scvBytes'
-      | 'scvString'
-      | 'scvSymbol'
-      | 'scvVec'
-      | 'scvMap'
-      | 'scvContractExecutable'
-      | 'scvAddress'
-      | 'scvLedgerKeyContractExecutable'
-      | 'scvLedgerKeyNonce';
+      | "scvBool"
+      | "scvVoid"
+      | "scvStatus"
+      | "scvU32"
+      | "scvI32"
+      | "scvU64"
+      | "scvI64"
+      | "scvTimepoint"
+      | "scvDuration"
+      | "scvU128"
+      | "scvI128"
+      | "scvU256"
+      | "scvI256"
+      | "scvBytes"
+      | "scvString"
+      | "scvSymbol"
+      | "scvVec"
+      | "scvMap"
+      | "scvContractExecutable"
+      | "scvAddress"
+      | "scvLedgerKeyContractExecutable"
+      | "scvLedgerKeyNonce";
 
     readonly value:
       | 0
@@ -1888,16 +1900,16 @@ export namespace xdr {
 
   class ScStatusType {
     readonly name:
-      | 'sstOk'
-      | 'sstUnknownError'
-      | 'sstHostValueError'
-      | 'sstHostObjectError'
-      | 'sstHostFunctionError'
-      | 'sstHostStorageError'
-      | 'sstHostContextError'
-      | 'sstVmError'
-      | 'sstContractError'
-      | 'sstHostAuthError';
+      | "sstOk"
+      | "sstUnknownError"
+      | "sstHostValueError"
+      | "sstHostObjectError"
+      | "sstHostFunctionError"
+      | "sstHostStorageError"
+      | "sstHostContextError"
+      | "sstVmError"
+      | "sstContractError"
+      | "sstHostAuthError";
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
@@ -1924,18 +1936,18 @@ export namespace xdr {
 
   class ScHostValErrorCode {
     readonly name:
-      | 'hostValueUnknownError'
-      | 'hostValueReservedTagValue'
-      | 'hostValueUnexpectedValType'
-      | 'hostValueU63OutOfRange'
-      | 'hostValueU32OutOfRange'
-      | 'hostValueStaticUnknown'
-      | 'hostValueMissingObject'
-      | 'hostValueSymbolTooLong'
-      | 'hostValueSymbolBadChar'
-      | 'hostValueSymbolContainsNonUtf8'
-      | 'hostValueBitsetTooManyBits'
-      | 'hostValueStatusUnknown';
+      | "hostValueUnknownError"
+      | "hostValueReservedTagValue"
+      | "hostValueUnexpectedValType"
+      | "hostValueU63OutOfRange"
+      | "hostValueU32OutOfRange"
+      | "hostValueStaticUnknown"
+      | "hostValueMissingObject"
+      | "hostValueSymbolTooLong"
+      | "hostValueSymbolBadChar"
+      | "hostValueSymbolContainsNonUtf8"
+      | "hostValueBitsetTooManyBits"
+      | "hostValueStatusUnknown";
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
@@ -1966,13 +1978,13 @@ export namespace xdr {
 
   class ScHostObjErrorCode {
     readonly name:
-      | 'hostObjectUnknownError'
-      | 'hostObjectUnknownReference'
-      | 'hostObjectUnexpectedType'
-      | 'hostObjectObjectCountExceedsU32Max'
-      | 'hostObjectObjectNotExist'
-      | 'hostObjectVecIndexOutOfBound'
-      | 'hostObjectContractHashWrongLength';
+      | "hostObjectUnknownError"
+      | "hostObjectUnknownReference"
+      | "hostObjectUnexpectedType"
+      | "hostObjectObjectCountExceedsU32Max"
+      | "hostObjectObjectNotExist"
+      | "hostObjectVecIndexOutOfBound"
+      | "hostObjectContractHashWrongLength";
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -1993,11 +2005,11 @@ export namespace xdr {
 
   class ScHostFnErrorCode {
     readonly name:
-      | 'hostFnUnknownError'
-      | 'hostFnUnexpectedHostFunctionAction'
-      | 'hostFnInputArgsWrongLength'
-      | 'hostFnInputArgsWrongType'
-      | 'hostFnInputArgsInvalid';
+      | "hostFnUnknownError"
+      | "hostFnUnexpectedHostFunctionAction"
+      | "hostFnInputArgsWrongLength"
+      | "hostFnInputArgsWrongType"
+      | "hostFnInputArgsInvalid";
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -2014,12 +2026,12 @@ export namespace xdr {
 
   class ScHostStorageErrorCode {
     readonly name:
-      | 'hostStorageUnknownError'
-      | 'hostStorageExpectContractData'
-      | 'hostStorageReadwriteAccessToReadonlyEntry'
-      | 'hostStorageAccessToUnknownEntry'
-      | 'hostStorageMissingKeyInGet'
-      | 'hostStorageGetOnDeletedKey';
+      | "hostStorageUnknownError"
+      | "hostStorageExpectContractData"
+      | "hostStorageReadwriteAccessToReadonlyEntry"
+      | "hostStorageAccessToUnknownEntry"
+      | "hostStorageMissingKeyInGet"
+      | "hostStorageGetOnDeletedKey";
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -2038,10 +2050,10 @@ export namespace xdr {
 
   class ScHostAuthErrorCode {
     readonly name:
-      | 'hostAuthUnknownError'
-      | 'hostAuthNonceError'
-      | 'hostAuthDuplicateAuthorization'
-      | 'hostAuthNotAuthorized';
+      | "hostAuthUnknownError"
+      | "hostAuthNonceError"
+      | "hostAuthDuplicateAuthorization"
+      | "hostAuthNotAuthorized";
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -2055,7 +2067,7 @@ export namespace xdr {
   }
 
   class ScHostContextErrorCode {
-    readonly name: 'hostContextUnknownError' | 'hostContextNoContractRunning';
+    readonly name: "hostContextUnknownError" | "hostContextNoContractRunning";
 
     readonly value: 0 | 1;
 
@@ -2066,25 +2078,25 @@ export namespace xdr {
 
   class ScVmErrorCode {
     readonly name:
-      | 'vmUnknown'
-      | 'vmValidation'
-      | 'vmInstantiation'
-      | 'vmFunction'
-      | 'vmTable'
-      | 'vmMemory'
-      | 'vmGlobal'
-      | 'vmValue'
-      | 'vmTrapUnreachable'
-      | 'vmTrapMemoryAccessOutOfBounds'
-      | 'vmTrapTableAccessOutOfBounds'
-      | 'vmTrapElemUninitialized'
-      | 'vmTrapDivisionByZero'
-      | 'vmTrapIntegerOverflow'
-      | 'vmTrapInvalidConversionToInt'
-      | 'vmTrapStackOverflow'
-      | 'vmTrapUnexpectedSignature'
-      | 'vmTrapMemLimitExceeded'
-      | 'vmTrapCpuLimitExceeded';
+      | "vmUnknown"
+      | "vmValidation"
+      | "vmInstantiation"
+      | "vmFunction"
+      | "vmTable"
+      | "vmMemory"
+      | "vmGlobal"
+      | "vmValue"
+      | "vmTrapUnreachable"
+      | "vmTrapMemoryAccessOutOfBounds"
+      | "vmTrapTableAccessOutOfBounds"
+      | "vmTrapElemUninitialized"
+      | "vmTrapDivisionByZero"
+      | "vmTrapIntegerOverflow"
+      | "vmTrapInvalidConversionToInt"
+      | "vmTrapStackOverflow"
+      | "vmTrapUnexpectedSignature"
+      | "vmTrapMemLimitExceeded"
+      | "vmTrapCpuLimitExceeded";
 
     readonly value:
       | 0
@@ -2147,7 +2159,7 @@ export namespace xdr {
   }
 
   class ScUnknownErrorCode {
-    readonly name: 'unknownErrorGeneral' | 'unknownErrorXdr';
+    readonly name: "unknownErrorGeneral" | "unknownErrorXdr";
 
     readonly value: 0 | 1;
 
@@ -2157,7 +2169,7 @@ export namespace xdr {
   }
 
   class ScContractExecutableType {
-    readonly name: 'sccontractExecutableWasmRef' | 'sccontractExecutableToken';
+    readonly name: "sccontractExecutableWasmRef" | "sccontractExecutableToken";
 
     readonly value: 0 | 1;
 
@@ -2167,7 +2179,7 @@ export namespace xdr {
   }
 
   class ScAddressType {
-    readonly name: 'scAddressTypeAccount' | 'scAddressTypeContract';
+    readonly name: "scAddressTypeAccount" | "scAddressTypeContract";
 
     readonly value: 0 | 1;
 
@@ -2177,7 +2189,7 @@ export namespace xdr {
   }
 
   class ScEnvMetaKind {
-    readonly name: 'scEnvMetaKindInterfaceVersion';
+    readonly name: "scEnvMetaKindInterfaceVersion";
 
     readonly value: 0;
 
@@ -2186,32 +2198,32 @@ export namespace xdr {
 
   class ScSpecType {
     readonly name:
-      | 'scSpecTypeVal'
-      | 'scSpecTypeBool'
-      | 'scSpecTypeVoid'
-      | 'scSpecTypeStatus'
-      | 'scSpecTypeU32'
-      | 'scSpecTypeI32'
-      | 'scSpecTypeU64'
-      | 'scSpecTypeI64'
-      | 'scSpecTypeTimepoint'
-      | 'scSpecTypeDuration'
-      | 'scSpecTypeU128'
-      | 'scSpecTypeI128'
-      | 'scSpecTypeU256'
-      | 'scSpecTypeI256'
-      | 'scSpecTypeBytes'
-      | 'scSpecTypeString'
-      | 'scSpecTypeSymbol'
-      | 'scSpecTypeAddress'
-      | 'scSpecTypeOption'
-      | 'scSpecTypeResult'
-      | 'scSpecTypeVec'
-      | 'scSpecTypeSet'
-      | 'scSpecTypeMap'
-      | 'scSpecTypeTuple'
-      | 'scSpecTypeBytesN'
-      | 'scSpecTypeUdt';
+      | "scSpecTypeVal"
+      | "scSpecTypeBool"
+      | "scSpecTypeVoid"
+      | "scSpecTypeStatus"
+      | "scSpecTypeU32"
+      | "scSpecTypeI32"
+      | "scSpecTypeU64"
+      | "scSpecTypeI64"
+      | "scSpecTypeTimepoint"
+      | "scSpecTypeDuration"
+      | "scSpecTypeU128"
+      | "scSpecTypeI128"
+      | "scSpecTypeU256"
+      | "scSpecTypeI256"
+      | "scSpecTypeBytes"
+      | "scSpecTypeString"
+      | "scSpecTypeSymbol"
+      | "scSpecTypeAddress"
+      | "scSpecTypeOption"
+      | "scSpecTypeResult"
+      | "scSpecTypeVec"
+      | "scSpecTypeSet"
+      | "scSpecTypeMap"
+      | "scSpecTypeTuple"
+      | "scSpecTypeBytesN"
+      | "scSpecTypeUdt";
 
     readonly value:
       | 0
@@ -2295,7 +2307,7 @@ export namespace xdr {
   }
 
   class ScSpecUdtUnionCaseV0Kind {
-    readonly name: 'scSpecUdtUnionCaseVoidV0' | 'scSpecUdtUnionCaseTupleV0';
+    readonly name: "scSpecUdtUnionCaseVoidV0" | "scSpecUdtUnionCaseTupleV0";
 
     readonly value: 0 | 1;
 
@@ -2306,11 +2318,11 @@ export namespace xdr {
 
   class ScSpecEntryKind {
     readonly name:
-      | 'scSpecEntryFunctionV0'
-      | 'scSpecEntryUdtStructV0'
-      | 'scSpecEntryUdtUnionV0'
-      | 'scSpecEntryUdtEnumV0'
-      | 'scSpecEntryUdtErrorEnumV0';
+      | "scSpecEntryFunctionV0"
+      | "scSpecEntryUdtStructV0"
+      | "scSpecEntryUdtUnionV0"
+      | "scSpecEntryUdtEnumV0"
+      | "scSpecEntryUdtErrorEnumV0";
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -2337,7 +2349,9 @@ export namespace xdr {
 
   const DataValue: VarOpaque;
 
-  type PoolId = typeof Hash;
+  type Hash = Opaque[];
+
+  type PoolId = Hash;
 
   const AssetCode4: Opaque;
 
@@ -2353,9 +2367,9 @@ export namespace xdr {
 
   const PeerStatList: XDRArray<PeerStats>;
 
-  const TxAdvertVector: XDRArray<typeof Hash>;
+  const TxAdvertVector: XDRArray<Hash>;
 
-  const TxDemandVector: XDRArray<typeof Hash>;
+  const TxDemandVector: XDRArray<Hash>;
 
   const Hash: Opaque;
 
@@ -2398,9 +2412,9 @@ export namespace xdr {
 
     value(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpBallot;
 
@@ -2410,13 +2424,13 @@ export namespace xdr {
 
     static toXDR(value: ScpBallot): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpBallot;
+    static fromXDR(input: Buffer, format?: "raw"): ScpBallot;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpBallot;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpBallot;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpNomination {
@@ -2432,9 +2446,9 @@ export namespace xdr {
 
     accepted(value?: Buffer[]): Buffer[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpNomination;
 
@@ -2444,13 +2458,13 @@ export namespace xdr {
 
     static toXDR(value: ScpNomination): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpNomination;
+    static fromXDR(input: Buffer, format?: "raw"): ScpNomination;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpNomination;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpNomination;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatementPrepare {
@@ -2475,9 +2489,9 @@ export namespace xdr {
 
     nH(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpStatementPrepare;
 
@@ -2487,16 +2501,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementPrepare): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementPrepare;
+    static fromXDR(input: Buffer, format?: "raw"): ScpStatementPrepare;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScpStatementPrepare;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatementConfirm {
@@ -2518,9 +2532,9 @@ export namespace xdr {
 
     quorumSetHash(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpStatementConfirm;
 
@@ -2530,16 +2544,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementConfirm): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementConfirm;
+    static fromXDR(input: Buffer, format?: "raw"): ScpStatementConfirm;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScpStatementConfirm;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatementExternalize {
@@ -2555,9 +2569,9 @@ export namespace xdr {
 
     commitQuorumSetHash(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpStatementExternalize;
 
@@ -2567,16 +2581,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementExternalize): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementExternalize;
+    static fromXDR(input: Buffer, format?: "raw"): ScpStatementExternalize;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScpStatementExternalize;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatement {
@@ -2592,9 +2606,9 @@ export namespace xdr {
 
     pledges(value?: ScpStatementPledges): ScpStatementPledges;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpStatement;
 
@@ -2604,13 +2618,13 @@ export namespace xdr {
 
     static toXDR(value: ScpStatement): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpStatement;
+    static fromXDR(input: Buffer, format?: "raw"): ScpStatement;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpStatement;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpStatement;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpEnvelope {
@@ -2620,9 +2634,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpEnvelope;
 
@@ -2632,13 +2646,13 @@ export namespace xdr {
 
     static toXDR(value: ScpEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpEnvelope;
+    static fromXDR(input: Buffer, format?: "raw"): ScpEnvelope;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpEnvelope;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpEnvelope;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpQuorumSet {
@@ -2654,9 +2668,9 @@ export namespace xdr {
 
     innerSets(value?: ScpQuorumSet[]): ScpQuorumSet[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpQuorumSet;
 
@@ -2666,13 +2680,13 @@ export namespace xdr {
 
     static toXDR(value: ScpQuorumSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpQuorumSet;
+    static fromXDR(input: Buffer, format?: "raw"): ScpQuorumSet;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpQuorumSet;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpQuorumSet;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AlphaNum4 {
@@ -2682,9 +2696,9 @@ export namespace xdr {
 
     issuer(value?: AccountId): AccountId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AlphaNum4;
 
@@ -2694,13 +2708,13 @@ export namespace xdr {
 
     static toXDR(value: AlphaNum4): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AlphaNum4;
+    static fromXDR(input: Buffer, format?: "raw"): AlphaNum4;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AlphaNum4;
+    static fromXDR(input: string, format: "hex" | "base64"): AlphaNum4;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AlphaNum12 {
@@ -2710,9 +2724,9 @@ export namespace xdr {
 
     issuer(value?: AccountId): AccountId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AlphaNum12;
 
@@ -2722,13 +2736,13 @@ export namespace xdr {
 
     static toXDR(value: AlphaNum12): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AlphaNum12;
+    static fromXDR(input: Buffer, format?: "raw"): AlphaNum12;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AlphaNum12;
+    static fromXDR(input: string, format: "hex" | "base64"): AlphaNum12;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Price {
@@ -2738,9 +2752,9 @@ export namespace xdr {
 
     d(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Price;
 
@@ -2750,13 +2764,13 @@ export namespace xdr {
 
     static toXDR(value: Price): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Price;
+    static fromXDR(input: Buffer, format?: "raw"): Price;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Price;
+    static fromXDR(input: string, format: "hex" | "base64"): Price;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Liabilities {
@@ -2766,9 +2780,9 @@ export namespace xdr {
 
     selling(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Liabilities;
 
@@ -2778,13 +2792,13 @@ export namespace xdr {
 
     static toXDR(value: Liabilities): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Liabilities;
+    static fromXDR(input: Buffer, format?: "raw"): Liabilities;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Liabilities;
+    static fromXDR(input: string, format: "hex" | "base64"): Liabilities;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Signer {
@@ -2794,9 +2808,9 @@ export namespace xdr {
 
     weight(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Signer;
 
@@ -2806,13 +2820,13 @@ export namespace xdr {
 
     static toXDR(value: Signer): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Signer;
+    static fromXDR(input: Buffer, format?: "raw"): Signer;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Signer;
+    static fromXDR(input: string, format: "hex" | "base64"): Signer;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExtensionV3 {
@@ -2828,9 +2842,9 @@ export namespace xdr {
 
     seqTime(value?: TimePoint): TimePoint;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExtensionV3;
 
@@ -2840,16 +2854,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV3): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV3;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV3;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AccountEntryExtensionV3;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExtensionV2 {
@@ -2870,9 +2884,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExtensionV2Ext): AccountEntryExtensionV2Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExtensionV2;
 
@@ -2882,16 +2896,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV2;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV2;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AccountEntryExtensionV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExtensionV1 {
@@ -2904,9 +2918,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExtensionV1Ext): AccountEntryExtensionV1Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExtensionV1;
 
@@ -2916,16 +2930,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV1;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AccountEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntry {
@@ -2962,9 +2976,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExt): AccountEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntry;
 
@@ -2974,13 +2988,13 @@ export namespace xdr {
 
     static toXDR(value: AccountEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntry;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AccountEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): AccountEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntryExtensionV2 {
@@ -2993,9 +3007,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryExtensionV2Ext): TrustLineEntryExtensionV2Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntryExtensionV2;
 
@@ -3005,16 +3019,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExtensionV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExtensionV2;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExtensionV2;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TrustLineEntryExtensionV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntryV1 {
@@ -3027,9 +3041,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryV1Ext): TrustLineEntryV1Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntryV1;
 
@@ -3039,13 +3053,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryV1;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryV1;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntryV1;
+    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntryV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntry {
@@ -3070,9 +3084,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryExt): TrustLineEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntry;
 
@@ -3082,13 +3096,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntry;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OfferEntry {
@@ -3119,9 +3133,9 @@ export namespace xdr {
 
     ext(value?: OfferEntryExt): OfferEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OfferEntry;
 
@@ -3131,13 +3145,13 @@ export namespace xdr {
 
     static toXDR(value: OfferEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OfferEntry;
+    static fromXDR(input: Buffer, format?: "raw"): OfferEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OfferEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): OfferEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class DataEntry {
@@ -3156,9 +3170,9 @@ export namespace xdr {
 
     ext(value?: DataEntryExt): DataEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): DataEntry;
 
@@ -3168,13 +3182,13 @@ export namespace xdr {
 
     static toXDR(value: DataEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): DataEntry;
+    static fromXDR(input: Buffer, format?: "raw"): DataEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): DataEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): DataEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimantV0 {
@@ -3187,9 +3201,9 @@ export namespace xdr {
 
     predicate(value?: ClaimPredicate): ClaimPredicate;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimantV0;
 
@@ -3199,13 +3213,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimantV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimantV0;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimantV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimantV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimantV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimableBalanceEntryExtensionV1 {
@@ -3220,9 +3234,9 @@ export namespace xdr {
 
     flags(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExtensionV1;
 
@@ -3234,17 +3248,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): ClaimableBalanceEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimableBalanceEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimableBalanceEntry {
@@ -3266,9 +3280,9 @@ export namespace xdr {
 
     ext(value?: ClaimableBalanceEntryExt): ClaimableBalanceEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimableBalanceEntry;
 
@@ -3278,16 +3292,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceEntry;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceEntry;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimableBalanceEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolConstantProductParameters {
@@ -3299,9 +3313,9 @@ export namespace xdr {
 
     fee(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolConstantProductParameters;
 
@@ -3316,17 +3330,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): LiquidityPoolConstantProductParameters;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolConstantProductParameters;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolEntryConstantProduct {
@@ -3350,9 +3364,9 @@ export namespace xdr {
 
     poolSharesTrustLineCount(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolEntryConstantProduct;
 
@@ -3364,17 +3378,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): LiquidityPoolEntryConstantProduct;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolEntryConstantProduct;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolEntry {
@@ -3387,9 +3401,9 @@ export namespace xdr {
 
     body(value?: LiquidityPoolEntryBody): LiquidityPoolEntryBody;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolEntry;
 
@@ -3399,13 +3413,13 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolEntry;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LiquidityPoolEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): LiquidityPoolEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ContractDataEntry {
@@ -3417,9 +3431,9 @@ export namespace xdr {
 
     val(value?: ScVal): ScVal;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ContractDataEntry;
 
@@ -3429,13 +3443,13 @@ export namespace xdr {
 
     static toXDR(value: ContractDataEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ContractDataEntry;
+    static fromXDR(input: Buffer, format?: "raw"): ContractDataEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ContractDataEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): ContractDataEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ContractCodeEntry {
@@ -3451,9 +3465,9 @@ export namespace xdr {
 
     code(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ContractCodeEntry;
 
@@ -3463,47 +3477,247 @@ export namespace xdr {
 
     static toXDR(value: ContractCodeEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ContractCodeEntry;
+    static fromXDR(input: Buffer, format?: "raw"): ContractCodeEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ContractCodeEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): ContractCodeEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
-  class ConfigSettingEntry {
+  class ConfigSettingContractComputeV0 {
     constructor(attributes: {
-      ext: ConfigSettingEntryExt;
-      configSettingId: ConfigSettingId;
-      setting: ConfigSetting;
+      ledgerMaxInstructions: Int64;
+      txMaxInstructions: Int64;
+      feeRatePerInstructionsIncrement: Int64;
+      memoryLimit: number;
     });
 
-    ext(value?: ConfigSettingEntryExt): ConfigSettingEntryExt;
+    ledgerMaxInstructions(value?: Int64): Int64;
 
-    configSettingId(value?: ConfigSettingId): ConfigSettingId;
+    txMaxInstructions(value?: Int64): Int64;
 
-    setting(value?: ConfigSetting): ConfigSetting;
+    feeRatePerInstructionsIncrement(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    memoryLimit(value?: number): number;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format?: "raw"): Buffer;
 
-    static read(io: Buffer): ConfigSettingEntry;
+    toXDR(format: "hex" | "base64"): string;
 
-    static write(value: ConfigSettingEntry, io: Buffer): void;
+    static read(io: Buffer): ConfigSettingContractComputeV0;
 
-    static isValid(value: ConfigSettingEntry): boolean;
+    static write(value: ConfigSettingContractComputeV0, io: Buffer): void;
 
-    static toXDR(value: ConfigSettingEntry): Buffer;
+    static isValid(value: ConfigSettingContractComputeV0): boolean;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ConfigSettingEntry;
+    static toXDR(value: ConfigSettingContractComputeV0): Buffer;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ConfigSettingEntry;
+    static fromXDR(
+      input: Buffer,
+      format?: "raw"
+    ): ConfigSettingContractComputeV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static fromXDR(
+      input: string,
+      format: "hex" | "base64"
+    ): ConfigSettingContractComputeV0;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class ConfigSettingContractLedgerCostV0 {
+    constructor(attributes: {
+      ledgerMaxReadLedgerEntries: number;
+      ledgerMaxReadBytes: number;
+      ledgerMaxWriteLedgerEntries: number;
+      ledgerMaxWriteBytes: number;
+      txMaxReadLedgerEntries: number;
+      txMaxReadBytes: number;
+      txMaxWriteLedgerEntries: number;
+      txMaxWriteBytes: number;
+      feeReadLedgerEntry: Int64;
+      feeWriteLedgerEntry: Int64;
+      feeRead1Kb: Int64;
+      feeWrite1Kb: Int64;
+      bucketListSizeBytes: Int64;
+      bucketListFeeRateLow: Int64;
+      bucketListFeeRateHigh: Int64;
+      bucketListGrowthFactor: number;
+    });
+
+    ledgerMaxReadLedgerEntries(value?: number): number;
+
+    ledgerMaxReadBytes(value?: number): number;
+
+    ledgerMaxWriteLedgerEntries(value?: number): number;
+
+    ledgerMaxWriteBytes(value?: number): number;
+
+    txMaxReadLedgerEntries(value?: number): number;
+
+    txMaxReadBytes(value?: number): number;
+
+    txMaxWriteLedgerEntries(value?: number): number;
+
+    txMaxWriteBytes(value?: number): number;
+
+    feeReadLedgerEntry(value?: Int64): Int64;
+
+    feeWriteLedgerEntry(value?: Int64): Int64;
+
+    feeRead1Kb(value?: Int64): Int64;
+
+    feeWrite1Kb(value?: Int64): Int64;
+
+    bucketListSizeBytes(value?: Int64): Int64;
+
+    bucketListFeeRateLow(value?: Int64): Int64;
+
+    bucketListFeeRateHigh(value?: Int64): Int64;
+
+    bucketListGrowthFactor(value?: number): number;
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): ConfigSettingContractLedgerCostV0;
+
+    static write(value: ConfigSettingContractLedgerCostV0, io: Buffer): void;
+
+    static isValid(value: ConfigSettingContractLedgerCostV0): boolean;
+
+    static toXDR(value: ConfigSettingContractLedgerCostV0): Buffer;
+
+    static fromXDR(
+      input: Buffer,
+      format?: "raw"
+    ): ConfigSettingContractLedgerCostV0;
+
+    static fromXDR(
+      input: string,
+      format: "hex" | "base64"
+    ): ConfigSettingContractLedgerCostV0;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class ConfigSettingContractHistoricalDataV0 {
+    constructor(attributes: { feeHistorical1Kb: Int64 });
+
+    feeHistorical1Kb(value?: Int64): Int64;
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): ConfigSettingContractHistoricalDataV0;
+
+    static write(
+      value: ConfigSettingContractHistoricalDataV0,
+      io: Buffer
+    ): void;
+
+    static isValid(value: ConfigSettingContractHistoricalDataV0): boolean;
+
+    static toXDR(value: ConfigSettingContractHistoricalDataV0): Buffer;
+
+    static fromXDR(
+      input: Buffer,
+      format?: "raw"
+    ): ConfigSettingContractHistoricalDataV0;
+
+    static fromXDR(
+      input: string,
+      format: "hex" | "base64"
+    ): ConfigSettingContractHistoricalDataV0;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class ConfigSettingContractMetaDataV0 {
+    constructor(attributes: {
+      txMaxExtendedMetaDataSizeBytes: number;
+      feeExtendedMetaData1Kb: Int64;
+    });
+
+    txMaxExtendedMetaDataSizeBytes(value?: number): number;
+
+    feeExtendedMetaData1Kb(value?: Int64): Int64;
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): ConfigSettingContractMetaDataV0;
+
+    static write(value: ConfigSettingContractMetaDataV0, io: Buffer): void;
+
+    static isValid(value: ConfigSettingContractMetaDataV0): boolean;
+
+    static toXDR(value: ConfigSettingContractMetaDataV0): Buffer;
+
+    static fromXDR(
+      input: Buffer,
+      format?: "raw"
+    ): ConfigSettingContractMetaDataV0;
+
+    static fromXDR(
+      input: string,
+      format: "hex" | "base64"
+    ): ConfigSettingContractMetaDataV0;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class ConfigSettingContractBandwidthV0 {
+    constructor(attributes: {
+      ledgerMaxPropagateSizeBytes: number;
+      txMaxSizeBytes: number;
+      feePropagateData1Kb: Int64;
+    });
+
+    ledgerMaxPropagateSizeBytes(value?: number): number;
+
+    txMaxSizeBytes(value?: number): number;
+
+    feePropagateData1Kb(value?: Int64): Int64;
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): ConfigSettingContractBandwidthV0;
+
+    static write(value: ConfigSettingContractBandwidthV0, io: Buffer): void;
+
+    static isValid(value: ConfigSettingContractBandwidthV0): boolean;
+
+    static toXDR(value: ConfigSettingContractBandwidthV0): Buffer;
+
+    static fromXDR(
+      input: Buffer,
+      format?: "raw"
+    ): ConfigSettingContractBandwidthV0;
+
+    static fromXDR(
+      input: string,
+      format: "hex" | "base64"
+    ): ConfigSettingContractBandwidthV0;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntryExtensionV1 {
@@ -3516,9 +3730,9 @@ export namespace xdr {
 
     ext(value?: LedgerEntryExtensionV1Ext): LedgerEntryExtensionV1Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntryExtensionV1;
 
@@ -3528,16 +3742,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExtensionV1;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntry {
@@ -3553,9 +3767,9 @@ export namespace xdr {
 
     ext(value?: LedgerEntryExt): LedgerEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntry;
 
@@ -3565,13 +3779,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntry;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyAccount {
@@ -3579,9 +3793,9 @@ export namespace xdr {
 
     accountId(value?: AccountId): AccountId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyAccount;
 
@@ -3591,13 +3805,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyAccount): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyAccount;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyAccount;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyAccount;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyAccount;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyTrustLine {
@@ -3607,9 +3821,9 @@ export namespace xdr {
 
     asset(value?: TrustLineAsset): TrustLineAsset;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyTrustLine;
 
@@ -3619,13 +3833,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyTrustLine): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyTrustLine;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyTrustLine;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyTrustLine;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyTrustLine;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyOffer {
@@ -3635,9 +3849,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyOffer;
 
@@ -3647,13 +3861,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyOffer): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyOffer;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyOffer;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyOffer;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyOffer;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyData {
@@ -3666,9 +3880,9 @@ export namespace xdr {
 
     dataName(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyData;
 
@@ -3678,13 +3892,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyData): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyData;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyData;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyData;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyData;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyClaimableBalance {
@@ -3692,9 +3906,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyClaimableBalance;
 
@@ -3704,16 +3918,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyClaimableBalance): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyClaimableBalance;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyClaimableBalance;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerKeyClaimableBalance;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyLiquidityPool {
@@ -3721,9 +3935,9 @@ export namespace xdr {
 
     liquidityPoolId(value?: PoolId): PoolId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyLiquidityPool;
 
@@ -3733,16 +3947,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyLiquidityPool): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyLiquidityPool;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyLiquidityPool;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerKeyLiquidityPool;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyContractData {
@@ -3752,9 +3966,9 @@ export namespace xdr {
 
     key(value?: ScVal): ScVal;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyContractData;
 
@@ -3764,16 +3978,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyContractData): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyContractData;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyContractData;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerKeyContractData;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyContractCode {
@@ -3781,9 +3995,9 @@ export namespace xdr {
 
     hash(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyContractCode;
 
@@ -3793,16 +4007,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyContractCode): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyContractCode;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyContractCode;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerKeyContractCode;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKeyConfigSetting {
@@ -3810,9 +4024,9 @@ export namespace xdr {
 
     configSettingId(value?: ConfigSettingId): ConfigSettingId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKeyConfigSetting;
 
@@ -3822,16 +4036,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyConfigSetting): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyConfigSetting;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyConfigSetting;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerKeyConfigSetting;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerCloseValueSignature {
@@ -3841,9 +4055,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerCloseValueSignature;
 
@@ -3853,16 +4067,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseValueSignature): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseValueSignature;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseValueSignature;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerCloseValueSignature;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class StellarValue {
@@ -3881,9 +4095,9 @@ export namespace xdr {
 
     ext(value?: StellarValueExt): StellarValueExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): StellarValue;
 
@@ -3893,13 +4107,13 @@ export namespace xdr {
 
     static toXDR(value: StellarValue): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): StellarValue;
+    static fromXDR(input: Buffer, format?: "raw"): StellarValue;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): StellarValue;
+    static fromXDR(input: string, format: "hex" | "base64"): StellarValue;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeaderExtensionV1 {
@@ -3909,9 +4123,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderExtensionV1Ext): LedgerHeaderExtensionV1Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeaderExtensionV1;
 
@@ -3921,16 +4135,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExtensionV1;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExtensionV1;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerHeaderExtensionV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeader {
@@ -3982,9 +4196,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderExt): LedgerHeaderExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeader;
 
@@ -3994,44 +4208,70 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeader): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeader;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeader;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerHeader;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerHeader;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
-  class LedgerUpgradeConfigSetting {
-    constructor(attributes: { id: ConfigSettingId; setting: ConfigSetting });
+  class ConfigUpgradeSetKey {
+    constructor(attributes: { contractId: Buffer; contentHash: Buffer });
 
-    id(value?: ConfigSettingId): ConfigSettingId;
+    contractId(value?: Buffer): Buffer;
 
-    setting(value?: ConfigSetting): ConfigSetting;
+    contentHash(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
-    static read(io: Buffer): LedgerUpgradeConfigSetting;
+    static read(io: Buffer): ConfigUpgradeSetKey;
 
-    static write(value: LedgerUpgradeConfigSetting, io: Buffer): void;
+    static write(value: ConfigUpgradeSetKey, io: Buffer): void;
 
-    static isValid(value: LedgerUpgradeConfigSetting): boolean;
+    static isValid(value: ConfigUpgradeSetKey): boolean;
 
-    static toXDR(value: LedgerUpgradeConfigSetting): Buffer;
+    static toXDR(value: ConfigUpgradeSetKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerUpgradeConfigSetting;
+    static fromXDR(input: Buffer, format?: "raw"): ConfigUpgradeSetKey;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
-    ): LedgerUpgradeConfigSetting;
+      format: "hex" | "base64"
+    ): ConfigUpgradeSetKey;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class ConfigUpgradeSet {
+    constructor(attributes: { updatedEntry: ConfigSettingEntry[] });
+
+    updatedEntry(value?: ConfigSettingEntry[]): ConfigSettingEntry[];
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): ConfigUpgradeSet;
+
+    static write(value: ConfigUpgradeSet, io: Buffer): void;
+
+    static isValid(value: ConfigUpgradeSet): boolean;
+
+    static toXDR(value: ConfigUpgradeSet): Buffer;
+
+    static fromXDR(input: Buffer, format?: "raw"): ConfigUpgradeSet;
+
+    static fromXDR(input: string, format: "hex" | "base64"): ConfigUpgradeSet;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BucketMetadata {
@@ -4041,9 +4281,9 @@ export namespace xdr {
 
     ext(value?: BucketMetadataExt): BucketMetadataExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BucketMetadata;
 
@@ -4053,13 +4293,13 @@ export namespace xdr {
 
     static toXDR(value: BucketMetadata): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): BucketMetadata;
+    static fromXDR(input: Buffer, format?: "raw"): BucketMetadata;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): BucketMetadata;
+    static fromXDR(input: string, format: "hex" | "base64"): BucketMetadata;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TxSetComponentTxsMaybeDiscountedFee {
@@ -4072,9 +4312,9 @@ export namespace xdr {
 
     txes(value?: TransactionEnvelope[]): TransactionEnvelope[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TxSetComponentTxsMaybeDiscountedFee;
 
@@ -4086,17 +4326,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): TxSetComponentTxsMaybeDiscountedFee;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TxSetComponentTxsMaybeDiscountedFee;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionSet {
@@ -4109,9 +4349,9 @@ export namespace xdr {
 
     txes(value?: TransactionEnvelope[]): TransactionEnvelope[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionSet;
 
@@ -4121,13 +4361,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionSet;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionSet;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionSet;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionSet;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionSetV1 {
@@ -4140,9 +4380,9 @@ export namespace xdr {
 
     phases(value?: TransactionPhase[]): TransactionPhase[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionSetV1;
 
@@ -4152,13 +4392,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionSetV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionSetV1;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionSetV1;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionSetV1;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionSetV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultPair {
@@ -4171,9 +4411,9 @@ export namespace xdr {
 
     result(value?: TransactionResult): TransactionResult;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultPair;
 
@@ -4183,16 +4423,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultPair): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultPair;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultPair;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultPair;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultSet {
@@ -4200,9 +4440,9 @@ export namespace xdr {
 
     results(value?: TransactionResultPair[]): TransactionResultPair[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultSet;
 
@@ -4212,16 +4452,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultSet;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultSet;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultSet;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionHistoryEntry {
@@ -4237,9 +4477,9 @@ export namespace xdr {
 
     ext(value?: TransactionHistoryEntryExt): TransactionHistoryEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionHistoryEntry;
 
@@ -4249,16 +4489,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionHistoryEntry;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionHistoryEntry;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionHistoryResultEntry {
@@ -4276,9 +4516,9 @@ export namespace xdr {
       value?: TransactionHistoryResultEntryExt
     ): TransactionHistoryResultEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionHistoryResultEntry;
 
@@ -4290,17 +4530,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): TransactionHistoryResultEntry;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionHistoryResultEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultPairV2 {
@@ -4313,9 +4553,9 @@ export namespace xdr {
 
     hashOfMetaHashes(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultPairV2;
 
@@ -4325,16 +4565,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultPairV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultPairV2;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultPairV2;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultPairV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultSetV2 {
@@ -4342,9 +4582,9 @@ export namespace xdr {
 
     results(value?: TransactionResultPairV2[]): TransactionResultPairV2[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultSetV2;
 
@@ -4354,16 +4594,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultSetV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultSetV2;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultSetV2;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultSetV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionHistoryResultEntryV2 {
@@ -4381,9 +4621,9 @@ export namespace xdr {
       value?: TransactionHistoryResultEntryV2Ext
     ): TransactionHistoryResultEntryV2Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionHistoryResultEntryV2;
 
@@ -4395,17 +4635,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): TransactionHistoryResultEntryV2;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionHistoryResultEntryV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeaderHistoryEntry {
@@ -4421,9 +4661,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderHistoryEntryExt): LedgerHeaderHistoryEntryExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeaderHistoryEntry;
 
@@ -4433,16 +4673,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderHistoryEntry;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderHistoryEntry;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerHeaderHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerScpMessages {
@@ -4452,9 +4692,9 @@ export namespace xdr {
 
     messages(value?: ScpEnvelope[]): ScpEnvelope[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerScpMessages;
 
@@ -4464,13 +4704,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerScpMessages): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerScpMessages;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerScpMessages;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerScpMessages;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerScpMessages;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpHistoryEntryV0 {
@@ -4483,9 +4723,9 @@ export namespace xdr {
 
     ledgerMessages(value?: LedgerScpMessages): LedgerScpMessages;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpHistoryEntryV0;
 
@@ -4495,13 +4735,13 @@ export namespace xdr {
 
     static toXDR(value: ScpHistoryEntryV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpHistoryEntryV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScpHistoryEntryV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpHistoryEntryV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpHistoryEntryV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OperationMeta {
@@ -4509,9 +4749,9 @@ export namespace xdr {
 
     changes(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OperationMeta;
 
@@ -4521,13 +4761,13 @@ export namespace xdr {
 
     static toXDR(value: OperationMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OperationMeta;
+    static fromXDR(input: Buffer, format?: "raw"): OperationMeta;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OperationMeta;
+    static fromXDR(input: string, format: "hex" | "base64"): OperationMeta;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionMetaV1 {
@@ -4540,9 +4780,9 @@ export namespace xdr {
 
     operations(value?: OperationMeta[]): OperationMeta[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionMetaV1;
 
@@ -4552,13 +4792,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMetaV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionMetaV1;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionMetaV1;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMetaV1;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionMetaV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionMetaV2 {
@@ -4574,9 +4814,9 @@ export namespace xdr {
 
     txChangesAfter(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionMetaV2;
 
@@ -4586,13 +4826,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMetaV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionMetaV2;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionMetaV2;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMetaV2;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionMetaV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ContractEventV0 {
@@ -4602,9 +4842,9 @@ export namespace xdr {
 
     data(value?: ScVal): ScVal;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ContractEventV0;
 
@@ -4614,13 +4854,13 @@ export namespace xdr {
 
     static toXDR(value: ContractEventV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ContractEventV0;
+    static fromXDR(input: Buffer, format?: "raw"): ContractEventV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ContractEventV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ContractEventV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ContractEvent {
@@ -4639,9 +4879,9 @@ export namespace xdr {
 
     body(value?: ContractEventBody): ContractEventBody;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ContractEvent;
 
@@ -4651,13 +4891,73 @@ export namespace xdr {
 
     static toXDR(value: ContractEvent): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ContractEvent;
+    static fromXDR(input: Buffer, format?: "raw"): ContractEvent;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ContractEvent;
+    static fromXDR(input: string, format: "hex" | "base64"): ContractEvent;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class DiagnosticEvent {
+    constructor(attributes: {
+      inSuccessfulContractCall: boolean;
+      event: ContractEvent;
+    });
+
+    inSuccessfulContractCall(value?: boolean): boolean;
+
+    event(value?: ContractEvent): ContractEvent;
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): DiagnosticEvent;
+
+    static write(value: DiagnosticEvent, io: Buffer): void;
+
+    static isValid(value: DiagnosticEvent): boolean;
+
+    static toXDR(value: DiagnosticEvent): Buffer;
+
+    static fromXDR(input: Buffer, format?: "raw"): DiagnosticEvent;
+
+    static fromXDR(input: string, format: "hex" | "base64"): DiagnosticEvent;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class OperationDiagnosticEvents {
+    constructor(attributes: { events: DiagnosticEvent[] });
+
+    events(value?: DiagnosticEvent[]): DiagnosticEvent[];
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): OperationDiagnosticEvents;
+
+    static write(value: OperationDiagnosticEvents, io: Buffer): void;
+
+    static isValid(value: OperationDiagnosticEvents): boolean;
+
+    static toXDR(value: OperationDiagnosticEvents): Buffer;
+
+    static fromXDR(input: Buffer, format?: "raw"): OperationDiagnosticEvents;
+
+    static fromXDR(
+      input: string,
+      format: "hex" | "base64"
+    ): OperationDiagnosticEvents;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OperationEvents {
@@ -4665,9 +4965,9 @@ export namespace xdr {
 
     events(value?: ContractEvent[]): ContractEvent[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OperationEvents;
 
@@ -4677,13 +4977,13 @@ export namespace xdr {
 
     static toXDR(value: OperationEvents): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OperationEvents;
+    static fromXDR(input: Buffer, format?: "raw"): OperationEvents;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OperationEvents;
+    static fromXDR(input: string, format: "hex" | "base64"): OperationEvents;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionMetaV3 {
@@ -4694,6 +4994,7 @@ export namespace xdr {
       events: OperationEvents[];
       txResult: TransactionResult;
       hashes: Buffer[];
+      diagnosticEvents: OperationDiagnosticEvents[];
     });
 
     txChangesBefore(value?: LedgerEntryChange[]): LedgerEntryChange[];
@@ -4708,9 +5009,13 @@ export namespace xdr {
 
     hashes(value?: Buffer[]): Buffer[];
 
-    toXDR(format?: 'raw'): Buffer;
+    diagnosticEvents(
+      value?: OperationDiagnosticEvents[]
+    ): OperationDiagnosticEvents[];
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionMetaV3;
 
@@ -4720,13 +5025,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMetaV3): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionMetaV3;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionMetaV3;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMetaV3;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionMetaV3;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultMeta {
@@ -4742,9 +5047,9 @@ export namespace xdr {
 
     txApplyProcessing(value?: TransactionMeta): TransactionMeta;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultMeta;
 
@@ -4754,16 +5059,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultMeta;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultMeta;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultMeta;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultMetaV2 {
@@ -4779,9 +5084,9 @@ export namespace xdr {
 
     txApplyProcessing(value?: TransactionMeta): TransactionMeta;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultMetaV2;
 
@@ -4791,16 +5096,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultMetaV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultMetaV2;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultMetaV2;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultMetaV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class UpgradeEntryMeta {
@@ -4813,9 +5118,9 @@ export namespace xdr {
 
     changes(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): UpgradeEntryMeta;
 
@@ -4825,13 +5130,13 @@ export namespace xdr {
 
     static toXDR(value: UpgradeEntryMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): UpgradeEntryMeta;
+    static fromXDR(input: Buffer, format?: "raw"): UpgradeEntryMeta;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): UpgradeEntryMeta;
+    static fromXDR(input: string, format: "hex" | "base64"): UpgradeEntryMeta;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerCloseMetaV0 {
@@ -4853,9 +5158,9 @@ export namespace xdr {
 
     scpInfo(value?: ScpHistoryEntry[]): ScpHistoryEntry[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerCloseMetaV0;
 
@@ -4865,13 +5170,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMetaV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMetaV0;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMetaV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMetaV0;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMetaV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerCloseMetaV1 {
@@ -4893,9 +5198,9 @@ export namespace xdr {
 
     scpInfo(value?: ScpHistoryEntry[]): ScpHistoryEntry[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerCloseMetaV1;
 
@@ -4905,13 +5210,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMetaV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMetaV1;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMetaV1;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMetaV1;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMetaV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerCloseMetaV2 {
@@ -4933,9 +5238,9 @@ export namespace xdr {
 
     scpInfo(value?: ScpHistoryEntry[]): ScpHistoryEntry[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerCloseMetaV2;
 
@@ -4945,13 +5250,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMetaV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMetaV2;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMetaV2;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMetaV2;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMetaV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Error {
@@ -4961,9 +5266,9 @@ export namespace xdr {
 
     msg(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Error;
 
@@ -4973,13 +5278,13 @@ export namespace xdr {
 
     static toXDR(value: Error): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Error;
+    static fromXDR(input: Buffer, format?: "raw"): Error;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Error;
+    static fromXDR(input: string, format: "hex" | "base64"): Error;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SendMore {
@@ -4987,9 +5292,9 @@ export namespace xdr {
 
     numMessages(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SendMore;
 
@@ -4999,13 +5304,13 @@ export namespace xdr {
 
     static toXDR(value: SendMore): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SendMore;
+    static fromXDR(input: Buffer, format?: "raw"): SendMore;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): SendMore;
+    static fromXDR(input: string, format: "hex" | "base64"): SendMore;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AuthCert {
@@ -5021,9 +5326,9 @@ export namespace xdr {
 
     sig(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AuthCert;
 
@@ -5033,13 +5338,13 @@ export namespace xdr {
 
     static toXDR(value: AuthCert): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AuthCert;
+    static fromXDR(input: Buffer, format?: "raw"): AuthCert;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AuthCert;
+    static fromXDR(input: string, format: "hex" | "base64"): AuthCert;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Hello {
@@ -5073,9 +5378,9 @@ export namespace xdr {
 
     nonce(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Hello;
 
@@ -5085,13 +5390,13 @@ export namespace xdr {
 
     static toXDR(value: Hello): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Hello;
+    static fromXDR(input: Buffer, format?: "raw"): Hello;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Hello;
+    static fromXDR(input: string, format: "hex" | "base64"): Hello;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Auth {
@@ -5099,9 +5404,9 @@ export namespace xdr {
 
     flags(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Auth;
 
@@ -5111,13 +5416,13 @@ export namespace xdr {
 
     static toXDR(value: Auth): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Auth;
+    static fromXDR(input: Buffer, format?: "raw"): Auth;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Auth;
+    static fromXDR(input: string, format: "hex" | "base64"): Auth;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PeerAddress {
@@ -5133,9 +5438,9 @@ export namespace xdr {
 
     numFailures(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PeerAddress;
 
@@ -5145,13 +5450,13 @@ export namespace xdr {
 
     static toXDR(value: PeerAddress): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PeerAddress;
+    static fromXDR(input: Buffer, format?: "raw"): PeerAddress;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PeerAddress;
+    static fromXDR(input: string, format: "hex" | "base64"): PeerAddress;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class DontHave {
@@ -5161,9 +5466,9 @@ export namespace xdr {
 
     reqHash(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): DontHave;
 
@@ -5173,13 +5478,13 @@ export namespace xdr {
 
     static toXDR(value: DontHave): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): DontHave;
+    static fromXDR(input: Buffer, format?: "raw"): DontHave;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): DontHave;
+    static fromXDR(input: string, format: "hex" | "base64"): DontHave;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SurveyRequestMessage {
@@ -5201,9 +5506,9 @@ export namespace xdr {
 
     commandType(value?: SurveyMessageCommandType): SurveyMessageCommandType;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SurveyRequestMessage;
 
@@ -5213,16 +5518,16 @@ export namespace xdr {
 
     static toXDR(value: SurveyRequestMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SurveyRequestMessage;
+    static fromXDR(input: Buffer, format?: "raw"): SurveyRequestMessage;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SurveyRequestMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SignedSurveyRequestMessage {
@@ -5235,9 +5540,9 @@ export namespace xdr {
 
     request(value?: SurveyRequestMessage): SurveyRequestMessage;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SignedSurveyRequestMessage;
 
@@ -5247,16 +5552,16 @@ export namespace xdr {
 
     static toXDR(value: SignedSurveyRequestMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SignedSurveyRequestMessage;
+    static fromXDR(input: Buffer, format?: "raw"): SignedSurveyRequestMessage;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SignedSurveyRequestMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SurveyResponseMessage {
@@ -5278,9 +5583,9 @@ export namespace xdr {
 
     encryptedBody(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SurveyResponseMessage;
 
@@ -5290,16 +5595,16 @@ export namespace xdr {
 
     static toXDR(value: SurveyResponseMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SurveyResponseMessage;
+    static fromXDR(input: Buffer, format?: "raw"): SurveyResponseMessage;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SurveyResponseMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SignedSurveyResponseMessage {
@@ -5312,9 +5617,9 @@ export namespace xdr {
 
     response(value?: SurveyResponseMessage): SurveyResponseMessage;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SignedSurveyResponseMessage;
 
@@ -5324,16 +5629,16 @@ export namespace xdr {
 
     static toXDR(value: SignedSurveyResponseMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SignedSurveyResponseMessage;
+    static fromXDR(input: Buffer, format?: "raw"): SignedSurveyResponseMessage;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SignedSurveyResponseMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PeerStats {
@@ -5385,9 +5690,9 @@ export namespace xdr {
 
     duplicateFetchMessageRecv(value?: Uint64): Uint64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PeerStats;
 
@@ -5397,13 +5702,13 @@ export namespace xdr {
 
     static toXDR(value: PeerStats): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PeerStats;
+    static fromXDR(input: Buffer, format?: "raw"): PeerStats;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PeerStats;
+    static fromXDR(input: string, format: "hex" | "base64"): PeerStats;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TopologyResponseBodyV0 {
@@ -5422,9 +5727,9 @@ export namespace xdr {
 
     totalOutboundPeerCount(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TopologyResponseBodyV0;
 
@@ -5434,16 +5739,16 @@ export namespace xdr {
 
     static toXDR(value: TopologyResponseBodyV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TopologyResponseBodyV0;
+    static fromXDR(input: Buffer, format?: "raw"): TopologyResponseBodyV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TopologyResponseBodyV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TopologyResponseBodyV1 {
@@ -5468,9 +5773,9 @@ export namespace xdr {
 
     maxOutboundPeerCount(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TopologyResponseBodyV1;
 
@@ -5480,26 +5785,26 @@ export namespace xdr {
 
     static toXDR(value: TopologyResponseBodyV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TopologyResponseBodyV1;
+    static fromXDR(input: Buffer, format?: "raw"): TopologyResponseBodyV1;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TopologyResponseBodyV1;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class FloodAdvert {
-    constructor(attributes: { txHashes: Array<typeof Hash> });
+    constructor(attributes: { txHashes: Hash[] });
 
-    txHashes(value?: Array<typeof Hash>): Array<typeof Hash>;
+    txHashes(value?: Hash[]): Hash[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): FloodAdvert;
 
@@ -5509,23 +5814,23 @@ export namespace xdr {
 
     static toXDR(value: FloodAdvert): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): FloodAdvert;
+    static fromXDR(input: Buffer, format?: "raw"): FloodAdvert;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): FloodAdvert;
+    static fromXDR(input: string, format: "hex" | "base64"): FloodAdvert;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class FloodDemand {
-    constructor(attributes: { txHashes: Array<typeof Hash> });
+    constructor(attributes: { txHashes: Hash[] });
 
-    txHashes(value?: Array<typeof Hash>): Array<typeof Hash>;
+    txHashes(value?: Hash[]): Hash[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): FloodDemand;
 
@@ -5535,13 +5840,13 @@ export namespace xdr {
 
     static toXDR(value: FloodDemand): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): FloodDemand;
+    static fromXDR(input: Buffer, format?: "raw"): FloodDemand;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): FloodDemand;
+    static fromXDR(input: string, format: "hex" | "base64"): FloodDemand;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AuthenticatedMessageV0 {
@@ -5557,9 +5862,9 @@ export namespace xdr {
 
     mac(value?: HmacSha256Mac): HmacSha256Mac;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AuthenticatedMessageV0;
 
@@ -5569,16 +5874,16 @@ export namespace xdr {
 
     static toXDR(value: AuthenticatedMessageV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AuthenticatedMessageV0;
+    static fromXDR(input: Buffer, format?: "raw"): AuthenticatedMessageV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AuthenticatedMessageV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class MuxedAccountMed25519 {
@@ -5588,9 +5893,9 @@ export namespace xdr {
 
     ed25519(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): MuxedAccountMed25519;
 
@@ -5600,16 +5905,16 @@ export namespace xdr {
 
     static toXDR(value: MuxedAccountMed25519): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): MuxedAccountMed25519;
+    static fromXDR(input: Buffer, format?: "raw"): MuxedAccountMed25519;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): MuxedAccountMed25519;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class DecoratedSignature {
@@ -5619,9 +5924,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): DecoratedSignature;
 
@@ -5631,13 +5936,13 @@ export namespace xdr {
 
     static toXDR(value: DecoratedSignature): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): DecoratedSignature;
+    static fromXDR(input: Buffer, format?: "raw"): DecoratedSignature;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): DecoratedSignature;
+    static fromXDR(input: string, format: "hex" | "base64"): DecoratedSignature;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerFootprint {
@@ -5647,9 +5952,9 @@ export namespace xdr {
 
     readWrite(value?: LedgerKey[]): LedgerKey[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerFootprint;
 
@@ -5659,13 +5964,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerFootprint): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerFootprint;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerFootprint;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerFootprint;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerFootprint;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreateAccountOp {
@@ -5675,9 +5980,9 @@ export namespace xdr {
 
     startingBalance(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreateAccountOp;
 
@@ -5687,13 +5992,13 @@ export namespace xdr {
 
     static toXDR(value: CreateAccountOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreateAccountOp;
+    static fromXDR(input: Buffer, format?: "raw"): CreateAccountOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): CreateAccountOp;
+    static fromXDR(input: string, format: "hex" | "base64"): CreateAccountOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PaymentOp {
@@ -5709,9 +6014,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PaymentOp;
 
@@ -5721,13 +6026,13 @@ export namespace xdr {
 
     static toXDR(value: PaymentOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PaymentOp;
+    static fromXDR(input: Buffer, format?: "raw"): PaymentOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PaymentOp;
+    static fromXDR(input: string, format: "hex" | "base64"): PaymentOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictReceiveOp {
@@ -5752,9 +6057,9 @@ export namespace xdr {
 
     path(value?: Asset[]): Asset[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveOp;
 
@@ -5764,16 +6069,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictReceiveOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictReceiveOp;
+    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictReceiveOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictReceiveOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictSendOp {
@@ -5798,9 +6103,9 @@ export namespace xdr {
 
     path(value?: Asset[]): Asset[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictSendOp;
 
@@ -5810,16 +6115,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictSendOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictSendOp;
+    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictSendOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictSendOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageSellOfferOp {
@@ -5841,9 +6146,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageSellOfferOp;
 
@@ -5853,13 +6158,13 @@ export namespace xdr {
 
     static toXDR(value: ManageSellOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageSellOfferOp;
+    static fromXDR(input: Buffer, format?: "raw"): ManageSellOfferOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ManageSellOfferOp;
+    static fromXDR(input: string, format: "hex" | "base64"): ManageSellOfferOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageBuyOfferOp {
@@ -5881,9 +6186,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageBuyOfferOp;
 
@@ -5893,13 +6198,13 @@ export namespace xdr {
 
     static toXDR(value: ManageBuyOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageBuyOfferOp;
+    static fromXDR(input: Buffer, format?: "raw"): ManageBuyOfferOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ManageBuyOfferOp;
+    static fromXDR(input: string, format: "hex" | "base64"): ManageBuyOfferOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreatePassiveSellOfferOp {
@@ -5918,9 +6223,9 @@ export namespace xdr {
 
     price(value?: Price): Price;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreatePassiveSellOfferOp;
 
@@ -5930,16 +6235,16 @@ export namespace xdr {
 
     static toXDR(value: CreatePassiveSellOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreatePassiveSellOfferOp;
+    static fromXDR(input: Buffer, format?: "raw"): CreatePassiveSellOfferOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): CreatePassiveSellOfferOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SetOptionsOp {
@@ -5973,9 +6278,9 @@ export namespace xdr {
 
     signer(value?: null | Signer): null | Signer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SetOptionsOp;
 
@@ -5985,13 +6290,13 @@ export namespace xdr {
 
     static toXDR(value: SetOptionsOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SetOptionsOp;
+    static fromXDR(input: Buffer, format?: "raw"): SetOptionsOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): SetOptionsOp;
+    static fromXDR(input: string, format: "hex" | "base64"): SetOptionsOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ChangeTrustOp {
@@ -6001,9 +6306,9 @@ export namespace xdr {
 
     limit(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ChangeTrustOp;
 
@@ -6013,13 +6318,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustOp;
+    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustOp;
+    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AllowTrustOp {
@@ -6035,9 +6340,9 @@ export namespace xdr {
 
     authorize(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AllowTrustOp;
 
@@ -6047,13 +6352,13 @@ export namespace xdr {
 
     static toXDR(value: AllowTrustOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AllowTrustOp;
+    static fromXDR(input: Buffer, format?: "raw"): AllowTrustOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AllowTrustOp;
+    static fromXDR(input: string, format: "hex" | "base64"): AllowTrustOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageDataOp {
@@ -6066,9 +6371,9 @@ export namespace xdr {
 
     dataValue(value?: null | Buffer): null | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageDataOp;
 
@@ -6078,13 +6383,13 @@ export namespace xdr {
 
     static toXDR(value: ManageDataOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageDataOp;
+    static fromXDR(input: Buffer, format?: "raw"): ManageDataOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ManageDataOp;
+    static fromXDR(input: string, format: "hex" | "base64"): ManageDataOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BumpSequenceOp {
@@ -6092,9 +6397,9 @@ export namespace xdr {
 
     bumpTo(value?: SequenceNumber): SequenceNumber;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BumpSequenceOp;
 
@@ -6104,13 +6409,13 @@ export namespace xdr {
 
     static toXDR(value: BumpSequenceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): BumpSequenceOp;
+    static fromXDR(input: Buffer, format?: "raw"): BumpSequenceOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): BumpSequenceOp;
+    static fromXDR(input: string, format: "hex" | "base64"): BumpSequenceOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreateClaimableBalanceOp {
@@ -6126,9 +6431,9 @@ export namespace xdr {
 
     claimants(value?: Claimant[]): Claimant[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreateClaimableBalanceOp;
 
@@ -6138,16 +6443,16 @@ export namespace xdr {
 
     static toXDR(value: CreateClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreateClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: "raw"): CreateClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): CreateClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimClaimableBalanceOp {
@@ -6155,9 +6460,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimClaimableBalanceOp;
 
@@ -6167,16 +6472,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BeginSponsoringFutureReservesOp {
@@ -6184,9 +6489,9 @@ export namespace xdr {
 
     sponsoredId(value?: AccountId): AccountId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BeginSponsoringFutureReservesOp;
 
@@ -6198,17 +6503,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): BeginSponsoringFutureReservesOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): BeginSponsoringFutureReservesOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class RevokeSponsorshipOpSigner {
@@ -6218,9 +6523,9 @@ export namespace xdr {
 
     signerKey(value?: SignerKey): SignerKey;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): RevokeSponsorshipOpSigner;
 
@@ -6230,16 +6535,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipOpSigner): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipOpSigner;
+    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipOpSigner;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): RevokeSponsorshipOpSigner;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClawbackOp {
@@ -6255,9 +6560,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClawbackOp;
 
@@ -6267,13 +6572,13 @@ export namespace xdr {
 
     static toXDR(value: ClawbackOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClawbackOp;
+    static fromXDR(input: Buffer, format?: "raw"): ClawbackOp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClawbackOp;
+    static fromXDR(input: string, format: "hex" | "base64"): ClawbackOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClawbackClaimableBalanceOp {
@@ -6281,9 +6586,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClawbackClaimableBalanceOp;
 
@@ -6293,16 +6598,16 @@ export namespace xdr {
 
     static toXDR(value: ClawbackClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClawbackClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: "raw"): ClawbackClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClawbackClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SetTrustLineFlagsOp {
@@ -6321,9 +6626,9 @@ export namespace xdr {
 
     setFlags(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SetTrustLineFlagsOp;
 
@@ -6333,16 +6638,16 @@ export namespace xdr {
 
     static toXDR(value: SetTrustLineFlagsOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SetTrustLineFlagsOp;
+    static fromXDR(input: Buffer, format?: "raw"): SetTrustLineFlagsOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SetTrustLineFlagsOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolDepositOp {
@@ -6364,9 +6669,9 @@ export namespace xdr {
 
     maxPrice(value?: Price): Price;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolDepositOp;
 
@@ -6376,16 +6681,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolDepositOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolDepositOp;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolDepositOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolDepositOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolWithdrawOp {
@@ -6404,9 +6709,9 @@ export namespace xdr {
 
     minAmountB(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolWithdrawOp;
 
@@ -6416,16 +6721,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolWithdrawOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolWithdrawOp;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolWithdrawOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolWithdrawOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InstallContractCodeArgs {
@@ -6433,9 +6738,9 @@ export namespace xdr {
 
     code(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InstallContractCodeArgs;
 
@@ -6445,16 +6750,16 @@ export namespace xdr {
 
     static toXDR(value: InstallContractCodeArgs): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InstallContractCodeArgs;
+    static fromXDR(input: Buffer, format?: "raw"): InstallContractCodeArgs;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InstallContractCodeArgs;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ContractIdFromEd25519PublicKey {
@@ -6466,9 +6771,9 @@ export namespace xdr {
 
     salt(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ContractIdFromEd25519PublicKey;
 
@@ -6480,17 +6785,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): ContractIdFromEd25519PublicKey;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ContractIdFromEd25519PublicKey;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreateContractArgs {
@@ -6503,9 +6808,9 @@ export namespace xdr {
 
     source(value?: ScContractExecutable): ScContractExecutable;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreateContractArgs;
 
@@ -6515,13 +6820,13 @@ export namespace xdr {
 
     static toXDR(value: CreateContractArgs): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreateContractArgs;
+    static fromXDR(input: Buffer, format?: "raw"): CreateContractArgs;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): CreateContractArgs;
+    static fromXDR(input: string, format: "hex" | "base64"): CreateContractArgs;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AuthorizedInvocation {
@@ -6540,9 +6845,9 @@ export namespace xdr {
 
     subInvocations(value?: AuthorizedInvocation[]): AuthorizedInvocation[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AuthorizedInvocation;
 
@@ -6552,16 +6857,16 @@ export namespace xdr {
 
     static toXDR(value: AuthorizedInvocation): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AuthorizedInvocation;
+    static fromXDR(input: Buffer, format?: "raw"): AuthorizedInvocation;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AuthorizedInvocation;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AddressWithNonce {
@@ -6571,9 +6876,9 @@ export namespace xdr {
 
     nonce(value?: Uint64): Uint64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AddressWithNonce;
 
@@ -6583,13 +6888,13 @@ export namespace xdr {
 
     static toXDR(value: AddressWithNonce): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AddressWithNonce;
+    static fromXDR(input: Buffer, format?: "raw"): AddressWithNonce;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AddressWithNonce;
+    static fromXDR(input: string, format: "hex" | "base64"): AddressWithNonce;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ContractAuth {
@@ -6605,9 +6910,9 @@ export namespace xdr {
 
     signatureArgs(value?: ScVal[]): ScVal[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ContractAuth;
 
@@ -6617,13 +6922,13 @@ export namespace xdr {
 
     static toXDR(value: ContractAuth): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ContractAuth;
+    static fromXDR(input: Buffer, format?: "raw"): ContractAuth;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ContractAuth;
+    static fromXDR(input: string, format: "hex" | "base64"): ContractAuth;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InvokeHostFunctionOp {
@@ -6639,9 +6944,9 @@ export namespace xdr {
 
     auth(value?: ContractAuth[]): ContractAuth[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InvokeHostFunctionOp;
 
@@ -6651,47 +6956,16 @@ export namespace xdr {
 
     static toXDR(value: InvokeHostFunctionOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InvokeHostFunctionOp;
+    static fromXDR(input: Buffer, format?: "raw"): InvokeHostFunctionOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InvokeHostFunctionOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
-  }
-
-  class Operation2 {
-    constructor(attributes: {
-      sourceAccount: null | MuxedAccount;
-      body: OperationBody;
-    });
-
-    sourceAccount(value?: null | MuxedAccount): null | MuxedAccount;
-
-    body(value?: OperationBody): OperationBody;
-
-    toXDR(format?: 'raw'): Buffer;
-
-    toXDR(format: 'hex' | 'base64'): string;
-
-    static read(io: Buffer): Operation;
-
-    static write(value: Operation, io: Buffer): void;
-
-    static isValid(value: Operation): boolean;
-
-    static toXDR(value: Operation): Buffer;
-
-    static fromXDR(input: Buffer, format?: 'raw'): Operation;
-
-    static fromXDR(input: string, format: 'hex' | 'base64'): Operation;
-
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
-
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimageOperationId {
@@ -6707,9 +6981,9 @@ export namespace xdr {
 
     opNum(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimageOperationId;
 
@@ -6719,16 +6993,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageOperationId): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageOperationId;
+    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageOperationId;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): HashIdPreimageOperationId;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimageRevokeId {
@@ -6750,9 +7024,9 @@ export namespace xdr {
 
     asset(value?: Asset): Asset;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimageRevokeId;
 
@@ -6762,16 +7036,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageRevokeId): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageRevokeId;
+    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageRevokeId;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): HashIdPreimageRevokeId;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimageEd25519ContractId {
@@ -6787,9 +7061,9 @@ export namespace xdr {
 
     salt(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimageEd25519ContractId;
 
@@ -6801,17 +7075,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): HashIdPreimageEd25519ContractId;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): HashIdPreimageEd25519ContractId;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimageContractId {
@@ -6827,9 +7101,9 @@ export namespace xdr {
 
     salt(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimageContractId;
 
@@ -6839,16 +7113,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageContractId): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageContractId;
+    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageContractId;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): HashIdPreimageContractId;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimageFromAsset {
@@ -6858,9 +7132,9 @@ export namespace xdr {
 
     asset(value?: Asset): Asset;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimageFromAsset;
 
@@ -6870,16 +7144,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageFromAsset): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageFromAsset;
+    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageFromAsset;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): HashIdPreimageFromAsset;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimageSourceAccountContractId {
@@ -6895,9 +7169,9 @@ export namespace xdr {
 
     salt(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimageSourceAccountContractId;
 
@@ -6912,17 +7186,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): HashIdPreimageSourceAccountContractId;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): HashIdPreimageSourceAccountContractId;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimageCreateContractArgs {
@@ -6938,9 +7212,9 @@ export namespace xdr {
 
     salt(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimageCreateContractArgs;
 
@@ -6952,17 +7226,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): HashIdPreimageCreateContractArgs;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): HashIdPreimageCreateContractArgs;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimageContractAuth {
@@ -6978,9 +7252,9 @@ export namespace xdr {
 
     invocation(value?: AuthorizedInvocation): AuthorizedInvocation;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimageContractAuth;
 
@@ -6990,16 +7264,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageContractAuth): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageContractAuth;
+    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageContractAuth;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): HashIdPreimageContractAuth;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TimeBounds {
@@ -7009,9 +7283,9 @@ export namespace xdr {
 
     maxTime(value?: TimePoint): TimePoint;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TimeBounds;
 
@@ -7021,13 +7295,13 @@ export namespace xdr {
 
     static toXDR(value: TimeBounds): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TimeBounds;
+    static fromXDR(input: Buffer, format?: "raw"): TimeBounds;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TimeBounds;
+    static fromXDR(input: string, format: "hex" | "base64"): TimeBounds;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerBounds {
@@ -7037,9 +7311,9 @@ export namespace xdr {
 
     maxLedger(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerBounds;
 
@@ -7049,13 +7323,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerBounds): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerBounds;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerBounds;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerBounds;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerBounds;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PreconditionsV2 {
@@ -7080,9 +7354,9 @@ export namespace xdr {
 
     extraSigners(value?: SignerKey[]): SignerKey[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PreconditionsV2;
 
@@ -7092,13 +7366,13 @@ export namespace xdr {
 
     static toXDR(value: PreconditionsV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PreconditionsV2;
+    static fromXDR(input: Buffer, format?: "raw"): PreconditionsV2;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PreconditionsV2;
+    static fromXDR(input: string, format: "hex" | "base64"): PreconditionsV2;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionV0 {
@@ -7126,9 +7400,9 @@ export namespace xdr {
 
     ext(value?: TransactionV0Ext): TransactionV0Ext;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionV0;
 
@@ -7138,13 +7412,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionV0;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionV0Envelope {
@@ -7157,9 +7431,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionV0Envelope;
 
@@ -7169,16 +7443,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0Envelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0Envelope;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionV0Envelope;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionV0Envelope;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Transaction {
@@ -7206,9 +7480,9 @@ export namespace xdr {
 
     ext(value?: TransactionExt): TransactionExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Transaction;
 
@@ -7218,13 +7492,13 @@ export namespace xdr {
 
     static toXDR(value: Transaction): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Transaction;
+    static fromXDR(input: Buffer, format?: "raw"): Transaction;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Transaction;
+    static fromXDR(input: string, format: "hex" | "base64"): Transaction;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionV1Envelope {
@@ -7237,9 +7511,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionV1Envelope;
 
@@ -7249,16 +7523,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionV1Envelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionV1Envelope;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionV1Envelope;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionV1Envelope;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class FeeBumpTransaction {
@@ -7277,9 +7551,9 @@ export namespace xdr {
 
     ext(value?: FeeBumpTransactionExt): FeeBumpTransactionExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): FeeBumpTransaction;
 
@@ -7289,13 +7563,13 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransaction): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransaction;
+    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransaction;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): FeeBumpTransaction;
+    static fromXDR(input: string, format: "hex" | "base64"): FeeBumpTransaction;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class FeeBumpTransactionEnvelope {
@@ -7308,9 +7582,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): FeeBumpTransactionEnvelope;
 
@@ -7320,16 +7594,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionEnvelope;
+    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionEnvelope;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): FeeBumpTransactionEnvelope;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionSignaturePayload {
@@ -7344,9 +7618,9 @@ export namespace xdr {
       value?: TransactionSignaturePayloadTaggedTransaction
     ): TransactionSignaturePayloadTaggedTransaction;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionSignaturePayload;
 
@@ -7356,16 +7630,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionSignaturePayload): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionSignaturePayload;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionSignaturePayload;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionSignaturePayload;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimOfferAtomV0 {
@@ -7390,9 +7664,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimOfferAtomV0;
 
@@ -7402,13 +7676,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimOfferAtomV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimOfferAtomV0;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimOfferAtomV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimOfferAtomV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimOfferAtomV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimOfferAtom {
@@ -7433,9 +7707,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimOfferAtom;
 
@@ -7445,13 +7719,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimOfferAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimOfferAtom;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimOfferAtom;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimOfferAtom;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimOfferAtom;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimLiquidityAtom {
@@ -7473,9 +7747,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimLiquidityAtom;
 
@@ -7485,13 +7759,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimLiquidityAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimLiquidityAtom;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimLiquidityAtom;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimLiquidityAtom;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimLiquidityAtom;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SimplePaymentResult {
@@ -7507,9 +7781,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SimplePaymentResult;
 
@@ -7519,16 +7793,16 @@ export namespace xdr {
 
     static toXDR(value: SimplePaymentResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SimplePaymentResult;
+    static fromXDR(input: Buffer, format?: "raw"): SimplePaymentResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SimplePaymentResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictReceiveResultSuccess {
@@ -7538,9 +7812,9 @@ export namespace xdr {
 
     last(value?: SimplePaymentResult): SimplePaymentResult;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveResultSuccess;
 
@@ -7555,17 +7829,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): PathPaymentStrictReceiveResultSuccess;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictReceiveResultSuccess;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictSendResultSuccess {
@@ -7575,9 +7849,9 @@ export namespace xdr {
 
     last(value?: SimplePaymentResult): SimplePaymentResult;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictSendResultSuccess;
 
@@ -7589,17 +7863,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): PathPaymentStrictSendResultSuccess;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictSendResultSuccess;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageOfferSuccessResult {
@@ -7612,9 +7886,9 @@ export namespace xdr {
 
     offer(value?: ManageOfferSuccessResultOffer): ManageOfferSuccessResultOffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageOfferSuccessResult;
 
@@ -7624,16 +7898,16 @@ export namespace xdr {
 
     static toXDR(value: ManageOfferSuccessResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageOfferSuccessResult;
+    static fromXDR(input: Buffer, format?: "raw"): ManageOfferSuccessResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ManageOfferSuccessResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InflationPayout {
@@ -7643,9 +7917,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InflationPayout;
 
@@ -7655,13 +7929,13 @@ export namespace xdr {
 
     static toXDR(value: InflationPayout): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InflationPayout;
+    static fromXDR(input: Buffer, format?: "raw"): InflationPayout;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): InflationPayout;
+    static fromXDR(input: string, format: "hex" | "base64"): InflationPayout;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InnerTransactionResult {
@@ -7677,9 +7951,9 @@ export namespace xdr {
 
     ext(value?: InnerTransactionResultExt): InnerTransactionResultExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InnerTransactionResult;
 
@@ -7689,16 +7963,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResult;
+    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InnerTransactionResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InnerTransactionResultPair {
@@ -7711,9 +7985,9 @@ export namespace xdr {
 
     result(value?: InnerTransactionResult): InnerTransactionResult;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InnerTransactionResultPair;
 
@@ -7723,16 +7997,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultPair): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultPair;
+    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultPair;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InnerTransactionResultPair;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResult {
@@ -7748,9 +8022,9 @@ export namespace xdr {
 
     ext(value?: TransactionResultExt): TransactionResultExt;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResult;
 
@@ -7760,13 +8034,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResult;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionResult;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SignerKeyEd25519SignedPayload {
@@ -7776,9 +8050,9 @@ export namespace xdr {
 
     payload(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SignerKeyEd25519SignedPayload;
 
@@ -7790,17 +8064,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): SignerKeyEd25519SignedPayload;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SignerKeyEd25519SignedPayload;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Curve25519Secret {
@@ -7808,9 +8082,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Curve25519Secret;
 
@@ -7820,13 +8094,13 @@ export namespace xdr {
 
     static toXDR(value: Curve25519Secret): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Curve25519Secret;
+    static fromXDR(input: Buffer, format?: "raw"): Curve25519Secret;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Curve25519Secret;
+    static fromXDR(input: string, format: "hex" | "base64"): Curve25519Secret;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Curve25519Public {
@@ -7834,9 +8108,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Curve25519Public;
 
@@ -7846,13 +8120,13 @@ export namespace xdr {
 
     static toXDR(value: Curve25519Public): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Curve25519Public;
+    static fromXDR(input: Buffer, format?: "raw"): Curve25519Public;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Curve25519Public;
+    static fromXDR(input: string, format: "hex" | "base64"): Curve25519Public;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HmacSha256Key {
@@ -7860,9 +8134,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HmacSha256Key;
 
@@ -7872,13 +8146,13 @@ export namespace xdr {
 
     static toXDR(value: HmacSha256Key): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HmacSha256Key;
+    static fromXDR(input: Buffer, format?: "raw"): HmacSha256Key;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): HmacSha256Key;
+    static fromXDR(input: string, format: "hex" | "base64"): HmacSha256Key;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HmacSha256Mac {
@@ -7886,9 +8160,9 @@ export namespace xdr {
 
     mac(value?: Buffer): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HmacSha256Mac;
 
@@ -7898,25 +8172,53 @@ export namespace xdr {
 
     static toXDR(value: HmacSha256Mac): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HmacSha256Mac;
+    static fromXDR(input: Buffer, format?: "raw"): HmacSha256Mac;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): HmacSha256Mac;
+    static fromXDR(input: string, format: "hex" | "base64"): HmacSha256Mac;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
-  class Int128Parts {
-    constructor(attributes: { lo: Uint64; hi: Uint64 });
-
-    lo(value?: Uint64): Uint64;
+  class UInt128Parts {
+    constructor(attributes: { hi: Uint64; lo: Uint64 });
 
     hi(value?: Uint64): Uint64;
 
-    toXDR(format?: 'raw'): Buffer;
+    lo(value?: Uint64): Uint64;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): UInt128Parts;
+
+    static write(value: UInt128Parts, io: Buffer): void;
+
+    static isValid(value: UInt128Parts): boolean;
+
+    static toXDR(value: UInt128Parts): Buffer;
+
+    static fromXDR(input: Buffer, format?: "raw"): UInt128Parts;
+
+    static fromXDR(input: string, format: "hex" | "base64"): UInt128Parts;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class Int128Parts {
+    constructor(attributes: { hi: Int64; lo: Uint64 });
+
+    hi(value?: Int64): Int64;
+
+    lo(value?: Uint64): Uint64;
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Int128Parts;
 
@@ -7926,13 +8228,87 @@ export namespace xdr {
 
     static toXDR(value: Int128Parts): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Int128Parts;
+    static fromXDR(input: Buffer, format?: "raw"): Int128Parts;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Int128Parts;
+    static fromXDR(input: string, format: "hex" | "base64"): Int128Parts;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class UInt256Parts {
+    constructor(attributes: {
+      hiHi: Uint64;
+      hiLo: Uint64;
+      loHi: Uint64;
+      loLo: Uint64;
+    });
+
+    hiHi(value?: Uint64): Uint64;
+
+    hiLo(value?: Uint64): Uint64;
+
+    loHi(value?: Uint64): Uint64;
+
+    loLo(value?: Uint64): Uint64;
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): UInt256Parts;
+
+    static write(value: UInt256Parts, io: Buffer): void;
+
+    static isValid(value: UInt256Parts): boolean;
+
+    static toXDR(value: UInt256Parts): Buffer;
+
+    static fromXDR(input: Buffer, format?: "raw"): UInt256Parts;
+
+    static fromXDR(input: string, format: "hex" | "base64"): UInt256Parts;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
+  class Int256Parts {
+    constructor(attributes: {
+      hiHi: Int64;
+      hiLo: Uint64;
+      loHi: Uint64;
+      loLo: Uint64;
+    });
+
+    hiHi(value?: Int64): Int64;
+
+    hiLo(value?: Uint64): Uint64;
+
+    loHi(value?: Uint64): Uint64;
+
+    loLo(value?: Uint64): Uint64;
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): Int256Parts;
+
+    static write(value: Int256Parts, io: Buffer): void;
+
+    static isValid(value: Int256Parts): boolean;
+
+    static toXDR(value: Int256Parts): Buffer;
+
+    static fromXDR(input: Buffer, format?: "raw"): Int256Parts;
+
+    static fromXDR(input: string, format: "hex" | "base64"): Int256Parts;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScNonceKey {
@@ -7940,9 +8316,9 @@ export namespace xdr {
 
     nonceAddress(value?: ScAddress): ScAddress;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScNonceKey;
 
@@ -7952,13 +8328,13 @@ export namespace xdr {
 
     static toXDR(value: ScNonceKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScNonceKey;
+    static fromXDR(input: Buffer, format?: "raw"): ScNonceKey;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScNonceKey;
+    static fromXDR(input: string, format: "hex" | "base64"): ScNonceKey;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScMapEntry {
@@ -7968,9 +8344,9 @@ export namespace xdr {
 
     val(value?: ScVal): ScVal;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScMapEntry;
 
@@ -7980,13 +8356,13 @@ export namespace xdr {
 
     static toXDR(value: ScMapEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScMapEntry;
+    static fromXDR(input: Buffer, format?: "raw"): ScMapEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScMapEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): ScMapEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecTypeOption {
@@ -7994,9 +8370,9 @@ export namespace xdr {
 
     valueType(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecTypeOption;
 
@@ -8006,13 +8382,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeOption): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeOption;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeOption;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeOption;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeOption;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecTypeResult {
@@ -8025,9 +8401,9 @@ export namespace xdr {
 
     errorType(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecTypeResult;
 
@@ -8037,13 +8413,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeResult;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeResult;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecTypeVec {
@@ -8051,9 +8427,9 @@ export namespace xdr {
 
     elementType(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecTypeVec;
 
@@ -8063,13 +8439,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeVec): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeVec;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeVec;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeVec;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeVec;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecTypeMap {
@@ -8082,9 +8458,9 @@ export namespace xdr {
 
     valueType(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecTypeMap;
 
@@ -8094,13 +8470,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeMap): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeMap;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeMap;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeMap;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeMap;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecTypeSet {
@@ -8108,9 +8484,9 @@ export namespace xdr {
 
     elementType(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecTypeSet;
 
@@ -8120,13 +8496,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeSet;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeSet;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeSet;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeSet;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecTypeTuple {
@@ -8134,9 +8510,9 @@ export namespace xdr {
 
     valueTypes(value?: ScSpecTypeDef[]): ScSpecTypeDef[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecTypeTuple;
 
@@ -8146,13 +8522,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeTuple): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeTuple;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeTuple;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeTuple;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeTuple;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecTypeBytesN {
@@ -8160,9 +8536,9 @@ export namespace xdr {
 
     n(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecTypeBytesN;
 
@@ -8172,13 +8548,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeBytesN): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeBytesN;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeBytesN;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeBytesN;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeBytesN;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecTypeUdt {
@@ -8186,9 +8562,9 @@ export namespace xdr {
 
     name(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecTypeUdt;
 
@@ -8198,13 +8574,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeUdt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeUdt;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeUdt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeUdt;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeUdt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecUdtStructFieldV0 {
@@ -8220,9 +8596,9 @@ export namespace xdr {
 
     type(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecUdtStructFieldV0;
 
@@ -8232,16 +8608,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtStructFieldV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtStructFieldV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtStructFieldV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScSpecUdtStructFieldV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecUdtStructV0 {
@@ -8260,9 +8636,9 @@ export namespace xdr {
 
     fields(value?: ScSpecUdtStructFieldV0[]): ScSpecUdtStructFieldV0[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecUdtStructV0;
 
@@ -8272,13 +8648,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtStructV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtStructV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtStructV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecUdtStructV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecUdtStructV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecUdtUnionCaseVoidV0 {
@@ -8288,9 +8664,9 @@ export namespace xdr {
 
     name(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecUdtUnionCaseVoidV0;
 
@@ -8300,16 +8676,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtUnionCaseVoidV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtUnionCaseVoidV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtUnionCaseVoidV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScSpecUdtUnionCaseVoidV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecUdtUnionCaseTupleV0 {
@@ -8325,9 +8701,9 @@ export namespace xdr {
 
     type(value?: ScSpecTypeDef[]): ScSpecTypeDef[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecUdtUnionCaseTupleV0;
 
@@ -8337,16 +8713,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtUnionCaseTupleV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtUnionCaseTupleV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtUnionCaseTupleV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScSpecUdtUnionCaseTupleV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecUdtUnionV0 {
@@ -8365,9 +8741,9 @@ export namespace xdr {
 
     cases(value?: ScSpecUdtUnionCaseV0[]): ScSpecUdtUnionCaseV0[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecUdtUnionV0;
 
@@ -8377,13 +8753,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtUnionV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtUnionV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtUnionV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecUdtUnionV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecUdtUnionV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecUdtEnumCaseV0 {
@@ -8399,9 +8775,9 @@ export namespace xdr {
 
     value(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecUdtEnumCaseV0;
 
@@ -8411,16 +8787,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtEnumCaseV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtEnumCaseV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtEnumCaseV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScSpecUdtEnumCaseV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecUdtEnumV0 {
@@ -8439,9 +8815,9 @@ export namespace xdr {
 
     cases(value?: ScSpecUdtEnumCaseV0[]): ScSpecUdtEnumCaseV0[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecUdtEnumV0;
 
@@ -8451,13 +8827,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtEnumV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtEnumV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtEnumV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecUdtEnumV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecUdtEnumV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecUdtErrorEnumCaseV0 {
@@ -8473,9 +8849,9 @@ export namespace xdr {
 
     value(value?: number): number;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecUdtErrorEnumCaseV0;
 
@@ -8485,16 +8861,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtErrorEnumCaseV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtErrorEnumCaseV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtErrorEnumCaseV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScSpecUdtErrorEnumCaseV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecUdtErrorEnumV0 {
@@ -8513,9 +8889,9 @@ export namespace xdr {
 
     cases(value?: ScSpecUdtErrorEnumCaseV0[]): ScSpecUdtErrorEnumCaseV0[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecUdtErrorEnumV0;
 
@@ -8525,16 +8901,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtErrorEnumV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtErrorEnumV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtErrorEnumV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScSpecUdtErrorEnumV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecFunctionInputV0 {
@@ -8550,9 +8926,9 @@ export namespace xdr {
 
     type(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecFunctionInputV0;
 
@@ -8562,16 +8938,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecFunctionInputV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecFunctionInputV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecFunctionInputV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScSpecFunctionInputV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecFunctionV0 {
@@ -8590,9 +8966,9 @@ export namespace xdr {
 
     outputs(value?: ScSpecTypeDef[]): ScSpecTypeDef[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecFunctionV0;
 
@@ -8602,13 +8978,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecFunctionV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecFunctionV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecFunctionV0;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecFunctionV0;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecFunctionV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpStatementPledges {
@@ -8638,9 +9014,9 @@ export namespace xdr {
       | ScpStatementExternalize
       | ScpNomination;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpStatementPledges;
 
@@ -8650,16 +9026,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementPledges): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementPledges;
+    static fromXDR(input: Buffer, format?: "raw"): ScpStatementPledges;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScpStatementPledges;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AssetCode {
@@ -8675,9 +9051,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AssetCode;
 
@@ -8687,13 +9063,13 @@ export namespace xdr {
 
     static toXDR(value: AssetCode): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AssetCode;
+    static fromXDR(input: Buffer, format?: "raw"): AssetCode;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AssetCode;
+    static fromXDR(input: string, format: "hex" | "base64"): AssetCode;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Asset {
@@ -8711,9 +9087,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Asset;
 
@@ -8723,13 +9099,13 @@ export namespace xdr {
 
     static toXDR(value: Asset): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Asset;
+    static fromXDR(input: Buffer, format?: "raw"): Asset;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Asset;
+    static fromXDR(input: string, format: "hex" | "base64"): Asset;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExtensionV2Ext {
@@ -8743,9 +9119,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV3 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExtensionV2Ext;
 
@@ -8755,16 +9131,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV2Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV2Ext;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV2Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AccountEntryExtensionV2Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExtensionV1Ext {
@@ -8778,9 +9154,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV2 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExtensionV1Ext;
 
@@ -8790,16 +9166,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AccountEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountEntryExt {
@@ -8813,9 +9189,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV1 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountEntryExt;
 
@@ -8825,13 +9201,13 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AccountEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): AccountEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineAsset {
@@ -8853,9 +9229,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | PoolId | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineAsset;
 
@@ -8865,13 +9241,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineAsset): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineAsset;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineAsset;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineAsset;
+    static fromXDR(input: string, format: "hex" | "base64"): TrustLineAsset;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntryExtensionV2Ext {
@@ -8881,9 +9257,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntryExtensionV2Ext;
 
@@ -8893,16 +9269,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExtensionV2Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExtensionV2Ext;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExtensionV2Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TrustLineEntryExtensionV2Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntryV1Ext {
@@ -8916,9 +9292,9 @@ export namespace xdr {
 
     value(): TrustLineEntryExtensionV2 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntryV1Ext;
 
@@ -8928,16 +9304,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryV1Ext;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryV1Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TrustLineEntryV1Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TrustLineEntryExt {
@@ -8951,9 +9327,9 @@ export namespace xdr {
 
     value(): TrustLineEntryV1 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TrustLineEntryExt;
 
@@ -8963,13 +9339,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OfferEntryExt {
@@ -8979,9 +9355,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OfferEntryExt;
 
@@ -8991,13 +9367,13 @@ export namespace xdr {
 
     static toXDR(value: OfferEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OfferEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): OfferEntryExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OfferEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): OfferEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class DataEntryExt {
@@ -9007,9 +9383,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): DataEntryExt;
 
@@ -9019,13 +9395,13 @@ export namespace xdr {
 
     static toXDR(value: DataEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): DataEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): DataEntryExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): DataEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): DataEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimPredicate {
@@ -9062,9 +9438,9 @@ export namespace xdr {
       | Int64
       | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimPredicate;
 
@@ -9074,13 +9450,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimPredicate): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimPredicate;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimPredicate;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimPredicate;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimPredicate;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Claimant {
@@ -9092,9 +9468,9 @@ export namespace xdr {
 
     value(): ClaimantV0;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Claimant;
 
@@ -9104,13 +9480,13 @@ export namespace xdr {
 
     static toXDR(value: Claimant): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Claimant;
+    static fromXDR(input: Buffer, format?: "raw"): Claimant;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Claimant;
+    static fromXDR(input: string, format: "hex" | "base64"): Claimant;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimableBalanceId {
@@ -9122,9 +9498,9 @@ export namespace xdr {
 
     value(): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimableBalanceId;
 
@@ -9134,13 +9510,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceId): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceId;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceId;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimableBalanceId;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimableBalanceId;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimableBalanceEntryExtensionV1Ext {
@@ -9150,9 +9526,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExtensionV1Ext;
 
@@ -9164,17 +9540,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): ClaimableBalanceEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimableBalanceEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimableBalanceEntryExt {
@@ -9190,9 +9566,9 @@ export namespace xdr {
 
     value(): ClaimableBalanceEntryExtensionV1 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExt;
 
@@ -9202,16 +9578,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceEntryExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimableBalanceEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolEntryBody {
@@ -9227,9 +9603,9 @@ export namespace xdr {
 
     value(): LiquidityPoolEntryConstantProduct;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolEntryBody;
 
@@ -9239,77 +9615,99 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolEntryBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolEntryBody;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolEntryBody;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolEntryBody;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
-  class ConfigSetting {
-    switch(): ConfigSettingType;
+  class ConfigSettingEntry {
+    switch(): ConfigSettingId;
 
-    uint32Val(value?: number): number;
+    contractMaxSizeBytes(value?: number): number;
 
-    static configSettingTypeUint32(value: number): ConfigSetting;
+    contractCompute(
+      value?: ConfigSettingContractComputeV0
+    ): ConfigSettingContractComputeV0;
 
-    value(): number;
+    contractLedgerCost(
+      value?: ConfigSettingContractLedgerCostV0
+    ): ConfigSettingContractLedgerCostV0;
 
-    toXDR(format?: 'raw'): Buffer;
+    contractHistoricalData(
+      value?: ConfigSettingContractHistoricalDataV0
+    ): ConfigSettingContractHistoricalDataV0;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    contractMetaData(
+      value?: ConfigSettingContractMetaDataV0
+    ): ConfigSettingContractMetaDataV0;
 
-    static read(io: Buffer): ConfigSetting;
+    contractBandwidth(
+      value?: ConfigSettingContractBandwidthV0
+    ): ConfigSettingContractBandwidthV0;
 
-    static write(value: ConfigSetting, io: Buffer): void;
+    contractHostLogicVersion(value?: number): number;
 
-    static isValid(value: ConfigSetting): boolean;
+    static configSettingContractMaxSizeBytes(value: number): ConfigSettingEntry;
 
-    static toXDR(value: ConfigSetting): Buffer;
+    static configSettingContractComputeV0(
+      value: ConfigSettingContractComputeV0
+    ): ConfigSettingEntry;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ConfigSetting;
+    static configSettingContractLedgerCostV0(
+      value: ConfigSettingContractLedgerCostV0
+    ): ConfigSettingEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ConfigSetting;
+    static configSettingContractHistoricalDataV0(
+      value: ConfigSettingContractHistoricalDataV0
+    ): ConfigSettingEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static configSettingContractMetaDataV0(
+      value: ConfigSettingContractMetaDataV0
+    ): ConfigSettingEntry;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
-  }
+    static configSettingContractBandwidthV0(
+      value: ConfigSettingContractBandwidthV0
+    ): ConfigSettingEntry;
 
-  class ConfigSettingEntryExt {
-    switch(): number;
+    static configSettingContractHostLogicVersion(
+      value: number
+    ): ConfigSettingEntry;
 
-    static 0(): ConfigSettingEntryExt;
+    value():
+      | number
+      | ConfigSettingContractComputeV0
+      | ConfigSettingContractLedgerCostV0
+      | ConfigSettingContractHistoricalDataV0
+      | ConfigSettingContractMetaDataV0
+      | ConfigSettingContractBandwidthV0
+      | number;
 
-    value(): void;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format: "hex" | "base64"): string;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    static read(io: Buffer): ConfigSettingEntry;
 
-    static read(io: Buffer): ConfigSettingEntryExt;
+    static write(value: ConfigSettingEntry, io: Buffer): void;
 
-    static write(value: ConfigSettingEntryExt, io: Buffer): void;
+    static isValid(value: ConfigSettingEntry): boolean;
 
-    static isValid(value: ConfigSettingEntryExt): boolean;
+    static toXDR(value: ConfigSettingEntry): Buffer;
 
-    static toXDR(value: ConfigSettingEntryExt): Buffer;
+    static fromXDR(input: Buffer, format?: "raw"): ConfigSettingEntry;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ConfigSettingEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): ConfigSettingEntry;
 
-    static fromXDR(
-      input: string,
-      format: 'hex' | 'base64'
-    ): ConfigSettingEntryExt;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
-
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntryExtensionV1Ext {
@@ -9319,9 +9717,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntryExtensionV1Ext;
 
@@ -9331,16 +9729,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntryData {
@@ -9393,9 +9791,9 @@ export namespace xdr {
       | ContractCodeEntry
       | ConfigSettingEntry;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntryData;
 
@@ -9405,13 +9803,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryData): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryData;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryData;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryData;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryData;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntryExt {
@@ -9425,9 +9823,9 @@ export namespace xdr {
 
     value(): LedgerEntryExtensionV1 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntryExt;
 
@@ -9437,13 +9835,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryExt;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerKey {
@@ -9498,9 +9896,9 @@ export namespace xdr {
       | LedgerKeyContractCode
       | LedgerKeyConfigSetting;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerKey;
 
@@ -9510,13 +9908,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerKey;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerKey;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKey;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerKey;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class StellarValueExt {
@@ -9534,9 +9932,9 @@ export namespace xdr {
 
     value(): LedgerCloseValueSignature | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): StellarValueExt;
 
@@ -9546,13 +9944,13 @@ export namespace xdr {
 
     static toXDR(value: StellarValueExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): StellarValueExt;
+    static fromXDR(input: Buffer, format?: "raw"): StellarValueExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): StellarValueExt;
+    static fromXDR(input: string, format: "hex" | "base64"): StellarValueExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeaderExtensionV1Ext {
@@ -9562,9 +9960,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeaderExtensionV1Ext;
 
@@ -9574,16 +9972,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerHeaderExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeaderExt {
@@ -9597,9 +9995,9 @@ export namespace xdr {
 
     value(): LedgerHeaderExtensionV1 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeaderExt;
 
@@ -9609,13 +10007,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExt;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerHeaderExt;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerHeaderExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerUpgrade {
@@ -9631,9 +10029,7 @@ export namespace xdr {
 
     newFlags(value?: number): number;
 
-    configSetting(
-      value?: LedgerUpgradeConfigSetting
-    ): LedgerUpgradeConfigSetting;
+    newConfig(value?: ConfigUpgradeSetKey): ConfigUpgradeSetKey;
 
     static ledgerUpgradeVersion(value: number): LedgerUpgrade;
 
@@ -9645,21 +10041,13 @@ export namespace xdr {
 
     static ledgerUpgradeFlags(value: number): LedgerUpgrade;
 
-    static ledgerUpgradeConfig(
-      value: LedgerUpgradeConfigSetting
-    ): LedgerUpgrade;
+    static ledgerUpgradeConfig(value: ConfigUpgradeSetKey): LedgerUpgrade;
 
-    value():
-      | number
-      | number
-      | number
-      | number
-      | number
-      | LedgerUpgradeConfigSetting;
+    value(): number | number | number | number | number | ConfigUpgradeSetKey;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerUpgrade;
 
@@ -9669,13 +10057,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerUpgrade): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerUpgrade;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerUpgrade;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerUpgrade;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerUpgrade;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BucketMetadataExt {
@@ -9685,9 +10073,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BucketMetadataExt;
 
@@ -9697,13 +10085,13 @@ export namespace xdr {
 
     static toXDR(value: BucketMetadataExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): BucketMetadataExt;
+    static fromXDR(input: Buffer, format?: "raw"): BucketMetadataExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): BucketMetadataExt;
+    static fromXDR(input: string, format: "hex" | "base64"): BucketMetadataExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BucketEntry {
@@ -9725,9 +10113,9 @@ export namespace xdr {
 
     value(): LedgerEntry | LedgerKey | BucketMetadata;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BucketEntry;
 
@@ -9737,13 +10125,13 @@ export namespace xdr {
 
     static toXDR(value: BucketEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): BucketEntry;
+    static fromXDR(input: Buffer, format?: "raw"): BucketEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): BucketEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): BucketEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TxSetComponent {
@@ -9759,9 +10147,9 @@ export namespace xdr {
 
     value(): TxSetComponentTxsMaybeDiscountedFee;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TxSetComponent;
 
@@ -9771,13 +10159,13 @@ export namespace xdr {
 
     static toXDR(value: TxSetComponent): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TxSetComponent;
+    static fromXDR(input: Buffer, format?: "raw"): TxSetComponent;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TxSetComponent;
+    static fromXDR(input: string, format: "hex" | "base64"): TxSetComponent;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionPhase {
@@ -9789,9 +10177,9 @@ export namespace xdr {
 
     value(): TxSetComponent[];
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionPhase;
 
@@ -9801,13 +10189,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionPhase): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionPhase;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionPhase;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionPhase;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionPhase;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class GeneralizedTransactionSet {
@@ -9819,9 +10207,9 @@ export namespace xdr {
 
     value(): TransactionSetV1;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): GeneralizedTransactionSet;
 
@@ -9831,16 +10219,16 @@ export namespace xdr {
 
     static toXDR(value: GeneralizedTransactionSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): GeneralizedTransactionSet;
+    static fromXDR(input: Buffer, format?: "raw"): GeneralizedTransactionSet;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): GeneralizedTransactionSet;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionHistoryEntryExt {
@@ -9856,9 +10244,9 @@ export namespace xdr {
 
     value(): GeneralizedTransactionSet | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionHistoryEntryExt;
 
@@ -9868,16 +10256,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionHistoryEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionHistoryEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionHistoryEntryExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionHistoryEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionHistoryResultEntryExt {
@@ -9887,9 +10275,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionHistoryResultEntryExt;
 
@@ -9901,17 +10289,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): TransactionHistoryResultEntryExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionHistoryResultEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionHistoryResultEntryV2Ext {
@@ -9921,9 +10309,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionHistoryResultEntryV2Ext;
 
@@ -9935,17 +10323,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): TransactionHistoryResultEntryV2Ext;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionHistoryResultEntryV2Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerHeaderHistoryEntryExt {
@@ -9955,9 +10343,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerHeaderHistoryEntryExt;
 
@@ -9967,16 +10355,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderHistoryEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderHistoryEntryExt;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderHistoryEntryExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LedgerHeaderHistoryEntryExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScpHistoryEntry {
@@ -9988,9 +10376,9 @@ export namespace xdr {
 
     value(): ScpHistoryEntryV0;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScpHistoryEntry;
 
@@ -10000,13 +10388,13 @@ export namespace xdr {
 
     static toXDR(value: ScpHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScpHistoryEntry;
+    static fromXDR(input: Buffer, format?: "raw"): ScpHistoryEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScpHistoryEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): ScpHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerEntryChange {
@@ -10030,9 +10418,9 @@ export namespace xdr {
 
     value(): LedgerEntry | LedgerEntry | LedgerKey | LedgerEntry;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerEntryChange;
 
@@ -10042,13 +10430,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryChange): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryChange;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryChange;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryChange;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryChange;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ContractEventBody {
@@ -10060,9 +10448,9 @@ export namespace xdr {
 
     value(): ContractEventV0;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ContractEventBody;
 
@@ -10072,13 +10460,13 @@ export namespace xdr {
 
     static toXDR(value: ContractEventBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ContractEventBody;
+    static fromXDR(input: Buffer, format?: "raw"): ContractEventBody;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ContractEventBody;
+    static fromXDR(input: string, format: "hex" | "base64"): ContractEventBody;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionMeta {
@@ -10106,9 +10494,9 @@ export namespace xdr {
       | TransactionMetaV2
       | TransactionMetaV3;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionMeta;
 
@@ -10118,13 +10506,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionMeta;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionMeta;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMeta;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionMeta;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LedgerCloseMeta {
@@ -10144,9 +10532,9 @@ export namespace xdr {
 
     value(): LedgerCloseMetaV0 | LedgerCloseMetaV1 | LedgerCloseMetaV2;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LedgerCloseMeta;
 
@@ -10156,13 +10544,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMeta;
+    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMeta;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMeta;
+    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMeta;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PeerAddressIp {
@@ -10178,9 +10566,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PeerAddressIp;
 
@@ -10190,13 +10578,13 @@ export namespace xdr {
 
     static toXDR(value: PeerAddressIp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PeerAddressIp;
+    static fromXDR(input: Buffer, format?: "raw"): PeerAddressIp;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PeerAddressIp;
+    static fromXDR(input: string, format: "hex" | "base64"): PeerAddressIp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SurveyResponseBody {
@@ -10220,9 +10608,9 @@ export namespace xdr {
 
     value(): TopologyResponseBodyV0 | TopologyResponseBodyV1;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SurveyResponseBody;
 
@@ -10232,13 +10620,13 @@ export namespace xdr {
 
     static toXDR(value: SurveyResponseBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SurveyResponseBody;
+    static fromXDR(input: Buffer, format?: "raw"): SurveyResponseBody;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): SurveyResponseBody;
+    static fromXDR(input: string, format: "hex" | "base64"): SurveyResponseBody;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class StellarMessage {
@@ -10345,9 +10733,9 @@ export namespace xdr {
       | FloodDemand
       | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): StellarMessage;
 
@@ -10357,13 +10745,13 @@ export namespace xdr {
 
     static toXDR(value: StellarMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): StellarMessage;
+    static fromXDR(input: Buffer, format?: "raw"): StellarMessage;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): StellarMessage;
+    static fromXDR(input: string, format: "hex" | "base64"): StellarMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AuthenticatedMessage {
@@ -10375,9 +10763,9 @@ export namespace xdr {
 
     value(): AuthenticatedMessageV0;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AuthenticatedMessage;
 
@@ -10387,16 +10775,16 @@ export namespace xdr {
 
     static toXDR(value: AuthenticatedMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AuthenticatedMessage;
+    static fromXDR(input: Buffer, format?: "raw"): AuthenticatedMessage;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): AuthenticatedMessage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolParameters {
@@ -10412,9 +10800,9 @@ export namespace xdr {
 
     value(): LiquidityPoolConstantProductParameters;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolParameters;
 
@@ -10424,16 +10812,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolParameters): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolParameters;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolParameters;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolParameters;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class MuxedAccount {
@@ -10449,9 +10837,9 @@ export namespace xdr {
 
     value(): Buffer | MuxedAccountMed25519;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): MuxedAccount;
 
@@ -10461,13 +10849,13 @@ export namespace xdr {
 
     static toXDR(value: MuxedAccount): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): MuxedAccount;
+    static fromXDR(input: Buffer, format?: "raw"): MuxedAccount;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): MuxedAccount;
+    static fromXDR(input: string, format: "hex" | "base64"): MuxedAccount;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ChangeTrustAsset {
@@ -10489,9 +10877,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | LiquidityPoolParameters | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ChangeTrustAsset;
 
@@ -10501,13 +10889,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustAsset): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustAsset;
+    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustAsset;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustAsset;
+    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustAsset;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class RevokeSponsorshipOp {
@@ -10525,9 +10913,9 @@ export namespace xdr {
 
     value(): LedgerKey | RevokeSponsorshipOpSigner;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): RevokeSponsorshipOp;
 
@@ -10537,16 +10925,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipOp;
+    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipOp;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): RevokeSponsorshipOp;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ContractId {
@@ -10570,9 +10958,9 @@ export namespace xdr {
 
     value(): Buffer | ContractIdFromEd25519PublicKey | Asset;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ContractId;
 
@@ -10582,13 +10970,13 @@ export namespace xdr {
 
     static toXDR(value: ContractId): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ContractId;
+    static fromXDR(input: Buffer, format?: "raw"): ContractId;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ContractId;
+    static fromXDR(input: string, format: "hex" | "base64"): ContractId;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HostFunction {
@@ -10614,9 +11002,9 @@ export namespace xdr {
 
     value(): ScVal[] | CreateContractArgs | InstallContractCodeArgs;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HostFunction;
 
@@ -10626,13 +11014,13 @@ export namespace xdr {
 
     static toXDR(value: HostFunction): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HostFunction;
+    static fromXDR(input: Buffer, format?: "raw"): HostFunction;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): HostFunction;
+    static fromXDR(input: string, format: "hex" | "base64"): HostFunction;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OperationBody {
@@ -10788,9 +11176,9 @@ export namespace xdr {
       | InvokeHostFunctionOp
       | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OperationBody;
 
@@ -10800,13 +11188,13 @@ export namespace xdr {
 
     static toXDR(value: OperationBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OperationBody;
+    static fromXDR(input: Buffer, format?: "raw"): OperationBody;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OperationBody;
+    static fromXDR(input: string, format: "hex" | "base64"): OperationBody;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class HashIdPreimage {
@@ -10876,9 +11264,9 @@ export namespace xdr {
       | HashIdPreimageCreateContractArgs
       | HashIdPreimageContractAuth;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): HashIdPreimage;
 
@@ -10888,13 +11276,13 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimage): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimage;
+    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimage;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): HashIdPreimage;
+    static fromXDR(input: string, format: "hex" | "base64"): HashIdPreimage;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Memo {
@@ -10920,9 +11308,9 @@ export namespace xdr {
 
     value(): string | Buffer | Uint64 | Buffer | Buffer | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Memo;
 
@@ -10932,13 +11320,13 @@ export namespace xdr {
 
     static toXDR(value: Memo): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Memo;
+    static fromXDR(input: Buffer, format?: "raw"): Memo;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Memo;
+    static fromXDR(input: string, format: "hex" | "base64"): Memo;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class Preconditions {
@@ -10956,9 +11344,9 @@ export namespace xdr {
 
     value(): TimeBounds | PreconditionsV2 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): Preconditions;
 
@@ -10968,13 +11356,13 @@ export namespace xdr {
 
     static toXDR(value: Preconditions): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Preconditions;
+    static fromXDR(input: Buffer, format?: "raw"): Preconditions;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Preconditions;
+    static fromXDR(input: string, format: "hex" | "base64"): Preconditions;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionV0Ext {
@@ -10984,9 +11372,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionV0Ext;
 
@@ -10996,13 +11384,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0Ext;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionV0Ext;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionV0Ext;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionV0Ext;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionExt {
@@ -11012,9 +11400,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionExt;
 
@@ -11024,13 +11412,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionExt;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionExt;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionExt;
+    static fromXDR(input: string, format: "hex" | "base64"): TransactionExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class FeeBumpTransactionInnerTx {
@@ -11044,9 +11432,9 @@ export namespace xdr {
 
     value(): TransactionV1Envelope;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): FeeBumpTransactionInnerTx;
 
@@ -11056,16 +11444,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionInnerTx): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionInnerTx;
+    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionInnerTx;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): FeeBumpTransactionInnerTx;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class FeeBumpTransactionExt {
@@ -11075,9 +11463,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): FeeBumpTransactionExt;
 
@@ -11087,16 +11475,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionExt;
+    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): FeeBumpTransactionExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionEnvelope {
@@ -11121,9 +11509,9 @@ export namespace xdr {
       | TransactionV1Envelope
       | FeeBumpTransactionEnvelope;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionEnvelope;
 
@@ -11133,16 +11521,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionEnvelope;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionEnvelope;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionEnvelope;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionSignaturePayloadTaggedTransaction {
@@ -11162,9 +11550,9 @@ export namespace xdr {
 
     value(): Transaction | FeeBumpTransaction;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionSignaturePayloadTaggedTransaction;
 
@@ -11181,17 +11569,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): TransactionSignaturePayloadTaggedTransaction;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionSignaturePayloadTaggedTransaction;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimAtom {
@@ -11211,9 +11599,9 @@ export namespace xdr {
 
     value(): ClaimOfferAtomV0 | ClaimOfferAtom | ClaimLiquidityAtom;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimAtom;
 
@@ -11223,13 +11611,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimAtom;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimAtom;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimAtom;
+    static fromXDR(input: string, format: "hex" | "base64"): ClaimAtom;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreateAccountResult {
@@ -11247,9 +11635,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreateAccountResult;
 
@@ -11259,16 +11647,16 @@ export namespace xdr {
 
     static toXDR(value: CreateAccountResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreateAccountResult;
+    static fromXDR(input: Buffer, format?: "raw"): CreateAccountResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): CreateAccountResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PaymentResult {
@@ -11296,9 +11684,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PaymentResult;
 
@@ -11308,13 +11696,13 @@ export namespace xdr {
 
     static toXDR(value: PaymentResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PaymentResult;
+    static fromXDR(input: Buffer, format?: "raw"): PaymentResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PaymentResult;
+    static fromXDR(input: string, format: "hex" | "base64"): PaymentResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictReceiveResult {
@@ -11358,9 +11746,9 @@ export namespace xdr {
 
     value(): PathPaymentStrictReceiveResultSuccess | Asset | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveResult;
 
@@ -11372,17 +11760,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): PathPaymentStrictReceiveResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictReceiveResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PathPaymentStrictSendResult {
@@ -11426,9 +11814,9 @@ export namespace xdr {
 
     value(): PathPaymentStrictSendResultSuccess | Asset | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PathPaymentStrictSendResult;
 
@@ -11438,16 +11826,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictSendResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictSendResult;
+    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictSendResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): PathPaymentStrictSendResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageOfferSuccessResultOffer {
@@ -11463,9 +11851,9 @@ export namespace xdr {
 
     value(): OfferEntry | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageOfferSuccessResultOffer;
 
@@ -11477,17 +11865,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): ManageOfferSuccessResultOffer;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ManageOfferSuccessResultOffer;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageSellOfferResult {
@@ -11525,9 +11913,9 @@ export namespace xdr {
 
     value(): ManageOfferSuccessResult | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageSellOfferResult;
 
@@ -11537,16 +11925,16 @@ export namespace xdr {
 
     static toXDR(value: ManageSellOfferResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageSellOfferResult;
+    static fromXDR(input: Buffer, format?: "raw"): ManageSellOfferResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ManageSellOfferResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageBuyOfferResult {
@@ -11584,9 +11972,9 @@ export namespace xdr {
 
     value(): ManageOfferSuccessResult | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageBuyOfferResult;
 
@@ -11596,16 +11984,16 @@ export namespace xdr {
 
     static toXDR(value: ManageBuyOfferResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageBuyOfferResult;
+    static fromXDR(input: Buffer, format?: "raw"): ManageBuyOfferResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ManageBuyOfferResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SetOptionsResult {
@@ -11635,9 +12023,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SetOptionsResult;
 
@@ -11647,13 +12035,13 @@ export namespace xdr {
 
     static toXDR(value: SetOptionsResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SetOptionsResult;
+    static fromXDR(input: Buffer, format?: "raw"): SetOptionsResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): SetOptionsResult;
+    static fromXDR(input: string, format: "hex" | "base64"): SetOptionsResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ChangeTrustResult {
@@ -11679,9 +12067,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ChangeTrustResult;
 
@@ -11691,13 +12079,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustResult;
+    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustResult;
+    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AllowTrustResult {
@@ -11719,9 +12107,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AllowTrustResult;
 
@@ -11731,13 +12119,13 @@ export namespace xdr {
 
     static toXDR(value: AllowTrustResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AllowTrustResult;
+    static fromXDR(input: Buffer, format?: "raw"): AllowTrustResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AllowTrustResult;
+    static fromXDR(input: string, format: "hex" | "base64"): AllowTrustResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class AccountMergeResult {
@@ -11763,9 +12151,9 @@ export namespace xdr {
 
     value(): Int64 | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): AccountMergeResult;
 
@@ -11775,13 +12163,13 @@ export namespace xdr {
 
     static toXDR(value: AccountMergeResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): AccountMergeResult;
+    static fromXDR(input: Buffer, format?: "raw"): AccountMergeResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): AccountMergeResult;
+    static fromXDR(input: string, format: "hex" | "base64"): AccountMergeResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InflationResult {
@@ -11795,9 +12183,9 @@ export namespace xdr {
 
     value(): InflationPayout[] | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InflationResult;
 
@@ -11807,13 +12195,13 @@ export namespace xdr {
 
     static toXDR(value: InflationResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InflationResult;
+    static fromXDR(input: Buffer, format?: "raw"): InflationResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): InflationResult;
+    static fromXDR(input: string, format: "hex" | "base64"): InflationResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ManageDataResult {
@@ -11831,9 +12219,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ManageDataResult;
 
@@ -11843,13 +12231,13 @@ export namespace xdr {
 
     static toXDR(value: ManageDataResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ManageDataResult;
+    static fromXDR(input: Buffer, format?: "raw"): ManageDataResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ManageDataResult;
+    static fromXDR(input: string, format: "hex" | "base64"): ManageDataResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BumpSequenceResult {
@@ -11861,9 +12249,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BumpSequenceResult;
 
@@ -11873,13 +12261,13 @@ export namespace xdr {
 
     static toXDR(value: BumpSequenceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): BumpSequenceResult;
+    static fromXDR(input: Buffer, format?: "raw"): BumpSequenceResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): BumpSequenceResult;
+    static fromXDR(input: string, format: "hex" | "base64"): BumpSequenceResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class CreateClaimableBalanceResult {
@@ -11903,9 +12291,9 @@ export namespace xdr {
 
     value(): ClaimableBalanceId | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): CreateClaimableBalanceResult;
 
@@ -11915,16 +12303,16 @@ export namespace xdr {
 
     static toXDR(value: CreateClaimableBalanceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): CreateClaimableBalanceResult;
+    static fromXDR(input: Buffer, format?: "raw"): CreateClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): CreateClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClaimClaimableBalanceResult {
@@ -11944,9 +12332,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClaimClaimableBalanceResult;
 
@@ -11956,16 +12344,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimClaimableBalanceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClaimClaimableBalanceResult;
+    static fromXDR(input: Buffer, format?: "raw"): ClaimClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClaimClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class BeginSponsoringFutureReservesResult {
@@ -11981,9 +12369,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): BeginSponsoringFutureReservesResult;
 
@@ -11995,17 +12383,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): BeginSponsoringFutureReservesResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): BeginSponsoringFutureReservesResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class EndSponsoringFutureReservesResult {
@@ -12017,9 +12405,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): EndSponsoringFutureReservesResult;
 
@@ -12031,17 +12419,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): EndSponsoringFutureReservesResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): EndSponsoringFutureReservesResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class RevokeSponsorshipResult {
@@ -12061,9 +12449,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): RevokeSponsorshipResult;
 
@@ -12073,16 +12461,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipResult;
+    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): RevokeSponsorshipResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClawbackResult {
@@ -12100,9 +12488,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClawbackResult;
 
@@ -12112,13 +12500,13 @@ export namespace xdr {
 
     static toXDR(value: ClawbackResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ClawbackResult;
+    static fromXDR(input: Buffer, format?: "raw"): ClawbackResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ClawbackResult;
+    static fromXDR(input: string, format: "hex" | "base64"): ClawbackResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ClawbackClaimableBalanceResult {
@@ -12134,9 +12522,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ClawbackClaimableBalanceResult;
 
@@ -12148,17 +12536,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: 'raw'
+      format?: "raw"
     ): ClawbackClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ClawbackClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SetTrustLineFlagsResult {
@@ -12178,9 +12566,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SetTrustLineFlagsResult;
 
@@ -12190,16 +12578,16 @@ export namespace xdr {
 
     static toXDR(value: SetTrustLineFlagsResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SetTrustLineFlagsResult;
+    static fromXDR(input: Buffer, format?: "raw"): SetTrustLineFlagsResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): SetTrustLineFlagsResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolDepositResult {
@@ -12223,9 +12611,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolDepositResult;
 
@@ -12235,16 +12623,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolDepositResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolDepositResult;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolDepositResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolDepositResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class LiquidityPoolWithdrawResult {
@@ -12264,9 +12652,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): LiquidityPoolWithdrawResult;
 
@@ -12276,16 +12664,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolWithdrawResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolWithdrawResult;
+    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolWithdrawResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): LiquidityPoolWithdrawResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InvokeHostFunctionResult {
@@ -12301,9 +12689,9 @@ export namespace xdr {
 
     value(): ScVal | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InvokeHostFunctionResult;
 
@@ -12313,16 +12701,16 @@ export namespace xdr {
 
     static toXDR(value: InvokeHostFunctionResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InvokeHostFunctionResult;
+    static fromXDR(input: Buffer, format?: "raw"): InvokeHostFunctionResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InvokeHostFunctionResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OperationResultTr {
@@ -12503,9 +12891,9 @@ export namespace xdr {
       | LiquidityPoolWithdrawResult
       | InvokeHostFunctionResult;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OperationResultTr;
 
@@ -12515,13 +12903,13 @@ export namespace xdr {
 
     static toXDR(value: OperationResultTr): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OperationResultTr;
+    static fromXDR(input: Buffer, format?: "raw"): OperationResultTr;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OperationResultTr;
+    static fromXDR(input: string, format: "hex" | "base64"): OperationResultTr;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class OperationResult {
@@ -12545,9 +12933,9 @@ export namespace xdr {
 
     value(): OperationResultTr | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): OperationResult;
 
@@ -12557,13 +12945,13 @@ export namespace xdr {
 
     static toXDR(value: OperationResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): OperationResult;
+    static fromXDR(input: Buffer, format?: "raw"): OperationResult;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): OperationResult;
+    static fromXDR(input: string, format: "hex" | "base64"): OperationResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InnerTransactionResultResult {
@@ -12605,9 +12993,9 @@ export namespace xdr {
 
     value(): OperationResult[] | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InnerTransactionResultResult;
 
@@ -12617,16 +13005,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultResult;
+    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InnerTransactionResultResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class InnerTransactionResultExt {
@@ -12636,9 +13024,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): InnerTransactionResultExt;
 
@@ -12648,16 +13036,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultExt;
+    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): InnerTransactionResultExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultResult {
@@ -12711,9 +13099,9 @@ export namespace xdr {
 
     value(): InnerTransactionResultPair | OperationResult[] | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultResult;
 
@@ -12723,16 +13111,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultResult;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultResult;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultResult;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class TransactionResultExt {
@@ -12742,9 +13130,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): TransactionResultExt;
 
@@ -12754,16 +13142,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultExt;
+    static fromXDR(input: Buffer, format?: "raw"): TransactionResultExt;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): TransactionResultExt;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ExtensionPoint {
@@ -12773,9 +13161,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ExtensionPoint;
 
@@ -12785,13 +13173,13 @@ export namespace xdr {
 
     static toXDR(value: ExtensionPoint): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ExtensionPoint;
+    static fromXDR(input: Buffer, format?: "raw"): ExtensionPoint;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ExtensionPoint;
+    static fromXDR(input: string, format: "hex" | "base64"): ExtensionPoint;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class PublicKey {
@@ -12803,9 +13191,9 @@ export namespace xdr {
 
     value(): Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): PublicKey;
 
@@ -12815,13 +13203,13 @@ export namespace xdr {
 
     static toXDR(value: PublicKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): PublicKey;
+    static fromXDR(input: Buffer, format?: "raw"): PublicKey;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): PublicKey;
+    static fromXDR(input: string, format: "hex" | "base64"): PublicKey;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class SignerKey {
@@ -12849,9 +13237,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer | Buffer | SignerKeyEd25519SignedPayload;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): SignerKey;
 
@@ -12861,13 +13249,13 @@ export namespace xdr {
 
     static toXDR(value: SignerKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): SignerKey;
+    static fromXDR(input: Buffer, format?: "raw"): SignerKey;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): SignerKey;
+    static fromXDR(input: string, format: "hex" | "base64"): SignerKey;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScStatus {
@@ -12923,9 +13311,9 @@ export namespace xdr {
       | ScHostAuthErrorCode
       | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScStatus;
 
@@ -12935,13 +13323,13 @@ export namespace xdr {
 
     static toXDR(value: ScStatus): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScStatus;
+    static fromXDR(input: Buffer, format?: "raw"): ScStatus;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScStatus;
+    static fromXDR(input: string, format: "hex" | "base64"): ScStatus;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScContractExecutable {
@@ -12955,9 +13343,9 @@ export namespace xdr {
 
     value(): Buffer | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScContractExecutable;
 
@@ -12967,16 +13355,16 @@ export namespace xdr {
 
     static toXDR(value: ScContractExecutable): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScContractExecutable;
+    static fromXDR(input: Buffer, format?: "raw"): ScContractExecutable;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScContractExecutable;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScAddress {
@@ -12992,9 +13380,9 @@ export namespace xdr {
 
     value(): AccountId | Buffer;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScAddress;
 
@@ -13004,13 +13392,13 @@ export namespace xdr {
 
     static toXDR(value: ScAddress): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScAddress;
+    static fromXDR(input: Buffer, format?: "raw"): ScAddress;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScAddress;
+    static fromXDR(input: string, format: "hex" | "base64"): ScAddress;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScVal {
@@ -13032,13 +13420,13 @@ export namespace xdr {
 
     duration(value?: Duration): Duration;
 
-    u128(value?: Int128Parts): Int128Parts;
+    u128(value?: UInt128Parts): UInt128Parts;
 
     i128(value?: Int128Parts): Int128Parts;
 
-    u256(value?: Buffer): Buffer;
+    u256(value?: UInt256Parts): UInt256Parts;
 
-    i256(value?: Buffer): Buffer;
+    i256(value?: Int256Parts): Int256Parts;
 
     bytes(value?: Buffer): Buffer;
 
@@ -13074,13 +13462,13 @@ export namespace xdr {
 
     static scvDuration(value: Duration): ScVal;
 
-    static scvU128(value: Int128Parts): ScVal;
+    static scvU128(value: UInt128Parts): ScVal;
 
     static scvI128(value: Int128Parts): ScVal;
 
-    static scvU256(value: Buffer): ScVal;
+    static scvU256(value: UInt256Parts): ScVal;
 
-    static scvI256(value: Buffer): ScVal;
+    static scvI256(value: Int256Parts): ScVal;
 
     static scvBytes(value: Buffer): ScVal;
 
@@ -13109,10 +13497,10 @@ export namespace xdr {
       | Int64
       | TimePoint
       | Duration
+      | UInt128Parts
       | Int128Parts
-      | Int128Parts
-      | Buffer
-      | Buffer
+      | UInt256Parts
+      | Int256Parts
       | Buffer
       | string
       | Buffer
@@ -13127,9 +13515,9 @@ export namespace xdr {
       | ScNonceKey
       | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScVal;
 
@@ -13139,13 +13527,13 @@ export namespace xdr {
 
     static toXDR(value: ScVal): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScVal;
+    static fromXDR(input: Buffer, format?: "raw"): ScVal;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScVal;
+    static fromXDR(input: string, format: "hex" | "base64"): ScVal;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScEnvMetaEntry {
@@ -13157,9 +13545,9 @@ export namespace xdr {
 
     value(): Uint64;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScEnvMetaEntry;
 
@@ -13169,13 +13557,13 @@ export namespace xdr {
 
     static toXDR(value: ScEnvMetaEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScEnvMetaEntry;
+    static fromXDR(input: Buffer, format?: "raw"): ScEnvMetaEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScEnvMetaEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): ScEnvMetaEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecTypeDef {
@@ -13260,9 +13648,9 @@ export namespace xdr {
       | ScSpecTypeUdt
       | void;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecTypeDef;
 
@@ -13272,13 +13660,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeDef): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeDef;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeDef;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeDef;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeDef;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecUdtUnionCaseV0 {
@@ -13298,9 +13686,9 @@ export namespace xdr {
 
     value(): ScSpecUdtUnionCaseVoidV0 | ScSpecUdtUnionCaseTupleV0;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecUdtUnionCaseV0;
 
@@ -13310,16 +13698,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtUnionCaseV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtUnionCaseV0;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtUnionCaseV0;
 
     static fromXDR(
       input: string,
-      format: 'hex' | 'base64'
+      format: "hex" | "base64"
     ): ScSpecUdtUnionCaseV0;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
   class ScSpecEntry {
@@ -13352,9 +13740,9 @@ export namespace xdr {
       | ScSpecUdtEnumV0
       | ScSpecUdtErrorEnumV0;
 
-    toXDR(format?: 'raw'): Buffer;
+    toXDR(format?: "raw"): Buffer;
 
-    toXDR(format: 'hex' | 'base64'): string;
+    toXDR(format: "hex" | "base64"): string;
 
     static read(io: Buffer): ScSpecEntry;
 
@@ -13364,12 +13752,12 @@ export namespace xdr {
 
     static toXDR(value: ScSpecEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): ScSpecEntry;
+    static fromXDR(input: Buffer, format?: "raw"): ScSpecEntry;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecEntry;
+    static fromXDR(input: string, format: "hex" | "base64"): ScSpecEntry;
 
-    static validateXDR(input: Buffer, format?: 'raw'): boolean;
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
 
-    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 }

--- a/types/next.d.ts
+++ b/types/next.d.ts
@@ -20,17 +20,17 @@ declare namespace xdrHidden {
 
     toXDR(format: 'hex' | 'base64'): string;
 
-    static read(io: Buffer): Operation;
+    static read(io: Buffer): xdr.Operation;
 
-    static write(value: Operation, io: Buffer): void;
+    static write(value: xdr.Operation, io: Buffer): void;
 
-    static isValid(value: Operation): boolean;
+    static isValid(value: xdr.Operation): boolean;
 
-    static toXDR(value: Operation): Buffer;
+    static toXDR(value: xdr.Operation): Buffer;
 
-    static fromXDR(input: Buffer, format?: 'raw'): Operation;
+    static fromXDR(input: Buffer, format?: 'raw'): xdr.Operation;
 
-    static fromXDR(input: string, format: 'hex' | 'base64'): Operation;
+    static fromXDR(input: string, format: 'hex' | 'base64'): xdr.Operation;
 
     static validateXDR(input: Buffer, format?: 'raw'): boolean;
 

--- a/types/next.d.ts
+++ b/types/next.d.ts
@@ -1,4 +1,4 @@
-// Automatically generated on 2022-08-12T12:40:00+01:00
+// Automatically generated on 2023-04-20T14:53:00-08:00
 import { Operation } from './index';
 
 export {};
@@ -16,9 +16,9 @@ declare namespace xdrHidden {
 
     body(value?: xdr.OperationBody): xdr.OperationBody;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Operation;
 
@@ -28,13 +28,13 @@ declare namespace xdrHidden {
 
     static toXDR(value: Operation): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Operation;
+    static fromXDR(input: Buffer, format?: 'raw'): Operation;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Operation;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Operation;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 }
 
@@ -48,10 +48,10 @@ export namespace xdr {
     write(value: number, io: Buffer): void;
     isValid(value: number): boolean;
     toXDR(value: number): Buffer;
-    fromXDR(input: Buffer, format?: "raw"): number;
-    fromXDR(input: string, format: "hex" | "base64"): number;
-    validateXDR(input: Buffer, format?: "raw"): boolean;
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    fromXDR(input: Buffer, format?: 'raw'): number;
+    fromXDR(input: string, format: 'hex' | 'base64'): number;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   interface UnsignedInt {
@@ -61,10 +61,10 @@ export namespace xdr {
     write(value: number, io: Buffer): void;
     isValid(value: number): boolean;
     toXDR(value: number): Buffer;
-    fromXDR(input: Buffer, format?: "raw"): number;
-    fromXDR(input: string, format: "hex" | "base64"): number;
-    validateXDR(input: Buffer, format?: "raw"): boolean;
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    fromXDR(input: Buffer, format?: 'raw'): number;
+    fromXDR(input: string, format: 'hex' | 'base64'): number;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   interface Bool {
@@ -72,10 +72,10 @@ export namespace xdr {
     write(value: boolean, io: Buffer): void;
     isValid(value: boolean): boolean;
     toXDR(value: boolean): Buffer;
-    fromXDR(input: Buffer, format?: "raw"): boolean;
-    fromXDR(input: string, format: "hex" | "base64"): boolean;
-    validateXDR(input: Buffer, format?: "raw"): boolean;
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    fromXDR(input: Buffer, format?: 'raw'): boolean;
+    fromXDR(input: string, format: 'hex' | 'base64'): boolean;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Hyper {
@@ -87,19 +87,19 @@ export namespace xdr {
 
     constructor(low: number, high: number);
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static toXDR(value: Hyper): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Hyper;
+    static fromXDR(input: Buffer, format?: 'raw'): Hyper;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Hyper;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Hyper;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
 
     static readonly MAX_VALUE: Hyper;
 
@@ -125,19 +125,19 @@ export namespace xdr {
 
     constructor(low: number, high: number);
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static toXDR(value: UnsignedHyper): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): UnsignedHyper;
+    static fromXDR(input: Buffer, format?: 'raw'): UnsignedHyper;
 
-    static fromXDR(input: string, format: "hex" | "base64"): UnsignedHyper;
+    static fromXDR(input: string, format: 'hex' | 'base64'): UnsignedHyper;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
 
     static readonly MAX_VALUE: UnsignedHyper;
 
@@ -167,13 +167,13 @@ export namespace xdr {
 
     toXDR(value: string | Buffer): Buffer;
 
-    fromXDR(input: Buffer, format?: "raw"): Buffer;
+    fromXDR(input: Buffer, format?: 'raw'): Buffer;
 
-    fromXDR(input: string, format: "hex" | "base64"): Buffer;
+    fromXDR(input: string, format: 'hex' | 'base64'): Buffer;
 
-    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class XDRArray<T> {
@@ -185,13 +185,13 @@ export namespace xdr {
 
     toXDR(value: T[]): Buffer;
 
-    fromXDR(input: Buffer, format?: "raw"): T[];
+    fromXDR(input: Buffer, format?: 'raw'): T[];
 
-    fromXDR(input: string, format: "hex" | "base64"): T[];
+    fromXDR(input: string, format: 'hex' | 'base64'): T[];
 
-    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Opaque {
@@ -205,13 +205,13 @@ export namespace xdr {
 
     toXDR(value: Buffer): Buffer;
 
-    fromXDR(input: Buffer, format?: "raw"): Buffer;
+    fromXDR(input: Buffer, format?: 'raw'): Buffer;
 
-    fromXDR(input: string, format: "hex" | "base64"): Buffer;
+    fromXDR(input: string, format: 'hex' | 'base64'): Buffer;
 
-    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class VarOpaque extends Opaque {}
@@ -231,21 +231,21 @@ export namespace xdr {
 
     toXDR(value: any): Buffer;
 
-    fromXDR(input: Buffer, format?: "raw"): any;
+    fromXDR(input: Buffer, format?: 'raw'): any;
 
-    fromXDR(input: string, format: "hex" | "base64"): any;
+    fromXDR(input: string, format: 'hex' | 'base64'): any;
 
-    validateXDR(input: Buffer, format?: "raw"): boolean;
+    validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    validateXDR(input: string, format: "hex" | "base64"): boolean;
+    validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatementType {
     readonly name:
-      | "scpStPrepare"
-      | "scpStConfirm"
-      | "scpStExternalize"
-      | "scpStNominate";
+      | 'scpStPrepare'
+      | 'scpStConfirm'
+      | 'scpStExternalize'
+      | 'scpStNominate';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -260,10 +260,10 @@ export namespace xdr {
 
   class AssetType {
     readonly name:
-      | "assetTypeNative"
-      | "assetTypeCreditAlphanum4"
-      | "assetTypeCreditAlphanum12"
-      | "assetTypePoolShare";
+      | 'assetTypeNative'
+      | 'assetTypeCreditAlphanum4'
+      | 'assetTypeCreditAlphanum12'
+      | 'assetTypePoolShare';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -278,10 +278,10 @@ export namespace xdr {
 
   class ThresholdIndices {
     readonly name:
-      | "thresholdMasterWeight"
-      | "thresholdLow"
-      | "thresholdMed"
-      | "thresholdHigh";
+      | 'thresholdMasterWeight'
+      | 'thresholdLow'
+      | 'thresholdMed'
+      | 'thresholdHigh';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -296,15 +296,15 @@ export namespace xdr {
 
   class LedgerEntryType {
     readonly name:
-      | "account"
-      | "trustline"
-      | "offer"
-      | "data"
-      | "claimableBalance"
-      | "liquidityPool"
-      | "contractData"
-      | "contractCode"
-      | "configSetting";
+      | 'account'
+      | 'trustline'
+      | 'offer'
+      | 'data'
+      | 'claimableBalance'
+      | 'liquidityPool'
+      | 'contractData'
+      | 'contractCode'
+      | 'configSetting';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
@@ -329,10 +329,10 @@ export namespace xdr {
 
   class AccountFlags {
     readonly name:
-      | "authRequiredFlag"
-      | "authRevocableFlag"
-      | "authImmutableFlag"
-      | "authClawbackEnabledFlag";
+      | 'authRequiredFlag'
+      | 'authRevocableFlag'
+      | 'authImmutableFlag'
+      | 'authClawbackEnabledFlag';
 
     readonly value: 1 | 2 | 4 | 8;
 
@@ -347,9 +347,9 @@ export namespace xdr {
 
   class TrustLineFlags {
     readonly name:
-      | "authorizedFlag"
-      | "authorizedToMaintainLiabilitiesFlag"
-      | "trustlineClawbackEnabledFlag";
+      | 'authorizedFlag'
+      | 'authorizedToMaintainLiabilitiesFlag'
+      | 'trustlineClawbackEnabledFlag';
 
     readonly value: 1 | 2 | 4;
 
@@ -361,7 +361,7 @@ export namespace xdr {
   }
 
   class LiquidityPoolType {
-    readonly name: "liquidityPoolConstantProduct";
+    readonly name: 'liquidityPoolConstantProduct';
 
     readonly value: 0;
 
@@ -369,7 +369,7 @@ export namespace xdr {
   }
 
   class OfferEntryFlags {
-    readonly name: "passiveFlag";
+    readonly name: 'passiveFlag';
 
     readonly value: 1;
 
@@ -378,12 +378,12 @@ export namespace xdr {
 
   class ClaimPredicateType {
     readonly name:
-      | "claimPredicateUnconditional"
-      | "claimPredicateAnd"
-      | "claimPredicateOr"
-      | "claimPredicateNot"
-      | "claimPredicateBeforeAbsoluteTime"
-      | "claimPredicateBeforeRelativeTime";
+      | 'claimPredicateUnconditional'
+      | 'claimPredicateAnd'
+      | 'claimPredicateOr'
+      | 'claimPredicateNot'
+      | 'claimPredicateBeforeAbsoluteTime'
+      | 'claimPredicateBeforeRelativeTime';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -401,7 +401,7 @@ export namespace xdr {
   }
 
   class ClaimantType {
-    readonly name: "claimantTypeV0";
+    readonly name: 'claimantTypeV0';
 
     readonly value: 0;
 
@@ -409,7 +409,7 @@ export namespace xdr {
   }
 
   class ClaimableBalanceIdType {
-    readonly name: "claimableBalanceIdTypeV0";
+    readonly name: 'claimableBalanceIdTypeV0';
 
     readonly value: 0;
 
@@ -417,7 +417,7 @@ export namespace xdr {
   }
 
   class ClaimableBalanceFlags {
-    readonly name: "claimableBalanceClawbackEnabledFlag";
+    readonly name: 'claimableBalanceClawbackEnabledFlag';
 
     readonly value: 1;
 
@@ -426,13 +426,13 @@ export namespace xdr {
 
   class ConfigSettingId {
     readonly name:
-      | "configSettingContractMaxSizeBytes"
-      | "configSettingContractComputeV0"
-      | "configSettingContractLedgerCostV0"
-      | "configSettingContractHistoricalDataV0"
-      | "configSettingContractMetaDataV0"
-      | "configSettingContractBandwidthV0"
-      | "configSettingContractHostLogicVersion";
+      | 'configSettingContractMaxSizeBytes'
+      | 'configSettingContractComputeV0'
+      | 'configSettingContractLedgerCostV0'
+      | 'configSettingContractHistoricalDataV0'
+      | 'configSettingContractMetaDataV0'
+      | 'configSettingContractBandwidthV0'
+      | 'configSettingContractHostLogicVersion';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -453,20 +453,20 @@ export namespace xdr {
 
   class EnvelopeType {
     readonly name:
-      | "envelopeTypeTxV0"
-      | "envelopeTypeScp"
-      | "envelopeTypeTx"
-      | "envelopeTypeAuth"
-      | "envelopeTypeScpvalue"
-      | "envelopeTypeTxFeeBump"
-      | "envelopeTypeOpId"
-      | "envelopeTypePoolRevokeOpId"
-      | "envelopeTypeContractIdFromEd25519"
-      | "envelopeTypeContractIdFromContract"
-      | "envelopeTypeContractIdFromAsset"
-      | "envelopeTypeContractIdFromSourceAccount"
-      | "envelopeTypeCreateContractArgs"
-      | "envelopeTypeContractAuth";
+      | 'envelopeTypeTxV0'
+      | 'envelopeTypeScp'
+      | 'envelopeTypeTx'
+      | 'envelopeTypeAuth'
+      | 'envelopeTypeScpvalue'
+      | 'envelopeTypeTxFeeBump'
+      | 'envelopeTypeOpId'
+      | 'envelopeTypePoolRevokeOpId'
+      | 'envelopeTypeContractIdFromEd25519'
+      | 'envelopeTypeContractIdFromContract'
+      | 'envelopeTypeContractIdFromAsset'
+      | 'envelopeTypeContractIdFromSourceAccount'
+      | 'envelopeTypeCreateContractArgs'
+      | 'envelopeTypeContractAuth';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;
 
@@ -500,7 +500,7 @@ export namespace xdr {
   }
 
   class StellarValueType {
-    readonly name: "stellarValueBasic" | "stellarValueSigned";
+    readonly name: 'stellarValueBasic' | 'stellarValueSigned';
 
     readonly value: 0 | 1;
 
@@ -511,13 +511,13 @@ export namespace xdr {
 
   class LedgerHeaderFlags {
     readonly name:
-      | "disableLiquidityPoolTradingFlag"
-      | "disableLiquidityPoolDepositFlag"
-      | "disableLiquidityPoolWithdrawalFlag"
-      | "disableContractCreate"
-      | "disableContractUpdate"
-      | "disableContractRemove"
-      | "disableContractInvoke";
+      | 'disableLiquidityPoolTradingFlag'
+      | 'disableLiquidityPoolDepositFlag'
+      | 'disableLiquidityPoolWithdrawalFlag'
+      | 'disableContractCreate'
+      | 'disableContractUpdate'
+      | 'disableContractRemove'
+      | 'disableContractInvoke';
 
     readonly value: 1 | 2 | 4 | 8 | 16 | 32 | 64;
 
@@ -538,12 +538,12 @@ export namespace xdr {
 
   class LedgerUpgradeType {
     readonly name:
-      | "ledgerUpgradeVersion"
-      | "ledgerUpgradeBaseFee"
-      | "ledgerUpgradeMaxTxSetSize"
-      | "ledgerUpgradeBaseReserve"
-      | "ledgerUpgradeFlags"
-      | "ledgerUpgradeConfig";
+      | 'ledgerUpgradeVersion'
+      | 'ledgerUpgradeBaseFee'
+      | 'ledgerUpgradeMaxTxSetSize'
+      | 'ledgerUpgradeBaseReserve'
+      | 'ledgerUpgradeFlags'
+      | 'ledgerUpgradeConfig';
 
     readonly value: 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -561,7 +561,7 @@ export namespace xdr {
   }
 
   class BucketEntryType {
-    readonly name: "metaentry" | "liveentry" | "deadentry" | "initentry";
+    readonly name: 'metaentry' | 'liveentry' | 'deadentry' | 'initentry';
 
     readonly value: -1 | 0 | 1 | 2;
 
@@ -575,7 +575,7 @@ export namespace xdr {
   }
 
   class TxSetComponentType {
-    readonly name: "txsetCompTxsMaybeDiscountedFee";
+    readonly name: 'txsetCompTxsMaybeDiscountedFee';
 
     readonly value: 0;
 
@@ -584,10 +584,10 @@ export namespace xdr {
 
   class LedgerEntryChangeType {
     readonly name:
-      | "ledgerEntryCreated"
-      | "ledgerEntryUpdated"
-      | "ledgerEntryRemoved"
-      | "ledgerEntryState";
+      | 'ledgerEntryCreated'
+      | 'ledgerEntryUpdated'
+      | 'ledgerEntryRemoved'
+      | 'ledgerEntryState';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -601,7 +601,7 @@ export namespace xdr {
   }
 
   class ContractEventType {
-    readonly name: "system" | "contract" | "diagnostic";
+    readonly name: 'system' | 'contract' | 'diagnostic';
 
     readonly value: 0 | 1 | 2;
 
@@ -613,7 +613,7 @@ export namespace xdr {
   }
 
   class ErrorCode {
-    readonly name: "errMisc" | "errData" | "errConf" | "errAuth" | "errLoad";
+    readonly name: 'errMisc' | 'errData' | 'errConf' | 'errAuth' | 'errLoad';
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -629,7 +629,7 @@ export namespace xdr {
   }
 
   class IpAddrType {
-    readonly name: "iPv4" | "iPv6";
+    readonly name: 'iPv4' | 'iPv6';
 
     readonly value: 0 | 1;
 
@@ -640,25 +640,25 @@ export namespace xdr {
 
   class MessageType {
     readonly name:
-      | "errorMsg"
-      | "auth"
-      | "dontHave"
-      | "getPeers"
-      | "peers"
-      | "getTxSet"
-      | "txSet"
-      | "generalizedTxSet"
-      | "transaction"
-      | "getScpQuorumset"
-      | "scpQuorumset"
-      | "scpMessage"
-      | "getScpState"
-      | "hello"
-      | "surveyRequest"
-      | "surveyResponse"
-      | "sendMore"
-      | "floodAdvert"
-      | "floodDemand";
+      | 'errorMsg'
+      | 'auth'
+      | 'dontHave'
+      | 'getPeers'
+      | 'peers'
+      | 'getTxSet'
+      | 'txSet'
+      | 'generalizedTxSet'
+      | 'transaction'
+      | 'getScpQuorumset'
+      | 'scpQuorumset'
+      | 'scpMessage'
+      | 'getScpState'
+      | 'hello'
+      | 'surveyRequest'
+      | 'surveyResponse'
+      | 'sendMore'
+      | 'floodAdvert'
+      | 'floodDemand';
 
     readonly value:
       | 0
@@ -721,7 +721,7 @@ export namespace xdr {
   }
 
   class SurveyMessageCommandType {
-    readonly name: "surveyTopology";
+    readonly name: 'surveyTopology';
 
     readonly value: 0;
 
@@ -729,7 +729,7 @@ export namespace xdr {
   }
 
   class SurveyMessageResponseType {
-    readonly name: "surveyTopologyResponseV0" | "surveyTopologyResponseV1";
+    readonly name: 'surveyTopologyResponseV0' | 'surveyTopologyResponseV1';
 
     readonly value: 0 | 1;
 
@@ -740,31 +740,31 @@ export namespace xdr {
 
   class OperationType {
     readonly name:
-      | "createAccount"
-      | "payment"
-      | "pathPaymentStrictReceive"
-      | "manageSellOffer"
-      | "createPassiveSellOffer"
-      | "setOptions"
-      | "changeTrust"
-      | "allowTrust"
-      | "accountMerge"
-      | "inflation"
-      | "manageData"
-      | "bumpSequence"
-      | "manageBuyOffer"
-      | "pathPaymentStrictSend"
-      | "createClaimableBalance"
-      | "claimClaimableBalance"
-      | "beginSponsoringFutureReserves"
-      | "endSponsoringFutureReserves"
-      | "revokeSponsorship"
-      | "clawback"
-      | "clawbackClaimableBalance"
-      | "setTrustLineFlags"
-      | "liquidityPoolDeposit"
-      | "liquidityPoolWithdraw"
-      | "invokeHostFunction";
+      | 'createAccount'
+      | 'payment'
+      | 'pathPaymentStrictReceive'
+      | 'manageSellOffer'
+      | 'createPassiveSellOffer'
+      | 'setOptions'
+      | 'changeTrust'
+      | 'allowTrust'
+      | 'accountMerge'
+      | 'inflation'
+      | 'manageData'
+      | 'bumpSequence'
+      | 'manageBuyOffer'
+      | 'pathPaymentStrictSend'
+      | 'createClaimableBalance'
+      | 'claimClaimableBalance'
+      | 'beginSponsoringFutureReserves'
+      | 'endSponsoringFutureReserves'
+      | 'revokeSponsorship'
+      | 'clawback'
+      | 'clawbackClaimableBalance'
+      | 'setTrustLineFlags'
+      | 'liquidityPoolDeposit'
+      | 'liquidityPoolWithdraw'
+      | 'invokeHostFunction';
 
     readonly value:
       | 0
@@ -845,7 +845,7 @@ export namespace xdr {
   }
 
   class RevokeSponsorshipType {
-    readonly name: "revokeSponsorshipLedgerEntry" | "revokeSponsorshipSigner";
+    readonly name: 'revokeSponsorshipLedgerEntry' | 'revokeSponsorshipSigner';
 
     readonly value: 0 | 1;
 
@@ -856,9 +856,9 @@ export namespace xdr {
 
   class HostFunctionType {
     readonly name:
-      | "hostFunctionTypeInvokeContract"
-      | "hostFunctionTypeCreateContract"
-      | "hostFunctionTypeInstallContractCode";
+      | 'hostFunctionTypeInvokeContract'
+      | 'hostFunctionTypeCreateContract'
+      | 'hostFunctionTypeInstallContractCode';
 
     readonly value: 0 | 1 | 2;
 
@@ -871,9 +871,9 @@ export namespace xdr {
 
   class ContractIdType {
     readonly name:
-      | "contractIdFromSourceAccount"
-      | "contractIdFromEd25519PublicKey"
-      | "contractIdFromAsset";
+      | 'contractIdFromSourceAccount'
+      | 'contractIdFromEd25519PublicKey'
+      | 'contractIdFromAsset';
 
     readonly value: 0 | 1 | 2;
 
@@ -886,8 +886,8 @@ export namespace xdr {
 
   class ContractIdPublicKeyType {
     readonly name:
-      | "contractIdPublicKeySourceAccount"
-      | "contractIdPublicKeyEd25519";
+      | 'contractIdPublicKeySourceAccount'
+      | 'contractIdPublicKeyEd25519';
 
     readonly value: 0 | 1;
 
@@ -898,11 +898,11 @@ export namespace xdr {
 
   class MemoType {
     readonly name:
-      | "memoNone"
-      | "memoText"
-      | "memoId"
-      | "memoHash"
-      | "memoReturn";
+      | 'memoNone'
+      | 'memoText'
+      | 'memoId'
+      | 'memoHash'
+      | 'memoReturn';
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -918,7 +918,7 @@ export namespace xdr {
   }
 
   class PreconditionType {
-    readonly name: "precondNone" | "precondTime" | "precondV2";
+    readonly name: 'precondNone' | 'precondTime' | 'precondV2';
 
     readonly value: 0 | 1 | 2;
 
@@ -931,9 +931,9 @@ export namespace xdr {
 
   class ClaimAtomType {
     readonly name:
-      | "claimAtomTypeV0"
-      | "claimAtomTypeOrderBook"
-      | "claimAtomTypeLiquidityPool";
+      | 'claimAtomTypeV0'
+      | 'claimAtomTypeOrderBook'
+      | 'claimAtomTypeLiquidityPool';
 
     readonly value: 0 | 1 | 2;
 
@@ -946,11 +946,11 @@ export namespace xdr {
 
   class CreateAccountResultCode {
     readonly name:
-      | "createAccountSuccess"
-      | "createAccountMalformed"
-      | "createAccountUnderfunded"
-      | "createAccountLowReserve"
-      | "createAccountAlreadyExist";
+      | 'createAccountSuccess'
+      | 'createAccountMalformed'
+      | 'createAccountUnderfunded'
+      | 'createAccountLowReserve'
+      | 'createAccountAlreadyExist';
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -967,16 +967,16 @@ export namespace xdr {
 
   class PaymentResultCode {
     readonly name:
-      | "paymentSuccess"
-      | "paymentMalformed"
-      | "paymentUnderfunded"
-      | "paymentSrcNoTrust"
-      | "paymentSrcNotAuthorized"
-      | "paymentNoDestination"
-      | "paymentNoTrust"
-      | "paymentNotAuthorized"
-      | "paymentLineFull"
-      | "paymentNoIssuer";
+      | 'paymentSuccess'
+      | 'paymentMalformed'
+      | 'paymentUnderfunded'
+      | 'paymentSrcNoTrust'
+      | 'paymentSrcNotAuthorized'
+      | 'paymentNoDestination'
+      | 'paymentNoTrust'
+      | 'paymentNotAuthorized'
+      | 'paymentLineFull'
+      | 'paymentNoIssuer';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9;
 
@@ -1003,19 +1003,19 @@ export namespace xdr {
 
   class PathPaymentStrictReceiveResultCode {
     readonly name:
-      | "pathPaymentStrictReceiveSuccess"
-      | "pathPaymentStrictReceiveMalformed"
-      | "pathPaymentStrictReceiveUnderfunded"
-      | "pathPaymentStrictReceiveSrcNoTrust"
-      | "pathPaymentStrictReceiveSrcNotAuthorized"
-      | "pathPaymentStrictReceiveNoDestination"
-      | "pathPaymentStrictReceiveNoTrust"
-      | "pathPaymentStrictReceiveNotAuthorized"
-      | "pathPaymentStrictReceiveLineFull"
-      | "pathPaymentStrictReceiveNoIssuer"
-      | "pathPaymentStrictReceiveTooFewOffers"
-      | "pathPaymentStrictReceiveOfferCrossSelf"
-      | "pathPaymentStrictReceiveOverSendmax";
+      | 'pathPaymentStrictReceiveSuccess'
+      | 'pathPaymentStrictReceiveMalformed'
+      | 'pathPaymentStrictReceiveUnderfunded'
+      | 'pathPaymentStrictReceiveSrcNoTrust'
+      | 'pathPaymentStrictReceiveSrcNotAuthorized'
+      | 'pathPaymentStrictReceiveNoDestination'
+      | 'pathPaymentStrictReceiveNoTrust'
+      | 'pathPaymentStrictReceiveNotAuthorized'
+      | 'pathPaymentStrictReceiveLineFull'
+      | 'pathPaymentStrictReceiveNoIssuer'
+      | 'pathPaymentStrictReceiveTooFewOffers'
+      | 'pathPaymentStrictReceiveOfferCrossSelf'
+      | 'pathPaymentStrictReceiveOverSendmax';
 
     readonly value:
       | 0
@@ -1061,19 +1061,19 @@ export namespace xdr {
 
   class PathPaymentStrictSendResultCode {
     readonly name:
-      | "pathPaymentStrictSendSuccess"
-      | "pathPaymentStrictSendMalformed"
-      | "pathPaymentStrictSendUnderfunded"
-      | "pathPaymentStrictSendSrcNoTrust"
-      | "pathPaymentStrictSendSrcNotAuthorized"
-      | "pathPaymentStrictSendNoDestination"
-      | "pathPaymentStrictSendNoTrust"
-      | "pathPaymentStrictSendNotAuthorized"
-      | "pathPaymentStrictSendLineFull"
-      | "pathPaymentStrictSendNoIssuer"
-      | "pathPaymentStrictSendTooFewOffers"
-      | "pathPaymentStrictSendOfferCrossSelf"
-      | "pathPaymentStrictSendUnderDestmin";
+      | 'pathPaymentStrictSendSuccess'
+      | 'pathPaymentStrictSendMalformed'
+      | 'pathPaymentStrictSendUnderfunded'
+      | 'pathPaymentStrictSendSrcNoTrust'
+      | 'pathPaymentStrictSendSrcNotAuthorized'
+      | 'pathPaymentStrictSendNoDestination'
+      | 'pathPaymentStrictSendNoTrust'
+      | 'pathPaymentStrictSendNotAuthorized'
+      | 'pathPaymentStrictSendLineFull'
+      | 'pathPaymentStrictSendNoIssuer'
+      | 'pathPaymentStrictSendTooFewOffers'
+      | 'pathPaymentStrictSendOfferCrossSelf'
+      | 'pathPaymentStrictSendUnderDestmin';
 
     readonly value:
       | 0
@@ -1119,19 +1119,19 @@ export namespace xdr {
 
   class ManageSellOfferResultCode {
     readonly name:
-      | "manageSellOfferSuccess"
-      | "manageSellOfferMalformed"
-      | "manageSellOfferSellNoTrust"
-      | "manageSellOfferBuyNoTrust"
-      | "manageSellOfferSellNotAuthorized"
-      | "manageSellOfferBuyNotAuthorized"
-      | "manageSellOfferLineFull"
-      | "manageSellOfferUnderfunded"
-      | "manageSellOfferCrossSelf"
-      | "manageSellOfferSellNoIssuer"
-      | "manageSellOfferBuyNoIssuer"
-      | "manageSellOfferNotFound"
-      | "manageSellOfferLowReserve";
+      | 'manageSellOfferSuccess'
+      | 'manageSellOfferMalformed'
+      | 'manageSellOfferSellNoTrust'
+      | 'manageSellOfferBuyNoTrust'
+      | 'manageSellOfferSellNotAuthorized'
+      | 'manageSellOfferBuyNotAuthorized'
+      | 'manageSellOfferLineFull'
+      | 'manageSellOfferUnderfunded'
+      | 'manageSellOfferCrossSelf'
+      | 'manageSellOfferSellNoIssuer'
+      | 'manageSellOfferBuyNoIssuer'
+      | 'manageSellOfferNotFound'
+      | 'manageSellOfferLowReserve';
 
     readonly value:
       | 0
@@ -1177,9 +1177,9 @@ export namespace xdr {
 
   class ManageOfferEffect {
     readonly name:
-      | "manageOfferCreated"
-      | "manageOfferUpdated"
-      | "manageOfferDeleted";
+      | 'manageOfferCreated'
+      | 'manageOfferUpdated'
+      | 'manageOfferDeleted';
 
     readonly value: 0 | 1 | 2;
 
@@ -1192,19 +1192,19 @@ export namespace xdr {
 
   class ManageBuyOfferResultCode {
     readonly name:
-      | "manageBuyOfferSuccess"
-      | "manageBuyOfferMalformed"
-      | "manageBuyOfferSellNoTrust"
-      | "manageBuyOfferBuyNoTrust"
-      | "manageBuyOfferSellNotAuthorized"
-      | "manageBuyOfferBuyNotAuthorized"
-      | "manageBuyOfferLineFull"
-      | "manageBuyOfferUnderfunded"
-      | "manageBuyOfferCrossSelf"
-      | "manageBuyOfferSellNoIssuer"
-      | "manageBuyOfferBuyNoIssuer"
-      | "manageBuyOfferNotFound"
-      | "manageBuyOfferLowReserve";
+      | 'manageBuyOfferSuccess'
+      | 'manageBuyOfferMalformed'
+      | 'manageBuyOfferSellNoTrust'
+      | 'manageBuyOfferBuyNoTrust'
+      | 'manageBuyOfferSellNotAuthorized'
+      | 'manageBuyOfferBuyNotAuthorized'
+      | 'manageBuyOfferLineFull'
+      | 'manageBuyOfferUnderfunded'
+      | 'manageBuyOfferCrossSelf'
+      | 'manageBuyOfferSellNoIssuer'
+      | 'manageBuyOfferBuyNoIssuer'
+      | 'manageBuyOfferNotFound'
+      | 'manageBuyOfferLowReserve';
 
     readonly value:
       | 0
@@ -1250,17 +1250,17 @@ export namespace xdr {
 
   class SetOptionsResultCode {
     readonly name:
-      | "setOptionsSuccess"
-      | "setOptionsLowReserve"
-      | "setOptionsTooManySigners"
-      | "setOptionsBadFlags"
-      | "setOptionsInvalidInflation"
-      | "setOptionsCantChange"
-      | "setOptionsUnknownFlag"
-      | "setOptionsThresholdOutOfRange"
-      | "setOptionsBadSigner"
-      | "setOptionsInvalidHomeDomain"
-      | "setOptionsAuthRevocableRequired";
+      | 'setOptionsSuccess'
+      | 'setOptionsLowReserve'
+      | 'setOptionsTooManySigners'
+      | 'setOptionsBadFlags'
+      | 'setOptionsInvalidInflation'
+      | 'setOptionsCantChange'
+      | 'setOptionsUnknownFlag'
+      | 'setOptionsThresholdOutOfRange'
+      | 'setOptionsBadSigner'
+      | 'setOptionsInvalidHomeDomain'
+      | 'setOptionsAuthRevocableRequired';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9 | -10;
 
@@ -1289,15 +1289,15 @@ export namespace xdr {
 
   class ChangeTrustResultCode {
     readonly name:
-      | "changeTrustSuccess"
-      | "changeTrustMalformed"
-      | "changeTrustNoIssuer"
-      | "changeTrustInvalidLimit"
-      | "changeTrustLowReserve"
-      | "changeTrustSelfNotAllowed"
-      | "changeTrustTrustLineMissing"
-      | "changeTrustCannotDelete"
-      | "changeTrustNotAuthMaintainLiabilities";
+      | 'changeTrustSuccess'
+      | 'changeTrustMalformed'
+      | 'changeTrustNoIssuer'
+      | 'changeTrustInvalidLimit'
+      | 'changeTrustLowReserve'
+      | 'changeTrustSelfNotAllowed'
+      | 'changeTrustTrustLineMissing'
+      | 'changeTrustCannotDelete'
+      | 'changeTrustNotAuthMaintainLiabilities';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8;
 
@@ -1322,13 +1322,13 @@ export namespace xdr {
 
   class AllowTrustResultCode {
     readonly name:
-      | "allowTrustSuccess"
-      | "allowTrustMalformed"
-      | "allowTrustNoTrustLine"
-      | "allowTrustTrustNotRequired"
-      | "allowTrustCantRevoke"
-      | "allowTrustSelfNotAllowed"
-      | "allowTrustLowReserve";
+      | 'allowTrustSuccess'
+      | 'allowTrustMalformed'
+      | 'allowTrustNoTrustLine'
+      | 'allowTrustTrustNotRequired'
+      | 'allowTrustCantRevoke'
+      | 'allowTrustSelfNotAllowed'
+      | 'allowTrustLowReserve';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6;
 
@@ -1349,14 +1349,14 @@ export namespace xdr {
 
   class AccountMergeResultCode {
     readonly name:
-      | "accountMergeSuccess"
-      | "accountMergeMalformed"
-      | "accountMergeNoAccount"
-      | "accountMergeImmutableSet"
-      | "accountMergeHasSubEntries"
-      | "accountMergeSeqnumTooFar"
-      | "accountMergeDestFull"
-      | "accountMergeIsSponsor";
+      | 'accountMergeSuccess'
+      | 'accountMergeMalformed'
+      | 'accountMergeNoAccount'
+      | 'accountMergeImmutableSet'
+      | 'accountMergeHasSubEntries'
+      | 'accountMergeSeqnumTooFar'
+      | 'accountMergeDestFull'
+      | 'accountMergeIsSponsor';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7;
 
@@ -1378,7 +1378,7 @@ export namespace xdr {
   }
 
   class InflationResultCode {
-    readonly name: "inflationSuccess" | "inflationNotTime";
+    readonly name: 'inflationSuccess' | 'inflationNotTime';
 
     readonly value: 0 | -1;
 
@@ -1389,11 +1389,11 @@ export namespace xdr {
 
   class ManageDataResultCode {
     readonly name:
-      | "manageDataSuccess"
-      | "manageDataNotSupportedYet"
-      | "manageDataNameNotFound"
-      | "manageDataLowReserve"
-      | "manageDataInvalidName";
+      | 'manageDataSuccess'
+      | 'manageDataNotSupportedYet'
+      | 'manageDataNameNotFound'
+      | 'manageDataLowReserve'
+      | 'manageDataInvalidName';
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -1409,7 +1409,7 @@ export namespace xdr {
   }
 
   class BumpSequenceResultCode {
-    readonly name: "bumpSequenceSuccess" | "bumpSequenceBadSeq";
+    readonly name: 'bumpSequenceSuccess' | 'bumpSequenceBadSeq';
 
     readonly value: 0 | -1;
 
@@ -1420,12 +1420,12 @@ export namespace xdr {
 
   class CreateClaimableBalanceResultCode {
     readonly name:
-      | "createClaimableBalanceSuccess"
-      | "createClaimableBalanceMalformed"
-      | "createClaimableBalanceLowReserve"
-      | "createClaimableBalanceNoTrust"
-      | "createClaimableBalanceNotAuthorized"
-      | "createClaimableBalanceUnderfunded";
+      | 'createClaimableBalanceSuccess'
+      | 'createClaimableBalanceMalformed'
+      | 'createClaimableBalanceLowReserve'
+      | 'createClaimableBalanceNoTrust'
+      | 'createClaimableBalanceNotAuthorized'
+      | 'createClaimableBalanceUnderfunded';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1444,12 +1444,12 @@ export namespace xdr {
 
   class ClaimClaimableBalanceResultCode {
     readonly name:
-      | "claimClaimableBalanceSuccess"
-      | "claimClaimableBalanceDoesNotExist"
-      | "claimClaimableBalanceCannotClaim"
-      | "claimClaimableBalanceLineFull"
-      | "claimClaimableBalanceNoTrust"
-      | "claimClaimableBalanceNotAuthorized";
+      | 'claimClaimableBalanceSuccess'
+      | 'claimClaimableBalanceDoesNotExist'
+      | 'claimClaimableBalanceCannotClaim'
+      | 'claimClaimableBalanceLineFull'
+      | 'claimClaimableBalanceNoTrust'
+      | 'claimClaimableBalanceNotAuthorized';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1468,10 +1468,10 @@ export namespace xdr {
 
   class BeginSponsoringFutureReservesResultCode {
     readonly name:
-      | "beginSponsoringFutureReservesSuccess"
-      | "beginSponsoringFutureReservesMalformed"
-      | "beginSponsoringFutureReservesAlreadySponsored"
-      | "beginSponsoringFutureReservesRecursive";
+      | 'beginSponsoringFutureReservesSuccess'
+      | 'beginSponsoringFutureReservesMalformed'
+      | 'beginSponsoringFutureReservesAlreadySponsored'
+      | 'beginSponsoringFutureReservesRecursive';
 
     readonly value: 0 | -1 | -2 | -3;
 
@@ -1486,8 +1486,8 @@ export namespace xdr {
 
   class EndSponsoringFutureReservesResultCode {
     readonly name:
-      | "endSponsoringFutureReservesSuccess"
-      | "endSponsoringFutureReservesNotSponsored";
+      | 'endSponsoringFutureReservesSuccess'
+      | 'endSponsoringFutureReservesNotSponsored';
 
     readonly value: 0 | -1;
 
@@ -1498,12 +1498,12 @@ export namespace xdr {
 
   class RevokeSponsorshipResultCode {
     readonly name:
-      | "revokeSponsorshipSuccess"
-      | "revokeSponsorshipDoesNotExist"
-      | "revokeSponsorshipNotSponsor"
-      | "revokeSponsorshipLowReserve"
-      | "revokeSponsorshipOnlyTransferable"
-      | "revokeSponsorshipMalformed";
+      | 'revokeSponsorshipSuccess'
+      | 'revokeSponsorshipDoesNotExist'
+      | 'revokeSponsorshipNotSponsor'
+      | 'revokeSponsorshipLowReserve'
+      | 'revokeSponsorshipOnlyTransferable'
+      | 'revokeSponsorshipMalformed';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1522,11 +1522,11 @@ export namespace xdr {
 
   class ClawbackResultCode {
     readonly name:
-      | "clawbackSuccess"
-      | "clawbackMalformed"
-      | "clawbackNotClawbackEnabled"
-      | "clawbackNoTrust"
-      | "clawbackUnderfunded";
+      | 'clawbackSuccess'
+      | 'clawbackMalformed'
+      | 'clawbackNotClawbackEnabled'
+      | 'clawbackNoTrust'
+      | 'clawbackUnderfunded';
 
     readonly value: 0 | -1 | -2 | -3 | -4;
 
@@ -1543,10 +1543,10 @@ export namespace xdr {
 
   class ClawbackClaimableBalanceResultCode {
     readonly name:
-      | "clawbackClaimableBalanceSuccess"
-      | "clawbackClaimableBalanceDoesNotExist"
-      | "clawbackClaimableBalanceNotIssuer"
-      | "clawbackClaimableBalanceNotClawbackEnabled";
+      | 'clawbackClaimableBalanceSuccess'
+      | 'clawbackClaimableBalanceDoesNotExist'
+      | 'clawbackClaimableBalanceNotIssuer'
+      | 'clawbackClaimableBalanceNotClawbackEnabled';
 
     readonly value: 0 | -1 | -2 | -3;
 
@@ -1561,12 +1561,12 @@ export namespace xdr {
 
   class SetTrustLineFlagsResultCode {
     readonly name:
-      | "setTrustLineFlagsSuccess"
-      | "setTrustLineFlagsMalformed"
-      | "setTrustLineFlagsNoTrustLine"
-      | "setTrustLineFlagsCantRevoke"
-      | "setTrustLineFlagsInvalidState"
-      | "setTrustLineFlagsLowReserve";
+      | 'setTrustLineFlagsSuccess'
+      | 'setTrustLineFlagsMalformed'
+      | 'setTrustLineFlagsNoTrustLine'
+      | 'setTrustLineFlagsCantRevoke'
+      | 'setTrustLineFlagsInvalidState'
+      | 'setTrustLineFlagsLowReserve';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1585,14 +1585,14 @@ export namespace xdr {
 
   class LiquidityPoolDepositResultCode {
     readonly name:
-      | "liquidityPoolDepositSuccess"
-      | "liquidityPoolDepositMalformed"
-      | "liquidityPoolDepositNoTrust"
-      | "liquidityPoolDepositNotAuthorized"
-      | "liquidityPoolDepositUnderfunded"
-      | "liquidityPoolDepositLineFull"
-      | "liquidityPoolDepositBadPrice"
-      | "liquidityPoolDepositPoolFull";
+      | 'liquidityPoolDepositSuccess'
+      | 'liquidityPoolDepositMalformed'
+      | 'liquidityPoolDepositNoTrust'
+      | 'liquidityPoolDepositNotAuthorized'
+      | 'liquidityPoolDepositUnderfunded'
+      | 'liquidityPoolDepositLineFull'
+      | 'liquidityPoolDepositBadPrice'
+      | 'liquidityPoolDepositPoolFull';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6 | -7;
 
@@ -1615,12 +1615,12 @@ export namespace xdr {
 
   class LiquidityPoolWithdrawResultCode {
     readonly name:
-      | "liquidityPoolWithdrawSuccess"
-      | "liquidityPoolWithdrawMalformed"
-      | "liquidityPoolWithdrawNoTrust"
-      | "liquidityPoolWithdrawUnderfunded"
-      | "liquidityPoolWithdrawLineFull"
-      | "liquidityPoolWithdrawUnderMinimum";
+      | 'liquidityPoolWithdrawSuccess'
+      | 'liquidityPoolWithdrawMalformed'
+      | 'liquidityPoolWithdrawNoTrust'
+      | 'liquidityPoolWithdrawUnderfunded'
+      | 'liquidityPoolWithdrawLineFull'
+      | 'liquidityPoolWithdrawUnderMinimum';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5;
 
@@ -1639,9 +1639,9 @@ export namespace xdr {
 
   class InvokeHostFunctionResultCode {
     readonly name:
-      | "invokeHostFunctionSuccess"
-      | "invokeHostFunctionMalformed"
-      | "invokeHostFunctionTrapped";
+      | 'invokeHostFunctionSuccess'
+      | 'invokeHostFunctionMalformed'
+      | 'invokeHostFunctionTrapped';
 
     readonly value: 0 | -1 | -2;
 
@@ -1654,13 +1654,13 @@ export namespace xdr {
 
   class OperationResultCode {
     readonly name:
-      | "opInner"
-      | "opBadAuth"
-      | "opNoAccount"
-      | "opNotSupported"
-      | "opTooManySubentries"
-      | "opExceededWorkLimit"
-      | "opTooManySponsoring";
+      | 'opInner'
+      | 'opBadAuth'
+      | 'opNoAccount'
+      | 'opNotSupported'
+      | 'opTooManySubentries'
+      | 'opExceededWorkLimit'
+      | 'opTooManySponsoring';
 
     readonly value: 0 | -1 | -2 | -3 | -4 | -5 | -6;
 
@@ -1681,24 +1681,24 @@ export namespace xdr {
 
   class TransactionResultCode {
     readonly name:
-      | "txFeeBumpInnerSuccess"
-      | "txSuccess"
-      | "txFailed"
-      | "txTooEarly"
-      | "txTooLate"
-      | "txMissingOperation"
-      | "txBadSeq"
-      | "txBadAuth"
-      | "txInsufficientBalance"
-      | "txNoAccount"
-      | "txInsufficientFee"
-      | "txBadAuthExtra"
-      | "txInternalError"
-      | "txNotSupported"
-      | "txFeeBumpInnerFailed"
-      | "txBadSponsorship"
-      | "txBadMinSeqAgeOrGap"
-      | "txMalformed";
+      | 'txFeeBumpInnerSuccess'
+      | 'txSuccess'
+      | 'txFailed'
+      | 'txTooEarly'
+      | 'txTooLate'
+      | 'txMissingOperation'
+      | 'txBadSeq'
+      | 'txBadAuth'
+      | 'txInsufficientBalance'
+      | 'txNoAccount'
+      | 'txInsufficientFee'
+      | 'txBadAuthExtra'
+      | 'txInternalError'
+      | 'txNotSupported'
+      | 'txFeeBumpInnerFailed'
+      | 'txBadSponsorship'
+      | 'txBadMinSeqAgeOrGap'
+      | 'txMalformed';
 
     readonly value:
       | 1
@@ -1759,11 +1759,11 @@ export namespace xdr {
 
   class CryptoKeyType {
     readonly name:
-      | "keyTypeEd25519"
-      | "keyTypePreAuthTx"
-      | "keyTypeHashX"
-      | "keyTypeEd25519SignedPayload"
-      | "keyTypeMuxedEd25519";
+      | 'keyTypeEd25519'
+      | 'keyTypePreAuthTx'
+      | 'keyTypeHashX'
+      | 'keyTypeEd25519SignedPayload'
+      | 'keyTypeMuxedEd25519';
 
     readonly value: 0 | 1 | 2 | 3 | 256;
 
@@ -1779,7 +1779,7 @@ export namespace xdr {
   }
 
   class PublicKeyType {
-    readonly name: "publicKeyTypeEd25519";
+    readonly name: 'publicKeyTypeEd25519';
 
     readonly value: 0;
 
@@ -1788,10 +1788,10 @@ export namespace xdr {
 
   class SignerKeyType {
     readonly name:
-      | "signerKeyTypeEd25519"
-      | "signerKeyTypePreAuthTx"
-      | "signerKeyTypeHashX"
-      | "signerKeyTypeEd25519SignedPayload";
+      | 'signerKeyTypeEd25519'
+      | 'signerKeyTypePreAuthTx'
+      | 'signerKeyTypeHashX'
+      | 'signerKeyTypeEd25519SignedPayload';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -1806,28 +1806,28 @@ export namespace xdr {
 
   class ScValType {
     readonly name:
-      | "scvBool"
-      | "scvVoid"
-      | "scvStatus"
-      | "scvU32"
-      | "scvI32"
-      | "scvU64"
-      | "scvI64"
-      | "scvTimepoint"
-      | "scvDuration"
-      | "scvU128"
-      | "scvI128"
-      | "scvU256"
-      | "scvI256"
-      | "scvBytes"
-      | "scvString"
-      | "scvSymbol"
-      | "scvVec"
-      | "scvMap"
-      | "scvContractExecutable"
-      | "scvAddress"
-      | "scvLedgerKeyContractExecutable"
-      | "scvLedgerKeyNonce";
+      | 'scvBool'
+      | 'scvVoid'
+      | 'scvStatus'
+      | 'scvU32'
+      | 'scvI32'
+      | 'scvU64'
+      | 'scvI64'
+      | 'scvTimepoint'
+      | 'scvDuration'
+      | 'scvU128'
+      | 'scvI128'
+      | 'scvU256'
+      | 'scvI256'
+      | 'scvBytes'
+      | 'scvString'
+      | 'scvSymbol'
+      | 'scvVec'
+      | 'scvMap'
+      | 'scvContractExecutable'
+      | 'scvAddress'
+      | 'scvLedgerKeyContractExecutable'
+      | 'scvLedgerKeyNonce';
 
     readonly value:
       | 0
@@ -1900,16 +1900,16 @@ export namespace xdr {
 
   class ScStatusType {
     readonly name:
-      | "sstOk"
-      | "sstUnknownError"
-      | "sstHostValueError"
-      | "sstHostObjectError"
-      | "sstHostFunctionError"
-      | "sstHostStorageError"
-      | "sstHostContextError"
-      | "sstVmError"
-      | "sstContractError"
-      | "sstHostAuthError";
+      | 'sstOk'
+      | 'sstUnknownError'
+      | 'sstHostValueError'
+      | 'sstHostObjectError'
+      | 'sstHostFunctionError'
+      | 'sstHostStorageError'
+      | 'sstHostContextError'
+      | 'sstVmError'
+      | 'sstContractError'
+      | 'sstHostAuthError';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
@@ -1936,18 +1936,18 @@ export namespace xdr {
 
   class ScHostValErrorCode {
     readonly name:
-      | "hostValueUnknownError"
-      | "hostValueReservedTagValue"
-      | "hostValueUnexpectedValType"
-      | "hostValueU63OutOfRange"
-      | "hostValueU32OutOfRange"
-      | "hostValueStaticUnknown"
-      | "hostValueMissingObject"
-      | "hostValueSymbolTooLong"
-      | "hostValueSymbolBadChar"
-      | "hostValueSymbolContainsNonUtf8"
-      | "hostValueBitsetTooManyBits"
-      | "hostValueStatusUnknown";
+      | 'hostValueUnknownError'
+      | 'hostValueReservedTagValue'
+      | 'hostValueUnexpectedValType'
+      | 'hostValueU63OutOfRange'
+      | 'hostValueU32OutOfRange'
+      | 'hostValueStaticUnknown'
+      | 'hostValueMissingObject'
+      | 'hostValueSymbolTooLong'
+      | 'hostValueSymbolBadChar'
+      | 'hostValueSymbolContainsNonUtf8'
+      | 'hostValueBitsetTooManyBits'
+      | 'hostValueStatusUnknown';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
@@ -1978,13 +1978,13 @@ export namespace xdr {
 
   class ScHostObjErrorCode {
     readonly name:
-      | "hostObjectUnknownError"
-      | "hostObjectUnknownReference"
-      | "hostObjectUnexpectedType"
-      | "hostObjectObjectCountExceedsU32Max"
-      | "hostObjectObjectNotExist"
-      | "hostObjectVecIndexOutOfBound"
-      | "hostObjectContractHashWrongLength";
+      | 'hostObjectUnknownError'
+      | 'hostObjectUnknownReference'
+      | 'hostObjectUnexpectedType'
+      | 'hostObjectObjectCountExceedsU32Max'
+      | 'hostObjectObjectNotExist'
+      | 'hostObjectVecIndexOutOfBound'
+      | 'hostObjectContractHashWrongLength';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -2005,11 +2005,11 @@ export namespace xdr {
 
   class ScHostFnErrorCode {
     readonly name:
-      | "hostFnUnknownError"
-      | "hostFnUnexpectedHostFunctionAction"
-      | "hostFnInputArgsWrongLength"
-      | "hostFnInputArgsWrongType"
-      | "hostFnInputArgsInvalid";
+      | 'hostFnUnknownError'
+      | 'hostFnUnexpectedHostFunctionAction'
+      | 'hostFnInputArgsWrongLength'
+      | 'hostFnInputArgsWrongType'
+      | 'hostFnInputArgsInvalid';
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -2026,12 +2026,12 @@ export namespace xdr {
 
   class ScHostStorageErrorCode {
     readonly name:
-      | "hostStorageUnknownError"
-      | "hostStorageExpectContractData"
-      | "hostStorageReadwriteAccessToReadonlyEntry"
-      | "hostStorageAccessToUnknownEntry"
-      | "hostStorageMissingKeyInGet"
-      | "hostStorageGetOnDeletedKey";
+      | 'hostStorageUnknownError'
+      | 'hostStorageExpectContractData'
+      | 'hostStorageReadwriteAccessToReadonlyEntry'
+      | 'hostStorageAccessToUnknownEntry'
+      | 'hostStorageMissingKeyInGet'
+      | 'hostStorageGetOnDeletedKey';
 
     readonly value: 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -2050,10 +2050,10 @@ export namespace xdr {
 
   class ScHostAuthErrorCode {
     readonly name:
-      | "hostAuthUnknownError"
-      | "hostAuthNonceError"
-      | "hostAuthDuplicateAuthorization"
-      | "hostAuthNotAuthorized";
+      | 'hostAuthUnknownError'
+      | 'hostAuthNonceError'
+      | 'hostAuthDuplicateAuthorization'
+      | 'hostAuthNotAuthorized';
 
     readonly value: 0 | 1 | 2 | 3;
 
@@ -2067,7 +2067,7 @@ export namespace xdr {
   }
 
   class ScHostContextErrorCode {
-    readonly name: "hostContextUnknownError" | "hostContextNoContractRunning";
+    readonly name: 'hostContextUnknownError' | 'hostContextNoContractRunning';
 
     readonly value: 0 | 1;
 
@@ -2078,25 +2078,25 @@ export namespace xdr {
 
   class ScVmErrorCode {
     readonly name:
-      | "vmUnknown"
-      | "vmValidation"
-      | "vmInstantiation"
-      | "vmFunction"
-      | "vmTable"
-      | "vmMemory"
-      | "vmGlobal"
-      | "vmValue"
-      | "vmTrapUnreachable"
-      | "vmTrapMemoryAccessOutOfBounds"
-      | "vmTrapTableAccessOutOfBounds"
-      | "vmTrapElemUninitialized"
-      | "vmTrapDivisionByZero"
-      | "vmTrapIntegerOverflow"
-      | "vmTrapInvalidConversionToInt"
-      | "vmTrapStackOverflow"
-      | "vmTrapUnexpectedSignature"
-      | "vmTrapMemLimitExceeded"
-      | "vmTrapCpuLimitExceeded";
+      | 'vmUnknown'
+      | 'vmValidation'
+      | 'vmInstantiation'
+      | 'vmFunction'
+      | 'vmTable'
+      | 'vmMemory'
+      | 'vmGlobal'
+      | 'vmValue'
+      | 'vmTrapUnreachable'
+      | 'vmTrapMemoryAccessOutOfBounds'
+      | 'vmTrapTableAccessOutOfBounds'
+      | 'vmTrapElemUninitialized'
+      | 'vmTrapDivisionByZero'
+      | 'vmTrapIntegerOverflow'
+      | 'vmTrapInvalidConversionToInt'
+      | 'vmTrapStackOverflow'
+      | 'vmTrapUnexpectedSignature'
+      | 'vmTrapMemLimitExceeded'
+      | 'vmTrapCpuLimitExceeded';
 
     readonly value:
       | 0
@@ -2159,7 +2159,7 @@ export namespace xdr {
   }
 
   class ScUnknownErrorCode {
-    readonly name: "unknownErrorGeneral" | "unknownErrorXdr";
+    readonly name: 'unknownErrorGeneral' | 'unknownErrorXdr';
 
     readonly value: 0 | 1;
 
@@ -2169,7 +2169,7 @@ export namespace xdr {
   }
 
   class ScContractExecutableType {
-    readonly name: "sccontractExecutableWasmRef" | "sccontractExecutableToken";
+    readonly name: 'sccontractExecutableWasmRef' | 'sccontractExecutableToken';
 
     readonly value: 0 | 1;
 
@@ -2179,7 +2179,7 @@ export namespace xdr {
   }
 
   class ScAddressType {
-    readonly name: "scAddressTypeAccount" | "scAddressTypeContract";
+    readonly name: 'scAddressTypeAccount' | 'scAddressTypeContract';
 
     readonly value: 0 | 1;
 
@@ -2189,7 +2189,7 @@ export namespace xdr {
   }
 
   class ScEnvMetaKind {
-    readonly name: "scEnvMetaKindInterfaceVersion";
+    readonly name: 'scEnvMetaKindInterfaceVersion';
 
     readonly value: 0;
 
@@ -2198,32 +2198,32 @@ export namespace xdr {
 
   class ScSpecType {
     readonly name:
-      | "scSpecTypeVal"
-      | "scSpecTypeBool"
-      | "scSpecTypeVoid"
-      | "scSpecTypeStatus"
-      | "scSpecTypeU32"
-      | "scSpecTypeI32"
-      | "scSpecTypeU64"
-      | "scSpecTypeI64"
-      | "scSpecTypeTimepoint"
-      | "scSpecTypeDuration"
-      | "scSpecTypeU128"
-      | "scSpecTypeI128"
-      | "scSpecTypeU256"
-      | "scSpecTypeI256"
-      | "scSpecTypeBytes"
-      | "scSpecTypeString"
-      | "scSpecTypeSymbol"
-      | "scSpecTypeAddress"
-      | "scSpecTypeOption"
-      | "scSpecTypeResult"
-      | "scSpecTypeVec"
-      | "scSpecTypeSet"
-      | "scSpecTypeMap"
-      | "scSpecTypeTuple"
-      | "scSpecTypeBytesN"
-      | "scSpecTypeUdt";
+      | 'scSpecTypeVal'
+      | 'scSpecTypeBool'
+      | 'scSpecTypeVoid'
+      | 'scSpecTypeStatus'
+      | 'scSpecTypeU32'
+      | 'scSpecTypeI32'
+      | 'scSpecTypeU64'
+      | 'scSpecTypeI64'
+      | 'scSpecTypeTimepoint'
+      | 'scSpecTypeDuration'
+      | 'scSpecTypeU128'
+      | 'scSpecTypeI128'
+      | 'scSpecTypeU256'
+      | 'scSpecTypeI256'
+      | 'scSpecTypeBytes'
+      | 'scSpecTypeString'
+      | 'scSpecTypeSymbol'
+      | 'scSpecTypeAddress'
+      | 'scSpecTypeOption'
+      | 'scSpecTypeResult'
+      | 'scSpecTypeVec'
+      | 'scSpecTypeSet'
+      | 'scSpecTypeMap'
+      | 'scSpecTypeTuple'
+      | 'scSpecTypeBytesN'
+      | 'scSpecTypeUdt';
 
     readonly value:
       | 0
@@ -2307,7 +2307,7 @@ export namespace xdr {
   }
 
   class ScSpecUdtUnionCaseV0Kind {
-    readonly name: "scSpecUdtUnionCaseVoidV0" | "scSpecUdtUnionCaseTupleV0";
+    readonly name: 'scSpecUdtUnionCaseVoidV0' | 'scSpecUdtUnionCaseTupleV0';
 
     readonly value: 0 | 1;
 
@@ -2318,11 +2318,11 @@ export namespace xdr {
 
   class ScSpecEntryKind {
     readonly name:
-      | "scSpecEntryFunctionV0"
-      | "scSpecEntryUdtStructV0"
-      | "scSpecEntryUdtUnionV0"
-      | "scSpecEntryUdtEnumV0"
-      | "scSpecEntryUdtErrorEnumV0";
+      | 'scSpecEntryFunctionV0'
+      | 'scSpecEntryUdtStructV0'
+      | 'scSpecEntryUdtUnionV0'
+      | 'scSpecEntryUdtEnumV0'
+      | 'scSpecEntryUdtErrorEnumV0';
 
     readonly value: 0 | 1 | 2 | 3 | 4;
 
@@ -2412,9 +2412,9 @@ export namespace xdr {
 
     value(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpBallot;
 
@@ -2424,13 +2424,13 @@ export namespace xdr {
 
     static toXDR(value: ScpBallot): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpBallot;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpBallot;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpBallot;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpBallot;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpNomination {
@@ -2446,9 +2446,9 @@ export namespace xdr {
 
     accepted(value?: Buffer[]): Buffer[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpNomination;
 
@@ -2458,13 +2458,13 @@ export namespace xdr {
 
     static toXDR(value: ScpNomination): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpNomination;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpNomination;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpNomination;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpNomination;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatementPrepare {
@@ -2489,9 +2489,9 @@ export namespace xdr {
 
     nH(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpStatementPrepare;
 
@@ -2501,16 +2501,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementPrepare): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpStatementPrepare;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementPrepare;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScpStatementPrepare;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatementConfirm {
@@ -2532,9 +2532,9 @@ export namespace xdr {
 
     quorumSetHash(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpStatementConfirm;
 
@@ -2544,16 +2544,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementConfirm): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpStatementConfirm;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementConfirm;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScpStatementConfirm;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatementExternalize {
@@ -2569,9 +2569,9 @@ export namespace xdr {
 
     commitQuorumSetHash(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpStatementExternalize;
 
@@ -2581,16 +2581,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementExternalize): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpStatementExternalize;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementExternalize;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScpStatementExternalize;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatement {
@@ -2606,9 +2606,9 @@ export namespace xdr {
 
     pledges(value?: ScpStatementPledges): ScpStatementPledges;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpStatement;
 
@@ -2618,13 +2618,13 @@ export namespace xdr {
 
     static toXDR(value: ScpStatement): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpStatement;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpStatement;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpStatement;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpStatement;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpEnvelope {
@@ -2634,9 +2634,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpEnvelope;
 
@@ -2646,13 +2646,13 @@ export namespace xdr {
 
     static toXDR(value: ScpEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpEnvelope;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpEnvelope;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpEnvelope;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpEnvelope;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpQuorumSet {
@@ -2668,9 +2668,9 @@ export namespace xdr {
 
     innerSets(value?: ScpQuorumSet[]): ScpQuorumSet[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpQuorumSet;
 
@@ -2680,13 +2680,13 @@ export namespace xdr {
 
     static toXDR(value: ScpQuorumSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpQuorumSet;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpQuorumSet;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpQuorumSet;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpQuorumSet;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AlphaNum4 {
@@ -2696,9 +2696,9 @@ export namespace xdr {
 
     issuer(value?: AccountId): AccountId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AlphaNum4;
 
@@ -2708,13 +2708,13 @@ export namespace xdr {
 
     static toXDR(value: AlphaNum4): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AlphaNum4;
+    static fromXDR(input: Buffer, format?: 'raw'): AlphaNum4;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AlphaNum4;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AlphaNum4;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AlphaNum12 {
@@ -2724,9 +2724,9 @@ export namespace xdr {
 
     issuer(value?: AccountId): AccountId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AlphaNum12;
 
@@ -2736,13 +2736,13 @@ export namespace xdr {
 
     static toXDR(value: AlphaNum12): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AlphaNum12;
+    static fromXDR(input: Buffer, format?: 'raw'): AlphaNum12;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AlphaNum12;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AlphaNum12;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Price {
@@ -2752,9 +2752,9 @@ export namespace xdr {
 
     d(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Price;
 
@@ -2764,13 +2764,13 @@ export namespace xdr {
 
     static toXDR(value: Price): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Price;
+    static fromXDR(input: Buffer, format?: 'raw'): Price;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Price;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Price;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Liabilities {
@@ -2780,9 +2780,9 @@ export namespace xdr {
 
     selling(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Liabilities;
 
@@ -2792,13 +2792,13 @@ export namespace xdr {
 
     static toXDR(value: Liabilities): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Liabilities;
+    static fromXDR(input: Buffer, format?: 'raw'): Liabilities;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Liabilities;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Liabilities;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Signer {
@@ -2808,9 +2808,9 @@ export namespace xdr {
 
     weight(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Signer;
 
@@ -2820,13 +2820,13 @@ export namespace xdr {
 
     static toXDR(value: Signer): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Signer;
+    static fromXDR(input: Buffer, format?: 'raw'): Signer;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Signer;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Signer;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExtensionV3 {
@@ -2842,9 +2842,9 @@ export namespace xdr {
 
     seqTime(value?: TimePoint): TimePoint;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExtensionV3;
 
@@ -2854,16 +2854,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV3): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV3;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV3;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AccountEntryExtensionV3;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExtensionV2 {
@@ -2884,9 +2884,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExtensionV2Ext): AccountEntryExtensionV2Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExtensionV2;
 
@@ -2896,16 +2896,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV2;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV2;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AccountEntryExtensionV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExtensionV1 {
@@ -2918,9 +2918,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExtensionV1Ext): AccountEntryExtensionV1Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExtensionV1;
 
@@ -2930,16 +2930,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV1;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AccountEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntry {
@@ -2976,9 +2976,9 @@ export namespace xdr {
 
     ext(value?: AccountEntryExt): AccountEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntry;
 
@@ -2988,13 +2988,13 @@ export namespace xdr {
 
     static toXDR(value: AccountEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AccountEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AccountEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntryExtensionV2 {
@@ -3007,9 +3007,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryExtensionV2Ext): TrustLineEntryExtensionV2Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntryExtensionV2;
 
@@ -3019,16 +3019,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExtensionV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExtensionV2;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExtensionV2;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TrustLineEntryExtensionV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntryV1 {
@@ -3041,9 +3041,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryV1Ext): TrustLineEntryV1Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntryV1;
 
@@ -3053,13 +3053,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryV1;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryV1;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntryV1;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntryV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntry {
@@ -3084,9 +3084,9 @@ export namespace xdr {
 
     ext(value?: TrustLineEntryExt): TrustLineEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntry;
 
@@ -3096,13 +3096,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OfferEntry {
@@ -3133,9 +3133,9 @@ export namespace xdr {
 
     ext(value?: OfferEntryExt): OfferEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OfferEntry;
 
@@ -3145,13 +3145,13 @@ export namespace xdr {
 
     static toXDR(value: OfferEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OfferEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): OfferEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OfferEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OfferEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class DataEntry {
@@ -3170,9 +3170,9 @@ export namespace xdr {
 
     ext(value?: DataEntryExt): DataEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): DataEntry;
 
@@ -3182,13 +3182,13 @@ export namespace xdr {
 
     static toXDR(value: DataEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): DataEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): DataEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): DataEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): DataEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimantV0 {
@@ -3201,9 +3201,9 @@ export namespace xdr {
 
     predicate(value?: ClaimPredicate): ClaimPredicate;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimantV0;
 
@@ -3213,13 +3213,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimantV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimantV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimantV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimantV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimantV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimableBalanceEntryExtensionV1 {
@@ -3234,9 +3234,9 @@ export namespace xdr {
 
     flags(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExtensionV1;
 
@@ -3248,17 +3248,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ClaimableBalanceEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimableBalanceEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimableBalanceEntry {
@@ -3280,9 +3280,9 @@ export namespace xdr {
 
     ext(value?: ClaimableBalanceEntryExt): ClaimableBalanceEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimableBalanceEntry;
 
@@ -3292,16 +3292,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceEntry;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimableBalanceEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolConstantProductParameters {
@@ -3313,9 +3313,9 @@ export namespace xdr {
 
     fee(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolConstantProductParameters;
 
@@ -3330,17 +3330,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): LiquidityPoolConstantProductParameters;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolConstantProductParameters;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolEntryConstantProduct {
@@ -3364,9 +3364,9 @@ export namespace xdr {
 
     poolSharesTrustLineCount(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolEntryConstantProduct;
 
@@ -3378,17 +3378,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): LiquidityPoolEntryConstantProduct;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolEntryConstantProduct;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolEntry {
@@ -3401,9 +3401,9 @@ export namespace xdr {
 
     body(value?: LiquidityPoolEntryBody): LiquidityPoolEntryBody;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolEntry;
 
@@ -3413,13 +3413,13 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LiquidityPoolEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LiquidityPoolEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ContractDataEntry {
@@ -3431,9 +3431,9 @@ export namespace xdr {
 
     val(value?: ScVal): ScVal;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ContractDataEntry;
 
@@ -3443,13 +3443,13 @@ export namespace xdr {
 
     static toXDR(value: ContractDataEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ContractDataEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): ContractDataEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ContractDataEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ContractDataEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ContractCodeEntry {
@@ -3465,9 +3465,9 @@ export namespace xdr {
 
     code(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ContractCodeEntry;
 
@@ -3477,13 +3477,13 @@ export namespace xdr {
 
     static toXDR(value: ContractCodeEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ContractCodeEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): ContractCodeEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ContractCodeEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ContractCodeEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ConfigSettingContractComputeV0 {
@@ -3502,9 +3502,9 @@ export namespace xdr {
 
     memoryLimit(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ConfigSettingContractComputeV0;
 
@@ -3516,17 +3516,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ConfigSettingContractComputeV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ConfigSettingContractComputeV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ConfigSettingContractLedgerCostV0 {
@@ -3581,9 +3581,9 @@ export namespace xdr {
 
     bucketListGrowthFactor(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ConfigSettingContractLedgerCostV0;
 
@@ -3595,17 +3595,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ConfigSettingContractLedgerCostV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ConfigSettingContractLedgerCostV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ConfigSettingContractHistoricalDataV0 {
@@ -3613,9 +3613,9 @@ export namespace xdr {
 
     feeHistorical1Kb(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ConfigSettingContractHistoricalDataV0;
 
@@ -3630,17 +3630,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ConfigSettingContractHistoricalDataV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ConfigSettingContractHistoricalDataV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ConfigSettingContractMetaDataV0 {
@@ -3653,9 +3653,9 @@ export namespace xdr {
 
     feeExtendedMetaData1Kb(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ConfigSettingContractMetaDataV0;
 
@@ -3667,17 +3667,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ConfigSettingContractMetaDataV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ConfigSettingContractMetaDataV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ConfigSettingContractBandwidthV0 {
@@ -3693,9 +3693,9 @@ export namespace xdr {
 
     feePropagateData1Kb(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ConfigSettingContractBandwidthV0;
 
@@ -3707,17 +3707,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ConfigSettingContractBandwidthV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ConfigSettingContractBandwidthV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntryExtensionV1 {
@@ -3730,9 +3730,9 @@ export namespace xdr {
 
     ext(value?: LedgerEntryExtensionV1Ext): LedgerEntryExtensionV1Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntryExtensionV1;
 
@@ -3742,16 +3742,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExtensionV1;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExtensionV1;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerEntryExtensionV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntry {
@@ -3767,9 +3767,9 @@ export namespace xdr {
 
     ext(value?: LedgerEntryExt): LedgerEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntry;
 
@@ -3779,13 +3779,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyAccount {
@@ -3793,9 +3793,9 @@ export namespace xdr {
 
     accountId(value?: AccountId): AccountId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyAccount;
 
@@ -3805,13 +3805,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyAccount): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyAccount;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyAccount;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyAccount;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyAccount;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyTrustLine {
@@ -3821,9 +3821,9 @@ export namespace xdr {
 
     asset(value?: TrustLineAsset): TrustLineAsset;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyTrustLine;
 
@@ -3833,13 +3833,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyTrustLine): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyTrustLine;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyTrustLine;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyTrustLine;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyTrustLine;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyOffer {
@@ -3849,9 +3849,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyOffer;
 
@@ -3861,13 +3861,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyOffer): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyOffer;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyOffer;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyOffer;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyOffer;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyData {
@@ -3880,9 +3880,9 @@ export namespace xdr {
 
     dataName(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyData;
 
@@ -3892,13 +3892,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyData): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyData;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyData;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerKeyData;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKeyData;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyClaimableBalance {
@@ -3906,9 +3906,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyClaimableBalance;
 
@@ -3918,16 +3918,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyClaimableBalance): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyClaimableBalance;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyClaimableBalance;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerKeyClaimableBalance;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyLiquidityPool {
@@ -3935,9 +3935,9 @@ export namespace xdr {
 
     liquidityPoolId(value?: PoolId): PoolId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyLiquidityPool;
 
@@ -3947,16 +3947,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyLiquidityPool): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyLiquidityPool;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyLiquidityPool;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerKeyLiquidityPool;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyContractData {
@@ -3966,9 +3966,9 @@ export namespace xdr {
 
     key(value?: ScVal): ScVal;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyContractData;
 
@@ -3978,16 +3978,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyContractData): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyContractData;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyContractData;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerKeyContractData;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyContractCode {
@@ -3995,9 +3995,9 @@ export namespace xdr {
 
     hash(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyContractCode;
 
@@ -4007,16 +4007,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyContractCode): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyContractCode;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyContractCode;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerKeyContractCode;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKeyConfigSetting {
@@ -4024,9 +4024,9 @@ export namespace xdr {
 
     configSettingId(value?: ConfigSettingId): ConfigSettingId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKeyConfigSetting;
 
@@ -4036,16 +4036,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerKeyConfigSetting): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKeyConfigSetting;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKeyConfigSetting;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerKeyConfigSetting;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerCloseValueSignature {
@@ -4055,9 +4055,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerCloseValueSignature;
 
@@ -4067,16 +4067,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseValueSignature): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseValueSignature;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseValueSignature;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerCloseValueSignature;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class StellarValue {
@@ -4095,9 +4095,9 @@ export namespace xdr {
 
     ext(value?: StellarValueExt): StellarValueExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): StellarValue;
 
@@ -4107,13 +4107,13 @@ export namespace xdr {
 
     static toXDR(value: StellarValue): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): StellarValue;
+    static fromXDR(input: Buffer, format?: 'raw'): StellarValue;
 
-    static fromXDR(input: string, format: "hex" | "base64"): StellarValue;
+    static fromXDR(input: string, format: 'hex' | 'base64'): StellarValue;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeaderExtensionV1 {
@@ -4123,9 +4123,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderExtensionV1Ext): LedgerHeaderExtensionV1Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeaderExtensionV1;
 
@@ -4135,16 +4135,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExtensionV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExtensionV1;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExtensionV1;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerHeaderExtensionV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeader {
@@ -4196,9 +4196,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderExt): LedgerHeaderExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeader;
 
@@ -4208,13 +4208,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeader): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeader;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeader;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerHeader;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerHeader;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ConfigUpgradeSetKey {
@@ -4224,9 +4224,9 @@ export namespace xdr {
 
     contentHash(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ConfigUpgradeSetKey;
 
@@ -4236,16 +4236,16 @@ export namespace xdr {
 
     static toXDR(value: ConfigUpgradeSetKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ConfigUpgradeSetKey;
+    static fromXDR(input: Buffer, format?: 'raw'): ConfigUpgradeSetKey;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ConfigUpgradeSetKey;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ConfigUpgradeSet {
@@ -4253,9 +4253,9 @@ export namespace xdr {
 
     updatedEntry(value?: ConfigSettingEntry[]): ConfigSettingEntry[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ConfigUpgradeSet;
 
@@ -4265,13 +4265,13 @@ export namespace xdr {
 
     static toXDR(value: ConfigUpgradeSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ConfigUpgradeSet;
+    static fromXDR(input: Buffer, format?: 'raw'): ConfigUpgradeSet;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ConfigUpgradeSet;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ConfigUpgradeSet;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BucketMetadata {
@@ -4281,9 +4281,9 @@ export namespace xdr {
 
     ext(value?: BucketMetadataExt): BucketMetadataExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BucketMetadata;
 
@@ -4293,13 +4293,13 @@ export namespace xdr {
 
     static toXDR(value: BucketMetadata): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): BucketMetadata;
+    static fromXDR(input: Buffer, format?: 'raw'): BucketMetadata;
 
-    static fromXDR(input: string, format: "hex" | "base64"): BucketMetadata;
+    static fromXDR(input: string, format: 'hex' | 'base64'): BucketMetadata;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TxSetComponentTxsMaybeDiscountedFee {
@@ -4312,9 +4312,9 @@ export namespace xdr {
 
     txes(value?: TransactionEnvelope[]): TransactionEnvelope[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TxSetComponentTxsMaybeDiscountedFee;
 
@@ -4326,17 +4326,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): TxSetComponentTxsMaybeDiscountedFee;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TxSetComponentTxsMaybeDiscountedFee;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionSet {
@@ -4349,9 +4349,9 @@ export namespace xdr {
 
     txes(value?: TransactionEnvelope[]): TransactionEnvelope[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionSet;
 
@@ -4361,13 +4361,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionSet;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionSet;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionSet;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionSet;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionSetV1 {
@@ -4380,9 +4380,9 @@ export namespace xdr {
 
     phases(value?: TransactionPhase[]): TransactionPhase[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionSetV1;
 
@@ -4392,13 +4392,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionSetV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionSetV1;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionSetV1;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionSetV1;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionSetV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultPair {
@@ -4411,9 +4411,9 @@ export namespace xdr {
 
     result(value?: TransactionResult): TransactionResult;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultPair;
 
@@ -4423,16 +4423,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultPair): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultPair;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultPair;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultPair;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultSet {
@@ -4440,9 +4440,9 @@ export namespace xdr {
 
     results(value?: TransactionResultPair[]): TransactionResultPair[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultSet;
 
@@ -4452,16 +4452,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultSet;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultSet;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultSet;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionHistoryEntry {
@@ -4477,9 +4477,9 @@ export namespace xdr {
 
     ext(value?: TransactionHistoryEntryExt): TransactionHistoryEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionHistoryEntry;
 
@@ -4489,16 +4489,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionHistoryEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionHistoryEntry;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionHistoryResultEntry {
@@ -4516,9 +4516,9 @@ export namespace xdr {
       value?: TransactionHistoryResultEntryExt
     ): TransactionHistoryResultEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionHistoryResultEntry;
 
@@ -4530,17 +4530,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): TransactionHistoryResultEntry;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionHistoryResultEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultPairV2 {
@@ -4553,9 +4553,9 @@ export namespace xdr {
 
     hashOfMetaHashes(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultPairV2;
 
@@ -4565,16 +4565,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultPairV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultPairV2;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultPairV2;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultPairV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultSetV2 {
@@ -4582,9 +4582,9 @@ export namespace xdr {
 
     results(value?: TransactionResultPairV2[]): TransactionResultPairV2[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultSetV2;
 
@@ -4594,16 +4594,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultSetV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultSetV2;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultSetV2;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultSetV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionHistoryResultEntryV2 {
@@ -4621,9 +4621,9 @@ export namespace xdr {
       value?: TransactionHistoryResultEntryV2Ext
     ): TransactionHistoryResultEntryV2Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionHistoryResultEntryV2;
 
@@ -4635,17 +4635,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): TransactionHistoryResultEntryV2;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionHistoryResultEntryV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeaderHistoryEntry {
@@ -4661,9 +4661,9 @@ export namespace xdr {
 
     ext(value?: LedgerHeaderHistoryEntryExt): LedgerHeaderHistoryEntryExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeaderHistoryEntry;
 
@@ -4673,16 +4673,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderHistoryEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderHistoryEntry;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerHeaderHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerScpMessages {
@@ -4692,9 +4692,9 @@ export namespace xdr {
 
     messages(value?: ScpEnvelope[]): ScpEnvelope[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerScpMessages;
 
@@ -4704,13 +4704,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerScpMessages): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerScpMessages;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerScpMessages;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerScpMessages;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerScpMessages;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpHistoryEntryV0 {
@@ -4723,9 +4723,9 @@ export namespace xdr {
 
     ledgerMessages(value?: LedgerScpMessages): LedgerScpMessages;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpHistoryEntryV0;
 
@@ -4735,13 +4735,13 @@ export namespace xdr {
 
     static toXDR(value: ScpHistoryEntryV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpHistoryEntryV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpHistoryEntryV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpHistoryEntryV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpHistoryEntryV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OperationMeta {
@@ -4749,9 +4749,9 @@ export namespace xdr {
 
     changes(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OperationMeta;
 
@@ -4761,13 +4761,13 @@ export namespace xdr {
 
     static toXDR(value: OperationMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OperationMeta;
+    static fromXDR(input: Buffer, format?: 'raw'): OperationMeta;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OperationMeta;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OperationMeta;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionMetaV1 {
@@ -4780,9 +4780,9 @@ export namespace xdr {
 
     operations(value?: OperationMeta[]): OperationMeta[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionMetaV1;
 
@@ -4792,13 +4792,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMetaV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionMetaV1;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionMetaV1;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionMetaV1;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMetaV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionMetaV2 {
@@ -4814,9 +4814,9 @@ export namespace xdr {
 
     txChangesAfter(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionMetaV2;
 
@@ -4826,13 +4826,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMetaV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionMetaV2;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionMetaV2;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionMetaV2;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMetaV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ContractEventV0 {
@@ -4842,9 +4842,9 @@ export namespace xdr {
 
     data(value?: ScVal): ScVal;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ContractEventV0;
 
@@ -4854,13 +4854,13 @@ export namespace xdr {
 
     static toXDR(value: ContractEventV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ContractEventV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ContractEventV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ContractEventV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ContractEventV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ContractEvent {
@@ -4879,9 +4879,9 @@ export namespace xdr {
 
     body(value?: ContractEventBody): ContractEventBody;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ContractEvent;
 
@@ -4891,13 +4891,13 @@ export namespace xdr {
 
     static toXDR(value: ContractEvent): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ContractEvent;
+    static fromXDR(input: Buffer, format?: 'raw'): ContractEvent;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ContractEvent;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ContractEvent;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class DiagnosticEvent {
@@ -4910,9 +4910,9 @@ export namespace xdr {
 
     event(value?: ContractEvent): ContractEvent;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): DiagnosticEvent;
 
@@ -4922,13 +4922,13 @@ export namespace xdr {
 
     static toXDR(value: DiagnosticEvent): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): DiagnosticEvent;
+    static fromXDR(input: Buffer, format?: 'raw'): DiagnosticEvent;
 
-    static fromXDR(input: string, format: "hex" | "base64"): DiagnosticEvent;
+    static fromXDR(input: string, format: 'hex' | 'base64'): DiagnosticEvent;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OperationDiagnosticEvents {
@@ -4936,9 +4936,9 @@ export namespace xdr {
 
     events(value?: DiagnosticEvent[]): DiagnosticEvent[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OperationDiagnosticEvents;
 
@@ -4948,16 +4948,16 @@ export namespace xdr {
 
     static toXDR(value: OperationDiagnosticEvents): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OperationDiagnosticEvents;
+    static fromXDR(input: Buffer, format?: 'raw'): OperationDiagnosticEvents;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): OperationDiagnosticEvents;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OperationEvents {
@@ -4965,9 +4965,9 @@ export namespace xdr {
 
     events(value?: ContractEvent[]): ContractEvent[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OperationEvents;
 
@@ -4977,13 +4977,13 @@ export namespace xdr {
 
     static toXDR(value: OperationEvents): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OperationEvents;
+    static fromXDR(input: Buffer, format?: 'raw'): OperationEvents;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OperationEvents;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OperationEvents;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionMetaV3 {
@@ -5013,9 +5013,9 @@ export namespace xdr {
       value?: OperationDiagnosticEvents[]
     ): OperationDiagnosticEvents[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionMetaV3;
 
@@ -5025,13 +5025,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMetaV3): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionMetaV3;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionMetaV3;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionMetaV3;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMetaV3;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultMeta {
@@ -5047,9 +5047,9 @@ export namespace xdr {
 
     txApplyProcessing(value?: TransactionMeta): TransactionMeta;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultMeta;
 
@@ -5059,16 +5059,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultMeta;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultMeta;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultMeta;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultMetaV2 {
@@ -5084,9 +5084,9 @@ export namespace xdr {
 
     txApplyProcessing(value?: TransactionMeta): TransactionMeta;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultMetaV2;
 
@@ -5096,16 +5096,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultMetaV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultMetaV2;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultMetaV2;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultMetaV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class UpgradeEntryMeta {
@@ -5118,9 +5118,9 @@ export namespace xdr {
 
     changes(value?: LedgerEntryChange[]): LedgerEntryChange[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): UpgradeEntryMeta;
 
@@ -5130,13 +5130,13 @@ export namespace xdr {
 
     static toXDR(value: UpgradeEntryMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): UpgradeEntryMeta;
+    static fromXDR(input: Buffer, format?: 'raw'): UpgradeEntryMeta;
 
-    static fromXDR(input: string, format: "hex" | "base64"): UpgradeEntryMeta;
+    static fromXDR(input: string, format: 'hex' | 'base64'): UpgradeEntryMeta;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerCloseMetaV0 {
@@ -5158,9 +5158,9 @@ export namespace xdr {
 
     scpInfo(value?: ScpHistoryEntry[]): ScpHistoryEntry[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerCloseMetaV0;
 
@@ -5170,13 +5170,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMetaV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMetaV0;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMetaV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMetaV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMetaV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerCloseMetaV1 {
@@ -5198,9 +5198,9 @@ export namespace xdr {
 
     scpInfo(value?: ScpHistoryEntry[]): ScpHistoryEntry[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerCloseMetaV1;
 
@@ -5210,13 +5210,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMetaV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMetaV1;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMetaV1;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMetaV1;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMetaV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerCloseMetaV2 {
@@ -5238,9 +5238,9 @@ export namespace xdr {
 
     scpInfo(value?: ScpHistoryEntry[]): ScpHistoryEntry[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerCloseMetaV2;
 
@@ -5250,13 +5250,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMetaV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMetaV2;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMetaV2;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMetaV2;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMetaV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Error {
@@ -5266,9 +5266,9 @@ export namespace xdr {
 
     msg(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Error;
 
@@ -5278,13 +5278,13 @@ export namespace xdr {
 
     static toXDR(value: Error): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Error;
+    static fromXDR(input: Buffer, format?: 'raw'): Error;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Error;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Error;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SendMore {
@@ -5292,9 +5292,9 @@ export namespace xdr {
 
     numMessages(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SendMore;
 
@@ -5304,13 +5304,13 @@ export namespace xdr {
 
     static toXDR(value: SendMore): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SendMore;
+    static fromXDR(input: Buffer, format?: 'raw'): SendMore;
 
-    static fromXDR(input: string, format: "hex" | "base64"): SendMore;
+    static fromXDR(input: string, format: 'hex' | 'base64'): SendMore;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AuthCert {
@@ -5326,9 +5326,9 @@ export namespace xdr {
 
     sig(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AuthCert;
 
@@ -5338,13 +5338,13 @@ export namespace xdr {
 
     static toXDR(value: AuthCert): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AuthCert;
+    static fromXDR(input: Buffer, format?: 'raw'): AuthCert;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AuthCert;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AuthCert;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Hello {
@@ -5378,9 +5378,9 @@ export namespace xdr {
 
     nonce(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Hello;
 
@@ -5390,13 +5390,13 @@ export namespace xdr {
 
     static toXDR(value: Hello): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Hello;
+    static fromXDR(input: Buffer, format?: 'raw'): Hello;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Hello;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Hello;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Auth {
@@ -5404,9 +5404,9 @@ export namespace xdr {
 
     flags(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Auth;
 
@@ -5416,13 +5416,13 @@ export namespace xdr {
 
     static toXDR(value: Auth): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Auth;
+    static fromXDR(input: Buffer, format?: 'raw'): Auth;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Auth;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Auth;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PeerAddress {
@@ -5438,9 +5438,9 @@ export namespace xdr {
 
     numFailures(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PeerAddress;
 
@@ -5450,13 +5450,13 @@ export namespace xdr {
 
     static toXDR(value: PeerAddress): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PeerAddress;
+    static fromXDR(input: Buffer, format?: 'raw'): PeerAddress;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PeerAddress;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PeerAddress;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class DontHave {
@@ -5466,9 +5466,9 @@ export namespace xdr {
 
     reqHash(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): DontHave;
 
@@ -5478,13 +5478,13 @@ export namespace xdr {
 
     static toXDR(value: DontHave): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): DontHave;
+    static fromXDR(input: Buffer, format?: 'raw'): DontHave;
 
-    static fromXDR(input: string, format: "hex" | "base64"): DontHave;
+    static fromXDR(input: string, format: 'hex' | 'base64'): DontHave;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SurveyRequestMessage {
@@ -5506,9 +5506,9 @@ export namespace xdr {
 
     commandType(value?: SurveyMessageCommandType): SurveyMessageCommandType;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SurveyRequestMessage;
 
@@ -5518,16 +5518,16 @@ export namespace xdr {
 
     static toXDR(value: SurveyRequestMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SurveyRequestMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): SurveyRequestMessage;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SurveyRequestMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SignedSurveyRequestMessage {
@@ -5540,9 +5540,9 @@ export namespace xdr {
 
     request(value?: SurveyRequestMessage): SurveyRequestMessage;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SignedSurveyRequestMessage;
 
@@ -5552,16 +5552,16 @@ export namespace xdr {
 
     static toXDR(value: SignedSurveyRequestMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SignedSurveyRequestMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): SignedSurveyRequestMessage;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SignedSurveyRequestMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SurveyResponseMessage {
@@ -5583,9 +5583,9 @@ export namespace xdr {
 
     encryptedBody(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SurveyResponseMessage;
 
@@ -5595,16 +5595,16 @@ export namespace xdr {
 
     static toXDR(value: SurveyResponseMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SurveyResponseMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): SurveyResponseMessage;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SurveyResponseMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SignedSurveyResponseMessage {
@@ -5617,9 +5617,9 @@ export namespace xdr {
 
     response(value?: SurveyResponseMessage): SurveyResponseMessage;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SignedSurveyResponseMessage;
 
@@ -5629,16 +5629,16 @@ export namespace xdr {
 
     static toXDR(value: SignedSurveyResponseMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SignedSurveyResponseMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): SignedSurveyResponseMessage;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SignedSurveyResponseMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PeerStats {
@@ -5690,9 +5690,9 @@ export namespace xdr {
 
     duplicateFetchMessageRecv(value?: Uint64): Uint64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PeerStats;
 
@@ -5702,13 +5702,13 @@ export namespace xdr {
 
     static toXDR(value: PeerStats): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PeerStats;
+    static fromXDR(input: Buffer, format?: 'raw'): PeerStats;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PeerStats;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PeerStats;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TopologyResponseBodyV0 {
@@ -5727,9 +5727,9 @@ export namespace xdr {
 
     totalOutboundPeerCount(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TopologyResponseBodyV0;
 
@@ -5739,16 +5739,16 @@ export namespace xdr {
 
     static toXDR(value: TopologyResponseBodyV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TopologyResponseBodyV0;
+    static fromXDR(input: Buffer, format?: 'raw'): TopologyResponseBodyV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TopologyResponseBodyV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TopologyResponseBodyV1 {
@@ -5773,9 +5773,9 @@ export namespace xdr {
 
     maxOutboundPeerCount(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TopologyResponseBodyV1;
 
@@ -5785,16 +5785,16 @@ export namespace xdr {
 
     static toXDR(value: TopologyResponseBodyV1): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TopologyResponseBodyV1;
+    static fromXDR(input: Buffer, format?: 'raw'): TopologyResponseBodyV1;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TopologyResponseBodyV1;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FloodAdvert {
@@ -5802,9 +5802,9 @@ export namespace xdr {
 
     txHashes(value?: Hash[]): Hash[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FloodAdvert;
 
@@ -5814,13 +5814,13 @@ export namespace xdr {
 
     static toXDR(value: FloodAdvert): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FloodAdvert;
+    static fromXDR(input: Buffer, format?: 'raw'): FloodAdvert;
 
-    static fromXDR(input: string, format: "hex" | "base64"): FloodAdvert;
+    static fromXDR(input: string, format: 'hex' | 'base64'): FloodAdvert;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FloodDemand {
@@ -5828,9 +5828,9 @@ export namespace xdr {
 
     txHashes(value?: Hash[]): Hash[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FloodDemand;
 
@@ -5840,13 +5840,13 @@ export namespace xdr {
 
     static toXDR(value: FloodDemand): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FloodDemand;
+    static fromXDR(input: Buffer, format?: 'raw'): FloodDemand;
 
-    static fromXDR(input: string, format: "hex" | "base64"): FloodDemand;
+    static fromXDR(input: string, format: 'hex' | 'base64'): FloodDemand;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AuthenticatedMessageV0 {
@@ -5862,9 +5862,9 @@ export namespace xdr {
 
     mac(value?: HmacSha256Mac): HmacSha256Mac;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AuthenticatedMessageV0;
 
@@ -5874,16 +5874,16 @@ export namespace xdr {
 
     static toXDR(value: AuthenticatedMessageV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AuthenticatedMessageV0;
+    static fromXDR(input: Buffer, format?: 'raw'): AuthenticatedMessageV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AuthenticatedMessageV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class MuxedAccountMed25519 {
@@ -5893,9 +5893,9 @@ export namespace xdr {
 
     ed25519(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): MuxedAccountMed25519;
 
@@ -5905,16 +5905,16 @@ export namespace xdr {
 
     static toXDR(value: MuxedAccountMed25519): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): MuxedAccountMed25519;
+    static fromXDR(input: Buffer, format?: 'raw'): MuxedAccountMed25519;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): MuxedAccountMed25519;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class DecoratedSignature {
@@ -5924,9 +5924,9 @@ export namespace xdr {
 
     signature(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): DecoratedSignature;
 
@@ -5936,13 +5936,13 @@ export namespace xdr {
 
     static toXDR(value: DecoratedSignature): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): DecoratedSignature;
+    static fromXDR(input: Buffer, format?: 'raw'): DecoratedSignature;
 
-    static fromXDR(input: string, format: "hex" | "base64"): DecoratedSignature;
+    static fromXDR(input: string, format: 'hex' | 'base64'): DecoratedSignature;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerFootprint {
@@ -5952,9 +5952,9 @@ export namespace xdr {
 
     readWrite(value?: LedgerKey[]): LedgerKey[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerFootprint;
 
@@ -5964,13 +5964,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerFootprint): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerFootprint;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerFootprint;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerFootprint;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerFootprint;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreateAccountOp {
@@ -5980,9 +5980,9 @@ export namespace xdr {
 
     startingBalance(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreateAccountOp;
 
@@ -5992,13 +5992,13 @@ export namespace xdr {
 
     static toXDR(value: CreateAccountOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreateAccountOp;
+    static fromXDR(input: Buffer, format?: 'raw'): CreateAccountOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): CreateAccountOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): CreateAccountOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PaymentOp {
@@ -6014,9 +6014,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PaymentOp;
 
@@ -6026,13 +6026,13 @@ export namespace xdr {
 
     static toXDR(value: PaymentOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PaymentOp;
+    static fromXDR(input: Buffer, format?: 'raw'): PaymentOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PaymentOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PaymentOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictReceiveOp {
@@ -6057,9 +6057,9 @@ export namespace xdr {
 
     path(value?: Asset[]): Asset[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveOp;
 
@@ -6069,16 +6069,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictReceiveOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictReceiveOp;
+    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictReceiveOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictReceiveOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictSendOp {
@@ -6103,9 +6103,9 @@ export namespace xdr {
 
     path(value?: Asset[]): Asset[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictSendOp;
 
@@ -6115,16 +6115,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictSendOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictSendOp;
+    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictSendOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictSendOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageSellOfferOp {
@@ -6146,9 +6146,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageSellOfferOp;
 
@@ -6158,13 +6158,13 @@ export namespace xdr {
 
     static toXDR(value: ManageSellOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageSellOfferOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageSellOfferOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ManageSellOfferOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ManageSellOfferOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageBuyOfferOp {
@@ -6186,9 +6186,9 @@ export namespace xdr {
 
     offerId(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageBuyOfferOp;
 
@@ -6198,13 +6198,13 @@ export namespace xdr {
 
     static toXDR(value: ManageBuyOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageBuyOfferOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageBuyOfferOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ManageBuyOfferOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ManageBuyOfferOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreatePassiveSellOfferOp {
@@ -6223,9 +6223,9 @@ export namespace xdr {
 
     price(value?: Price): Price;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreatePassiveSellOfferOp;
 
@@ -6235,16 +6235,16 @@ export namespace xdr {
 
     static toXDR(value: CreatePassiveSellOfferOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreatePassiveSellOfferOp;
+    static fromXDR(input: Buffer, format?: 'raw'): CreatePassiveSellOfferOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): CreatePassiveSellOfferOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SetOptionsOp {
@@ -6278,9 +6278,9 @@ export namespace xdr {
 
     signer(value?: null | Signer): null | Signer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SetOptionsOp;
 
@@ -6290,13 +6290,13 @@ export namespace xdr {
 
     static toXDR(value: SetOptionsOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SetOptionsOp;
+    static fromXDR(input: Buffer, format?: 'raw'): SetOptionsOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): SetOptionsOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): SetOptionsOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ChangeTrustOp {
@@ -6306,9 +6306,9 @@ export namespace xdr {
 
     limit(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ChangeTrustOp;
 
@@ -6318,13 +6318,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AllowTrustOp {
@@ -6340,9 +6340,9 @@ export namespace xdr {
 
     authorize(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AllowTrustOp;
 
@@ -6352,13 +6352,13 @@ export namespace xdr {
 
     static toXDR(value: AllowTrustOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AllowTrustOp;
+    static fromXDR(input: Buffer, format?: 'raw'): AllowTrustOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AllowTrustOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AllowTrustOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageDataOp {
@@ -6371,9 +6371,9 @@ export namespace xdr {
 
     dataValue(value?: null | Buffer): null | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageDataOp;
 
@@ -6383,13 +6383,13 @@ export namespace xdr {
 
     static toXDR(value: ManageDataOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageDataOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageDataOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ManageDataOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ManageDataOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BumpSequenceOp {
@@ -6397,9 +6397,9 @@ export namespace xdr {
 
     bumpTo(value?: SequenceNumber): SequenceNumber;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BumpSequenceOp;
 
@@ -6409,13 +6409,13 @@ export namespace xdr {
 
     static toXDR(value: BumpSequenceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): BumpSequenceOp;
+    static fromXDR(input: Buffer, format?: 'raw'): BumpSequenceOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): BumpSequenceOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): BumpSequenceOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreateClaimableBalanceOp {
@@ -6431,9 +6431,9 @@ export namespace xdr {
 
     claimants(value?: Claimant[]): Claimant[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreateClaimableBalanceOp;
 
@@ -6443,16 +6443,16 @@ export namespace xdr {
 
     static toXDR(value: CreateClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreateClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: 'raw'): CreateClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): CreateClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimClaimableBalanceOp {
@@ -6460,9 +6460,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimClaimableBalanceOp;
 
@@ -6472,16 +6472,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BeginSponsoringFutureReservesOp {
@@ -6489,9 +6489,9 @@ export namespace xdr {
 
     sponsoredId(value?: AccountId): AccountId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BeginSponsoringFutureReservesOp;
 
@@ -6503,17 +6503,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): BeginSponsoringFutureReservesOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): BeginSponsoringFutureReservesOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class RevokeSponsorshipOpSigner {
@@ -6523,9 +6523,9 @@ export namespace xdr {
 
     signerKey(value?: SignerKey): SignerKey;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): RevokeSponsorshipOpSigner;
 
@@ -6535,16 +6535,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipOpSigner): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipOpSigner;
+    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipOpSigner;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): RevokeSponsorshipOpSigner;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClawbackOp {
@@ -6560,9 +6560,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClawbackOp;
 
@@ -6572,13 +6572,13 @@ export namespace xdr {
 
     static toXDR(value: ClawbackOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClawbackOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ClawbackOp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClawbackOp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClawbackOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClawbackClaimableBalanceOp {
@@ -6586,9 +6586,9 @@ export namespace xdr {
 
     balanceId(value?: ClaimableBalanceId): ClaimableBalanceId;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClawbackClaimableBalanceOp;
 
@@ -6598,16 +6598,16 @@ export namespace xdr {
 
     static toXDR(value: ClawbackClaimableBalanceOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClawbackClaimableBalanceOp;
+    static fromXDR(input: Buffer, format?: 'raw'): ClawbackClaimableBalanceOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClawbackClaimableBalanceOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SetTrustLineFlagsOp {
@@ -6626,9 +6626,9 @@ export namespace xdr {
 
     setFlags(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SetTrustLineFlagsOp;
 
@@ -6638,16 +6638,16 @@ export namespace xdr {
 
     static toXDR(value: SetTrustLineFlagsOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SetTrustLineFlagsOp;
+    static fromXDR(input: Buffer, format?: 'raw'): SetTrustLineFlagsOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SetTrustLineFlagsOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolDepositOp {
@@ -6669,9 +6669,9 @@ export namespace xdr {
 
     maxPrice(value?: Price): Price;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolDepositOp;
 
@@ -6681,16 +6681,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolDepositOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolDepositOp;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolDepositOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolDepositOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolWithdrawOp {
@@ -6709,9 +6709,9 @@ export namespace xdr {
 
     minAmountB(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolWithdrawOp;
 
@@ -6721,16 +6721,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolWithdrawOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolWithdrawOp;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolWithdrawOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolWithdrawOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InstallContractCodeArgs {
@@ -6738,9 +6738,9 @@ export namespace xdr {
 
     code(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InstallContractCodeArgs;
 
@@ -6750,16 +6750,16 @@ export namespace xdr {
 
     static toXDR(value: InstallContractCodeArgs): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InstallContractCodeArgs;
+    static fromXDR(input: Buffer, format?: 'raw'): InstallContractCodeArgs;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InstallContractCodeArgs;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ContractIdFromEd25519PublicKey {
@@ -6771,9 +6771,9 @@ export namespace xdr {
 
     salt(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ContractIdFromEd25519PublicKey;
 
@@ -6785,17 +6785,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ContractIdFromEd25519PublicKey;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ContractIdFromEd25519PublicKey;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreateContractArgs {
@@ -6808,9 +6808,9 @@ export namespace xdr {
 
     source(value?: ScContractExecutable): ScContractExecutable;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreateContractArgs;
 
@@ -6820,13 +6820,13 @@ export namespace xdr {
 
     static toXDR(value: CreateContractArgs): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreateContractArgs;
+    static fromXDR(input: Buffer, format?: 'raw'): CreateContractArgs;
 
-    static fromXDR(input: string, format: "hex" | "base64"): CreateContractArgs;
+    static fromXDR(input: string, format: 'hex' | 'base64'): CreateContractArgs;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AuthorizedInvocation {
@@ -6845,9 +6845,9 @@ export namespace xdr {
 
     subInvocations(value?: AuthorizedInvocation[]): AuthorizedInvocation[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AuthorizedInvocation;
 
@@ -6857,16 +6857,16 @@ export namespace xdr {
 
     static toXDR(value: AuthorizedInvocation): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AuthorizedInvocation;
+    static fromXDR(input: Buffer, format?: 'raw'): AuthorizedInvocation;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AuthorizedInvocation;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AddressWithNonce {
@@ -6876,9 +6876,9 @@ export namespace xdr {
 
     nonce(value?: Uint64): Uint64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AddressWithNonce;
 
@@ -6888,13 +6888,13 @@ export namespace xdr {
 
     static toXDR(value: AddressWithNonce): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AddressWithNonce;
+    static fromXDR(input: Buffer, format?: 'raw'): AddressWithNonce;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AddressWithNonce;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AddressWithNonce;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ContractAuth {
@@ -6910,9 +6910,9 @@ export namespace xdr {
 
     signatureArgs(value?: ScVal[]): ScVal[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ContractAuth;
 
@@ -6922,13 +6922,13 @@ export namespace xdr {
 
     static toXDR(value: ContractAuth): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ContractAuth;
+    static fromXDR(input: Buffer, format?: 'raw'): ContractAuth;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ContractAuth;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ContractAuth;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InvokeHostFunctionOp {
@@ -6944,9 +6944,9 @@ export namespace xdr {
 
     auth(value?: ContractAuth[]): ContractAuth[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InvokeHostFunctionOp;
 
@@ -6956,16 +6956,16 @@ export namespace xdr {
 
     static toXDR(value: InvokeHostFunctionOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InvokeHostFunctionOp;
+    static fromXDR(input: Buffer, format?: 'raw'): InvokeHostFunctionOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InvokeHostFunctionOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimageOperationId {
@@ -6981,9 +6981,9 @@ export namespace xdr {
 
     opNum(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimageOperationId;
 
@@ -6993,16 +6993,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageOperationId): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageOperationId;
+    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageOperationId;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): HashIdPreimageOperationId;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimageRevokeId {
@@ -7024,9 +7024,9 @@ export namespace xdr {
 
     asset(value?: Asset): Asset;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimageRevokeId;
 
@@ -7036,16 +7036,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageRevokeId): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageRevokeId;
+    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageRevokeId;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): HashIdPreimageRevokeId;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimageEd25519ContractId {
@@ -7061,9 +7061,9 @@ export namespace xdr {
 
     salt(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimageEd25519ContractId;
 
@@ -7075,17 +7075,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): HashIdPreimageEd25519ContractId;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): HashIdPreimageEd25519ContractId;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimageContractId {
@@ -7101,9 +7101,9 @@ export namespace xdr {
 
     salt(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimageContractId;
 
@@ -7113,16 +7113,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageContractId): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageContractId;
+    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageContractId;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): HashIdPreimageContractId;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimageFromAsset {
@@ -7132,9 +7132,9 @@ export namespace xdr {
 
     asset(value?: Asset): Asset;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimageFromAsset;
 
@@ -7144,16 +7144,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageFromAsset): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageFromAsset;
+    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageFromAsset;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): HashIdPreimageFromAsset;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimageSourceAccountContractId {
@@ -7169,9 +7169,9 @@ export namespace xdr {
 
     salt(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimageSourceAccountContractId;
 
@@ -7186,17 +7186,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): HashIdPreimageSourceAccountContractId;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): HashIdPreimageSourceAccountContractId;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimageCreateContractArgs {
@@ -7212,9 +7212,9 @@ export namespace xdr {
 
     salt(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimageCreateContractArgs;
 
@@ -7226,17 +7226,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): HashIdPreimageCreateContractArgs;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): HashIdPreimageCreateContractArgs;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimageContractAuth {
@@ -7252,9 +7252,9 @@ export namespace xdr {
 
     invocation(value?: AuthorizedInvocation): AuthorizedInvocation;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimageContractAuth;
 
@@ -7264,16 +7264,16 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimageContractAuth): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimageContractAuth;
+    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimageContractAuth;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): HashIdPreimageContractAuth;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TimeBounds {
@@ -7283,9 +7283,9 @@ export namespace xdr {
 
     maxTime(value?: TimePoint): TimePoint;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TimeBounds;
 
@@ -7295,13 +7295,13 @@ export namespace xdr {
 
     static toXDR(value: TimeBounds): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TimeBounds;
+    static fromXDR(input: Buffer, format?: 'raw'): TimeBounds;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TimeBounds;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TimeBounds;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerBounds {
@@ -7311,9 +7311,9 @@ export namespace xdr {
 
     maxLedger(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerBounds;
 
@@ -7323,13 +7323,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerBounds): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerBounds;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerBounds;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerBounds;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerBounds;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PreconditionsV2 {
@@ -7354,9 +7354,9 @@ export namespace xdr {
 
     extraSigners(value?: SignerKey[]): SignerKey[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PreconditionsV2;
 
@@ -7366,13 +7366,13 @@ export namespace xdr {
 
     static toXDR(value: PreconditionsV2): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PreconditionsV2;
+    static fromXDR(input: Buffer, format?: 'raw'): PreconditionsV2;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PreconditionsV2;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PreconditionsV2;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionV0 {
@@ -7400,9 +7400,9 @@ export namespace xdr {
 
     ext(value?: TransactionV0Ext): TransactionV0Ext;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionV0;
 
@@ -7412,13 +7412,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionV0;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionV0Envelope {
@@ -7431,9 +7431,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionV0Envelope;
 
@@ -7443,16 +7443,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0Envelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionV0Envelope;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0Envelope;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionV0Envelope;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Transaction {
@@ -7480,9 +7480,9 @@ export namespace xdr {
 
     ext(value?: TransactionExt): TransactionExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Transaction;
 
@@ -7492,13 +7492,13 @@ export namespace xdr {
 
     static toXDR(value: Transaction): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Transaction;
+    static fromXDR(input: Buffer, format?: 'raw'): Transaction;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Transaction;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Transaction;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionV1Envelope {
@@ -7511,9 +7511,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionV1Envelope;
 
@@ -7523,16 +7523,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionV1Envelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionV1Envelope;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionV1Envelope;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionV1Envelope;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FeeBumpTransaction {
@@ -7551,9 +7551,9 @@ export namespace xdr {
 
     ext(value?: FeeBumpTransactionExt): FeeBumpTransactionExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FeeBumpTransaction;
 
@@ -7563,13 +7563,13 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransaction): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransaction;
+    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransaction;
 
-    static fromXDR(input: string, format: "hex" | "base64"): FeeBumpTransaction;
+    static fromXDR(input: string, format: 'hex' | 'base64'): FeeBumpTransaction;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FeeBumpTransactionEnvelope {
@@ -7582,9 +7582,9 @@ export namespace xdr {
 
     signatures(value?: DecoratedSignature[]): DecoratedSignature[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FeeBumpTransactionEnvelope;
 
@@ -7594,16 +7594,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionEnvelope;
+    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionEnvelope;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): FeeBumpTransactionEnvelope;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionSignaturePayload {
@@ -7618,9 +7618,9 @@ export namespace xdr {
       value?: TransactionSignaturePayloadTaggedTransaction
     ): TransactionSignaturePayloadTaggedTransaction;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionSignaturePayload;
 
@@ -7630,16 +7630,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionSignaturePayload): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionSignaturePayload;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionSignaturePayload;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionSignaturePayload;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimOfferAtomV0 {
@@ -7664,9 +7664,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimOfferAtomV0;
 
@@ -7676,13 +7676,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimOfferAtomV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimOfferAtomV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimOfferAtomV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimOfferAtomV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimOfferAtomV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimOfferAtom {
@@ -7707,9 +7707,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimOfferAtom;
 
@@ -7719,13 +7719,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimOfferAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimOfferAtom;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimOfferAtom;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimOfferAtom;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimOfferAtom;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimLiquidityAtom {
@@ -7747,9 +7747,9 @@ export namespace xdr {
 
     amountBought(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimLiquidityAtom;
 
@@ -7759,13 +7759,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimLiquidityAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimLiquidityAtom;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimLiquidityAtom;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimLiquidityAtom;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimLiquidityAtom;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SimplePaymentResult {
@@ -7781,9 +7781,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SimplePaymentResult;
 
@@ -7793,16 +7793,16 @@ export namespace xdr {
 
     static toXDR(value: SimplePaymentResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SimplePaymentResult;
+    static fromXDR(input: Buffer, format?: 'raw'): SimplePaymentResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SimplePaymentResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictReceiveResultSuccess {
@@ -7812,9 +7812,9 @@ export namespace xdr {
 
     last(value?: SimplePaymentResult): SimplePaymentResult;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveResultSuccess;
 
@@ -7829,17 +7829,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): PathPaymentStrictReceiveResultSuccess;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictReceiveResultSuccess;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictSendResultSuccess {
@@ -7849,9 +7849,9 @@ export namespace xdr {
 
     last(value?: SimplePaymentResult): SimplePaymentResult;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictSendResultSuccess;
 
@@ -7863,17 +7863,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): PathPaymentStrictSendResultSuccess;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictSendResultSuccess;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageOfferSuccessResult {
@@ -7886,9 +7886,9 @@ export namespace xdr {
 
     offer(value?: ManageOfferSuccessResultOffer): ManageOfferSuccessResultOffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageOfferSuccessResult;
 
@@ -7898,16 +7898,16 @@ export namespace xdr {
 
     static toXDR(value: ManageOfferSuccessResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageOfferSuccessResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageOfferSuccessResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ManageOfferSuccessResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InflationPayout {
@@ -7917,9 +7917,9 @@ export namespace xdr {
 
     amount(value?: Int64): Int64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InflationPayout;
 
@@ -7929,13 +7929,13 @@ export namespace xdr {
 
     static toXDR(value: InflationPayout): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InflationPayout;
+    static fromXDR(input: Buffer, format?: 'raw'): InflationPayout;
 
-    static fromXDR(input: string, format: "hex" | "base64"): InflationPayout;
+    static fromXDR(input: string, format: 'hex' | 'base64'): InflationPayout;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InnerTransactionResult {
@@ -7951,9 +7951,9 @@ export namespace xdr {
 
     ext(value?: InnerTransactionResultExt): InnerTransactionResultExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InnerTransactionResult;
 
@@ -7963,16 +7963,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResult;
+    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InnerTransactionResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InnerTransactionResultPair {
@@ -7985,9 +7985,9 @@ export namespace xdr {
 
     result(value?: InnerTransactionResult): InnerTransactionResult;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InnerTransactionResultPair;
 
@@ -7997,16 +7997,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultPair): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultPair;
+    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultPair;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InnerTransactionResultPair;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResult {
@@ -8022,9 +8022,9 @@ export namespace xdr {
 
     ext(value?: TransactionResultExt): TransactionResultExt;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResult;
 
@@ -8034,13 +8034,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResult;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SignerKeyEd25519SignedPayload {
@@ -8050,9 +8050,9 @@ export namespace xdr {
 
     payload(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SignerKeyEd25519SignedPayload;
 
@@ -8064,17 +8064,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): SignerKeyEd25519SignedPayload;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SignerKeyEd25519SignedPayload;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Curve25519Secret {
@@ -8082,9 +8082,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Curve25519Secret;
 
@@ -8094,13 +8094,13 @@ export namespace xdr {
 
     static toXDR(value: Curve25519Secret): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Curve25519Secret;
+    static fromXDR(input: Buffer, format?: 'raw'): Curve25519Secret;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Curve25519Secret;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Curve25519Secret;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Curve25519Public {
@@ -8108,9 +8108,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Curve25519Public;
 
@@ -8120,13 +8120,13 @@ export namespace xdr {
 
     static toXDR(value: Curve25519Public): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Curve25519Public;
+    static fromXDR(input: Buffer, format?: 'raw'): Curve25519Public;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Curve25519Public;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Curve25519Public;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HmacSha256Key {
@@ -8134,9 +8134,9 @@ export namespace xdr {
 
     key(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HmacSha256Key;
 
@@ -8146,13 +8146,13 @@ export namespace xdr {
 
     static toXDR(value: HmacSha256Key): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HmacSha256Key;
+    static fromXDR(input: Buffer, format?: 'raw'): HmacSha256Key;
 
-    static fromXDR(input: string, format: "hex" | "base64"): HmacSha256Key;
+    static fromXDR(input: string, format: 'hex' | 'base64'): HmacSha256Key;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HmacSha256Mac {
@@ -8160,9 +8160,9 @@ export namespace xdr {
 
     mac(value?: Buffer): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HmacSha256Mac;
 
@@ -8172,13 +8172,13 @@ export namespace xdr {
 
     static toXDR(value: HmacSha256Mac): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HmacSha256Mac;
+    static fromXDR(input: Buffer, format?: 'raw'): HmacSha256Mac;
 
-    static fromXDR(input: string, format: "hex" | "base64"): HmacSha256Mac;
+    static fromXDR(input: string, format: 'hex' | 'base64'): HmacSha256Mac;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class UInt128Parts {
@@ -8188,9 +8188,9 @@ export namespace xdr {
 
     lo(value?: Uint64): Uint64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): UInt128Parts;
 
@@ -8200,13 +8200,13 @@ export namespace xdr {
 
     static toXDR(value: UInt128Parts): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): UInt128Parts;
+    static fromXDR(input: Buffer, format?: 'raw'): UInt128Parts;
 
-    static fromXDR(input: string, format: "hex" | "base64"): UInt128Parts;
+    static fromXDR(input: string, format: 'hex' | 'base64'): UInt128Parts;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Int128Parts {
@@ -8216,9 +8216,9 @@ export namespace xdr {
 
     lo(value?: Uint64): Uint64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Int128Parts;
 
@@ -8228,13 +8228,13 @@ export namespace xdr {
 
     static toXDR(value: Int128Parts): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Int128Parts;
+    static fromXDR(input: Buffer, format?: 'raw'): Int128Parts;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Int128Parts;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Int128Parts;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class UInt256Parts {
@@ -8253,9 +8253,9 @@ export namespace xdr {
 
     loLo(value?: Uint64): Uint64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): UInt256Parts;
 
@@ -8265,13 +8265,13 @@ export namespace xdr {
 
     static toXDR(value: UInt256Parts): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): UInt256Parts;
+    static fromXDR(input: Buffer, format?: 'raw'): UInt256Parts;
 
-    static fromXDR(input: string, format: "hex" | "base64"): UInt256Parts;
+    static fromXDR(input: string, format: 'hex' | 'base64'): UInt256Parts;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Int256Parts {
@@ -8290,9 +8290,9 @@ export namespace xdr {
 
     loLo(value?: Uint64): Uint64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Int256Parts;
 
@@ -8302,13 +8302,13 @@ export namespace xdr {
 
     static toXDR(value: Int256Parts): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Int256Parts;
+    static fromXDR(input: Buffer, format?: 'raw'): Int256Parts;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Int256Parts;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Int256Parts;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScNonceKey {
@@ -8316,9 +8316,9 @@ export namespace xdr {
 
     nonceAddress(value?: ScAddress): ScAddress;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScNonceKey;
 
@@ -8328,13 +8328,13 @@ export namespace xdr {
 
     static toXDR(value: ScNonceKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScNonceKey;
+    static fromXDR(input: Buffer, format?: 'raw'): ScNonceKey;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScNonceKey;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScNonceKey;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScMapEntry {
@@ -8344,9 +8344,9 @@ export namespace xdr {
 
     val(value?: ScVal): ScVal;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScMapEntry;
 
@@ -8356,13 +8356,13 @@ export namespace xdr {
 
     static toXDR(value: ScMapEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScMapEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): ScMapEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScMapEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScMapEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecTypeOption {
@@ -8370,9 +8370,9 @@ export namespace xdr {
 
     valueType(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecTypeOption;
 
@@ -8382,13 +8382,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeOption): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeOption;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeOption;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeOption;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeOption;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecTypeResult {
@@ -8401,9 +8401,9 @@ export namespace xdr {
 
     errorType(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecTypeResult;
 
@@ -8413,13 +8413,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecTypeVec {
@@ -8427,9 +8427,9 @@ export namespace xdr {
 
     elementType(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecTypeVec;
 
@@ -8439,13 +8439,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeVec): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeVec;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeVec;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeVec;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeVec;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecTypeMap {
@@ -8458,9 +8458,9 @@ export namespace xdr {
 
     valueType(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecTypeMap;
 
@@ -8470,13 +8470,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeMap): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeMap;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeMap;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeMap;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeMap;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecTypeSet {
@@ -8484,9 +8484,9 @@ export namespace xdr {
 
     elementType(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecTypeSet;
 
@@ -8496,13 +8496,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeSet;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeSet;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeSet;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeSet;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecTypeTuple {
@@ -8510,9 +8510,9 @@ export namespace xdr {
 
     valueTypes(value?: ScSpecTypeDef[]): ScSpecTypeDef[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecTypeTuple;
 
@@ -8522,13 +8522,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeTuple): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeTuple;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeTuple;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeTuple;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeTuple;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecTypeBytesN {
@@ -8536,9 +8536,9 @@ export namespace xdr {
 
     n(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecTypeBytesN;
 
@@ -8548,13 +8548,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeBytesN): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeBytesN;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeBytesN;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeBytesN;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeBytesN;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecTypeUdt {
@@ -8562,9 +8562,9 @@ export namespace xdr {
 
     name(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecTypeUdt;
 
@@ -8574,13 +8574,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeUdt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeUdt;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeUdt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeUdt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeUdt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecUdtStructFieldV0 {
@@ -8596,9 +8596,9 @@ export namespace xdr {
 
     type(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecUdtStructFieldV0;
 
@@ -8608,16 +8608,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtStructFieldV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtStructFieldV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtStructFieldV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScSpecUdtStructFieldV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecUdtStructV0 {
@@ -8636,9 +8636,9 @@ export namespace xdr {
 
     fields(value?: ScSpecUdtStructFieldV0[]): ScSpecUdtStructFieldV0[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecUdtStructV0;
 
@@ -8648,13 +8648,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtStructV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtStructV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtStructV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecUdtStructV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecUdtStructV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecUdtUnionCaseVoidV0 {
@@ -8664,9 +8664,9 @@ export namespace xdr {
 
     name(value?: string | Buffer): string | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecUdtUnionCaseVoidV0;
 
@@ -8676,16 +8676,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtUnionCaseVoidV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtUnionCaseVoidV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtUnionCaseVoidV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScSpecUdtUnionCaseVoidV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecUdtUnionCaseTupleV0 {
@@ -8701,9 +8701,9 @@ export namespace xdr {
 
     type(value?: ScSpecTypeDef[]): ScSpecTypeDef[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecUdtUnionCaseTupleV0;
 
@@ -8713,16 +8713,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtUnionCaseTupleV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtUnionCaseTupleV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtUnionCaseTupleV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScSpecUdtUnionCaseTupleV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecUdtUnionV0 {
@@ -8741,9 +8741,9 @@ export namespace xdr {
 
     cases(value?: ScSpecUdtUnionCaseV0[]): ScSpecUdtUnionCaseV0[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecUdtUnionV0;
 
@@ -8753,13 +8753,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtUnionV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtUnionV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtUnionV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecUdtUnionV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecUdtUnionV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecUdtEnumCaseV0 {
@@ -8775,9 +8775,9 @@ export namespace xdr {
 
     value(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecUdtEnumCaseV0;
 
@@ -8787,16 +8787,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtEnumCaseV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtEnumCaseV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtEnumCaseV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScSpecUdtEnumCaseV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecUdtEnumV0 {
@@ -8815,9 +8815,9 @@ export namespace xdr {
 
     cases(value?: ScSpecUdtEnumCaseV0[]): ScSpecUdtEnumCaseV0[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecUdtEnumV0;
 
@@ -8827,13 +8827,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtEnumV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtEnumV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtEnumV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecUdtEnumV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecUdtEnumV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecUdtErrorEnumCaseV0 {
@@ -8849,9 +8849,9 @@ export namespace xdr {
 
     value(value?: number): number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecUdtErrorEnumCaseV0;
 
@@ -8861,16 +8861,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtErrorEnumCaseV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtErrorEnumCaseV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtErrorEnumCaseV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScSpecUdtErrorEnumCaseV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecUdtErrorEnumV0 {
@@ -8889,9 +8889,9 @@ export namespace xdr {
 
     cases(value?: ScSpecUdtErrorEnumCaseV0[]): ScSpecUdtErrorEnumCaseV0[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecUdtErrorEnumV0;
 
@@ -8901,16 +8901,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtErrorEnumV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtErrorEnumV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtErrorEnumV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScSpecUdtErrorEnumV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecFunctionInputV0 {
@@ -8926,9 +8926,9 @@ export namespace xdr {
 
     type(value?: ScSpecTypeDef): ScSpecTypeDef;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecFunctionInputV0;
 
@@ -8938,16 +8938,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecFunctionInputV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecFunctionInputV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecFunctionInputV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScSpecFunctionInputV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecFunctionV0 {
@@ -8966,9 +8966,9 @@ export namespace xdr {
 
     outputs(value?: ScSpecTypeDef[]): ScSpecTypeDef[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecFunctionV0;
 
@@ -8978,13 +8978,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecFunctionV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecFunctionV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecFunctionV0;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecFunctionV0;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecFunctionV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpStatementPledges {
@@ -9014,9 +9014,9 @@ export namespace xdr {
       | ScpStatementExternalize
       | ScpNomination;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpStatementPledges;
 
@@ -9026,16 +9026,16 @@ export namespace xdr {
 
     static toXDR(value: ScpStatementPledges): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpStatementPledges;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpStatementPledges;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScpStatementPledges;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AssetCode {
@@ -9051,9 +9051,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AssetCode;
 
@@ -9063,13 +9063,13 @@ export namespace xdr {
 
     static toXDR(value: AssetCode): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AssetCode;
+    static fromXDR(input: Buffer, format?: 'raw'): AssetCode;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AssetCode;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AssetCode;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Asset {
@@ -9087,9 +9087,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Asset;
 
@@ -9099,13 +9099,13 @@ export namespace xdr {
 
     static toXDR(value: Asset): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Asset;
+    static fromXDR(input: Buffer, format?: 'raw'): Asset;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Asset;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Asset;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExtensionV2Ext {
@@ -9119,9 +9119,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV3 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExtensionV2Ext;
 
@@ -9131,16 +9131,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV2Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV2Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV2Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AccountEntryExtensionV2Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExtensionV1Ext {
@@ -9154,9 +9154,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV2 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExtensionV1Ext;
 
@@ -9166,16 +9166,16 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AccountEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountEntryExt {
@@ -9189,9 +9189,9 @@ export namespace xdr {
 
     value(): AccountEntryExtensionV1 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountEntryExt;
 
@@ -9201,13 +9201,13 @@ export namespace xdr {
 
     static toXDR(value: AccountEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountEntryExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AccountEntryExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AccountEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineAsset {
@@ -9229,9 +9229,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | PoolId | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineAsset;
 
@@ -9241,13 +9241,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineAsset): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineAsset;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineAsset;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TrustLineAsset;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineAsset;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntryExtensionV2Ext {
@@ -9257,9 +9257,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntryExtensionV2Ext;
 
@@ -9269,16 +9269,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExtensionV2Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExtensionV2Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExtensionV2Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TrustLineEntryExtensionV2Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntryV1Ext {
@@ -9292,9 +9292,9 @@ export namespace xdr {
 
     value(): TrustLineEntryExtensionV2 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntryV1Ext;
 
@@ -9304,16 +9304,16 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryV1Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryV1Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TrustLineEntryV1Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TrustLineEntryExt {
@@ -9327,9 +9327,9 @@ export namespace xdr {
 
     value(): TrustLineEntryV1 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TrustLineEntryExt;
 
@@ -9339,13 +9339,13 @@ export namespace xdr {
 
     static toXDR(value: TrustLineEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TrustLineEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): TrustLineEntryExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TrustLineEntryExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TrustLineEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OfferEntryExt {
@@ -9355,9 +9355,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OfferEntryExt;
 
@@ -9367,13 +9367,13 @@ export namespace xdr {
 
     static toXDR(value: OfferEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OfferEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): OfferEntryExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OfferEntryExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OfferEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class DataEntryExt {
@@ -9383,9 +9383,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): DataEntryExt;
 
@@ -9395,13 +9395,13 @@ export namespace xdr {
 
     static toXDR(value: DataEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): DataEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): DataEntryExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): DataEntryExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): DataEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimPredicate {
@@ -9438,9 +9438,9 @@ export namespace xdr {
       | Int64
       | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimPredicate;
 
@@ -9450,13 +9450,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimPredicate): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimPredicate;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimPredicate;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimPredicate;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimPredicate;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Claimant {
@@ -9468,9 +9468,9 @@ export namespace xdr {
 
     value(): ClaimantV0;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Claimant;
 
@@ -9480,13 +9480,13 @@ export namespace xdr {
 
     static toXDR(value: Claimant): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Claimant;
+    static fromXDR(input: Buffer, format?: 'raw'): Claimant;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Claimant;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Claimant;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimableBalanceId {
@@ -9498,9 +9498,9 @@ export namespace xdr {
 
     value(): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimableBalanceId;
 
@@ -9510,13 +9510,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceId): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceId;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceId;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimableBalanceId;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimableBalanceId;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimableBalanceEntryExtensionV1Ext {
@@ -9526,9 +9526,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExtensionV1Ext;
 
@@ -9540,17 +9540,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ClaimableBalanceEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimableBalanceEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimableBalanceEntryExt {
@@ -9566,9 +9566,9 @@ export namespace xdr {
 
     value(): ClaimableBalanceEntryExtensionV1 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimableBalanceEntryExt;
 
@@ -9578,16 +9578,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimableBalanceEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimableBalanceEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimableBalanceEntryExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimableBalanceEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolEntryBody {
@@ -9603,9 +9603,9 @@ export namespace xdr {
 
     value(): LiquidityPoolEntryConstantProduct;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolEntryBody;
 
@@ -9615,16 +9615,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolEntryBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolEntryBody;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolEntryBody;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolEntryBody;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ConfigSettingEntry {
@@ -9689,9 +9689,9 @@ export namespace xdr {
       | ConfigSettingContractBandwidthV0
       | number;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ConfigSettingEntry;
 
@@ -9701,13 +9701,13 @@ export namespace xdr {
 
     static toXDR(value: ConfigSettingEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ConfigSettingEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): ConfigSettingEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ConfigSettingEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ConfigSettingEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntryExtensionV1Ext {
@@ -9717,9 +9717,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntryExtensionV1Ext;
 
@@ -9729,16 +9729,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerEntryExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntryData {
@@ -9791,9 +9791,9 @@ export namespace xdr {
       | ContractCodeEntry
       | ConfigSettingEntry;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntryData;
 
@@ -9803,13 +9803,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryData): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryData;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryData;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryData;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryData;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntryExt {
@@ -9823,9 +9823,9 @@ export namespace xdr {
 
     value(): LedgerEntryExtensionV1 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntryExt;
 
@@ -9835,13 +9835,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerKey {
@@ -9896,9 +9896,9 @@ export namespace xdr {
       | LedgerKeyContractCode
       | LedgerKeyConfigSetting;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerKey;
 
@@ -9908,13 +9908,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerKey;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerKey;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerKey;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerKey;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class StellarValueExt {
@@ -9932,9 +9932,9 @@ export namespace xdr {
 
     value(): LedgerCloseValueSignature | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): StellarValueExt;
 
@@ -9944,13 +9944,13 @@ export namespace xdr {
 
     static toXDR(value: StellarValueExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): StellarValueExt;
+    static fromXDR(input: Buffer, format?: 'raw'): StellarValueExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): StellarValueExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): StellarValueExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeaderExtensionV1Ext {
@@ -9960,9 +9960,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeaderExtensionV1Ext;
 
@@ -9972,16 +9972,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExtensionV1Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExtensionV1Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExtensionV1Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerHeaderExtensionV1Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeaderExt {
@@ -9995,9 +9995,9 @@ export namespace xdr {
 
     value(): LedgerHeaderExtensionV1 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeaderExt;
 
@@ -10007,13 +10007,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderExt;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerHeaderExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerHeaderExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerUpgrade {
@@ -10045,9 +10045,9 @@ export namespace xdr {
 
     value(): number | number | number | number | number | ConfigUpgradeSetKey;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerUpgrade;
 
@@ -10057,13 +10057,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerUpgrade): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerUpgrade;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerUpgrade;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerUpgrade;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerUpgrade;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BucketMetadataExt {
@@ -10073,9 +10073,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BucketMetadataExt;
 
@@ -10085,13 +10085,13 @@ export namespace xdr {
 
     static toXDR(value: BucketMetadataExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): BucketMetadataExt;
+    static fromXDR(input: Buffer, format?: 'raw'): BucketMetadataExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): BucketMetadataExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): BucketMetadataExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BucketEntry {
@@ -10113,9 +10113,9 @@ export namespace xdr {
 
     value(): LedgerEntry | LedgerKey | BucketMetadata;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BucketEntry;
 
@@ -10125,13 +10125,13 @@ export namespace xdr {
 
     static toXDR(value: BucketEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): BucketEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): BucketEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): BucketEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): BucketEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TxSetComponent {
@@ -10147,9 +10147,9 @@ export namespace xdr {
 
     value(): TxSetComponentTxsMaybeDiscountedFee;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TxSetComponent;
 
@@ -10159,13 +10159,13 @@ export namespace xdr {
 
     static toXDR(value: TxSetComponent): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TxSetComponent;
+    static fromXDR(input: Buffer, format?: 'raw'): TxSetComponent;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TxSetComponent;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TxSetComponent;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionPhase {
@@ -10177,9 +10177,9 @@ export namespace xdr {
 
     value(): TxSetComponent[];
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionPhase;
 
@@ -10189,13 +10189,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionPhase): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionPhase;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionPhase;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionPhase;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionPhase;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class GeneralizedTransactionSet {
@@ -10207,9 +10207,9 @@ export namespace xdr {
 
     value(): TransactionSetV1;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): GeneralizedTransactionSet;
 
@@ -10219,16 +10219,16 @@ export namespace xdr {
 
     static toXDR(value: GeneralizedTransactionSet): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): GeneralizedTransactionSet;
+    static fromXDR(input: Buffer, format?: 'raw'): GeneralizedTransactionSet;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): GeneralizedTransactionSet;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionHistoryEntryExt {
@@ -10244,9 +10244,9 @@ export namespace xdr {
 
     value(): GeneralizedTransactionSet | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionHistoryEntryExt;
 
@@ -10256,16 +10256,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionHistoryEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionHistoryEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionHistoryEntryExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionHistoryEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionHistoryResultEntryExt {
@@ -10275,9 +10275,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionHistoryResultEntryExt;
 
@@ -10289,17 +10289,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): TransactionHistoryResultEntryExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionHistoryResultEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionHistoryResultEntryV2Ext {
@@ -10309,9 +10309,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionHistoryResultEntryV2Ext;
 
@@ -10323,17 +10323,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): TransactionHistoryResultEntryV2Ext;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionHistoryResultEntryV2Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerHeaderHistoryEntryExt {
@@ -10343,9 +10343,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerHeaderHistoryEntryExt;
 
@@ -10355,16 +10355,16 @@ export namespace xdr {
 
     static toXDR(value: LedgerHeaderHistoryEntryExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerHeaderHistoryEntryExt;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerHeaderHistoryEntryExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LedgerHeaderHistoryEntryExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScpHistoryEntry {
@@ -10376,9 +10376,9 @@ export namespace xdr {
 
     value(): ScpHistoryEntryV0;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScpHistoryEntry;
 
@@ -10388,13 +10388,13 @@ export namespace xdr {
 
     static toXDR(value: ScpHistoryEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScpHistoryEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): ScpHistoryEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScpHistoryEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScpHistoryEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerEntryChange {
@@ -10418,9 +10418,9 @@ export namespace xdr {
 
     value(): LedgerEntry | LedgerEntry | LedgerKey | LedgerEntry;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerEntryChange;
 
@@ -10430,13 +10430,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerEntryChange): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerEntryChange;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerEntryChange;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerEntryChange;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerEntryChange;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ContractEventBody {
@@ -10448,9 +10448,9 @@ export namespace xdr {
 
     value(): ContractEventV0;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ContractEventBody;
 
@@ -10460,13 +10460,13 @@ export namespace xdr {
 
     static toXDR(value: ContractEventBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ContractEventBody;
+    static fromXDR(input: Buffer, format?: 'raw'): ContractEventBody;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ContractEventBody;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ContractEventBody;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionMeta {
@@ -10494,9 +10494,9 @@ export namespace xdr {
       | TransactionMetaV2
       | TransactionMetaV3;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionMeta;
 
@@ -10506,13 +10506,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionMeta;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionMeta;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionMeta;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionMeta;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LedgerCloseMeta {
@@ -10532,9 +10532,9 @@ export namespace xdr {
 
     value(): LedgerCloseMetaV0 | LedgerCloseMetaV1 | LedgerCloseMetaV2;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LedgerCloseMeta;
 
@@ -10544,13 +10544,13 @@ export namespace xdr {
 
     static toXDR(value: LedgerCloseMeta): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LedgerCloseMeta;
+    static fromXDR(input: Buffer, format?: 'raw'): LedgerCloseMeta;
 
-    static fromXDR(input: string, format: "hex" | "base64"): LedgerCloseMeta;
+    static fromXDR(input: string, format: 'hex' | 'base64'): LedgerCloseMeta;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PeerAddressIp {
@@ -10566,9 +10566,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PeerAddressIp;
 
@@ -10578,13 +10578,13 @@ export namespace xdr {
 
     static toXDR(value: PeerAddressIp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PeerAddressIp;
+    static fromXDR(input: Buffer, format?: 'raw'): PeerAddressIp;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PeerAddressIp;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PeerAddressIp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SurveyResponseBody {
@@ -10608,9 +10608,9 @@ export namespace xdr {
 
     value(): TopologyResponseBodyV0 | TopologyResponseBodyV1;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SurveyResponseBody;
 
@@ -10620,13 +10620,13 @@ export namespace xdr {
 
     static toXDR(value: SurveyResponseBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SurveyResponseBody;
+    static fromXDR(input: Buffer, format?: 'raw'): SurveyResponseBody;
 
-    static fromXDR(input: string, format: "hex" | "base64"): SurveyResponseBody;
+    static fromXDR(input: string, format: 'hex' | 'base64'): SurveyResponseBody;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class StellarMessage {
@@ -10733,9 +10733,9 @@ export namespace xdr {
       | FloodDemand
       | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): StellarMessage;
 
@@ -10745,13 +10745,13 @@ export namespace xdr {
 
     static toXDR(value: StellarMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): StellarMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): StellarMessage;
 
-    static fromXDR(input: string, format: "hex" | "base64"): StellarMessage;
+    static fromXDR(input: string, format: 'hex' | 'base64'): StellarMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AuthenticatedMessage {
@@ -10763,9 +10763,9 @@ export namespace xdr {
 
     value(): AuthenticatedMessageV0;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AuthenticatedMessage;
 
@@ -10775,16 +10775,16 @@ export namespace xdr {
 
     static toXDR(value: AuthenticatedMessage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AuthenticatedMessage;
+    static fromXDR(input: Buffer, format?: 'raw'): AuthenticatedMessage;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): AuthenticatedMessage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolParameters {
@@ -10800,9 +10800,9 @@ export namespace xdr {
 
     value(): LiquidityPoolConstantProductParameters;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolParameters;
 
@@ -10812,16 +10812,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolParameters): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolParameters;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolParameters;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolParameters;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class MuxedAccount {
@@ -10837,9 +10837,9 @@ export namespace xdr {
 
     value(): Buffer | MuxedAccountMed25519;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): MuxedAccount;
 
@@ -10849,13 +10849,13 @@ export namespace xdr {
 
     static toXDR(value: MuxedAccount): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): MuxedAccount;
+    static fromXDR(input: Buffer, format?: 'raw'): MuxedAccount;
 
-    static fromXDR(input: string, format: "hex" | "base64"): MuxedAccount;
+    static fromXDR(input: string, format: 'hex' | 'base64'): MuxedAccount;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ChangeTrustAsset {
@@ -10877,9 +10877,9 @@ export namespace xdr {
 
     value(): AlphaNum4 | AlphaNum12 | LiquidityPoolParameters | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ChangeTrustAsset;
 
@@ -10889,13 +10889,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustAsset): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustAsset;
+    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustAsset;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustAsset;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustAsset;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class RevokeSponsorshipOp {
@@ -10913,9 +10913,9 @@ export namespace xdr {
 
     value(): LedgerKey | RevokeSponsorshipOpSigner;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): RevokeSponsorshipOp;
 
@@ -10925,16 +10925,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipOp): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipOp;
+    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipOp;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): RevokeSponsorshipOp;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ContractId {
@@ -10958,9 +10958,9 @@ export namespace xdr {
 
     value(): Buffer | ContractIdFromEd25519PublicKey | Asset;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ContractId;
 
@@ -10970,13 +10970,13 @@ export namespace xdr {
 
     static toXDR(value: ContractId): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ContractId;
+    static fromXDR(input: Buffer, format?: 'raw'): ContractId;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ContractId;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ContractId;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HostFunction {
@@ -11002,9 +11002,9 @@ export namespace xdr {
 
     value(): ScVal[] | CreateContractArgs | InstallContractCodeArgs;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HostFunction;
 
@@ -11014,13 +11014,13 @@ export namespace xdr {
 
     static toXDR(value: HostFunction): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HostFunction;
+    static fromXDR(input: Buffer, format?: 'raw'): HostFunction;
 
-    static fromXDR(input: string, format: "hex" | "base64"): HostFunction;
+    static fromXDR(input: string, format: 'hex' | 'base64'): HostFunction;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OperationBody {
@@ -11176,9 +11176,9 @@ export namespace xdr {
       | InvokeHostFunctionOp
       | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OperationBody;
 
@@ -11188,13 +11188,13 @@ export namespace xdr {
 
     static toXDR(value: OperationBody): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OperationBody;
+    static fromXDR(input: Buffer, format?: 'raw'): OperationBody;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OperationBody;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OperationBody;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class HashIdPreimage {
@@ -11264,9 +11264,9 @@ export namespace xdr {
       | HashIdPreimageCreateContractArgs
       | HashIdPreimageContractAuth;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): HashIdPreimage;
 
@@ -11276,13 +11276,13 @@ export namespace xdr {
 
     static toXDR(value: HashIdPreimage): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): HashIdPreimage;
+    static fromXDR(input: Buffer, format?: 'raw'): HashIdPreimage;
 
-    static fromXDR(input: string, format: "hex" | "base64"): HashIdPreimage;
+    static fromXDR(input: string, format: 'hex' | 'base64'): HashIdPreimage;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Memo {
@@ -11308,9 +11308,9 @@ export namespace xdr {
 
     value(): string | Buffer | Uint64 | Buffer | Buffer | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Memo;
 
@@ -11320,13 +11320,13 @@ export namespace xdr {
 
     static toXDR(value: Memo): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Memo;
+    static fromXDR(input: Buffer, format?: 'raw'): Memo;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Memo;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Memo;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class Preconditions {
@@ -11344,9 +11344,9 @@ export namespace xdr {
 
     value(): TimeBounds | PreconditionsV2 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): Preconditions;
 
@@ -11356,13 +11356,13 @@ export namespace xdr {
 
     static toXDR(value: Preconditions): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Preconditions;
+    static fromXDR(input: Buffer, format?: 'raw'): Preconditions;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Preconditions;
+    static fromXDR(input: string, format: 'hex' | 'base64'): Preconditions;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionV0Ext {
@@ -11372,9 +11372,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionV0Ext;
 
@@ -11384,13 +11384,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionV0Ext): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionV0Ext;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionV0Ext;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionV0Ext;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionV0Ext;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionExt {
@@ -11400,9 +11400,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionExt;
 
@@ -11412,13 +11412,13 @@ export namespace xdr {
 
     static toXDR(value: TransactionExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionExt;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionExt;
 
-    static fromXDR(input: string, format: "hex" | "base64"): TransactionExt;
+    static fromXDR(input: string, format: 'hex' | 'base64'): TransactionExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FeeBumpTransactionInnerTx {
@@ -11432,9 +11432,9 @@ export namespace xdr {
 
     value(): TransactionV1Envelope;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FeeBumpTransactionInnerTx;
 
@@ -11444,16 +11444,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionInnerTx): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionInnerTx;
+    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionInnerTx;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): FeeBumpTransactionInnerTx;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class FeeBumpTransactionExt {
@@ -11463,9 +11463,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): FeeBumpTransactionExt;
 
@@ -11475,16 +11475,16 @@ export namespace xdr {
 
     static toXDR(value: FeeBumpTransactionExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): FeeBumpTransactionExt;
+    static fromXDR(input: Buffer, format?: 'raw'): FeeBumpTransactionExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): FeeBumpTransactionExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionEnvelope {
@@ -11509,9 +11509,9 @@ export namespace xdr {
       | TransactionV1Envelope
       | FeeBumpTransactionEnvelope;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionEnvelope;
 
@@ -11521,16 +11521,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionEnvelope): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionEnvelope;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionEnvelope;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionEnvelope;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionSignaturePayloadTaggedTransaction {
@@ -11550,9 +11550,9 @@ export namespace xdr {
 
     value(): Transaction | FeeBumpTransaction;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionSignaturePayloadTaggedTransaction;
 
@@ -11569,17 +11569,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): TransactionSignaturePayloadTaggedTransaction;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionSignaturePayloadTaggedTransaction;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimAtom {
@@ -11599,9 +11599,9 @@ export namespace xdr {
 
     value(): ClaimOfferAtomV0 | ClaimOfferAtom | ClaimLiquidityAtom;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimAtom;
 
@@ -11611,13 +11611,13 @@ export namespace xdr {
 
     static toXDR(value: ClaimAtom): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimAtom;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimAtom;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClaimAtom;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClaimAtom;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreateAccountResult {
@@ -11635,9 +11635,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreateAccountResult;
 
@@ -11647,16 +11647,16 @@ export namespace xdr {
 
     static toXDR(value: CreateAccountResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreateAccountResult;
+    static fromXDR(input: Buffer, format?: 'raw'): CreateAccountResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): CreateAccountResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PaymentResult {
@@ -11684,9 +11684,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PaymentResult;
 
@@ -11696,13 +11696,13 @@ export namespace xdr {
 
     static toXDR(value: PaymentResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PaymentResult;
+    static fromXDR(input: Buffer, format?: 'raw'): PaymentResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PaymentResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PaymentResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictReceiveResult {
@@ -11746,9 +11746,9 @@ export namespace xdr {
 
     value(): PathPaymentStrictReceiveResultSuccess | Asset | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictReceiveResult;
 
@@ -11760,17 +11760,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): PathPaymentStrictReceiveResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictReceiveResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PathPaymentStrictSendResult {
@@ -11814,9 +11814,9 @@ export namespace xdr {
 
     value(): PathPaymentStrictSendResultSuccess | Asset | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PathPaymentStrictSendResult;
 
@@ -11826,16 +11826,16 @@ export namespace xdr {
 
     static toXDR(value: PathPaymentStrictSendResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PathPaymentStrictSendResult;
+    static fromXDR(input: Buffer, format?: 'raw'): PathPaymentStrictSendResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): PathPaymentStrictSendResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageOfferSuccessResultOffer {
@@ -11851,9 +11851,9 @@ export namespace xdr {
 
     value(): OfferEntry | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageOfferSuccessResultOffer;
 
@@ -11865,17 +11865,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ManageOfferSuccessResultOffer;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ManageOfferSuccessResultOffer;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageSellOfferResult {
@@ -11913,9 +11913,9 @@ export namespace xdr {
 
     value(): ManageOfferSuccessResult | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageSellOfferResult;
 
@@ -11925,16 +11925,16 @@ export namespace xdr {
 
     static toXDR(value: ManageSellOfferResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageSellOfferResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageSellOfferResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ManageSellOfferResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageBuyOfferResult {
@@ -11972,9 +11972,9 @@ export namespace xdr {
 
     value(): ManageOfferSuccessResult | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageBuyOfferResult;
 
@@ -11984,16 +11984,16 @@ export namespace xdr {
 
     static toXDR(value: ManageBuyOfferResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageBuyOfferResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageBuyOfferResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ManageBuyOfferResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SetOptionsResult {
@@ -12023,9 +12023,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SetOptionsResult;
 
@@ -12035,13 +12035,13 @@ export namespace xdr {
 
     static toXDR(value: SetOptionsResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SetOptionsResult;
+    static fromXDR(input: Buffer, format?: 'raw'): SetOptionsResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): SetOptionsResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): SetOptionsResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ChangeTrustResult {
@@ -12067,9 +12067,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ChangeTrustResult;
 
@@ -12079,13 +12079,13 @@ export namespace xdr {
 
     static toXDR(value: ChangeTrustResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ChangeTrustResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ChangeTrustResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ChangeTrustResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ChangeTrustResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AllowTrustResult {
@@ -12107,9 +12107,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AllowTrustResult;
 
@@ -12119,13 +12119,13 @@ export namespace xdr {
 
     static toXDR(value: AllowTrustResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AllowTrustResult;
+    static fromXDR(input: Buffer, format?: 'raw'): AllowTrustResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AllowTrustResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AllowTrustResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class AccountMergeResult {
@@ -12151,9 +12151,9 @@ export namespace xdr {
 
     value(): Int64 | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): AccountMergeResult;
 
@@ -12163,13 +12163,13 @@ export namespace xdr {
 
     static toXDR(value: AccountMergeResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): AccountMergeResult;
+    static fromXDR(input: Buffer, format?: 'raw'): AccountMergeResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): AccountMergeResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): AccountMergeResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InflationResult {
@@ -12183,9 +12183,9 @@ export namespace xdr {
 
     value(): InflationPayout[] | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InflationResult;
 
@@ -12195,13 +12195,13 @@ export namespace xdr {
 
     static toXDR(value: InflationResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InflationResult;
+    static fromXDR(input: Buffer, format?: 'raw'): InflationResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): InflationResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): InflationResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ManageDataResult {
@@ -12219,9 +12219,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ManageDataResult;
 
@@ -12231,13 +12231,13 @@ export namespace xdr {
 
     static toXDR(value: ManageDataResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ManageDataResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ManageDataResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ManageDataResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ManageDataResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BumpSequenceResult {
@@ -12249,9 +12249,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BumpSequenceResult;
 
@@ -12261,13 +12261,13 @@ export namespace xdr {
 
     static toXDR(value: BumpSequenceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): BumpSequenceResult;
+    static fromXDR(input: Buffer, format?: 'raw'): BumpSequenceResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): BumpSequenceResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): BumpSequenceResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class CreateClaimableBalanceResult {
@@ -12291,9 +12291,9 @@ export namespace xdr {
 
     value(): ClaimableBalanceId | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): CreateClaimableBalanceResult;
 
@@ -12303,16 +12303,16 @@ export namespace xdr {
 
     static toXDR(value: CreateClaimableBalanceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): CreateClaimableBalanceResult;
+    static fromXDR(input: Buffer, format?: 'raw'): CreateClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): CreateClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClaimClaimableBalanceResult {
@@ -12332,9 +12332,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClaimClaimableBalanceResult;
 
@@ -12344,16 +12344,16 @@ export namespace xdr {
 
     static toXDR(value: ClaimClaimableBalanceResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClaimClaimableBalanceResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ClaimClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClaimClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class BeginSponsoringFutureReservesResult {
@@ -12369,9 +12369,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): BeginSponsoringFutureReservesResult;
 
@@ -12383,17 +12383,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): BeginSponsoringFutureReservesResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): BeginSponsoringFutureReservesResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class EndSponsoringFutureReservesResult {
@@ -12405,9 +12405,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): EndSponsoringFutureReservesResult;
 
@@ -12419,17 +12419,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): EndSponsoringFutureReservesResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): EndSponsoringFutureReservesResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class RevokeSponsorshipResult {
@@ -12449,9 +12449,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): RevokeSponsorshipResult;
 
@@ -12461,16 +12461,16 @@ export namespace xdr {
 
     static toXDR(value: RevokeSponsorshipResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): RevokeSponsorshipResult;
+    static fromXDR(input: Buffer, format?: 'raw'): RevokeSponsorshipResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): RevokeSponsorshipResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClawbackResult {
@@ -12488,9 +12488,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClawbackResult;
 
@@ -12500,13 +12500,13 @@ export namespace xdr {
 
     static toXDR(value: ClawbackResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ClawbackResult;
+    static fromXDR(input: Buffer, format?: 'raw'): ClawbackResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ClawbackResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ClawbackResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ClawbackClaimableBalanceResult {
@@ -12522,9 +12522,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ClawbackClaimableBalanceResult;
 
@@ -12536,17 +12536,17 @@ export namespace xdr {
 
     static fromXDR(
       input: Buffer,
-      format?: "raw"
+      format?: 'raw'
     ): ClawbackClaimableBalanceResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ClawbackClaimableBalanceResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SetTrustLineFlagsResult {
@@ -12566,9 +12566,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SetTrustLineFlagsResult;
 
@@ -12578,16 +12578,16 @@ export namespace xdr {
 
     static toXDR(value: SetTrustLineFlagsResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SetTrustLineFlagsResult;
+    static fromXDR(input: Buffer, format?: 'raw'): SetTrustLineFlagsResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): SetTrustLineFlagsResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolDepositResult {
@@ -12611,9 +12611,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolDepositResult;
 
@@ -12623,16 +12623,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolDepositResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolDepositResult;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolDepositResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolDepositResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class LiquidityPoolWithdrawResult {
@@ -12652,9 +12652,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): LiquidityPoolWithdrawResult;
 
@@ -12664,16 +12664,16 @@ export namespace xdr {
 
     static toXDR(value: LiquidityPoolWithdrawResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): LiquidityPoolWithdrawResult;
+    static fromXDR(input: Buffer, format?: 'raw'): LiquidityPoolWithdrawResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): LiquidityPoolWithdrawResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InvokeHostFunctionResult {
@@ -12689,9 +12689,9 @@ export namespace xdr {
 
     value(): ScVal | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InvokeHostFunctionResult;
 
@@ -12701,16 +12701,16 @@ export namespace xdr {
 
     static toXDR(value: InvokeHostFunctionResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InvokeHostFunctionResult;
+    static fromXDR(input: Buffer, format?: 'raw'): InvokeHostFunctionResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InvokeHostFunctionResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OperationResultTr {
@@ -12891,9 +12891,9 @@ export namespace xdr {
       | LiquidityPoolWithdrawResult
       | InvokeHostFunctionResult;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OperationResultTr;
 
@@ -12903,13 +12903,13 @@ export namespace xdr {
 
     static toXDR(value: OperationResultTr): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OperationResultTr;
+    static fromXDR(input: Buffer, format?: 'raw'): OperationResultTr;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OperationResultTr;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OperationResultTr;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class OperationResult {
@@ -12933,9 +12933,9 @@ export namespace xdr {
 
     value(): OperationResultTr | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): OperationResult;
 
@@ -12945,13 +12945,13 @@ export namespace xdr {
 
     static toXDR(value: OperationResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): OperationResult;
+    static fromXDR(input: Buffer, format?: 'raw'): OperationResult;
 
-    static fromXDR(input: string, format: "hex" | "base64"): OperationResult;
+    static fromXDR(input: string, format: 'hex' | 'base64'): OperationResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InnerTransactionResultResult {
@@ -12993,9 +12993,9 @@ export namespace xdr {
 
     value(): OperationResult[] | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InnerTransactionResultResult;
 
@@ -13005,16 +13005,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultResult;
+    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InnerTransactionResultResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class InnerTransactionResultExt {
@@ -13024,9 +13024,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): InnerTransactionResultExt;
 
@@ -13036,16 +13036,16 @@ export namespace xdr {
 
     static toXDR(value: InnerTransactionResultExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): InnerTransactionResultExt;
+    static fromXDR(input: Buffer, format?: 'raw'): InnerTransactionResultExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): InnerTransactionResultExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultResult {
@@ -13099,9 +13099,9 @@ export namespace xdr {
 
     value(): InnerTransactionResultPair | OperationResult[] | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultResult;
 
@@ -13111,16 +13111,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultResult): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultResult;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultResult;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultResult;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class TransactionResultExt {
@@ -13130,9 +13130,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): TransactionResultExt;
 
@@ -13142,16 +13142,16 @@ export namespace xdr {
 
     static toXDR(value: TransactionResultExt): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): TransactionResultExt;
+    static fromXDR(input: Buffer, format?: 'raw'): TransactionResultExt;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): TransactionResultExt;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ExtensionPoint {
@@ -13161,9 +13161,9 @@ export namespace xdr {
 
     value(): void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ExtensionPoint;
 
@@ -13173,13 +13173,13 @@ export namespace xdr {
 
     static toXDR(value: ExtensionPoint): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ExtensionPoint;
+    static fromXDR(input: Buffer, format?: 'raw'): ExtensionPoint;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ExtensionPoint;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ExtensionPoint;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class PublicKey {
@@ -13191,9 +13191,9 @@ export namespace xdr {
 
     value(): Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): PublicKey;
 
@@ -13203,13 +13203,13 @@ export namespace xdr {
 
     static toXDR(value: PublicKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): PublicKey;
+    static fromXDR(input: Buffer, format?: 'raw'): PublicKey;
 
-    static fromXDR(input: string, format: "hex" | "base64"): PublicKey;
+    static fromXDR(input: string, format: 'hex' | 'base64'): PublicKey;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class SignerKey {
@@ -13237,9 +13237,9 @@ export namespace xdr {
 
     value(): Buffer | Buffer | Buffer | SignerKeyEd25519SignedPayload;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): SignerKey;
 
@@ -13249,13 +13249,13 @@ export namespace xdr {
 
     static toXDR(value: SignerKey): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): SignerKey;
+    static fromXDR(input: Buffer, format?: 'raw'): SignerKey;
 
-    static fromXDR(input: string, format: "hex" | "base64"): SignerKey;
+    static fromXDR(input: string, format: 'hex' | 'base64'): SignerKey;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScStatus {
@@ -13311,9 +13311,9 @@ export namespace xdr {
       | ScHostAuthErrorCode
       | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScStatus;
 
@@ -13323,13 +13323,13 @@ export namespace xdr {
 
     static toXDR(value: ScStatus): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScStatus;
+    static fromXDR(input: Buffer, format?: 'raw'): ScStatus;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScStatus;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScStatus;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScContractExecutable {
@@ -13343,9 +13343,9 @@ export namespace xdr {
 
     value(): Buffer | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScContractExecutable;
 
@@ -13355,16 +13355,16 @@ export namespace xdr {
 
     static toXDR(value: ScContractExecutable): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScContractExecutable;
+    static fromXDR(input: Buffer, format?: 'raw'): ScContractExecutable;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScContractExecutable;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScAddress {
@@ -13380,9 +13380,9 @@ export namespace xdr {
 
     value(): AccountId | Buffer;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScAddress;
 
@@ -13392,13 +13392,13 @@ export namespace xdr {
 
     static toXDR(value: ScAddress): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScAddress;
+    static fromXDR(input: Buffer, format?: 'raw'): ScAddress;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScAddress;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScAddress;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScVal {
@@ -13515,9 +13515,9 @@ export namespace xdr {
       | ScNonceKey
       | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScVal;
 
@@ -13527,13 +13527,13 @@ export namespace xdr {
 
     static toXDR(value: ScVal): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScVal;
+    static fromXDR(input: Buffer, format?: 'raw'): ScVal;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScVal;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScVal;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScEnvMetaEntry {
@@ -13545,9 +13545,9 @@ export namespace xdr {
 
     value(): Uint64;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScEnvMetaEntry;
 
@@ -13557,13 +13557,13 @@ export namespace xdr {
 
     static toXDR(value: ScEnvMetaEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScEnvMetaEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): ScEnvMetaEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScEnvMetaEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScEnvMetaEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecTypeDef {
@@ -13648,9 +13648,9 @@ export namespace xdr {
       | ScSpecTypeUdt
       | void;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecTypeDef;
 
@@ -13660,13 +13660,13 @@ export namespace xdr {
 
     static toXDR(value: ScSpecTypeDef): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecTypeDef;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecTypeDef;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecTypeDef;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecTypeDef;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecUdtUnionCaseV0 {
@@ -13686,9 +13686,9 @@ export namespace xdr {
 
     value(): ScSpecUdtUnionCaseVoidV0 | ScSpecUdtUnionCaseTupleV0;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecUdtUnionCaseV0;
 
@@ -13698,16 +13698,16 @@ export namespace xdr {
 
     static toXDR(value: ScSpecUdtUnionCaseV0): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecUdtUnionCaseV0;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecUdtUnionCaseV0;
 
     static fromXDR(
       input: string,
-      format: "hex" | "base64"
+      format: 'hex' | 'base64'
     ): ScSpecUdtUnionCaseV0;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 
   class ScSpecEntry {
@@ -13740,9 +13740,9 @@ export namespace xdr {
       | ScSpecUdtEnumV0
       | ScSpecUdtErrorEnumV0;
 
-    toXDR(format?: "raw"): Buffer;
+    toXDR(format?: 'raw'): Buffer;
 
-    toXDR(format: "hex" | "base64"): string;
+    toXDR(format: 'hex' | 'base64'): string;
 
     static read(io: Buffer): ScSpecEntry;
 
@@ -13752,12 +13752,12 @@ export namespace xdr {
 
     static toXDR(value: ScSpecEntry): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): ScSpecEntry;
+    static fromXDR(input: Buffer, format?: 'raw'): ScSpecEntry;
 
-    static fromXDR(input: string, format: "hex" | "base64"): ScSpecEntry;
+    static fromXDR(input: string, format: 'hex' | 'base64'): ScSpecEntry;
 
-    static validateXDR(input: Buffer, format?: "raw"): boolean;
+    static validateXDR(input: Buffer, format?: 'raw'): boolean;
 
-    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+    static validateXDR(input: string, format: 'hex' | 'base64'): boolean;
   }
 }

--- a/xdr/curr/Stellar-overlay.x
+++ b/xdr/curr/Stellar-overlay.x
@@ -47,11 +47,20 @@ struct Hello
     uint256 nonce;
 };
 
+
+// During the roll-out phrase, pull mode will be optional.
+// Therefore, we need a way to communicate with other nodes
+// that we want/don't want pull mode.
+// However, the goal is for everyone to enable it by default,
+// so we don't want to introduce a new member variable.
+// For now, we'll use the `flags` field (originally named
+// `unused`) in `Auth`.
+// 100 is just a number that is not 0.
+const AUTH_MSG_FLAG_PULL_MODE_REQUESTED = 100;
+
 struct Auth
 {
-    // Empty message, just to confirm
-    // establishment of MAC keys.
-    int unused;
+    int flags;
 };
 
 enum IPAddrType
@@ -102,7 +111,9 @@ enum MessageType
     SURVEY_REQUEST = 14,
     SURVEY_RESPONSE = 15,
 
-    SEND_MORE = 16
+    SEND_MORE = 16,
+    FLOOD_ADVERT = 18,
+    FLOOD_DEMAND = 19
 };
 
 struct DontHave
@@ -185,6 +196,22 @@ case SURVEY_TOPOLOGY:
     TopologyResponseBody topologyResponseBody;
 };
 
+const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
+typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
+
+struct FloodAdvert
+{
+    TxAdvertVector txHashes;
+};
+
+const TX_DEMAND_VECTOR_MAX_SIZE = 1000;
+typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
+
+struct FloodDemand
+{
+    TxDemandVector txHashes;
+};
+
 union StellarMessage switch (MessageType type)
 {
 case ERROR_MSG:
@@ -227,6 +254,12 @@ case GET_SCP_STATE:
     uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
 case SEND_MORE:
     SendMore sendMoreMessage;
+
+// Pull mode
+case FLOOD_ADVERT:
+     FloodAdvert floodAdvert;
+case FLOOD_DEMAND:
+     FloodDemand floodDemand;
 };
 
 union AuthenticatedMessage switch (uint32 v)

--- a/xdr/next/Stellar-contract.x
+++ b/xdr/next/Stellar-contract.x
@@ -201,12 +201,36 @@ case SST_HOST_AUTH_ERROR:
     SCHostAuthErrorCode authCode;
 };
 
-struct Int128Parts {
-    // Both signed and unsigned 128-bit ints
-    // are transported in a pair of uint64s
-    // to reduce the risk of sign-extension.
-    uint64 lo;
+struct UInt128Parts {
     uint64 hi;
+    uint64 lo;
+};
+
+// A signed int128 has a high sign bit and 127 value bits. We break it into a
+// signed high int64 (that carries the sign bit and the high 63 value bits) and
+// a low unsigned uint64 that carries the low 64 bits. This will sort in
+// generated code in the same order the underlying int128 sorts.
+struct Int128Parts {
+    int64 hi;
+    uint64 lo;
+};
+
+struct UInt256Parts {
+    uint64 hi_hi;
+    uint64 hi_lo;
+    uint64 lo_hi;
+    uint64 lo_lo;
+};
+
+// A signed int256 has a high sign bit and 255 value bits. We break it into a
+// signed high int64 (that carries the sign bit and the high 63 value bits) and
+// three low unsigned `uint64`s that carry the lower bits. This will sort in
+// generated code in the same order the underlying int256 sorts.
+struct Int256Parts {
+    int64 hi_hi;
+    uint64 hi_lo;
+    uint64 lo_hi;
+    uint64 lo_lo;
 };
 
 enum SCContractExecutableType
@@ -279,14 +303,14 @@ case SCV_DURATION:
     Duration duration;
 
 case SCV_U128:
-    Int128Parts u128;
+    UInt128Parts u128;
 case SCV_I128:
     Int128Parts i128;
 
 case SCV_U256:
-    uint256 u256;
+    UInt256Parts u256;
 case SCV_I256:
-    uint256 i256;
+    Int256Parts i256;
 
 case SCV_BYTES:
     SCBytes bytes;

--- a/xdr/next/Stellar-ledger-entries.x
+++ b/xdr/next/Stellar-ledger-entries.x
@@ -505,33 +505,115 @@ struct ContractCodeEntry {
     opaque code<SCVAL_LIMIT>;
 };
 
-enum ConfigSettingType
-{
-    CONFIG_SETTING_TYPE_UINT32 = 0
-};
-
-union ConfigSetting switch (ConfigSettingType type)
-{
-case CONFIG_SETTING_TYPE_UINT32:
-    uint32 uint32Val;
-};
-
+// Identifiers of all the network settings.
 enum ConfigSettingID
 {
-    CONFIG_SETTING_CONTRACT_MAX_SIZE = 0
+    CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES = 0,
+    CONFIG_SETTING_CONTRACT_COMPUTE_V0 = 1,
+    CONFIG_SETTING_CONTRACT_LEDGER_COST_V0 = 2,
+    CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0 = 3,
+    CONFIG_SETTING_CONTRACT_META_DATA_V0 = 4,
+    CONFIG_SETTING_CONTRACT_BANDWIDTH_V0 = 5,
+    CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION = 6
 };
 
-struct ConfigSettingEntry
+// "Compute" settings for contracts (instructions and memory).
+struct ConfigSettingContractComputeV0
 {
-    union switch (int v)
-    {
-    case 0:
-        void;
-    }
-    ext;
+    // Maximum instructions per ledger
+    int64 ledgerMaxInstructions;
+    // Maximum instructions per transaction
+    int64 txMaxInstructions;
+    // Cost of 10000 instructions
+    int64 feeRatePerInstructionsIncrement;
 
-    ConfigSettingID configSettingID;
-    ConfigSetting setting;
+    // Memory limit per contract/host function invocation. Unlike 
+    // instructions, there is no fee for memory and it's not
+    // accumulated between operations - the same limit is applied 
+    // to every operation.
+    uint32 memoryLimit;
+};
+
+// Ledger access settings for contracts.
+struct ConfigSettingContractLedgerCostV0
+{
+    // Maximum number of ledger entry read operations per ledger
+    uint32 ledgerMaxReadLedgerEntries;
+    // Maximum number of bytes that can be read per ledger
+    uint32 ledgerMaxReadBytes;
+    // Maximum number of ledger entry write operations per ledger
+    uint32 ledgerMaxWriteLedgerEntries;
+    // Maximum number of bytes that can be written per ledger
+    uint32 ledgerMaxWriteBytes;
+
+    // Maximum number of ledger entry read operations per transaction
+    uint32 txMaxReadLedgerEntries;
+    // Maximum number of bytes that can be read per transaction
+    uint32 txMaxReadBytes;
+    // Maximum number of ledger entry write operations per transaction
+    uint32 txMaxWriteLedgerEntries;
+    // Maximum number of bytes that can be written per transaction
+    uint32 txMaxWriteBytes;
+
+    int64 feeReadLedgerEntry;  // Fee per ledger entry read
+    int64 feeWriteLedgerEntry; // Fee per ledger entry write
+
+    int64 feeRead1KB;  // Fee for reading 1KB    
+    int64 feeWrite1KB; // Fee for writing 1KB
+
+    // Bucket list fees grow slowly up to that size
+    int64 bucketListSizeBytes;
+    // Fee rate in stroops when the bucket list is empty
+    int64 bucketListFeeRateLow;
+    // Fee rate in stroops when the bucket list reached bucketListSizeBytes
+    int64 bucketListFeeRateHigh;
+    // Rate multiplier for any additional data past the first bucketListSizeBytes
+    uint32 bucketListGrowthFactor;
+};
+
+// Historical data (pushed to core archives) settings for contracts.
+struct ConfigSettingContractHistoricalDataV0
+{
+    int64 feeHistorical1KB; // Fee for storing 1KB in archives
+};
+
+// Meta data (pushed to downstream systems) settings for contracts.
+struct ConfigSettingContractMetaDataV0
+{
+    // Maximum size of extended meta data produced by a transaction
+    uint32 txMaxExtendedMetaDataSizeBytes;
+    // Fee for generating 1KB of extended meta data
+    int64 feeExtendedMetaData1KB;
+};
+
+// Bandwidth related data settings for contracts
+struct ConfigSettingContractBandwidthV0
+{
+    // Maximum size in bytes to propagate per ledger
+    uint32 ledgerMaxPropagateSizeBytes;
+    // Maximum size in bytes for a transaction
+    uint32 txMaxSizeBytes;
+
+    // Fee for propagating 1KB of data
+    int64 feePropagateData1KB;
+};
+
+union ConfigSettingEntry switch (ConfigSettingID configSettingID)
+{
+case CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES:
+    uint32 contractMaxSizeBytes;
+case CONFIG_SETTING_CONTRACT_COMPUTE_V0:
+    ConfigSettingContractComputeV0 contractCompute;
+case CONFIG_SETTING_CONTRACT_LEDGER_COST_V0:
+    ConfigSettingContractLedgerCostV0 contractLedgerCost;
+case CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0:
+    ConfigSettingContractHistoricalDataV0 contractHistoricalData;
+case CONFIG_SETTING_CONTRACT_META_DATA_V0:
+    ConfigSettingContractMetaDataV0 contractMetaData;
+case CONFIG_SETTING_CONTRACT_BANDWIDTH_V0:
+    ConfigSettingContractBandwidthV0 contractBandwidth;
+case CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION:
+    uint32 contractHostLogicVersion;
 };
 
 struct LedgerEntryExtensionV1

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,11 +3,19 @@
 
 
 "@ampproject/remapping@^2.2.0":
+<<<<<<< HEAD
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
   integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
   dependencies:
     "@jridgewell/gen-mapping" "^0.1.0"
+=======
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
+  integrity sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+>>>>>>> master
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@babel/cli@^7.21.0":
@@ -1058,10 +1066,17 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+<<<<<<< HEAD
 "@eslint/js@8.37.0":
   version "8.37.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.37.0.tgz#cf1b5fa24217fe007f6487a26d765274925efa7d"
   integrity sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==
+=======
+"@eslint/js@8.38.0":
+  version "8.38.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.38.0.tgz#73a8a0d8aa8a8e6fe270431c5e72ae91b5337892"
+  integrity sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==
+>>>>>>> master
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
@@ -1122,6 +1137,7 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
+<<<<<<< HEAD
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
@@ -1134,34 +1150,71 @@
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
   integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
+=======
+"@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
+  integrity sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
+>>>>>>> master
   dependencies:
     "@jridgewell/set-array" "^1.0.1"
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+<<<<<<< HEAD
 "@jridgewell/resolve-uri@3.1.0", "@jridgewell/resolve-uri@^3.0.3":
+=======
+"@jridgewell/resolve-uri@3.1.0":
+>>>>>>> master
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
+<<<<<<< HEAD
 "@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
+=======
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+
+"@jridgewell/set-array@^1.0.1":
+>>>>>>> master
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
 "@jridgewell/source-map@^0.3.2":
+<<<<<<< HEAD
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
   integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
+=======
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.3.tgz#8108265659d4c33e72ffe14e33d6cc5eb59f2fda"
+  integrity sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==
+>>>>>>> master
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+<<<<<<< HEAD
 "@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
+=======
+"@jridgewell/sourcemap-codec@1.4.14":
+>>>>>>> master
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
+<<<<<<< HEAD
+=======
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+>>>>>>> master
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
@@ -1171,9 +1224,15 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
+<<<<<<< HEAD
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
   integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
+=======
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
+  integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
+>>>>>>> master
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
@@ -1322,7 +1381,11 @@
     "@types/eslint" "*"
     "@types/estree" "*"
 
+<<<<<<< HEAD
 "@types/eslint@*", "@types/eslint@^8.4.10":
+=======
+"@types/eslint@*", "@types/eslint@^8.37.0":
+>>>>>>> master
   version "8.37.0"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.37.0.tgz#29cebc6c2a3ac7fea7113207bf5a828fdf4d7ef1"
   integrity sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==
@@ -1330,6 +1393,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
+<<<<<<< HEAD
 "@types/estree@*":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
@@ -1339,6 +1403,12 @@
   version "0.0.51"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+=======
+"@types/estree@*", "@types/estree@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
+  integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
+>>>>>>> master
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.4"
@@ -1420,6 +1490,7 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^5.55.0":
+<<<<<<< HEAD
   version "5.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.1.tgz#d1ab162a3cd2671b8a1c9ddf6e2db73b14439735"
   integrity sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==
@@ -1428,6 +1499,16 @@
     "@typescript-eslint/scope-manager" "5.57.1"
     "@typescript-eslint/type-utils" "5.57.1"
     "@typescript-eslint/utils" "5.57.1"
+=======
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.0.tgz#c0e10eeb936debe5d1c3433cf36206a95befefd0"
+  integrity sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==
+  dependencies:
+    "@eslint-community/regexpp" "^4.4.0"
+    "@typescript-eslint/scope-manager" "5.59.0"
+    "@typescript-eslint/type-utils" "5.59.0"
+    "@typescript-eslint/utils" "5.59.0"
+>>>>>>> master
     debug "^4.3.4"
     grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
@@ -1436,6 +1517,7 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.55.0", "@typescript-eslint/parser@^5.57.1":
+<<<<<<< HEAD
   version "5.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.57.1.tgz#af911234bd4401d09668c5faf708a0570a17a748"
   integrity sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==
@@ -1475,20 +1557,69 @@
   dependencies:
     "@typescript-eslint/types" "5.57.1"
     "@typescript-eslint/visitor-keys" "5.57.1"
+=======
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.0.tgz#0ad7cd019346cc5d150363f64869eca10ca9977c"
+  integrity sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.59.0"
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/typescript-estree" "5.59.0"
+    debug "^4.3.4"
+
+"@typescript-eslint/scope-manager@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz#86501d7a17885710b6716a23be2e93fc54a4fe8c"
+  integrity sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/visitor-keys" "5.59.0"
+
+"@typescript-eslint/type-utils@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.0.tgz#8e8d1420fc2265989fa3a0d897bde37f3851e8c9"
+  integrity sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.59.0"
+    "@typescript-eslint/utils" "5.59.0"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/types@5.59.0", "@typescript-eslint/types@^5.56.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.0.tgz#3fcdac7dbf923ec5251545acdd9f1d42d7c4fe32"
+  integrity sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==
+
+"@typescript-eslint/typescript-estree@5.59.0", "@typescript-eslint/typescript-estree@^5.55.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz#8869156ee1dcfc5a95be3ed0e2809969ea28e965"
+  integrity sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/visitor-keys" "5.59.0"
+>>>>>>> master
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+<<<<<<< HEAD
 "@typescript-eslint/utils@5.57.1", "@typescript-eslint/utils@^5.55.0":
   version "5.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.57.1.tgz#0f97b0bbd88c2d5e2036869f26466be5f4c69475"
   integrity sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==
+=======
+"@typescript-eslint/utils@5.59.0", "@typescript-eslint/utils@^5.55.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.0.tgz#063d066b3bc4850c18872649ed0da9ee72d833d5"
+  integrity sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==
+>>>>>>> master
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
+<<<<<<< HEAD
     "@typescript-eslint/scope-manager" "5.57.1"
     "@typescript-eslint/types" "5.57.1"
     "@typescript-eslint/typescript-estree" "5.57.1"
@@ -1622,6 +1753,141 @@
   integrity sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==
   dependencies:
     "@webassemblyjs/ast" "1.11.1"
+=======
+    "@typescript-eslint/scope-manager" "5.59.0"
+    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/typescript-estree" "5.59.0"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
+
+"@typescript-eslint/visitor-keys@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz#a59913f2bf0baeb61b5cfcb6135d3926c3854365"
+  integrity sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==
+  dependencies:
+    "@typescript-eslint/types" "5.59.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@webassemblyjs/ast@1.11.5", "@webassemblyjs/ast@^1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.5.tgz#6e818036b94548c1fb53b754b5cae3c9b208281c"
+  integrity sha512-LHY/GSAZZRpsNQH+/oHqhRQ5FT7eoULcBqgfyTB5nQHogFnK3/7QoN7dLnwSE/JkUAF0SrRuclT7ODqMFtWxxQ==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.5"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.5"
+
+"@webassemblyjs/floating-point-hex-parser@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.5.tgz#e85dfdb01cad16b812ff166b96806c050555f1b4"
+  integrity sha512-1j1zTIC5EZOtCplMBG/IEwLtUojtwFVwdyVMbL/hwWqbzlQoJsWCOavrdnLkemwNoC/EOwtUFch3fuo+cbcXYQ==
+
+"@webassemblyjs/helper-api-error@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.5.tgz#1e82fa7958c681ddcf4eabef756ce09d49d442d1"
+  integrity sha512-L65bDPmfpY0+yFrsgz8b6LhXmbbs38OnwDCf6NpnMUYqa+ENfE5Dq9E42ny0qz/PdR0LJyq/T5YijPnU8AXEpA==
+
+"@webassemblyjs/helper-buffer@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.5.tgz#91381652ea95bb38bbfd270702351c0c89d69fba"
+  integrity sha512-fDKo1gstwFFSfacIeH5KfwzjykIE6ldh1iH9Y/8YkAZrhmu4TctqYjSh7t0K2VyDSXOZJ1MLhht/k9IvYGcIxg==
+
+"@webassemblyjs/helper-numbers@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.5.tgz#23380c910d56764957292839006fecbe05e135a9"
+  integrity sha512-DhykHXM0ZABqfIGYNv93A5KKDw/+ywBFnuWybZZWcuzWHfbp21wUfRkbtz7dMGwGgT4iXjWuhRMA2Mzod6W4WA==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.5"
+    "@webassemblyjs/helper-api-error" "1.11.5"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.5.tgz#e258a25251bc69a52ef817da3001863cc1c24b9f"
+  integrity sha512-oC4Qa0bNcqnjAowFn7MPCETQgDYytpsfvz4ujZz63Zu/a/v71HeCAAmZsgZ3YVKec3zSPYytG3/PrRCqbtcAvA==
+
+"@webassemblyjs/helper-wasm-section@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.5.tgz#966e855a6fae04d5570ad4ec87fbcf29b42ba78e"
+  integrity sha512-uEoThA1LN2NA+K3B9wDo3yKlBfVtC6rh0i4/6hvbz071E8gTNZD/pT0MsBf7MeD6KbApMSkaAK0XeKyOZC7CIA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.5"
+    "@webassemblyjs/helper-buffer" "1.11.5"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.5"
+    "@webassemblyjs/wasm-gen" "1.11.5"
+
+"@webassemblyjs/ieee754@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.5.tgz#b2db1b33ce9c91e34236194c2b5cba9b25ca9d60"
+  integrity sha512-37aGq6qVL8A8oPbPrSGMBcp38YZFXcHfiROflJn9jxSdSMMM5dS5P/9e2/TpaJuhE+wFrbukN2WI6Hw9MH5acg==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.5.tgz#482e44d26b6b949edf042a8525a66c649e38935a"
+  integrity sha512-ajqrRSXaTJoPW+xmkfYN6l8VIeNnR4vBOTQO9HzR7IygoCcKWkICbKFbVTNMjMgMREqXEr0+2M6zukzM47ZUfQ==
+  dependencies:
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/utf8@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.5.tgz#83bef94856e399f3740e8df9f63bc47a987eae1a"
+  integrity sha512-WiOhulHKTZU5UPlRl53gHR8OxdGsSOxqfpqWeA2FmcwBMaoEdz6b2x2si3IwC9/fSPLfe8pBMRTHVMk5nlwnFQ==
+
+"@webassemblyjs/wasm-edit@^1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.5.tgz#93ee10a08037657e21c70de31c47fdad6b522b2d"
+  integrity sha512-C0p9D2fAu3Twwqvygvf42iGCQ4av8MFBLiTb+08SZ4cEdwzWx9QeAHDo1E2k+9s/0w1DM40oflJOpkZ8jW4HCQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.5"
+    "@webassemblyjs/helper-buffer" "1.11.5"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.5"
+    "@webassemblyjs/helper-wasm-section" "1.11.5"
+    "@webassemblyjs/wasm-gen" "1.11.5"
+    "@webassemblyjs/wasm-opt" "1.11.5"
+    "@webassemblyjs/wasm-parser" "1.11.5"
+    "@webassemblyjs/wast-printer" "1.11.5"
+
+"@webassemblyjs/wasm-gen@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.5.tgz#ceb1c82b40bf0cf67a492c53381916756ef7f0b1"
+  integrity sha512-14vteRlRjxLK9eSyYFvw1K8Vv+iPdZU0Aebk3j6oB8TQiQYuO6hj9s4d7qf6f2HJr2khzvNldAFG13CgdkAIfA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.5"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.5"
+    "@webassemblyjs/ieee754" "1.11.5"
+    "@webassemblyjs/leb128" "1.11.5"
+    "@webassemblyjs/utf8" "1.11.5"
+
+"@webassemblyjs/wasm-opt@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.5.tgz#b52bac29681fa62487e16d3bb7f0633d5e62ca0a"
+  integrity sha512-tcKwlIXstBQgbKy1MlbDMlXaxpucn42eb17H29rawYLxm5+MsEmgPzeCP8B1Cl69hCice8LeKgZpRUAPtqYPgw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.5"
+    "@webassemblyjs/helper-buffer" "1.11.5"
+    "@webassemblyjs/wasm-gen" "1.11.5"
+    "@webassemblyjs/wasm-parser" "1.11.5"
+
+"@webassemblyjs/wasm-parser@1.11.5", "@webassemblyjs/wasm-parser@^1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.5.tgz#7ba0697ca74c860ea13e3ba226b29617046982e2"
+  integrity sha512-SVXUIwsLQlc8srSD7jejsfTU83g7pIGr2YYNb9oHdtldSxaOhvA5xwvIiWIfcX8PlSakgqMXsLpLfbbJ4cBYew==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.5"
+    "@webassemblyjs/helper-api-error" "1.11.5"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.5"
+    "@webassemblyjs/ieee754" "1.11.5"
+    "@webassemblyjs/leb128" "1.11.5"
+    "@webassemblyjs/utf8" "1.11.5"
+
+"@webassemblyjs/wast-printer@1.11.5":
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.5.tgz#7a5e9689043f3eca82d544d7be7a8e6373a6fa98"
+  integrity sha512-f7Pq3wvg3GSPUPzR0F6bmI89Hdb+u9WXrSKc4v+N0aV0q6r42WoF92Jp2jEorBEBRoRNXgjp53nBniDXcqZYPA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.5"
+>>>>>>> master
     "@xtuc/long" "4.2.2"
 
 "@webpack-cli/configtest@^2.0.1":
@@ -1704,7 +1970,11 @@ ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
+<<<<<<< HEAD
 ajv-keywords@^5.0.0:
+=======
+ajv-keywords@^5.1.0:
+>>>>>>> master
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
   integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
@@ -1721,7 +1991,11 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+<<<<<<< HEAD
 ajv@^8.0.0, ajv@^8.8.0:
+=======
+ajv@^8.0.0, ajv@^8.9.0:
+>>>>>>> master
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
@@ -2252,9 +2526,15 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001449:
+<<<<<<< HEAD
   version "1.0.30001474"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz#13b6fe301a831fe666cce8ca4ef89352334133d5"
   integrity sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==
+=======
+  version "1.0.30001480"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz#9bbd35ee44c2480a1e3a3b9f4496f5066817164a"
+  integrity sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==
+>>>>>>> master
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2449,9 +2729,15 @@ color-name@~1.1.4:
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 colorette@^2.0.14, colorette@^2.0.19:
+<<<<<<< HEAD
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
+=======
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+>>>>>>> master
 
 colors@~0.6.0-1:
   version "0.6.2"
@@ -2478,9 +2764,15 @@ commander@2.9.0:
     graceful-readlink ">= 1.0.0"
 
 commander@^10.0.0:
+<<<<<<< HEAD
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.0.tgz#71797971162cd3cf65f0b9d24eb28f8d303acdf1"
   integrity sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==
+=======
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+>>>>>>> master
 
 commander@^2.12.1, commander@^2.20.0:
   version "2.20.3"
@@ -2568,9 +2860,15 @@ cookie@~0.4.1:
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 core-js-compat@^3.25.1:
+<<<<<<< HEAD
   version "3.30.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.30.0.tgz#99aa2789f6ed2debfa1df3232784126ee97f4d80"
   integrity sha512-P5A2h/9mRYZFIAP+5Ab8ns6083IyVpSclU74UNvbGVQ8VM7n3n3/g2yF3AkKQ9NXz2O+ioxLbEWKnDtgsFamhg==
+=======
+  version "3.30.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.30.1.tgz#961541e22db9c27fc48bfc13a3cafa8734171dfe"
+  integrity sha512-d690npR7MC6P0gq4npTl5n2VQeNAmUrJ90n+MHiKS7W2+xno4o3F5GDEuylSdi6EJ3VssibSGXOa1r3YXD3Mhw==
+>>>>>>> master
   dependencies:
     browserslist "^4.21.5"
 
@@ -2733,7 +3031,11 @@ default-require-extensions@^3.0.0:
   dependencies:
     strip-bom "^4.0.0"
 
+<<<<<<< HEAD
 define-properties@^1.1.3, define-properties@^1.1.4:
+=======
+define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
+>>>>>>> master
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
   integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
@@ -2858,9 +3160,15 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.284:
+<<<<<<< HEAD
   version "1.4.351"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.351.tgz#949144993f3ed5c18601e37c786bb72540dbf9e9"
   integrity sha512-W35n4jAsyj6OZGxeWe+gA6+2Md4jDO19fzfsRKEt3DBwIdlVTT8O9Uv8ojgUAoQeXASdgG9zMU+8n8Xg/W6dRQ==
+=======
+  version "1.4.368"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.368.tgz#75901f97d3e23da2e66feb1e61fbb8e70ac96430"
+  integrity sha512-e2aeCAixCj9M7nJxdB/wDjO6mbYX+lJJxSJCXDzlr5YPGYVofuJwGN9nKg2o6wWInjX6XmxRinn3AeJMK81ltw==
+>>>>>>> master
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -2918,10 +3226,17 @@ engine.io@~6.4.1:
     engine.io-parser "~5.0.3"
     ws "~8.11.0"
 
+<<<<<<< HEAD
 enhanced-resolve@^5.10.0:
   version "5.12.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
   integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
+=======
+enhanced-resolve@^5.13.0:
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz#26d1ecc448c02de997133217b5c1053f34a0a275"
+  integrity sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==
+>>>>>>> master
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -2981,10 +3296,17 @@ es-abstract@^1.19.0, es-abstract@^1.20.4:
     unbox-primitive "^1.0.2"
     which-typed-array "^1.1.9"
 
+<<<<<<< HEAD
 es-module-lexer@^0.9.0:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
   integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
+=======
+es-module-lexer@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.2.1.tgz#ba303831f63e6a394983fde2f97ad77b22324527"
+  integrity sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==
+>>>>>>> master
 
 es-set-tostringtag@^2.0.1:
   version "2.0.1"
@@ -3071,9 +3393,15 @@ eslint-import-resolver-node@^0.3.7:
     resolve "^1.22.1"
 
 eslint-module-utils@^2.7.4:
+<<<<<<< HEAD
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
   integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
+=======
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz#e439fee65fc33f6bba630ff621efc38ec0375c49"
+  integrity sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==
+>>>>>>> master
   dependencies:
     debug "^3.2.7"
 
@@ -3144,9 +3472,15 @@ eslint-scope@5.1.1, eslint-scope@^5.1.1:
     estraverse "^4.1.1"
 
 eslint-scope@^7.1.1:
+<<<<<<< HEAD
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
   integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
+=======
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
+  integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
+>>>>>>> master
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -3174,25 +3508,44 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.0:
   integrity sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==
 
 eslint-webpack-plugin@^4.0.0:
+<<<<<<< HEAD
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-4.0.0.tgz#f77f37b2bbb8ad5c4197b5e55f5f2a49365a1a81"
   integrity sha512-eM9ccGRWkU+btBSVfABRn8CjT7jZ2Q+UV/RfErMDVCFXpihEbvajNrLltZpwTAcEoXSqESGlEPIUxl7PoDlLWw==
   dependencies:
     "@types/eslint" "^8.4.10"
     jest-worker "^29.4.1"
+=======
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-4.0.1.tgz#f0f0e9afff2801d8bd41eac88e5409821ecbaccb"
+  integrity sha512-fUFcXpui/FftGx3NzvWgLZXlLbu+m74sUxGEgxgoxYcUtkIQbS6SdNNZkS99m5ycb23TfoNYrDpp1k/CK5j6Hw==
+  dependencies:
+    "@types/eslint" "^8.37.0"
+    jest-worker "^29.5.0"
+>>>>>>> master
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     schema-utils "^4.0.0"
 
 eslint@^8.17.0, eslint@^8.37.0:
+<<<<<<< HEAD
   version "8.37.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.37.0.tgz#1f660ef2ce49a0bfdec0b0d698e0b8b627287412"
   integrity sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==
+=======
+  version "8.38.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.38.0.tgz#a62c6f36e548a5574dd35728ac3c6209bd1e2f1a"
+  integrity sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==
+>>>>>>> master
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.4.0"
     "@eslint/eslintrc" "^2.0.2"
+<<<<<<< HEAD
     "@eslint/js" "8.37.0"
+=======
+    "@eslint/js" "8.38.0"
+>>>>>>> master
     "@humanwhocodes/config-array" "^0.11.8"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
@@ -3577,7 +3930,11 @@ function.prototype.name@^1.1.5:
     es-abstract "^1.19.0"
     functions-have-names "^1.2.2"
 
+<<<<<<< HEAD
 functions-have-names@^1.2.2:
+=======
+functions-have-names@^1.2.2, functions-have-names@^1.2.3:
+>>>>>>> master
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
@@ -4033,10 +4390,17 @@ is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
+<<<<<<< HEAD
 is-core-module@^2.11.0, is-core-module@^2.5.0, is-core-module@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
   integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
+=======
+is-core-module@^2.11.0, is-core-module@^2.5.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.0.tgz#36ad62f6f73c8253fd6472517a12483cf03e7ec4"
+  integrity sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==
+>>>>>>> master
   dependencies:
     has "^1.0.3"
 
@@ -4331,7 +4695,11 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+<<<<<<< HEAD
 jest-worker@^29.4.1:
+=======
+jest-worker@^29.5.0:
+>>>>>>> master
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.5.0.tgz#bdaefb06811bd3384d93f009755014d8acb4615d"
   integrity sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==
@@ -4350,6 +4718,7 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==
+<<<<<<< HEAD
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -4357,6 +4726,15 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-xdr@^1.1.3:
+=======
+
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+js-xdr@1.3.0:
+>>>>>>> master
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.3.0.tgz#e72e77c00bbdae62689062b95fe35ae2bd90df32"
   integrity sha512-fjLTm2uBtFvWsE3l2J14VjTuuB8vJfeTtYuNS7LiLHDWIX2kt0l1pqq9334F8kODUkKPMuULjEcbGbkFFwhx5g==
@@ -4609,9 +4987,15 @@ linkify-it@^3.0.1:
     uc.micro "^1.0.1"
 
 lint-staged@^13.2.0:
+<<<<<<< HEAD
   version "13.2.0"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.2.0.tgz#b7abaf79c91cd36d824f17b23a4ce5209206126a"
   integrity sha512-GbyK5iWinax5Dfw5obm2g2ccUiZXNGtAS4mCbJ0Lv4rq6iEtfBSjOYdcbOtAIFtM114t0vdpViDDetjVTSd8Vw==
+=======
+  version "13.2.1"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.2.1.tgz#9d30a14e3e42897ef417bc98556fb757f75cae87"
+  integrity sha512-8gfzinVXoPfga5Dz/ZOn8I2GOhf81Wvs+KwbEXQn/oWZAvCVS2PivrXfVbFJc93zD16uC0neS47RXHIjXKYZQw==
+>>>>>>> master
   dependencies:
     chalk "5.2.0"
     cli-truncate "^3.1.0"
@@ -4925,9 +5309,15 @@ minipass@^3.0.0, minipass@^3.1.1:
     yallist "^4.0.0"
 
 minipass@^4.0.0:
+<<<<<<< HEAD
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.5.tgz#9e0e5256f1e3513f8c34691dd68549e85b2c8ceb"
   integrity sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==
+=======
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
+>>>>>>> master
 
 minizlib@^2.1.1:
   version "2.1.2"
@@ -5670,6 +6060,7 @@ regenerator-transform@^0.15.1:
     "@babel/runtime" "^7.8.4"
 
 regexp.prototype.flags@^1.4.3:
+<<<<<<< HEAD
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
   integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
@@ -5677,6 +6068,15 @@ regexp.prototype.flags@^1.4.3:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     functions-have-names "^1.2.2"
+=======
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
+  integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    functions-have-names "^1.2.3"
+>>>>>>> master
 
 regexpp@^3.0.0:
   version "3.2.0"
@@ -5780,11 +6180,19 @@ resolve-from@^5.0.0:
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 resolve@^1.10.1, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.3.2:
+<<<<<<< HEAD
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
   dependencies:
     is-core-module "^2.9.0"
+=======
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
+  integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
+  dependencies:
+    is-core-module "^2.11.0"
+>>>>>>> master
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -5871,16 +6279,24 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+<<<<<<< HEAD
 schema-utils@^3.1.0, schema-utils@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
   integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
+=======
+schema-utils@^3.1.1, schema-utils@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.2.tgz#36c10abca6f7577aeae136c804b0c741edeadc99"
+  integrity sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==
+>>>>>>> master
   dependencies:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
 schema-utils@^4.0.0:
+<<<<<<< HEAD
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.0.0.tgz#60331e9e3ae78ec5d16353c467c34b3a0a1d3df7"
   integrity sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==
@@ -5894,6 +6310,21 @@ schema-utils@^4.0.0:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+=======
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.0.1.tgz#eb2d042df8b01f4b5c276a2dfd41ba0faab72e8d"
+  integrity sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ajv "^8.9.0"
+    ajv-formats "^2.1.1"
+    ajv-keywords "^5.1.0"
+
+"semver@2 >=2.2.1 || 3.x || 4 || 5 || 7", semver@^7.3.4, semver@^7.3.7:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
+  integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==
+>>>>>>> master
   dependencies:
     lru-cache "^6.0.0"
 
@@ -6062,10 +6493,17 @@ socket.io@^4.4.1:
     socket.io-adapter "~2.5.2"
     socket.io-parser "~4.2.1"
 
+<<<<<<< HEAD
 sodium-native@^3.3.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-3.4.1.tgz#44616c07ccecea15195f553af88b3e574b659741"
   integrity sha512-PaNN/roiFWzVVTL6OqjzYct38NSXewdl2wz8SRB51Br/MLIJPrbM3XexhVWkq7D3UWMysfrhKVf1v1phZq6MeQ==
+=======
+sodium-native@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-4.0.1.tgz#773201b0d7872da294b9b12cd90d4a913dc9a2dd"
+  integrity sha512-OQTaxrVLtMvrnfcwZVsOTHe58MfDApJiHJNoOwcmmrhwvlYkfaUt2WuzRio8PgEMOd96R5aDHY49DCtock1zsA==
+>>>>>>> master
   dependencies:
     node-gyp-build "^4.3.0"
 
@@ -6377,7 +6815,11 @@ tar@^6.1.11:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
+<<<<<<< HEAD
 terser-webpack-plugin@^5.1.3, terser-webpack-plugin@^5.3.7:
+=======
+terser-webpack-plugin@^5.3.7:
+>>>>>>> master
   version "5.3.7"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz#ef760632d24991760f339fe9290deb936ad1ffc7"
   integrity sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==
@@ -6389,9 +6831,15 @@ terser-webpack-plugin@^5.1.3, terser-webpack-plugin@^5.3.7:
     terser "^5.16.5"
 
 terser@^5.16.5:
+<<<<<<< HEAD
   version "5.16.8"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.8.tgz#ccde583dabe71df3f4ed02b65eb6532e0fae15d5"
   integrity sha512-QI5g1E/ef7d+PsDifb+a6nnVgC4F22Bg6T0xrBrz6iloVB4PUkkunp6V8nzoOOZJIzjWVdAGqCdlKlhLq/TbIA==
+=======
+  version "5.17.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.17.1.tgz#948f10830454761e2eeedc6debe45c532c83fd69"
+  integrity sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==
+>>>>>>> master
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"
@@ -6612,9 +7060,15 @@ typedarray@^0.0.6:
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
 typescript@^5.0.3:
+<<<<<<< HEAD
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.3.tgz#fe976f0c826a88d0a382007681cbb2da44afdedf"
   integrity sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==
+=======
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+>>>>>>> master
 
 ua-parser-js@^0.7.30:
   version "0.7.35"
@@ -6675,9 +7129,15 @@ unpipe@1.0.0, unpipe@~1.0.0:
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
 update-browserslist-db@^1.0.10:
+<<<<<<< HEAD
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
   integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
+=======
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz#9a2a641ad2907ae7b3616506f4b977851db5b940"
+  integrity sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==
+>>>>>>> master
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"
@@ -6820,6 +7280,7 @@ webpack-sources@^3.2.3:
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.77.0:
+<<<<<<< HEAD
   version "5.77.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.77.0.tgz#dea3ad16d7ea6b84aa55fa42f4eac9f30e7eb9b4"
   integrity sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==
@@ -6829,12 +7290,28 @@ webpack@^5.77.0:
     "@webassemblyjs/ast" "1.11.1"
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
+=======
+  version "5.80.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.80.0.tgz#3e660b4ab572be38c5e954bdaae7e2bf76010fdc"
+  integrity sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==
+  dependencies:
+    "@types/eslint-scope" "^3.7.3"
+    "@types/estree" "^1.0.0"
+    "@webassemblyjs/ast" "^1.11.5"
+    "@webassemblyjs/wasm-edit" "^1.11.5"
+    "@webassemblyjs/wasm-parser" "^1.11.5"
+>>>>>>> master
     acorn "^8.7.1"
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
+<<<<<<< HEAD
     enhanced-resolve "^5.10.0"
     es-module-lexer "^0.9.0"
+=======
+    enhanced-resolve "^5.13.0"
+    es-module-lexer "^1.2.1"
+>>>>>>> master
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
@@ -6843,9 +7320,15 @@ webpack@^5.77.0:
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
+<<<<<<< HEAD
     schema-utils "^3.1.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
+=======
+    schema-utils "^3.1.2"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.3.7"
+>>>>>>> master
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,19 +3,11 @@
 
 
 "@ampproject/remapping@^2.2.0":
-<<<<<<< HEAD
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
-  integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
-  dependencies:
-    "@jridgewell/gen-mapping" "^0.1.0"
-=======
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
   integrity sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.0"
->>>>>>> master
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@babel/cli@^7.21.0":
@@ -1066,17 +1058,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-<<<<<<< HEAD
-"@eslint/js@8.37.0":
-  version "8.37.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.37.0.tgz#cf1b5fa24217fe007f6487a26d765274925efa7d"
-  integrity sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==
-=======
 "@eslint/js@8.38.0":
   version "8.38.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.38.0.tgz#73a8a0d8aa8a8e6fe270431c5e72ae91b5337892"
   integrity sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==
->>>>>>> master
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
@@ -1137,84 +1122,48 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-<<<<<<< HEAD
-"@jridgewell/gen-mapping@^0.1.0":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
-  integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
-  dependencies:
-    "@jridgewell/set-array" "^1.0.0"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
-"@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
-  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
-=======
 "@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
   integrity sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
->>>>>>> master
   dependencies:
     "@jridgewell/set-array" "^1.0.1"
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-<<<<<<< HEAD
-"@jridgewell/resolve-uri@3.1.0", "@jridgewell/resolve-uri@^3.0.3":
-=======
 "@jridgewell/resolve-uri@3.1.0":
->>>>>>> master
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
-<<<<<<< HEAD
-"@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
-=======
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
 
 "@jridgewell/set-array@^1.0.1":
->>>>>>> master
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
 "@jridgewell/source-map@^0.3.2":
-<<<<<<< HEAD
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
-  integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
-=======
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.3.tgz#8108265659d4c33e72ffe14e33d6cc5eb59f2fda"
   integrity sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==
->>>>>>> master
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-<<<<<<< HEAD
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
-=======
 "@jridgewell/sourcemap-codec@1.4.14":
->>>>>>> master
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-<<<<<<< HEAD
-=======
 "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
->>>>>>> master
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
@@ -1224,15 +1173,9 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
-<<<<<<< HEAD
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
-  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
-=======
   version "0.3.18"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
   integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
->>>>>>> master
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
@@ -1381,11 +1324,7 @@
     "@types/eslint" "*"
     "@types/estree" "*"
 
-<<<<<<< HEAD
-"@types/eslint@*", "@types/eslint@^8.4.10":
-=======
 "@types/eslint@*", "@types/eslint@^8.37.0":
->>>>>>> master
   version "8.37.0"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.37.0.tgz#29cebc6c2a3ac7fea7113207bf5a828fdf4d7ef1"
   integrity sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==
@@ -1393,22 +1332,10 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-<<<<<<< HEAD
-"@types/estree@*":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
-  integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
-
-"@types/estree@^0.0.51":
-  version "0.0.51"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
-  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
-=======
 "@types/estree@*", "@types/estree@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
   integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
->>>>>>> master
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.4"
@@ -1458,9 +1385,9 @@
   integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
 
 "@types/node@*", "@types/node@>=10.0.0", "@types/node@^18.15.11":
-  version "18.15.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
-  integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
+  version "18.15.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.12.tgz#833756634e78c829e1254db006468dadbb0c696b"
+  integrity sha512-Wha1UwsB3CYdqUm2PPzh/1gujGCNtWVUYF0mB00fJFoR4gTyWTDPjSm+zBF787Ahw8vSGgBja90MkgFwvB86Dg==
 
 "@types/node@^14.14.35":
   version "14.18.42"
@@ -1490,16 +1417,6 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^5.55.0":
-<<<<<<< HEAD
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.1.tgz#d1ab162a3cd2671b8a1c9ddf6e2db73b14439735"
-  integrity sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==
-  dependencies:
-    "@eslint-community/regexpp" "^4.4.0"
-    "@typescript-eslint/scope-manager" "5.57.1"
-    "@typescript-eslint/type-utils" "5.57.1"
-    "@typescript-eslint/utils" "5.57.1"
-=======
   version "5.59.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.0.tgz#c0e10eeb936debe5d1c3433cf36206a95befefd0"
   integrity sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==
@@ -1508,7 +1425,6 @@
     "@typescript-eslint/scope-manager" "5.59.0"
     "@typescript-eslint/type-utils" "5.59.0"
     "@typescript-eslint/utils" "5.59.0"
->>>>>>> master
     debug "^4.3.4"
     grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
@@ -1517,47 +1433,6 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.55.0", "@typescript-eslint/parser@^5.57.1":
-<<<<<<< HEAD
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.57.1.tgz#af911234bd4401d09668c5faf708a0570a17a748"
-  integrity sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.57.1"
-    "@typescript-eslint/types" "5.57.1"
-    "@typescript-eslint/typescript-estree" "5.57.1"
-    debug "^4.3.4"
-
-"@typescript-eslint/scope-manager@5.57.1":
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.57.1.tgz#5d28799c0fc8b501a29ba1749d827800ef22d710"
-  integrity sha512-N/RrBwEUKMIYxSKl0oDK5sFVHd6VI7p9K5MyUlVYAY6dyNb/wHUqndkTd3XhpGlXgnQsBkRZuu4f9kAHghvgPw==
-  dependencies:
-    "@typescript-eslint/types" "5.57.1"
-    "@typescript-eslint/visitor-keys" "5.57.1"
-
-"@typescript-eslint/type-utils@5.57.1":
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.57.1.tgz#235daba621d3f882b8488040597b33777c74bbe9"
-  integrity sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==
-  dependencies:
-    "@typescript-eslint/typescript-estree" "5.57.1"
-    "@typescript-eslint/utils" "5.57.1"
-    debug "^4.3.4"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/types@5.57.1", "@typescript-eslint/types@^5.56.0":
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.57.1.tgz#d9989c7a9025897ea6f0550b7036027f69e8a603"
-  integrity sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==
-
-"@typescript-eslint/typescript-estree@5.57.1", "@typescript-eslint/typescript-estree@^5.55.0":
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz#10d9643e503afc1ca4f5553d9bbe672ea4050b71"
-  integrity sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==
-  dependencies:
-    "@typescript-eslint/types" "5.57.1"
-    "@typescript-eslint/visitor-keys" "5.57.1"
-=======
   version "5.59.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.0.tgz#0ad7cd019346cc5d150363f64869eca10ca9977c"
   integrity sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==
@@ -1597,163 +1472,20 @@
   dependencies:
     "@typescript-eslint/types" "5.59.0"
     "@typescript-eslint/visitor-keys" "5.59.0"
->>>>>>> master
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-<<<<<<< HEAD
-"@typescript-eslint/utils@5.57.1", "@typescript-eslint/utils@^5.55.0":
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.57.1.tgz#0f97b0bbd88c2d5e2036869f26466be5f4c69475"
-  integrity sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==
-=======
 "@typescript-eslint/utils@5.59.0", "@typescript-eslint/utils@^5.55.0":
   version "5.59.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.0.tgz#063d066b3bc4850c18872649ed0da9ee72d833d5"
   integrity sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==
->>>>>>> master
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-<<<<<<< HEAD
-    "@typescript-eslint/scope-manager" "5.57.1"
-    "@typescript-eslint/types" "5.57.1"
-    "@typescript-eslint/typescript-estree" "5.57.1"
-    eslint-scope "^5.1.1"
-    semver "^7.3.7"
-
-"@typescript-eslint/visitor-keys@5.57.1":
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz#585e5fa42a9bbcd9065f334fd7c8a4ddfa7d905e"
-  integrity sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==
-  dependencies:
-    "@typescript-eslint/types" "5.57.1"
-    eslint-visitor-keys "^3.3.0"
-
-"@webassemblyjs/ast@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
-  integrity sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==
-  dependencies:
-    "@webassemblyjs/helper-numbers" "1.11.1"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
-
-"@webassemblyjs/floating-point-hex-parser@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f"
-  integrity sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==
-
-"@webassemblyjs/helper-api-error@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#1a63192d8788e5c012800ba6a7a46c705288fd16"
-  integrity sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==
-
-"@webassemblyjs/helper-buffer@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#832a900eb444884cde9a7cad467f81500f5e5ab5"
-  integrity sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==
-
-"@webassemblyjs/helper-numbers@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz#64d81da219fbbba1e3bd1bfc74f6e8c4e10a62ae"
-  integrity sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==
-  dependencies:
-    "@webassemblyjs/floating-point-hex-parser" "1.11.1"
-    "@webassemblyjs/helper-api-error" "1.11.1"
-    "@xtuc/long" "4.2.2"
-
-"@webassemblyjs/helper-wasm-bytecode@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#f328241e41e7b199d0b20c18e88429c4433295e1"
-  integrity sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==
-
-"@webassemblyjs/helper-wasm-section@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz#21ee065a7b635f319e738f0dd73bfbda281c097a"
-  integrity sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.1"
-    "@webassemblyjs/helper-buffer" "1.11.1"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
-    "@webassemblyjs/wasm-gen" "1.11.1"
-
-"@webassemblyjs/ieee754@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#963929e9bbd05709e7e12243a099180812992614"
-  integrity sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==
-  dependencies:
-    "@xtuc/ieee754" "^1.2.0"
-
-"@webassemblyjs/leb128@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.1.tgz#ce814b45574e93d76bae1fb2644ab9cdd9527aa5"
-  integrity sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==
-  dependencies:
-    "@xtuc/long" "4.2.2"
-
-"@webassemblyjs/utf8@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#d1f8b764369e7c6e6bae350e854dec9a59f0a3ff"
-  integrity sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==
-
-"@webassemblyjs/wasm-edit@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz#ad206ebf4bf95a058ce9880a8c092c5dec8193d6"
-  integrity sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.1"
-    "@webassemblyjs/helper-buffer" "1.11.1"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
-    "@webassemblyjs/helper-wasm-section" "1.11.1"
-    "@webassemblyjs/wasm-gen" "1.11.1"
-    "@webassemblyjs/wasm-opt" "1.11.1"
-    "@webassemblyjs/wasm-parser" "1.11.1"
-    "@webassemblyjs/wast-printer" "1.11.1"
-
-"@webassemblyjs/wasm-gen@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#86c5ea304849759b7d88c47a32f4f039ae3c8f76"
-  integrity sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.1"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
-    "@webassemblyjs/ieee754" "1.11.1"
-    "@webassemblyjs/leb128" "1.11.1"
-    "@webassemblyjs/utf8" "1.11.1"
-
-"@webassemblyjs/wasm-opt@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#657b4c2202f4cf3b345f8a4c6461c8c2418985f2"
-  integrity sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.1"
-    "@webassemblyjs/helper-buffer" "1.11.1"
-    "@webassemblyjs/wasm-gen" "1.11.1"
-    "@webassemblyjs/wasm-parser" "1.11.1"
-
-"@webassemblyjs/wasm-parser@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz#86ca734534f417e9bd3c67c7a1c75d8be41fb199"
-  integrity sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.1"
-    "@webassemblyjs/helper-api-error" "1.11.1"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
-    "@webassemblyjs/ieee754" "1.11.1"
-    "@webassemblyjs/leb128" "1.11.1"
-    "@webassemblyjs/utf8" "1.11.1"
-
-"@webassemblyjs/wast-printer@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz#d0c73beda8eec5426f10ae8ef55cee5e7084c2f0"
-  integrity sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.1"
-=======
     "@typescript-eslint/scope-manager" "5.59.0"
     "@typescript-eslint/types" "5.59.0"
     "@typescript-eslint/typescript-estree" "5.59.0"
@@ -1887,7 +1619,6 @@
   integrity sha512-f7Pq3wvg3GSPUPzR0F6bmI89Hdb+u9WXrSKc4v+N0aV0q6r42WoF92Jp2jEorBEBRoRNXgjp53nBniDXcqZYPA==
   dependencies:
     "@webassemblyjs/ast" "1.11.5"
->>>>>>> master
     "@xtuc/long" "4.2.2"
 
 "@webpack-cli/configtest@^2.0.1":
@@ -1970,11 +1701,7 @@ ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-<<<<<<< HEAD
-ajv-keywords@^5.0.0:
-=======
 ajv-keywords@^5.1.0:
->>>>>>> master
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
   integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
@@ -1991,11 +1718,7 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-<<<<<<< HEAD
-ajv@^8.0.0, ajv@^8.8.0:
-=======
 ajv@^8.0.0, ajv@^8.9.0:
->>>>>>> master
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
@@ -2526,15 +2249,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001449:
-<<<<<<< HEAD
-  version "1.0.30001474"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz#13b6fe301a831fe666cce8ca4ef89352334133d5"
-  integrity sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==
-=======
   version "1.0.30001480"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz#9bbd35ee44c2480a1e3a3b9f4496f5066817164a"
   integrity sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==
->>>>>>> master
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2729,15 +2446,9 @@ color-name@~1.1.4:
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 colorette@^2.0.14, colorette@^2.0.19:
-<<<<<<< HEAD
-  version "2.0.19"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
-  integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
-=======
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
->>>>>>> master
 
 colors@~0.6.0-1:
   version "0.6.2"
@@ -2764,15 +2475,9 @@ commander@2.9.0:
     graceful-readlink ">= 1.0.0"
 
 commander@^10.0.0:
-<<<<<<< HEAD
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.0.tgz#71797971162cd3cf65f0b9d24eb28f8d303acdf1"
-  integrity sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==
-=======
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
->>>>>>> master
 
 commander@^2.12.1, commander@^2.20.0:
   version "2.20.3"
@@ -2860,15 +2565,9 @@ cookie@~0.4.1:
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 core-js-compat@^3.25.1:
-<<<<<<< HEAD
-  version "3.30.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.30.0.tgz#99aa2789f6ed2debfa1df3232784126ee97f4d80"
-  integrity sha512-P5A2h/9mRYZFIAP+5Ab8ns6083IyVpSclU74UNvbGVQ8VM7n3n3/g2yF3AkKQ9NXz2O+ioxLbEWKnDtgsFamhg==
-=======
   version "3.30.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.30.1.tgz#961541e22db9c27fc48bfc13a3cafa8734171dfe"
   integrity sha512-d690npR7MC6P0gq4npTl5n2VQeNAmUrJ90n+MHiKS7W2+xno4o3F5GDEuylSdi6EJ3VssibSGXOa1r3YXD3Mhw==
->>>>>>> master
   dependencies:
     browserslist "^4.21.5"
 
@@ -3031,11 +2730,7 @@ default-require-extensions@^3.0.0:
   dependencies:
     strip-bom "^4.0.0"
 
-<<<<<<< HEAD
-define-properties@^1.1.3, define-properties@^1.1.4:
-=======
 define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
->>>>>>> master
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
   integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
@@ -3160,15 +2855,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.284:
-<<<<<<< HEAD
-  version "1.4.351"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.351.tgz#949144993f3ed5c18601e37c786bb72540dbf9e9"
-  integrity sha512-W35n4jAsyj6OZGxeWe+gA6+2Md4jDO19fzfsRKEt3DBwIdlVTT8O9Uv8ojgUAoQeXASdgG9zMU+8n8Xg/W6dRQ==
-=======
   version "1.4.368"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.368.tgz#75901f97d3e23da2e66feb1e61fbb8e70ac96430"
   integrity sha512-e2aeCAixCj9M7nJxdB/wDjO6mbYX+lJJxSJCXDzlr5YPGYVofuJwGN9nKg2o6wWInjX6XmxRinn3AeJMK81ltw==
->>>>>>> master
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -3226,17 +2915,10 @@ engine.io@~6.4.1:
     engine.io-parser "~5.0.3"
     ws "~8.11.0"
 
-<<<<<<< HEAD
-enhanced-resolve@^5.10.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
-  integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
-=======
 enhanced-resolve@^5.13.0:
   version "5.13.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz#26d1ecc448c02de997133217b5c1053f34a0a275"
   integrity sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==
->>>>>>> master
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -3296,17 +2978,10 @@ es-abstract@^1.19.0, es-abstract@^1.20.4:
     unbox-primitive "^1.0.2"
     which-typed-array "^1.1.9"
 
-<<<<<<< HEAD
-es-module-lexer@^0.9.0:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
-  integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
-=======
 es-module-lexer@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.2.1.tgz#ba303831f63e6a394983fde2f97ad77b22324527"
   integrity sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==
->>>>>>> master
 
 es-set-tostringtag@^2.0.1:
   version "2.0.1"
@@ -3393,15 +3068,9 @@ eslint-import-resolver-node@^0.3.7:
     resolve "^1.22.1"
 
 eslint-module-utils@^2.7.4:
-<<<<<<< HEAD
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
-  integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
-=======
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz#e439fee65fc33f6bba630ff621efc38ec0375c49"
   integrity sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==
->>>>>>> master
   dependencies:
     debug "^3.2.7"
 
@@ -3472,15 +3141,9 @@ eslint-scope@5.1.1, eslint-scope@^5.1.1:
     estraverse "^4.1.1"
 
 eslint-scope@^7.1.1:
-<<<<<<< HEAD
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
-  integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
-=======
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
   integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
->>>>>>> master
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -3508,44 +3171,25 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.0:
   integrity sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==
 
 eslint-webpack-plugin@^4.0.0:
-<<<<<<< HEAD
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-4.0.0.tgz#f77f37b2bbb8ad5c4197b5e55f5f2a49365a1a81"
-  integrity sha512-eM9ccGRWkU+btBSVfABRn8CjT7jZ2Q+UV/RfErMDVCFXpihEbvajNrLltZpwTAcEoXSqESGlEPIUxl7PoDlLWw==
-  dependencies:
-    "@types/eslint" "^8.4.10"
-    jest-worker "^29.4.1"
-=======
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-4.0.1.tgz#f0f0e9afff2801d8bd41eac88e5409821ecbaccb"
   integrity sha512-fUFcXpui/FftGx3NzvWgLZXlLbu+m74sUxGEgxgoxYcUtkIQbS6SdNNZkS99m5ycb23TfoNYrDpp1k/CK5j6Hw==
   dependencies:
     "@types/eslint" "^8.37.0"
     jest-worker "^29.5.0"
->>>>>>> master
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     schema-utils "^4.0.0"
 
 eslint@^8.17.0, eslint@^8.37.0:
-<<<<<<< HEAD
-  version "8.37.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.37.0.tgz#1f660ef2ce49a0bfdec0b0d698e0b8b627287412"
-  integrity sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==
-=======
   version "8.38.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.38.0.tgz#a62c6f36e548a5574dd35728ac3c6209bd1e2f1a"
   integrity sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==
->>>>>>> master
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.4.0"
     "@eslint/eslintrc" "^2.0.2"
-<<<<<<< HEAD
-    "@eslint/js" "8.37.0"
-=======
     "@eslint/js" "8.38.0"
->>>>>>> master
     "@humanwhocodes/config-array" "^0.11.8"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
@@ -3930,11 +3574,7 @@ function.prototype.name@^1.1.5:
     es-abstract "^1.19.0"
     functions-have-names "^1.2.2"
 
-<<<<<<< HEAD
-functions-have-names@^1.2.2:
-=======
 functions-have-names@^1.2.2, functions-have-names@^1.2.3:
->>>>>>> master
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
@@ -4390,17 +4030,10 @@ is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
-<<<<<<< HEAD
-is-core-module@^2.11.0, is-core-module@^2.5.0, is-core-module@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
-  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
-=======
 is-core-module@^2.11.0, is-core-module@^2.5.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.0.tgz#36ad62f6f73c8253fd6472517a12483cf03e7ec4"
   integrity sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==
->>>>>>> master
   dependencies:
     has "^1.0.3"
 
@@ -4695,11 +4328,7 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-<<<<<<< HEAD
-jest-worker@^29.4.1:
-=======
 jest-worker@^29.5.0:
->>>>>>> master
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.5.0.tgz#bdaefb06811bd3384d93f009755014d8acb4615d"
   integrity sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==
@@ -4718,23 +4347,13 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==
-<<<<<<< HEAD
 
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-xdr@^1.1.3:
-=======
-
-js-tokens@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
-  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
-js-xdr@1.3.0:
->>>>>>> master
+js-xdr@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.3.0.tgz#e72e77c00bbdae62689062b95fe35ae2bd90df32"
   integrity sha512-fjLTm2uBtFvWsE3l2J14VjTuuB8vJfeTtYuNS7LiLHDWIX2kt0l1pqq9334F8kODUkKPMuULjEcbGbkFFwhx5g==
@@ -4877,9 +4496,9 @@ just-extend@^4.0.2:
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
 karma-chrome-launcher@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.1.1.tgz#baca9cc071b1562a1db241827257bfe5cab597ea"
-  integrity sha512-hsIglcq1vtboGPAN+DGCISCFOxW+ZVnIqhDQcCMqqCp+4dmJ0Qpq5QAjkbA0X2L9Mi6OBkHi2Srrbmm7pUKkzQ==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.2.0.tgz#eb9c95024f2d6dfbb3748d3415ac9b381906b9a9"
+  integrity sha512-rE9RkUPI7I9mAxByQWkGJFXfFD6lE4gC5nPuZdobf/QdTEJI6EU4yIay/cfU/xV4ZxlM5JiTv7zWYgA64NpS5Q==
   dependencies:
     which "^1.2.1"
 
@@ -4987,15 +4606,9 @@ linkify-it@^3.0.1:
     uc.micro "^1.0.1"
 
 lint-staged@^13.2.0:
-<<<<<<< HEAD
-  version "13.2.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.2.0.tgz#b7abaf79c91cd36d824f17b23a4ce5209206126a"
-  integrity sha512-GbyK5iWinax5Dfw5obm2g2ccUiZXNGtAS4mCbJ0Lv4rq6iEtfBSjOYdcbOtAIFtM114t0vdpViDDetjVTSd8Vw==
-=======
   version "13.2.1"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.2.1.tgz#9d30a14e3e42897ef417bc98556fb757f75cae87"
   integrity sha512-8gfzinVXoPfga5Dz/ZOn8I2GOhf81Wvs+KwbEXQn/oWZAvCVS2PivrXfVbFJc93zD16uC0neS47RXHIjXKYZQw==
->>>>>>> master
   dependencies:
     chalk "5.2.0"
     cli-truncate "^3.1.0"
@@ -5309,15 +4922,9 @@ minipass@^3.0.0, minipass@^3.1.1:
     yallist "^4.0.0"
 
 minipass@^4.0.0:
-<<<<<<< HEAD
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.5.tgz#9e0e5256f1e3513f8c34691dd68549e85b2c8ceb"
-  integrity sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==
-=======
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
   integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
->>>>>>> master
 
 minizlib@^2.1.1:
   version "2.1.2"
@@ -6060,15 +5667,6 @@ regenerator-transform@^0.15.1:
     "@babel/runtime" "^7.8.4"
 
 regexp.prototype.flags@^1.4.3:
-<<<<<<< HEAD
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
-  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    functions-have-names "^1.2.2"
-=======
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
   integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
@@ -6076,7 +5674,6 @@ regexp.prototype.flags@^1.4.3:
     call-bind "^1.0.2"
     define-properties "^1.2.0"
     functions-have-names "^1.2.3"
->>>>>>> master
 
 regexpp@^3.0.0:
   version "3.2.0"
@@ -6180,19 +5777,11 @@ resolve-from@^5.0.0:
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 resolve@^1.10.1, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.3.2:
-<<<<<<< HEAD
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
-  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
-  dependencies:
-    is-core-module "^2.9.0"
-=======
   version "1.22.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
   integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
   dependencies:
     is-core-module "^2.11.0"
->>>>>>> master
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -6279,38 +5868,16 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-<<<<<<< HEAD
-schema-utils@^3.1.0, schema-utils@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
-  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
-=======
 schema-utils@^3.1.1, schema-utils@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.2.tgz#36c10abca6f7577aeae136c804b0c741edeadc99"
   integrity sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==
->>>>>>> master
   dependencies:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
 schema-utils@^4.0.0:
-<<<<<<< HEAD
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.0.0.tgz#60331e9e3ae78ec5d16353c467c34b3a0a1d3df7"
-  integrity sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==
-  dependencies:
-    "@types/json-schema" "^7.0.9"
-    ajv "^8.8.0"
-    ajv-formats "^2.1.1"
-    ajv-keywords "^5.0.0"
-
-"semver@2 >=2.2.1 || 3.x || 4 || 5 || 7", semver@^7.3.4, semver@^7.3.7:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
-=======
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.0.1.tgz#eb2d042df8b01f4b5c276a2dfd41ba0faab72e8d"
   integrity sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==
@@ -6324,7 +5891,6 @@ schema-utils@^4.0.0:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
   integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==
->>>>>>> master
   dependencies:
     lru-cache "^6.0.0"
 
@@ -6414,9 +5980,9 @@ sinon-chai@^3.7.0:
   integrity sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==
 
 sinon@^15.0.3:
-  version "15.0.3"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-15.0.3.tgz#38005fcd80827177b6aa0245f82401d9ec88994b"
-  integrity sha512-si3geiRkeovP7Iel2O+qGL4NrO9vbMf3KsrJEi0ghP1l5aBkB5UxARea5j0FUsSqH3HLBh0dQPAyQ8fObRUqHw==
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-15.0.4.tgz#bcca6fef19b14feccc96473f0d7adc81e0bc5268"
+  integrity sha512-uzmfN6zx3GQaria1kwgWGeKiXSSbShBbue6Dcj0SI8fiCNFbiUDqKl57WFlY5lyhxZVUKmXvzgG2pilRQCBwWg==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
     "@sinonjs/fake-timers" "^10.0.2"
@@ -6493,17 +6059,10 @@ socket.io@^4.4.1:
     socket.io-adapter "~2.5.2"
     socket.io-parser "~4.2.1"
 
-<<<<<<< HEAD
-sodium-native@^3.3.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-3.4.1.tgz#44616c07ccecea15195f553af88b3e574b659741"
-  integrity sha512-PaNN/roiFWzVVTL6OqjzYct38NSXewdl2wz8SRB51Br/MLIJPrbM3XexhVWkq7D3UWMysfrhKVf1v1phZq6MeQ==
-=======
 sodium-native@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-4.0.1.tgz#773201b0d7872da294b9b12cd90d4a913dc9a2dd"
   integrity sha512-OQTaxrVLtMvrnfcwZVsOTHe58MfDApJiHJNoOwcmmrhwvlYkfaUt2WuzRio8PgEMOd96R5aDHY49DCtock1zsA==
->>>>>>> master
   dependencies:
     node-gyp-build "^4.3.0"
 
@@ -6815,11 +6374,7 @@ tar@^6.1.11:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-<<<<<<< HEAD
-terser-webpack-plugin@^5.1.3, terser-webpack-plugin@^5.3.7:
-=======
 terser-webpack-plugin@^5.3.7:
->>>>>>> master
   version "5.3.7"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz#ef760632d24991760f339fe9290deb936ad1ffc7"
   integrity sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==
@@ -6831,15 +6386,9 @@ terser-webpack-plugin@^5.3.7:
     terser "^5.16.5"
 
 terser@^5.16.5:
-<<<<<<< HEAD
-  version "5.16.8"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.8.tgz#ccde583dabe71df3f4ed02b65eb6532e0fae15d5"
-  integrity sha512-QI5g1E/ef7d+PsDifb+a6nnVgC4F22Bg6T0xrBrz6iloVB4PUkkunp6V8nzoOOZJIzjWVdAGqCdlKlhLq/TbIA==
-=======
   version "5.17.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.17.1.tgz#948f10830454761e2eeedc6debe45c532c83fd69"
   integrity sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==
->>>>>>> master
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"
@@ -7060,15 +6609,9 @@ typedarray@^0.0.6:
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
 typescript@^5.0.3:
-<<<<<<< HEAD
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.3.tgz#fe976f0c826a88d0a382007681cbb2da44afdedf"
-  integrity sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==
-=======
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
   integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
->>>>>>> master
 
 ua-parser-js@^0.7.30:
   version "0.7.35"
@@ -7129,15 +6672,9 @@ unpipe@1.0.0, unpipe@~1.0.0:
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
 update-browserslist-db@^1.0.10:
-<<<<<<< HEAD
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
-  integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
-=======
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz#9a2a641ad2907ae7b3616506f4b977851db5b940"
   integrity sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==
->>>>>>> master
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"
@@ -7280,17 +6817,6 @@ webpack-sources@^3.2.3:
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.77.0:
-<<<<<<< HEAD
-  version "5.77.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.77.0.tgz#dea3ad16d7ea6b84aa55fa42f4eac9f30e7eb9b4"
-  integrity sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==
-  dependencies:
-    "@types/eslint-scope" "^3.7.3"
-    "@types/estree" "^0.0.51"
-    "@webassemblyjs/ast" "1.11.1"
-    "@webassemblyjs/wasm-edit" "1.11.1"
-    "@webassemblyjs/wasm-parser" "1.11.1"
-=======
   version "5.80.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.80.0.tgz#3e660b4ab572be38c5e954bdaae7e2bf76010fdc"
   integrity sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==
@@ -7300,18 +6826,12 @@ webpack@^5.77.0:
     "@webassemblyjs/ast" "^1.11.5"
     "@webassemblyjs/wasm-edit" "^1.11.5"
     "@webassemblyjs/wasm-parser" "^1.11.5"
->>>>>>> master
     acorn "^8.7.1"
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-<<<<<<< HEAD
-    enhanced-resolve "^5.10.0"
-    es-module-lexer "^0.9.0"
-=======
     enhanced-resolve "^5.13.0"
     es-module-lexer "^1.2.1"
->>>>>>> master
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
@@ -7320,15 +6840,9 @@ webpack@^5.77.0:
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
-<<<<<<< HEAD
-    schema-utils "^3.1.0"
-    tapable "^2.1.1"
-    terser-webpack-plugin "^5.1.3"
-=======
     schema-utils "^3.1.2"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.3.7"
->>>>>>> master
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 


### PR DESCRIPTION
### What

Merge released upstream changes ([v9.0.0-beta.0](https://github.com/stellar/js-stellar-base/releases/tag/v9.0.0-beta.0)) into the Soroban branch and drop a new release (called `v9.0.0-soroban.0`). Steps taken:

 - `git merge master`: resolve conflicts except XDR stuff :
 - `make reset-xdr`: grab and generate latest XDR 
 - `git checkout v9.0.0-beta.0 -- types/{curr,next}.d.ts`: add manual `Operation` etc. fixes back in
 - modify `next_generated.js` to resolve the xdrgen bugs around using constants in arrays (see e.g. stellar/xdrgen#152), for example 
```js
xdr.varOpaque(SCVAL_LIMIT)
// into
xdr.varOpaque(xdr.lookup("SCVAL_LIMIT"))
```
 - this was done for `SCVAL_LIMIT`, `SCSYMBOL_LIMIT`, and `SC_SPEC_DOC_LIMIT`
 - (this isn't done in `master` since `next.d.ts` isn't used, but it probably should be)
 - `rm yarn.lock; yarn` to ensure latest dep versions are locked in :lock:
 - `yarn preversion` to lint and test everything :+1:

### Why
This change+release is necessary to be able to properly overhaul and modernize [stellar/js-soroban-client](https://github.com/stellar/js-soroban-client/).

### Known Limitations
@paulbellamy note that this will overwrite any **other** manual changes made to the generated XDR which is what I'm most concerned about getting reviewed here. I looked at the `types/next.d.ts` diff pretty closely (I can't avoid the linting changes for some reason :cry:) and it looks okay, but have any tweaks needed to be made to e.g. work around `xdrgen` bugs?

Should the new version instead be `v9.0.0-soroban.13`, `v8.2.2-soroban.13`, or something else? I'm unsure about the convention here.