### PR TITLE
Expand contract footprint with contract code ledger key.

### DIFF
--- a/src/contract.js
+++ b/src/contract.js
@@ -36,6 +36,10 @@ export class Contract {
     return StrKey.encodeContract(this._id);
   }
 
+  toString() {
+    return this.contractId();
+  }
+
   /**
    * Returns the address of this contract as an Address type.
    * @returns {Address}
@@ -64,20 +68,29 @@ export class Contract {
   }
 
   /**
-   * Returns the read-only footprint entry necessary for any invocations to this
-   * contract, for convenience when adding it to your transaction's overall
-   * footprint.
+   * Returns the read-only footprint entries necessary for any invocations to
+   * this contract, for convenience when adding it to your transaction's overall
+   * footprint or doing bump/restore operations.
    *
-   * @returns {xdr.LedgerKey} the contract's executable data ledger key
+   * @returns {xdr.LedgerKey[]} the ledger keys containing the contract's code
+   *    (first) and its deployed contract instance (second)
    */
   getFootprint() {
-    return xdr.LedgerKey.contractData(
-      new xdr.LedgerKeyContractData({
-        contract: this.address().toScAddress(),
-        key: xdr.ScVal.scvLedgerKeyContractInstance(),
-        durability: xdr.ContractDataDurability.persistent(),
-        bodyType: xdr.ContractEntryBodyType.dataEntry()
-      })
-    );
+    return [
+      xdr.LedgerKey.contractCode(
+        new xdr.LedgerKeyContractCode({
+          hash: this._id,
+          bodyType: xdr.ContractEntryBodyType.dataEntry(),
+        })
+      ),
+      xdr.LedgerKey.contractData(
+        new xdr.LedgerKeyContractData({
+          contract: this.address().toScAddress(),
+          key: xdr.ScVal.scvLedgerKeyContractInstance(),
+          durability: xdr.ContractDataDurability.persistent(),
+          bodyType: xdr.ContractEntryBodyType.dataEntry()
+        })
+      )
+    ];
   }
 }

--- a/src/contract.js
+++ b/src/contract.js
@@ -80,7 +80,7 @@ export class Contract {
       xdr.LedgerKey.contractCode(
         new xdr.LedgerKeyContractCode({
           hash: this._id,
-          bodyType: xdr.ContractEntryBodyType.dataEntry(),
+          bodyType: xdr.ContractEntryBodyType.dataEntry()
         })
       ),
       xdr.LedgerKey.contractData(

--- a/src/contract.js
+++ b/src/contract.js
@@ -36,14 +36,12 @@ export class Contract {
     return StrKey.encodeContract(this._id);
   }
 
+  /** @returns {string} the ID as a strkey (C...) */
   toString() {
     return this.contractId();
   }
 
-  /**
-   * Returns the address of this contract as an Address type.
-   * @returns {Address}
-   */
+  /** @returns {Address} the wrapped address of this contract */
   address() {
     return Address.contract(this._id);
   }

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -41,7 +41,7 @@ describe('Contract', function () {
         new xdr.LedgerKey.contractCode(
           new xdr.LedgerKeyContractCode({
             hash: StellarBase.StrKey.decodeContract(contract.contractId()),
-            bodyType: xdr.ContractEntryBodyType.dataEntry(),
+            bodyType: xdr.ContractEntryBodyType.dataEntry()
           })
         ),
         new xdr.LedgerKey.contractData(

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -1,3 +1,5 @@
+const xdr = StellarBase.xdr;
+
 const NULL_ADDRESS = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
 
 describe('Contract', function () {
@@ -30,30 +32,36 @@ describe('Contract', function () {
   });
 
   describe('getFootprint', function () {
-    it('includes the correct contract code footprint', function () {
+    it('includes the correct contract ledger keys', function () {
       let contract = new StellarBase.Contract(NULL_ADDRESS);
       expect(contract.contractId()).to.equal(NULL_ADDRESS);
 
-      const fp = contract.getFootprint();
+      const actual = contract.getFootprint();
+      const expected = [
+        new xdr.LedgerKey.contractCode(
+          new xdr.LedgerKeyContractCode({
+            hash: StellarBase.StrKey.decodeContract(contract.contractId()),
+            bodyType: xdr.ContractEntryBodyType.dataEntry(),
+          })
+        ),
+        new xdr.LedgerKey.contractData(
+          new xdr.LedgerKeyContractData({
+            contract: contract.address().toScAddress(),
+            key: xdr.ScVal.scvLedgerKeyContractInstance(),
+            durability: xdr.ContractDataDurability.persistent(),
+            bodyType: xdr.ContractEntryBodyType.dataEntry()
+          })
+        )
+      ];
 
-      let expected = new StellarBase.xdr.LedgerKey.contractData(
-        new StellarBase.xdr.LedgerKeyContractData({
-          contract: contract.address().toScAddress(),
-          key: StellarBase.xdr.ScVal.scvLedgerKeyContractInstance(),
-          durability: StellarBase.xdr.ContractDataDurability.persistent(),
-          bodyType: StellarBase.xdr.ContractEntryBodyType.dataEntry()
-        })
-      )
-        .toXDR()
-        .toString('base64');
-      expect(fp.toXDR().toString('base64')).to.equal(expected);
+      expect(actual).to.eql(expected);
     });
   });
 
   describe('call', function () {
     let call = new StellarBase.Contract(NULL_ADDRESS).call(
       'method',
-      StellarBase.xdr.ScVal.scvU32(123)
+      xdr.ScVal.scvU32(123)
     );
     let args = call
       .body()
@@ -68,11 +76,11 @@ describe('Contract', function () {
     });
 
     it('passes the method name as the second arg', function () {
-      expect(args[1]).to.deep.equal(StellarBase.xdr.ScVal.scvSymbol('method'));
+      expect(args[1]).to.deep.equal(xdr.ScVal.scvSymbol('method'));
     });
 
     it('passes all params after that', function () {
-      expect(args[2]).to.deep.equal(StellarBase.xdr.ScVal.scvU32(123));
+      expect(args[2]).to.deep.equal(xdr.ScVal.scvU32(123));
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,10 +27,12 @@ export class Address {
 
 export class Contract {
   constructor(contractId: string);
+  call(method: string, ...params: xdr.ScVal[]): xdr.Operation<Operation.InvokeHostFunction>;
   contractId(): string;
   address(): Address;
-  call(method: string, ...params: xdr.ScVal[]): xdr.Operation<Operation.InvokeHostFunction>;
-  getFootprint(): xdr.LedgerKey;
+  getFootprint(): xdr.LedgerKey[];
+
+  toString(): string;
 }
 
 export class MuxedAccount {


### PR DESCRIPTION
Add the correct `xdr.LedgerKeyContractCode` instance to the contract's default access footprint.