### PR TITLE
Update completed sprint on issue/pr closed

### DIFF
--- a/.github/workflows/update-completed-sprint-on-issue-closed.yml
+++ b/.github/workflows/update-completed-sprint-on-issue-closed.yml
@@ -1,0 +1,25 @@
+name: Update CompletedSprint on Issue Closed
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  update-completed-sprint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_ID }}
+          private_key: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_PEM }}
+      - name: Update CompletedSprint on Issue Closed
+        id: update_completedsprint_on_issue_closed
+        uses: stellar/actions/update-completed-sprint-on-issue-closed@main
+        with:
+          project_name: "Platform Scrum"
+          field_name: "CompletedSprint"
+          project_token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Use https://github.com/stellar/actions/pull/52, to automatically set the CompletedSprint field on issues/PRs in the Platform Scrum project when they are closed.