### PR TITLE
Add fully-qualified `Operation` type to XDR type definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 
 ## Unreleased
 
-## [v9.0.0-beta.0](https://github.com/stellar/js-stellar-base/compare/v8.2.2..v9.0.0)
+
+## [v9.0.0-beta.1](https://github.com/stellar/js-stellar-base/compare/v9.0.0-beta.0..v9.0.0-beta.1)
+
+### Fix
+
+- Correct XDR type definition for raw `xdr.Operation`s ([#591](https://github.com/stellar/js-stellar-base/pull/591)).
+
+
+## [v9.0.0-beta.0](https://github.com/stellar/js-stellar-base/compare/v8.2.2..v9.0.0-beta.0)
 
 This version is marked by a major version bump because of the significant upgrades to underlying dependencies. While there should be no noticeable API changes from a downstream perspective, there may be breaking changes in the way that this library is bundled.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "9.0.0-beta.0",
+  "version": "9.0.0-beta.1",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/types/curr.d.ts
+++ b/types/curr.d.ts
@@ -1,4 +1,4 @@
-// Automatically generated on 2022-08-12T12:40:00+01:00
+// Automatically generated on 2023-04-20T14:53:00-08:00
 import { Operation } from './index';
 
 export {};
@@ -20,17 +20,17 @@ declare namespace xdrHidden {
 
     toXDR(format: "hex" | "base64"): string;
 
-    static read(io: Buffer): Operation;
+    static read(io: Buffer): xdr.Operation;
 
-    static write(value: Operation, io: Buffer): void;
+    static write(value: xdr.Operation, io: Buffer): void;
 
-    static isValid(value: Operation): boolean;
+    static isValid(value: xdr.Operation): boolean;
 
-    static toXDR(value: Operation): Buffer;
+    static toXDR(value: xdr.Operation): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Operation;
+    static fromXDR(input: Buffer, format?: "raw"): xdr.Operation;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Operation;
+    static fromXDR(input: string, format: "hex" | "base64"): xdr.Operation;
 
     static validateXDR(input: Buffer, format?: "raw"): boolean;
 

--- a/types/next.d.ts
+++ b/types/next.d.ts
@@ -1,4 +1,4 @@
-// Automatically generated on 2022-08-12T12:40:00+01:00
+// Automatically generated on 2023-04-20T14:53:00-08:00
 import { Operation } from './index';
 
 export {};
@@ -20,17 +20,17 @@ declare namespace xdrHidden {
 
     toXDR(format: "hex" | "base64"): string;
 
-    static read(io: Buffer): Operation;
+    static read(io: Buffer): xdr.Operation;
 
-    static write(value: Operation, io: Buffer): void;
+    static write(value: xdr.Operation, io: Buffer): void;
 
-    static isValid(value: Operation): boolean;
+    static isValid(value: xdr.Operation): boolean;
 
-    static toXDR(value: Operation): Buffer;
+    static toXDR(value: xdr.Operation): Buffer;
 
-    static fromXDR(input: Buffer, format?: "raw"): Operation;
+    static fromXDR(input: Buffer, format?: "raw"): xdr.Operation;
 
-    static fromXDR(input: string, format: "hex" | "base64"): Operation;
+    static fromXDR(input: string, format: "hex" | "base64"): xdr.Operation;
 
     static validateXDR(input: Buffer, format?: "raw"): boolean;
 


### PR DESCRIPTION
`Operation` refers to the high-level operation, when it should be `xdr.Operation` (or, alternatively, `Operation2`, but that's uglier).