### PR TITLE
Add Contract support for strkey-style contract IDs

### DIFF
--- a/src/contract.js
+++ b/src/contract.js
@@ -26,7 +26,7 @@ export class Contract {
     } catch (_) {
       // If that fails, try it as a hex string
       // TODO: Add methods based on the contractSpec (or do that elsewhere?)
-      let b = Buffer.from(contractId, 'hex');
+      const b = Buffer.from(contractId, 'hex');
       if (b.length !== 32) {
         throw new Error('Invalid contract ID');
       }

--- a/src/contract.js
+++ b/src/contract.js
@@ -1,5 +1,6 @@
 import { Operation } from './operation';
 import xdr from './xdr';
+import { StrKey } from './strkey';
 
 /**
  * Create a new Contract object.
@@ -12,23 +13,42 @@ import xdr from './xdr';
  * @constructor
  *
  * @param {string} contractId - ID of the contract (ex.
+ *     `CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE`, or as a
+ *     32-byte hex string
  *     `000000000000000000000000000000000000000000000000000000000000000001`).
  */
 // TODO: Support contract deployment, maybe?
 export class Contract {
-  // TODO: Figure out contract owner/id stuff here. How should we represent that?
   constructor(contractId) {
-    // TODO: Add methods based on the contractSpec (or do that elsewhere?)
-    this._id = Buffer.from(contractId, 'hex');
+    try {
+      // First, try it as a strkey
+      this._id = StrKey.decodeContract(contractId);
+    } catch (_) {
+      // If that fails, try it as a hex string
+      // TODO: Add methods based on the contractSpec (or do that elsewhere?)
+      let b = Buffer.from(contractId, 'hex');
+      if (b.length !== 32) {
+        throw new Error('Invalid contract ID');
+      }
+      this._id = b;
+    }
   }
 
   /**
-   * Returns Stellar contract ID as a hex string, ex.
+   * Returns Stellar contract ID as a strkey, or hex string, ex.
    * `000000000000000000000000000000000000000000000000000000000000000001`.
+   * @param {'hex'|'strkey'} format - format of output, defaults to 'strkey'
    * @returns {string}
    */
-  contractId() {
-    return this._id.toString('hex');
+  contractId(format = 'strkey') {
+    switch (format) {
+    case 'strkey':
+      return StrKey.encodeContract(this._id);
+    case 'hex':
+      return this._id.toString('hex');
+    default:
+      throw new Error(`Invalid format: ${format}`);
+    }
   }
 
   /**

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -1,20 +1,42 @@
-describe('Contract.getFootprint', function () {
-  it('includes the correct contract code footprint', function () {
-    let contractId = '0'.repeat(63) + '1';
+describe('Contract', function () {
+  describe('constructor', function () {
+    it('parses strkeys', function () {
+      let contractId = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+      let contract = new StellarBase.Contract(contractId);
+      expect(contract.contractId('strkey')).to.equal(contractId);
+    });
 
-    let contract = new StellarBase.Contract(contractId);
-    expect(contract.contractId()).to.equal(contractId);
+    it('parses hex addresses', function () {
+      let contractId = '0'.repeat(63) + '1';
+      let contract = new StellarBase.Contract(contractId);
+      expect(contract.contractId('hex')).to.equal(contractId);
+    });
 
-    const fp = contract.getFootprint();
+    it('parses throws on invalid ids', function () {
+      expect(() => {
+        new StellarBase.Contract('foobar')
+      }).to.throw();
+    });
+  });
 
-    let expected = new StellarBase.xdr.LedgerKey.contractData(
-      new StellarBase.xdr.LedgerKeyContractData({
-        contractId: Buffer.from(contractId, 'hex'),
-        key: StellarBase.xdr.ScVal.scvLedgerKeyContractExecutable()
-      })
-    )
-      .toXDR()
-      .toString('base64');
-    expect(fp.toXDR().toString('base64')).to.equal(expected);
+  describe('getFootprint', function () {
+    it('includes the correct contract code footprint', function () {
+      let contractId = '0'.repeat(63) + '1';
+
+      let contract = new StellarBase.Contract(contractId);
+      expect(contract.contractId('hex')).to.equal(contractId);
+
+      const fp = contract.getFootprint();
+
+      let expected = new StellarBase.xdr.LedgerKey.contractData(
+        new StellarBase.xdr.LedgerKeyContractData({
+          contractId: Buffer.from(contractId, 'hex'),
+          key: StellarBase.xdr.ScVal.scvLedgerKeyContractExecutable()
+        })
+      )
+        .toXDR()
+        .toString('base64');
+      expect(fp.toXDR().toString('base64')).to.equal(expected);
+    });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,7 +27,7 @@ export class Address {
 
 export class Contract {
   constructor(contractId: string);
-  contractId(): string;
+  contractId(format?: 'hex' | 'strkey'): string;
   call(method: string, ...params: xdr.ScVal[]): xdr.Operation<Operation.InvokeHostFunction>;
 }
 


### PR DESCRIPTION
Will fix the system-tests breakage at: https://github.com/stellar/soroban-tools/actions/runs/5121655313/jobs/9209699526?pr=668

Now you can do:
```
// constructor will auto-detect c-strkey, or hex string
let c = new Contract("C...1234");

// default is changed to strkey output
console.log(c.contractId());
// C...1234

// old style hex output is via the new format parameter
console.log(c.contractId('hex'));
// abcd1234
```