### PR TITLE
Fix Preview 10 contract invoke & Release `v10.0.0-soroban.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "10.0.0-soroban.2",
+  "version": "10.0.0-soroban.3",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
   "browser": "./dist/stellar-base.min.js",

--- a/src/contract.js
+++ b/src/contract.js
@@ -69,11 +69,9 @@ export class Contract {
    * contract.
    */
   call(method, ...params) {
-    const contractId = Buffer.from(this._id, 'hex');
-
     return Operation.invokeHostFunction({
       func: xdr.HostFunction.hostFunctionTypeInvokeContract([
-        xdr.ScVal.scvBytes(contractId),
+        this.address().toScVal(),
         xdr.ScVal.scvSymbol(method),
         ...params
       ]),

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -60,4 +60,31 @@ describe('Contract', function () {
       expect(fp.toXDR().toString('base64')).to.equal(expected);
     });
   });
+
+  describe('call', function () {
+    let contractId = '0'.repeat(63) + '1';
+    let call = new StellarBase.Contract(contractId).call(
+      'method',
+      StellarBase.xdr.ScVal.scvU32(123)
+    );
+    let args = call
+      .body()
+      .invokeHostFunctionOp()
+      .hostFunction()
+      .invokeContract();
+
+    it('passes the contract id as an ScAddress', function () {
+      expect(args[0]).to.deep.equal(
+        StellarBase.Address.contract(Buffer.from(contractId, 'hex')).toScVal()
+      );
+    });
+
+    it('passes the method name as the second arg', function () {
+      expect(args[1]).to.deep.equal(StellarBase.xdr.ScVal.scvSymbol('method'));
+    });
+
+    it('passes all params after that', function () {
+      expect(args[2]).to.deep.equal(StellarBase.xdr.ScVal.scvU32(123));
+    });
+  });
 });


### PR DESCRIPTION
For preview 10 we need to pass the contract id as an ScAddress, not an ScBytes.