### PR TITLE
added transaction ext as tx builder param

### DIFF
--- a/src/operations/invoke_host_function.js
+++ b/src/operations/invoke_host_function.js
@@ -16,7 +16,14 @@ import xdr from '../xdr';
  *    (xdr.InvokeHostFunctionOp)
  */
 export function invokeHostFunction(opts) {
-  return this.invokeHostFunctions({ source: opts.source, functions: [opts] });
+  if (!opts.args) {
+    throw new TypeError(
+      `function arguments ('args') required (got ${JSON.stringify(opts)})`
+    );
+  }
+
+  const hostFn = new xdr.HostFunction({args: opts.args, auth: opts.auth || []});
+  return this.invokeHostFunctions({ source: opts.source, functions: [hostFn] });
 }
 
 /**
@@ -27,29 +34,18 @@ export function invokeHostFunction(opts) {
  *
  * @param {object} opts - options for the operation
  * @param {xdr.HostFunction[]} opts.functions - a list of contract functions to
- *    invoke in this operation. each item should contain an object with a set of
- *    args and an optional list of auths (like those required by
- *    {@link Operation.invokeHostFunction}).
+ *    invoke in this operation. 
  * @param {string} [opts.source] - an optional source account
  *
  * @returns {xdr.Operation} an Invoke Host Function operation
  *    (xdr.InvokeHostFunctionOp) with xdr.HostFunction instances corresponding
  *    to each invocation
  *
- * @warning This function does not support setting a different source acco
+ * @warning This function does not support setting a different source account.
  */
 export function invokeHostFunctions(opts) {
-  const functions = opts.functions.map((hostFn) => {
-    if (!hostFn.args) {
-      throw new TypeError(
-        `function arguments ('args') required (got ${JSON.stringify(hostFn)})`
-      );
-    }
-
-    return new xdr.HostFunction(hostFn);
-  });
-
-  const invokeHostFunctionOp = new xdr.InvokeHostFunctionOp({ functions });
+  
+  const invokeHostFunctionOp = new xdr.InvokeHostFunctionOp({ functions: opts.functions });
   const opAttributes = {
     body: xdr.OperationBody.invokeHostFunction(invokeHostFunctionOp)
   };

--- a/src/operations/invoke_host_function.js
+++ b/src/operations/invoke_host_function.js
@@ -41,7 +41,6 @@ export function invokeHostFunction(opts) {
  *    (xdr.InvokeHostFunctionOp) with xdr.HostFunction instances corresponding
  *    to each invocation
  *
- * @warning This function does not support setting a different source account.
  */
 export function invokeHostFunctions(opts) {
   

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -110,6 +110,7 @@ export const TimeoutInfinite = 0;
  * @param {string}              [opts.networkPassphrase] passphrase of the
  *     target Stellar network (e.g. "Public Global Stellar Network ; September
  *     2015" for the pubnet)
+ * @param {object}              [opts.ext] - the optional xdr Ext to set on transaction
  */
 export class TransactionBuilder {
   constructor(sourceAccount, opts = {}) {
@@ -133,6 +134,7 @@ export class TransactionBuilder {
     this.extraSigners = clone(opts.extraSigners) || null;
     this.memo = opts.memo || Memo.none();
     this.networkPassphrase = opts.networkPassphrase || null;
+    this.ext = opts.ext || null;
   }
 
   /**
@@ -438,6 +440,23 @@ export class TransactionBuilder {
     return this;
   }
 
+   /**
+   * Set optional Transaction Ext  
+   *
+   * @param {object} ext    the Ext as xdr object or base64 string
+   *                        to be set as the Transaction's Ext.
+   *
+   * @returns {TransactionBuilder}
+   */
+  setExt(ext) {
+    if (typeof ext === 'string') {
+      const buffer = Buffer.from(ext, 'base64');
+      ext = xdr.TransactionExt.fromXDR(buffer);
+    }
+    this.ext = ext;
+    return this;
+  }
+
   /**
    * This will build the transaction.
    * It will also increment the source account's sequence number by 1.
@@ -517,7 +536,7 @@ export class TransactionBuilder {
     }
 
     attrs.sourceAccount = decodeAddressToMuxedAccount(this.source.accountId());
-    attrs.ext = new xdr.TransactionExt(0);
+    attrs.ext = this.ext || new xdr.TransactionExt(0);
 
     const xtx = new xdr.Transaction(attrs);
     xtx.operations(this.operations);

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -545,7 +545,11 @@ export class TransactionBuilder {
     }
 
     attrs.sourceAccount = decodeAddressToMuxedAccount(this.source.accountId());
-    attrs.ext = this.ext || new xdr.TransactionExt(0);
+    
+    // TODO - remove this workaround with hardcoded xdr for empty 'v0' TransactionExt 
+    //       and use the typescript generated static factory method once fixed
+    //       https://github.com/stellar/xdrgen/issues/157
+    attrs.ext = this.ext || xdr.TransactionExt.fromXDR("AAAAAA==", "base64"); 
 
     const xtx = new xdr.Transaction(attrs);
     xtx.operations(this.operations);

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -546,9 +546,9 @@ export class TransactionBuilder {
 
     attrs.sourceAccount = decodeAddressToMuxedAccount(this.source.accountId());
     
-    // TODO - remove this workaround to use hidden TransactionExt ts constructor
+    // TODO - remove this workaround for TransactionExt ts constructor
     //       and use the typescript generated static factory method once fixed
-    //       https://github.com/stellar/xdrgen/issues/157
+    //       https://github.com/stellar/dts-xdr/issues/5
     // @ts-ignore
     attrs.ext = this.ext || new xdr.TransactionExt(0, xdr.Void); 
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -110,7 +110,14 @@ export const TimeoutInfinite = 0;
  * @param {string}              [opts.networkPassphrase] passphrase of the
  *     target Stellar network (e.g. "Public Global Stellar Network ; September
  *     2015" for the pubnet)
- * @param {object}              [opts.ext] - the optional xdr Ext to set on transaction
+ * @param {xdr.TransactionExt}  [opts.ext] - an optional xdr instance of TransactionExt 
+ * to be set as Ext on {Transaction}. For non-contract(non-Soroban) transactions, 
+ * Ext is defined but is unused and setting this has no effect. 
+ * In the case of Soroban transactions, Ext should be set to an instance of the 
+ * TransactionExt version 1, with SorobanTransactionData set in the instance.
+ * TransactionExt.SorobanTransactionData is obtained from a prior simulation of 
+ * the contract invocation and provides necessary resource estimations. 
+ *     
  */
 export class TransactionBuilder {
   constructor(sourceAccount, opts = {}) {

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -546,10 +546,11 @@ export class TransactionBuilder {
 
     attrs.sourceAccount = decodeAddressToMuxedAccount(this.source.accountId());
     
-    // TODO - remove this workaround with hardcoded xdr for empty 'v0' TransactionExt 
+    // TODO - remove this workaround to use hidden TransactionExt ts constructor
     //       and use the typescript generated static factory method once fixed
     //       https://github.com/stellar/xdrgen/issues/157
-    attrs.ext = this.ext || xdr.TransactionExt.fromXDR("AAAAAA==", "base64"); 
+    // @ts-ignore
+    attrs.ext = this.ext || new xdr.TransactionExt(0, xdr.Void); 
 
     const xtx = new xdr.Transaction(attrs);
     xtx.operations(this.operations);

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2033,6 +2033,12 @@ describe('Operation', function () {
       expect(obj.type).to.be.equal('invokeHostFunction');
       expect(obj.functions).to.have.lengthOf(1);
     });
+    it('throws when single invokeHostFunction and no args passed', function () {
+      expect(() =>
+        StellarBase.Operation.invokeHostFunction({   
+          auth: []
+      })).to.throw(/function arguments \('args'\) required/); 
+    });
     it('creates multiple invokeHostFunctions', function () {
       const op = StellarBase.Operation.invokeHostFunctions({
         functions: [

--- a/test/unit/operation_test.js
+++ b/test/unit/operation_test.js
@@ -2019,6 +2019,44 @@ describe('Operation', function () {
     });
   });
 
+  describe('invokeHostFunction()', function () {
+    it('creates single invokeHostFunction', function () {
+      const op = StellarBase.Operation.invokeHostFunction({   
+          args: new StellarBase.xdr.HostFunctionArgs.hostFunctionTypeInvokeContract([]),
+          auth: []
+      });
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      
+      expect(operation.body().switch().name).to.equal('invokeHostFunction');
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('invokeHostFunction');
+      expect(obj.functions).to.have.lengthOf(1);
+    });
+    it('creates multiple invokeHostFunctions', function () {
+      const op = StellarBase.Operation.invokeHostFunctions({
+        functions: [
+          new StellarBase.xdr.HostFunction( 
+            {
+              args: new StellarBase.xdr.HostFunctionArgs.hostFunctionTypeInvokeContract([]),
+              auth: []
+            }),
+          new StellarBase.xdr.HostFunction( 
+            {
+              args: new StellarBase.xdr.HostFunctionArgs.hostFunctionTypeInvokeContract([]),
+              auth: []
+            })
+        ]
+      });
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+      
+      expect(operation.body().switch().name).to.equal('invokeHostFunction');
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('invokeHostFunction');
+      expect(obj.functions).to.have.lengthOf(2);
+    });
+  });
   describe('revokeTrustlineSponsorship()', function () {
     it('creates a revokeTrustlineSponsorship', function () {
       const account =

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -67,9 +67,9 @@ describe('TransactionBuilder', function () {
     var source;
     var transactionData;
     beforeEach(function () {
-      // TODO - remove this workaround with hardcoded 'v1' TransactionExt union xdr
+      // TODO - remove this workaround for TransactionExt union xdr
       //       and use the typescript generated static factory method once fixed
-      //       https://github.com/stellar/xdrgen/issues/157
+      //       https://github.com/stellar/dts-xdr/issues/5
       ext = StellarBase.xdr.TransactionExt.fromXDR("AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAA==", "base64");
       source = new StellarBase.Account(
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
@@ -150,9 +150,9 @@ describe('TransactionBuilder', function () {
         .setTimeout(StellarBase.TimeoutInfinite)
         .build();
 
-      // TODO - remove this workaround with hardcoded 'v0' TransactionExt union xdr
+      // TODO - remove this workaround for TransactionExt union xdr
       //       and use the typescript generated static factory method once fixed
-      //       https://github.com/stellar/xdrgen/issues/157
+      //       https://github.com/stellar/dts-xdr/issues/5
       const defaultV0Ext = StellarBase.xdr.TransactionExt.fromXDR("AAAAAA==", "base64");
       expect(transaction
         .toEnvelope()

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -62,6 +62,77 @@ describe('TransactionBuilder', function () {
     });
   });
 
+  describe('constructs a soroban contract transaction', function () {
+    var ext;
+    var source;
+    var transactionData;
+    beforeEach(function () {
+      ext = new StellarBase.xdr.TransactionExt(1);
+      source = new StellarBase.Account(
+        'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        '0'
+      );
+      transactionData = new StellarBase.xdr.SorobanTransactionData({
+        resources: new StellarBase.xdr.SorobanResources({
+          footprint: new StellarBase.xdr.LedgerFootprint({
+            readOnly: [],
+            readWrite: [],
+          }),
+          instructions: 0,
+          readBytes: 5,
+          writeBytes: 0,
+          extendedMetaDataSizeBytes: 0,
+        }),
+        refundableFee: StellarBase.xdr.Int64.fromString("0"),
+        ext: new StellarBase.xdr.ExtensionPoint(0),
+      });
+      ext.sorobanData(transactionData);
+    });
+
+    it('should set the transaction Ext from object', function (done) {
+      let transaction = new StellarBase.TransactionBuilder(source, {
+        fee: 100,
+        networkPassphrase: StellarBase.Networks.TESTNET
+      })
+        .addOperation(
+            StellarBase.Operation.invokeHostFunction({   
+            args: new StellarBase.xdr.HostFunctionArgs.hostFunctionTypeInvokeContract([]),
+            auth: []
+          })
+        )
+        .setExt(ext)
+        .setTimeout(StellarBase.TimeoutInfinite)
+        .build();
+
+      expect(transaction
+        .toEnvelope()
+        .tx()
+        .ext()).to.be.equal(ext);
+      done();
+    });
+    it('should set the transaction Ext from xdr string', function (done) {
+      let transaction = new StellarBase.TransactionBuilder(source, {
+        fee: 100,
+        networkPassphrase: StellarBase.Networks.TESTNET
+      })
+        .addOperation(
+            StellarBase.Operation.invokeHostFunction({   
+            args: new StellarBase.xdr.HostFunctionArgs.hostFunctionTypeInvokeContract([]),
+            auth: []
+          })
+        )
+        .setExt(ext.toXDR("base64"))
+        .setTimeout(StellarBase.TimeoutInfinite)
+        .build();
+
+      expect(transaction
+        .toEnvelope()
+        .tx()
+        .ext()).to.be.equal(ext);
+      done();
+    });
+  });
+
   describe('constructs a native payment transaction with two operations', function () {
     var source;
     var destination1;

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -62,20 +62,16 @@ describe('TransactionBuilder', function () {
     });
   });
 
-  describe('constructs a transaction with ext', function () {
+  describe('constructs a transaction with soroban data', function () {
     var ext;
     var source;
-    var transactionData;
+    var sorobanTransactionData;
     beforeEach(function () {
-      // TODO - remove this workaround for TransactionExt union xdr
-      //       and use the typescript generated static factory method once fixed
-      //       https://github.com/stellar/dts-xdr/issues/5
-      ext = StellarBase.xdr.TransactionExt.fromXDR("AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAA==", "base64");
       source = new StellarBase.Account(
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
         '0'
       );
-      transactionData = new StellarBase.xdr.SorobanTransactionData({
+      sorobanTransactionData = new StellarBase.xdr.SorobanTransactionData({
         resources: new StellarBase.xdr.SorobanResources({
           footprint: new StellarBase.xdr.LedgerFootprint({
             readOnly: [],
@@ -89,10 +85,9 @@ describe('TransactionBuilder', function () {
         refundableFee: StellarBase.xdr.Int64.fromString("1"),
         ext: new StellarBase.xdr.ExtensionPoint(0),
       });
-      ext.sorobanData(transactionData);
     });
 
-    it('should set the transaction Ext from object', function (done) {
+    it('should set the soroban data from object', function (done) {
       let transaction = new StellarBase.TransactionBuilder(source, {
         fee: 100,
         networkPassphrase: StellarBase.Networks.TESTNET
@@ -103,7 +98,7 @@ describe('TransactionBuilder', function () {
             auth: []
           })
         )
-        .setExt(ext)
+        .setSorobanData(sorobanTransactionData)
         .setTimeout(StellarBase.TimeoutInfinite)
         .build();
 
@@ -111,10 +106,11 @@ describe('TransactionBuilder', function () {
         .toEnvelope()
         .v1()
         .tx()
-        .ext()).to.deep.equal(ext);
+        .ext()
+        .sorobanData()).to.deep.equal(sorobanTransactionData);
       done();
     });
-    it('should set the transaction Ext from xdr string', function (done) {
+    it('should set the soroban data from xdr string', function (done) {
       let transaction = new StellarBase.TransactionBuilder(source, {
         fee: 100,
         networkPassphrase: StellarBase.Networks.TESTNET
@@ -125,7 +121,7 @@ describe('TransactionBuilder', function () {
             auth: []
           })
         )
-        .setExt(ext.toXDR("base64"))
+        .setSorobanData(sorobanTransactionData.toXDR("base64"))
         .setTimeout(StellarBase.TimeoutInfinite)
         .build();
 
@@ -133,10 +129,11 @@ describe('TransactionBuilder', function () {
         .toEnvelope()
         .v1()
         .tx()
-        .ext()).to.deep.equal(ext);
+        .ext()
+        .sorobanData()).to.deep.equal(sorobanTransactionData);
       done();
     });
-    it('should set the transaction Ext to default when not present', function (done) {
+    it('should set the transaction Ext to default when soroban data present', function (done) {
       let transaction = new StellarBase.TransactionBuilder(source, {
         fee: 100,
         networkPassphrase: StellarBase.Networks.TESTNET
@@ -150,15 +147,12 @@ describe('TransactionBuilder', function () {
         .setTimeout(StellarBase.TimeoutInfinite)
         .build();
 
-      // TODO - remove this workaround for TransactionExt union xdr
-      //       and use the typescript generated static factory method once fixed
-      //       https://github.com/stellar/dts-xdr/issues/5
-      const defaultV0Ext = StellarBase.xdr.TransactionExt.fromXDR("AAAAAA==", "base64");
       expect(transaction
         .toEnvelope()
         .v1()
         .tx()
-        .ext()).to.deep.equal(defaultV0Ext);
+        .ext()
+        .switch()).equal(0);
       done();
     });
   });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -538,6 +538,10 @@ export namespace OperationOptions {
     minAmountB: string;
   }
   interface InvokeHostFunction extends BaseOptions {
+    args: xdr.HostFunctionArgs;
+    auth: xdr.ContractAuth[];
+  }
+  interface InvokeHostFunctions extends BaseOptions {
     functions: xdr.HostFunction[];
   }
 }
@@ -857,6 +861,9 @@ export namespace Operation {
   }
   function invokeHostFunction(
     options: OperationOptions.InvokeHostFunction
+  ): xdr.Operation<InvokeHostFunction>;
+  function invokeHostFunctions(
+    options: OperationOptions.InvokeHostFunctions
   ): xdr.Operation<InvokeHostFunction>;
 
   function fromXDRObject<T extends Operation = Operation>(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -538,10 +538,7 @@ export namespace OperationOptions {
     minAmountB: string;
   }
   interface InvokeHostFunction extends BaseOptions {
-    function: xdr.HostFunction;
-    parameters: xdr.ScVal[];
-    footprint: xdr.LedgerFootprint;
-    auth: xdr.ContractAuth[];
+    functions: xdr.HostFunction[];
   }
 }
 export type OperationOptions =
@@ -856,10 +853,7 @@ export namespace Operation {
     options: OperationOptions.LiquidityPoolWithdraw
   ): xdr.Operation<LiquidityPoolWithdraw>;
   interface InvokeHostFunction extends BaseOperation<OperationType.InvokeHostFunction> {
-    function: xdr.HostFunction;
-    parameters: xdr.ScVal[];
-    footprint: xdr.LedgerFootprint;
-    auth: xdr.ContractAuth[];
+    functions: xdr.HostFunction[];
   }
   function invokeHostFunction(
     options: OperationOptions.InvokeHostFunction
@@ -1001,6 +995,7 @@ export class TransactionBuilder {
   setMinAccountSequenceAge(durationInSeconds: number): this;
   setMinAccountSequenceLedgerGap(gap: number): this;
   setExtraSigners(extraSigners: string[]): this;
+  setExt(ext: string | xdr.TransactionExt): this;
   build(): Transaction;
   setNetworkPassphrase(networkPassphrase: string): this;
   static buildFeeBumpTransaction(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1002,7 +1002,7 @@ export class TransactionBuilder {
   setMinAccountSequenceAge(durationInSeconds: number): this;
   setMinAccountSequenceLedgerGap(gap: number): this;
   setExtraSigners(extraSigners: string[]): this;
-  setExt(ext: string | xdr.TransactionExt): this;
+  setSorobanData(sorobanData: string | xdr.SorobanTransactionData): this;
   build(): Transaction;
   setNetworkPassphrase(networkPassphrase: string): this;
   static buildFeeBumpTransaction(
@@ -1035,6 +1035,7 @@ export namespace TransactionBuilder {
     minAccountSequenceAge?: number;
     minAccountSequenceLedgerGap?: number;
     extraSigners?: string[];
+    sorobanData?: string | xdr.SorobanTransactionData;
   }
 }
 


### PR DESCRIPTION
while developing soroban-client to support new rpc simulation on [js-soroban-client#77](https://github.com/stellar/js-soroban-client/pull/77), needed a way to stuff the new SorobanTransactionData from simulation into the transaction during TxBuilder for easier client usage.

