### PR TITLE
Add GitHub Action to ensure `prettier` is always run on PRs.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
     - name: Build All
       run: yarn build:prod
 
-    - name: Run Prettier Checks
-      run: yarn fmt && (git diff-index --quiet HEAD; git diff) && yarn lint
-
     - name: Run Node Tests
       run: yarn test:node
 
     - name: Run Browser Tests
       run: yarn build:browser:prod && yarn test:browser
+
+    - name: Run Prettier Checks
+      run: yarn fmt && (git diff-index --quiet HEAD; git diff)
 
     - name: Run Linter
       run: yarn lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Build All
       run: yarn build:prod
 
+    - name: Run Prettier Checks
+      run: yarn fmt && (git diff-index --quiet HEAD; git diff) && yarn lint
+
     - name: Run Node Tests
       run: yarn test:node
 

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -14,9 +14,11 @@ describe('Contract', function () {
     });
 
     it('converts strkeys to hex', function () {
-      let contractId = 'CDYFWOUPJCGPFU2CS33BZSEUD7INMFKXKJ25TIMRUHQGAFISBVM2D7J6';
+      let contractId =
+        'CDYFWOUPJCGPFU2CS33BZSEUD7INMFKXKJ25TIMRUHQGAFISBVM2D7J6';
       let contract = new StellarBase.Contract(contractId);
-      let expected = 'f05b3a8f488cf2d34296f61cc8941fd0d615575275d9a191a1e06015120d59a1';
+      let expected =
+        'f05b3a8f488cf2d34296f61cc8941fd0d615575275d9a191a1e06015120d59a1';
       expect(contract.contractId('hex')).to.equal(expected);
     });
 

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -14,11 +14,9 @@ describe('Contract', function () {
     });
 
     it('converts strkeys to hex', function () {
-      let contractId =
-        'CDYFWOUPJCGPFU2CS33BZSEUD7INMFKXKJ25TIMRUHQGAFISBVM2D7J6';
+      let contractId = 'CDYFWOUPJCGPFU2CS33BZSEUD7INMFKXKJ25TIMRUHQGAFISBVM2D7J6';
       let contract = new StellarBase.Contract(contractId);
-      let expected =
-        'f05b3a8f488cf2d34296f61cc8941fd0d615575275d9a191a1e06015120d59a1';
+      let expected = 'f05b3a8f488cf2d34296f61cc8941fd0d615575275d9a191a1e06015120d59a1';
       expect(contract.contractId('hex')).to.equal(expected);
     });
 


### PR DESCRIPTION
There are whitespace inconsistencies now because even though `yarn fmt` exists, it isn't enforced. This will enforce it!