### PR TITLE
Adds missing jsdoc for `Operation.isValidAmount`.

### DIFF
--- a/src/operation.js
+++ b/src/operation.js
@@ -380,6 +380,21 @@ export class Operation {
     return result;
   }
 
+  /**
+   * Validates that a given amount is possible for a Stellar asset.
+   *
+   * Specifically, this means that the amount is well, a valid number, but also
+   * that it is within the int64 range and has no more than 7 decimal levels of
+   * precision.
+   *
+   * Note that while smart contracts allow larger amounts, this is oriented
+   * towards validating the standard Stellar operations.
+   *
+   * @param {string} value          the amount to validate
+   * @param {[boolean]} allowZero   whether or not zero is valid (default: no)
+   *
+   * @returns {boolean}
+   */
   static isValidAmount(value, allowZero = false) {
     if (!isString(value)) {
       return false;


### PR DESCRIPTION
Closes #568.