### PR TITLE
Fix asset code sorting with mixed cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## Unreleased
 
+- Fix bug in asset sorting. We were not correctly sorting in ascii bytes
+  ([#606](https://github.com/stellar/js-stellar-base/pull/606))
+
 
 ## [v9.0.0-beta.2](https://github.com/stellar/js-stellar-base/compare/v9.0.0-beta.1..v9.0.0-beta.2)
 

--- a/src/asset.js
+++ b/src/asset.js
@@ -261,30 +261,47 @@ export class Asset {
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
  */
 function asciiCompare(a, b) {
-  if (a==b) return 0;
-  for (each in a) {
-    let letterpos = parseInt(each)
+  if (a === b) {
+    return 0;
+  }
+
+  for (let each in a) {
+    let letterpos = parseInt(each);
     //example if the letters position being compared is in the 4th position, and it hasn't been sorted yet,
     //and the b string doesnot have a letter in that position, well then... return -1 because a goes first.
-    if((letterpos + 1) > b.length){
-        return -1
+    if (letterpos + 1 > b.length) {
+      return -1;
     }
     //if all the characters are the same and string b is longer, b goes first.
-    if( ( (letterpos +1) == a.length && b.length > a.length ) ){
-        return 1
-        }
-    //if they're both the same letter go to the next letter.
-    if(a[letterpos] == b[letterpos]){continue};
-    //if a is upper case and b is not, return -1 to indicate 'a' goes first.
-    if( (a[letterpos].toUpperCase()  == a[letterpos] && b[letterpos].toUpperCase() != b[letterpos]) ){
-        return -1 
-        }
-    if( (b[letterpos].toUpperCase()  == b[letterpos] && a[letterpos].toUpperCase() != a[letterpos]) ){
-        return 1
-        }    
-    if(( a[letterpos].toUpperCase()==a[letterpos] && b[letterpos].toUpperCase() == b[letterpos] ) ||
-        ( a[letterpos].toLowerCase()==a[letterpos] && b[letterpos].toLowerCase() == b[letterpos] ) ) {
-        return a[letterpos].localeCompare(b[letterpos], 'en', { caseFirst: 'upper' });
-      }
+    if (letterpos + 1 == a.length && b.length > a.length) {
+      return 1;
     }
+    //if they're both the same letter go to the next letter.
+    if (a[letterpos] == b[letterpos]) {
+      continue;
+    }
+    //if a is upper case and b is not, return -1 to indicate 'a' goes first.
+    if (
+      a[letterpos].toUpperCase() == a[letterpos] &&
+      b[letterpos].toUpperCase() != b[letterpos]
+    ) {
+      return -1;
+    }
+    if (
+      b[letterpos].toUpperCase() == b[letterpos] &&
+      a[letterpos].toUpperCase() != a[letterpos]
+    ) {
+      return 1;
+    }
+    if (
+      (a[letterpos].toUpperCase() == a[letterpos] &&
+        b[letterpos].toUpperCase() == b[letterpos]) ||
+      (a[letterpos].toLowerCase() == a[letterpos] &&
+        b[letterpos].toLowerCase() == b[letterpos])
+    ) {
+      return a[letterpos].localeCompare(b[letterpos], 'en', {
+        caseFirst: 'upper'
+      });
+    }
+  }
 }

--- a/src/asset.js
+++ b/src/asset.js
@@ -261,47 +261,5 @@ export class Asset {
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
  */
 function asciiCompare(a, b) {
-  if (a === b) {
-    return 0;
-  }
-
-  for (let each in a) {
-    let letterpos = parseInt(each);
-    //example if the letters position being compared is in the 4th position, and it hasn't been sorted yet,
-    //and the b string doesnot have a letter in that position, well then... return -1 because a goes first.
-    if (letterpos + 1 > b.length) {
-      return -1;
-    }
-    //if all the characters are the same and string b is longer, b goes first.
-    if (letterpos + 1 == a.length && b.length > a.length) {
-      return 1;
-    }
-    //if they're both the same letter go to the next letter.
-    if (a[letterpos] == b[letterpos]) {
-      continue;
-    }
-    //if a is upper case and b is not, return -1 to indicate 'a' goes first.
-    if (
-      a[letterpos].toUpperCase() == a[letterpos] &&
-      b[letterpos].toUpperCase() != b[letterpos]
-    ) {
-      return -1;
-    }
-    if (
-      b[letterpos].toUpperCase() == b[letterpos] &&
-      a[letterpos].toUpperCase() != a[letterpos]
-    ) {
-      return 1;
-    }
-    if (
-      (a[letterpos].toUpperCase() == a[letterpos] &&
-        b[letterpos].toUpperCase() == b[letterpos]) ||
-      (a[letterpos].toLowerCase() == a[letterpos] &&
-        b[letterpos].toLowerCase() == b[letterpos])
-    ) {
-      return a[letterpos].localeCompare(b[letterpos], 'en', {
-        caseFirst: 'upper'
-      });
-    }
-  }
+  return Buffer.compare(Buffer.from(a, 'ascii'), Buffer.from(b, 'ascii'));
 }

--- a/src/asset.js
+++ b/src/asset.js
@@ -261,5 +261,29 @@ export class Asset {
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
  */
 function asciiCompare(a, b) {
-  return a.localeCompare(b, 'en', { caseFirst: 'upper' });
+  if (a==b) return 0;
+  for (each in a) {
+    //example if the letters position being compared is in the 4th position, and it hasn't been sorted yet,
+    //and the b string doesnot have a letter in that position, well then... return -1 because a goes first.
+    if((each + 1) > b.length){
+        return -1
+    }
+    //if all the characters are the same and string b is longer, b goes first.
+    if( ( (each +1) == a.length && b.length > a.length ) ){
+        return 1
+        }
+    //if they're both the same letter go to the next letter.
+    if(a[each] == b[each]){continue};
+    //if a is upper case and b is not, return -1 to indicate 'a' goes first.
+    if( (a[each].toUpperCase()  == a[each] && b[each].toUpperCase() != b[each]) ){
+        return -1 
+        }
+    if( (b[each].toUpperCase()  == b[each] && a[each].toUpperCase() != a[each]) ){
+        return 1
+        }    
+    if(( a[each].toUpperCase()==a[each] && b[each].toUpperCase() == b[each] ) ||
+        ( a[each].toLowerCase()==a[each] && b[each].toLowerCase() == b[each] ) ) {
+        return a[each].localeCompare(b[each], 'en', { caseFirst: 'upper' });
+      }
+    }
 }

--- a/src/asset.js
+++ b/src/asset.js
@@ -257,8 +257,6 @@ export class Asset {
  *     -1 if `a < b`, 0 if `a == b`, and 1 if `a > b`
  *
  * @warning No type-checks are done on the parameters
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
  */
 function asciiCompare(a, b) {
   return Buffer.compare(Buffer.from(a, 'ascii'), Buffer.from(b, 'ascii'));

--- a/src/asset.js
+++ b/src/asset.js
@@ -263,27 +263,28 @@ export class Asset {
 function asciiCompare(a, b) {
   if (a==b) return 0;
   for (each in a) {
+    let letterpos = parseInt(each)
     //example if the letters position being compared is in the 4th position, and it hasn't been sorted yet,
     //and the b string doesnot have a letter in that position, well then... return -1 because a goes first.
-    if((each + 1) > b.length){
+    if((letterpos + 1) > b.length){
         return -1
     }
     //if all the characters are the same and string b is longer, b goes first.
-    if( ( (each +1) == a.length && b.length > a.length ) ){
+    if( ( (letterpos +1) == a.length && b.length > a.length ) ){
         return 1
         }
     //if they're both the same letter go to the next letter.
-    if(a[each] == b[each]){continue};
+    if(a[letterpos] == b[letterpos]){continue};
     //if a is upper case and b is not, return -1 to indicate 'a' goes first.
-    if( (a[each].toUpperCase()  == a[each] && b[each].toUpperCase() != b[each]) ){
+    if( (a[letterpos].toUpperCase()  == a[letterpos] && b[letterpos].toUpperCase() != b[letterpos]) ){
         return -1 
         }
-    if( (b[each].toUpperCase()  == b[each] && a[each].toUpperCase() != a[each]) ){
+    if( (b[letterpos].toUpperCase()  == b[letterpos] && a[letterpos].toUpperCase() != a[letterpos]) ){
         return 1
         }    
-    if(( a[each].toUpperCase()==a[each] && b[each].toUpperCase() == b[each] ) ||
-        ( a[each].toLowerCase()==a[each] && b[each].toLowerCase() == b[each] ) ) {
-        return a[each].localeCompare(b[each], 'en', { caseFirst: 'upper' });
+    if(( a[letterpos].toUpperCase()==a[letterpos] && b[letterpos].toUpperCase() == b[letterpos] ) ||
+        ( a[letterpos].toLowerCase()==a[letterpos] && b[letterpos].toLowerCase() == b[letterpos] ) ) {
+        return a[letterpos].localeCompare(b[letterpos], 'en', { caseFirst: 'upper' });
       }
     }
 }

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -364,5 +364,13 @@ describe('Asset', function () {
       expect(StellarBase.Asset.compare(assetIssuerB, assetIssuerA)).to.eq(1);
       expect(StellarBase.Asset.compare(assetIssuerB, assetIssuerB)).to.eq(0);
     });
+
+    it('test if codes with upper-case letters are sorted before lower-case letters', function () {
+      // All upper-case letters should come before any lower-case ones
+      const assetA = new StellarBase.Asset('B', 'GA7NLOF4EHWMJF6DBXXV2H6AYI7IHYWNFZR6R52BYBLY7TE5Q74AIDRA');
+      const assetB = new StellarBase.Asset('a', 'GA7NLOF4EHWMJF6DBXXV2H6AYI7IHYWNFZR6R52BYBLY7TE5Q74AIDRA');
+
+      expect(StellarBase.Asset.compare(assetA, assetB)).to.eq(-1);
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/stellar/js-stellar-base/issues/593

Based on https://github.com/stellar/js-stellar-base/pull/605, but because what we want is ascii byte comparison. We can use `Buffer.compare` to do that for us.