### PR TITLE
Release `v10.0.0-soroban.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "9.0.0-soroban.3",
+  "version": "10.0.0-soroban.0",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/src/operations/invoke_host_function.js
+++ b/src/operations/invoke_host_function.js
@@ -9,7 +9,8 @@ import xdr from '../xdr';
  * @param {object} opts - options object
  * @param {xdr.HostFunction} opts.func - host function to execute (with its
  *    wrapped parameters)
- * @param {xdr.ContractAuth[]} [opts.auth] - list of authorizations for the call
+ * @param {xdr.SorobanAuthorizationEntry[]} [opts.auth] - list outlining the
+ *    tree of authorizations required for the call
  * @param {string} [opts.source] - an optional source account
  *
  * @returns {xdr.Operation} an Invoke Host Function operation

--- a/src/transaction_base.js
+++ b/src/transaction_base.js
@@ -69,23 +69,6 @@ export class TransactionBase {
    * @returns {void}
    */
   sign(...keypairs) {
-    // Temporary warning for contract auth-next signatures not being supported.
-    const requiresContractSignatures = (this.operations || []).some(
-      (op) =>
-        op.type === 'invokeHostFunction' &&
-        op.auth.some(
-          (auth) =>
-            auth.credentials().switch().name === 'sorobanCredentialsAddress'
-        )
-    );
-
-    if (requiresContractSignatures) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Soroban contract signatures are not well-supported in this version of the SDK.'
-      );
-    }
-
     const txHash = this.hash();
     keypairs.forEach((kp) => {
       const sig = kp.signDecorated(txHash);

--- a/src/transaction_base.js
+++ b/src/transaction_base.js
@@ -80,8 +80,9 @@ export class TransactionBase {
     );
 
     if (requiresContractSignatures) {
-      throw new Error(
-        'Soroban contract signatures are not supported in this version of the SDK.'
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Soroban contract signatures are not well-supported in this version of the SDK.'
       );
     }
 

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -299,9 +299,7 @@ describe('Transaction', function () {
       .setTimeout(StellarBase.TimeoutInfinite)
       .build();
 
-    expect(() => tx.sign(signer)).to.throw(
-      /Soroban contract signatures are not supported in this version of the SDK./
-    );
+    tx.sign(signer);
   });
 
   it('adds signature correctly', function () {

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -253,55 +253,6 @@ describe('Transaction', function () {
     );
   });
 
-  it('returns error when transaction includes soroban contract auth', function () {
-    let source = new StellarBase.Account(
-      'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB',
-      '0'
-    );
-    let signer = StellarBase.Keypair.master(StellarBase.Networks.TESTNET);
-    let scAddress = new StellarBase.Address(source.accountId()).toScAddress();
-
-    let tx = new StellarBase.TransactionBuilder(source, {
-      fee: 100,
-      networkPassphrase: StellarBase.Networks.TESTNET
-    })
-      .addOperation(
-        StellarBase.Operation.invokeHostFunction({
-          func: StellarBase.xdr.HostFunction.hostFunctionTypeInvokeContract([]),
-          auth: [
-            new StellarBase.xdr.SorobanAuthorizationEntry({
-              // Include a credentials w/ a nonce to trigger this
-              credentials:
-                new StellarBase.xdr.SorobanCredentials.sorobanCredentialsAddress(
-                  new StellarBase.xdr.SorobanAddressCredentials({
-                    address: scAddress,
-                    nonce: new StellarBase.xdr.Int64(1234),
-                    signatureExpirationLedger: 1,
-                    signatureArgs: []
-                  })
-                ),
-              // Rest of params are irrelevant
-              rootInvocation: new StellarBase.xdr.SorobanAuthorizedInvocation({
-                function:
-                  StellarBase.xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
-                    new StellarBase.xdr.SorobanAuthorizedContractFunction({
-                      contractAddress: scAddress,
-                      functionName: 'test',
-                      args: []
-                    })
-                  ),
-                subInvocations: []
-              })
-            })
-          ]
-        })
-      )
-      .setTimeout(StellarBase.TimeoutInfinite)
-      .build();
-
-    tx.sign(signer);
-  });
-
   it('adds signature correctly', function () {
     const sourceKey =
       'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB';


### PR DESCRIPTION
## Preview 10 Release: v10.0.0-soroban.0 ([diff](https://github.com/stellar/js-stellar-base/compare/eaaaeb3d6bcae14677fee0797e4693ce0671744d...v10.0.0-soroban.0))

### Breaking Changes

- Many XDR structures have changed, please refer to the `types/next.d.ts` diff for details ([#633](https://github.com/stellar/js-stellar-base/pull/633)).
- We have returned to the world in which **one** transaction contains **one** operation which contains **one** host function invocation. This means `Operation.invokeHostFunctions` is gone and `Operation.invokeHostFunction` has changed to accept `{ func, auth }`, where `func` is the correct `xdr.HostFunction` and `auth` is a list of `xdr.SorobanAuthorizationEntry` items that outline the authorization tree for the call stack ([#633](https://github.com/stellar/js-stellar-base/pull/633)). Better abstractions for creating an `xdr.HostFunction` are forthcoming, though you can still refer to `Contract.call()` for help.

### Added

- A new abstraction for dealing with large integers and `ScVal`s: see `ScInt`, `XdrLargeInt`, and `scValToBigInt` ([#620](https://github.com/stellar/js-stellar-base/pull/620)).
- A new abstraction for converting between native JavaScript types and complex `ScVal`s: see `nativeToScVal` and `scValToNative` ([#630](https://github.com/stellar/js-stellar-base/pull/630)).
- We have added two new operations related to state expiration in Soroban: `BumpFootprintExpiration` and `RestoreFootprint`. Please refer to their docstrings for details ([#633](https://github.com/stellar/js-stellar-base/pull/633)).

cc @piyalbasu @aristidesstaffieri for downstream context