### PR TITLE
Prototype for Soroban auth-next signing

### DIFF
--- a/src/contract_auth.js
+++ b/src/contract_auth.js
@@ -1,0 +1,22 @@
+import { ContractAuth, HashIdPreimageContractAuth } from './xdr';
+
+ContractAuth.prototype.canSign = (keypair) => {
+  const address = this.addressWithNonce()?.address();
+  if (!address || address.switch() !== 'scAddressTypeAccount') return false;
+  return (
+    keypair.publicKey() ===
+    StellarSdk.StrKey.encodeEd25519PublicKey(address.accountId().ed25519())
+  );
+};
+
+ContractAuth.prototype.sign = (keypair, networkId) => {
+  const a = this.addressWithNonce();
+  const sig = keypair.sign(
+    new HashIdPreimageContractAuth({
+      networkId,
+      nonce: a.nonce(),
+      invocation: this.rootInvocation()
+    }).toXDR('raw')
+  );
+  this.signatureArgs.push(sig);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import xdr from './xdr';
 
 BigNumber.DEBUG = true; // gives us exceptions on bad constructor values
 
+import './contract_auth';
 export { xdr };
 export { hash } from './hashing';
 export { sign, verify, FastSigning } from './signing';


### PR DESCRIPTION
Inspired by @aristidesstaffieri big mega-thread asking how to sign ContractAuth in a transaction... As well as @overcat's nice python sdk signing (https://github.com/StellarCN/py-stellar-base/blob/soroban/stellar_sdk/soroban/contract_auth.py)

This is a rough proposal for how to add support for soroban auth-next contract-auth signing to the sdk.

Usage:
```ts
// The "figure it out" mode, where you pass all the keys, and it figures out which one
// should sign which contract auths. Side effect here is that all keys will also sign the
// txn (which may or may not be desired).
txn.sign(key1, key2)

// Alternatively, if you have access to the ContractAuth components you could sign them
// individually. We would probably do this in js-soroban-client's `prepareTransaction` method:
function prepareTransaction(txn, key) {
  // simulate it to get the auths
  op.auths.forEach(auth => {
    if (auth.canSign(key)) {
      auth.sign(key)
    } else {
      // We need another key to sign this. Figure out what to do here. Panic?
    }
  })
  // sign the whole txn
  tx.sign(key)
  // submit & send
}
```

Obviously, it needs updating for preview 10, as well as some tests written, and types updated.

Thoughts?