### PR TITLE
Make opinionated judgements about string/symbol decoding

### DIFF
--- a/src/scval.js
+++ b/src/scval.js
@@ -320,11 +320,16 @@ export function scValToNative(scv) {
     // encoded non-printable bytes in their string value, that's on them.
     //
     // note that we assume a utf8 encoding, which is ascii-compatible. for other
-    // encodings, you should probably use bytes anyway.
+    // encodings, you should probably use bytes anyway. if it cannot be decoded,
+    // the raw bytes are returned.
     case xdr.ScValType.scvString().value: {
       const v = scv.value(); // string|Buffer
       if (Buffer.isBuffer(v) || ArrayBuffer.isView(v)) {
-        return new TextDecoder().decode(v);
+        try {
+          return new TextDecoder().decode(v);
+        } catch (e) {
+          return new Uint8Array(v.buffer); // copy of bytes
+        }
       }
       return v; // string already
     }

--- a/src/scval.js
+++ b/src/scval.js
@@ -334,7 +334,7 @@ export function scValToNative(scv) {
       const v = scv.value(); // string|Buffer
       if (Buffer.isBuffer(v) || ArrayBuffer.isView(v)) {
         // we don't need the add'l complexity of utf8 since the charset is known
-        return Array.from(v).map(char => String.fromCharCode(char));
+        return Array.from(v).map(char => String.fromCharCode(char)).join('');
       }
       return v; // string already
     }

--- a/src/scval.js
+++ b/src/scval.js
@@ -321,12 +321,13 @@ export function scValToNative(scv) {
     //
     // note that we assume a utf8 encoding, which is ascii-compatible. for other
     // encodings, you should probably use bytes anyway.
-    case xdr.ScValType.scvString().value:
+    case xdr.ScValType.scvString().value: {
       const v = scv.value(); // string|Buffer
       if (Buffer.isBuffer(v) || ArrayBuffer.isView(v)) {
-        return new TextDecoder(v);
+        return new TextDecoder().decode(v);
       }
       return v; // string already
+    }
 
     // these are limited to [a-zA-Z0-9_]+, so we can safely make ascii strings
     case xdr.ScValType.scvSymbol().value: {

--- a/src/scval.js
+++ b/src/scval.js
@@ -339,7 +339,9 @@ export function scValToNative(scv) {
       const v = scv.value(); // string|Buffer
       if (Buffer.isBuffer(v) || ArrayBuffer.isView(v)) {
         // we don't need the add'l complexity of utf8 since the charset is known
-        return Array.from(v).map(char => String.fromCharCode(char)).join('');
+        return Array.from(v)
+          .map((char) => String.fromCharCode(char))
+          .join('');
       }
       return v; // string already
     }

--- a/test/unit/scval_test.js
+++ b/test/unit/scval_test.js
@@ -110,8 +110,8 @@ describe('parsing and building ScVals', function () {
       ],
       [xdr.ScVal.scvString('hello there!'), 'hello there!'],
       [xdr.ScVal.scvSymbol('hello'), 'hello'],
-      [xdr.ScVal.scvString(Buffer.from('hello')), Buffer.from('hello')], // ensure no conversion
-      [xdr.ScVal.scvSymbol(Buffer.from('hello')), Buffer.from('hello')], // ensure no conversion
+      [xdr.ScVal.scvString(Buffer.from('hello')), 'hello'], // ensure conversion
+      [xdr.ScVal.scvSymbol(Buffer.from('hello')), 'hello'], // ensure conversion
       [
         new StellarBase.Address(kp.publicKey()).toScVal(),
         (actual) => actual.toString() === kp.publicKey()


### PR DESCRIPTION
### What 
The conversion behavior of strings and symbols has changed:

 * before: `scvString` -> `Uint8Array` OR `string`
 * after: `scvString` -> decoded as UTF-8, returns `string`
 * before: `scvSymbol` -> `Uint8Array` OR `string`
 * after: `scvString` -> always decoded as an ascii `string`

### Why
The following is true:

 * symbols MUST be strings, as their input is enforced to be `[a-zA-Z0-9_]+`
 * strings are "bytes with a hint of being text," so we should respect that 

Previously, users were seeing byte arrays when they expected strings, so this rectifies that unintuitive behavior.

### Known Limitations
UTF-8 encoding is assumed for `scvString`s (because it's ascii-compatible), but there's not really a compelling reason to assume anything else (utf8 is assumed throughout most of the toolchain, and if you want something different you can always [a] request a feature or [b] use raw `scvBytes`)