### PR TITLE
Fix TypeScript definition for `Operation.invokeHostFunction` options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "10.0.0-soroban.0",
+  "version": "10.0.0-soroban.1",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -544,7 +544,7 @@ export namespace OperationOptions {
     minAmountB: string;
   }
   interface InvokeHostFunction extends BaseOptions {
-    args: xdr.HostFunction;
+    func: xdr.HostFunction;
     auth: xdr.SorobanAuthorizationEntry[];
   }
   interface BumpFootprintExpiration extends BaseOptions {


### PR DESCRIPTION
This was overlooked in #633 and prevents `soroban-client` from building invocations correctly without `as unknown` hacks.