### PR TITLE
Add helpers method to build authorization entries.

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -48,15 +48,6 @@ export function authorizeInvocation(
 }
 
 /**
- * An asynchronous callback to sign an input buffer.
- *
- * @async
- * @callback signingCallback
- * @param {Uint8Array} input  the raw buffer to sign
- * @returns {Uint8Array} the signature on the input buffer
- */
-
-/**
  * This works like {@link authorizeInvocation}, but allows passing an
  * asynchronous callback as a "signing method" (e.g. {@link Keypair.sign}) and a
  * public key instead of a specific {@link Keypair}.

--- a/src/auth.js
+++ b/src/auth.js
@@ -6,17 +6,25 @@ import { nativeToScVal } from './scval';
 import xdr from './xdr';
 
 /**
- * Builds an {@link xdr.SorobanAuthorizationEntry} that indicates to
+ * This builds an authorization entry that indicates to
  * {@link Operation.invokeHostFunction} that a particular identity (i.e. signing
  * {@link Keypair}) approves the execution of an invocation tree (i.e. a
  * simulation-acquired {@link xdr.SorobanAuthorizedInvocation}) on a particular
  * network (uniquely identified by its passphrase, see {@link Networks}) until a
  * particular ledger sequence is reached.
  *
- * @param {Keypair} signer  the identity authorizing this invocation tree
+ * This enables building an {@link xdr.SorobanAuthorizationEntry} without
+ * worrying about how to combine {@link buildAuthEnvelope} and
+ * {@link buildAuthEntry}, while those allow advanced, asynchronous, two-step
+ * building+signing of the authorization entries.
+ *
+ * This one lets you pass a either a {@link Keypair} or a callback function to
+ * handle signing the envelope hash.
+ *
+ * @param {Keypair} signer   the identity keypair authorizing this invocation
  * @param {string}  networkPassphrase   the network passphrase is incorprated
  *    into the signature (see {@link Networks} for options)
- * @param {number}  validUntil the (exclusive) future ledger sequence number
+ * @param {number}  validUntil  the (exclusive) future ledger sequence number
  *    until which this authorization entry should be valid (if
  *    `currentLedgerSeq==validUntil`, this is expired))
  * @param {xdr.SorobanAuthorizedInvocation} invocation the invocation tree that
@@ -31,6 +39,35 @@ export function authorizeInvocation(
   validUntil,
   invocation
 ) {
+  const preimage = buildAuthEnvelope(networkPassphrase, validUntil, invocation);
+  const input = hash(preimage.toXDR());
+  const signature = signer.sign(input);
+  return buildAuthEntry(preimage, signature, publicKey);
+}
+
+/**
+ * Builds an {@link xdr.HashIdPreimage} that, when hashed and signed, can be
+ * used to build an {@link xdr.SorobanAuthorizationEntry} via
+ * {@link buildAuthEnvelope} to approve {@link Operation.invokeHostFunction}
+ * invocations.
+ *
+ * The envelope built here will approve the execution of an invocation tree
+ * (i.e. a simulation-acquired {@link xdr.SorobanAuthorizedInvocation}) on a
+ * particular network (uniquely identified by its passphrase, see
+ * {@link Networks}) until a particular ledger sequence is reached (exclusive).
+ *
+ * @param {string}  networkPassphrase   the network passphrase is incorprated
+ *    into the signature (see {@link Networks} for options)
+ * @param {number}  validUntil the (exclusive) future ledger sequence number
+ *    until which this authorization entry should be valid
+ * @param {xdr.SorobanAuthorizedInvocation} invocation the invocation tree that
+ *    we're authorizing (likely, this comes from transaction simulation)
+ *
+ * @returns {xdr.HashIdPreimage}  a preimage envelope that, when hashed and
+ *    signed, represents the signature necessary to build a proper
+ *    {@link xdr.SorobanAuthorizationEntry} via {@link buildAuthEntry}.
+ */
+export function buildAuthEnvelope(networkPassphrase, validUntil, invocation) {
   // We use keypairs as a source of randomness for the nonce to avoid mucking
   // with any crypto dependencies. Note that this just has to be random and
   // unique, not cryptographically secure, so it's fine.
@@ -44,21 +81,57 @@ export function authorizeInvocation(
     nonce,
     signatureExpirationLedger: validUntil
   });
-  const preimage = hash(
-    xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(envelope).toXDR()
-  );
+
+  return xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(envelope);
+}
+
+/**
+ * Builds an auth entry with a signed invocation tree.
+ *
+ * You should first build the envelope using {@link buildAuthEnvelope}. If you
+ * have a signing {@link Keypair}, you can use the more convenient
+ * {@link authorizeInvocation} to do signing for you.
+ *
+ * @param {xdr.HashIdPreimage} envelope   an envelope to represent the call tree
+ *    being signed, probably built by {@link buildAuthEnvelope}
+ * @param {Buffer|Uint8Array} signature   a signature of the hash of the
+ *    envelope by the private key corresponding to `publicKey` (in other words,
+ *    `signature = sign(hash(envelope))`)
+ * @param {string} publicKey  the public identity that signed this envelope
+ *
+ * @returns {xdr.SorobanAuthorizationEntry}
+ *
+ * @throws {Error} if `verify(hash(envelope), signature, publicKey)` does not
+ *    pass, meaning one of the arguments was not passed or built correctly
+ * @throws {TypeError} if the envelope does not hold an
+ *    {@link xdr.HashIdPreimageSorobanAuthorization} instance
+ */
+export function buildAuthEntry(envelope, signature, publicKey) {
+  // ensure this identity signed this envelope correctly
+  if (!Keypair.fromPublicKey(publicKey).verify(hash(envelope), signature)) {
+    throw new Error(`signature does not match envelope or identity`);
+  }
+
+  if (
+    envelope.switch() !== xdr.EnvelopeType.envelopeTypeSorobanAuthorization()
+  ) {
+    throw new TypeError(
+      `expected sorobanAuthorization envelope, got ${envelope.switch().name}`
+    );
+  }
 
   return new xdr.SorobanAuthorizationEntry({
+    rootInvocation: invocation,
     credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
       new xdr.SorobanAddressCredentials({
-        address: new Address(signer.publicKey()).toScAddress(),
-        nonce: envelope.nonce(),
+        address: new Address(publicKey).toScAddress(),
+        nonce: envelope.sorobanAuthorization().nonce(),
         signatureExpirationLedger: envelope.signatureExpirationLedger(),
         signatureArgs: [
           nativeToScVal(
             {
-              public_key: signer.rawPublicKey(),
-              signature: signer.sign(preimage)
+              public_key: StrKey.decodeEd25519PublicKey(publicKey),
+              signature
             },
             {
               // force the keys to be interpreted as symbols (expected for
@@ -71,7 +144,6 @@ export function authorizeInvocation(
           )
         ]
       })
-    ),
-    rootInvocation: invocation
+    )
   });
 }

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,77 @@
+import { Address } from './address';
+import { Keypair } from './keypair';
+import { hash } from './signing';
+
+import { nativeToScVal } from './scval';
+import xdr from './xdr';
+
+/**
+ * Builds an {@link xdr.SorobanAuthorizationEntry} that indicates to
+ * {@link Operation.invokeHostFunction} that a particular identity (i.e. signing
+ * {@link Keypair}) approves the execution of an invocation tree (i.e. a
+ * simulation-acquired {@link xdr.SorobanAuthorizedInvocation}) on a particular
+ * network (uniquely identified by its passphrase, see {@link Networks}) until a
+ * particular ledger sequence is reached.
+ *
+ * @param {Keypair} signer  the identity authorizing this invocation tree
+ * @param {string}  networkPassphrase   the network passphrase is incorprated
+ *    into the signature (see {@link Networks} for options)
+ * @param {number}  validUntil the (exclusive) future ledger sequence number
+ *    until which this authorization entry should be valid (if
+ *    `currentLedgerSeq==validUntil`, this is expired))
+ * @param {xdr.SorobanAuthorizedInvocation} invocation the invocation tree that
+ *    we're authorizing (likely, this comes from transaction simulation)
+ *
+ * @returns {xdr.SorobanAuthorizationEntry}  an authorization entry that you can
+ *    pass along to {@link Operation.invokeHostFunction}
+ */
+export function authorizeInvocation(
+  signer,
+  networkPassphrase,
+  validUntil,
+  invocation
+) {
+  // We use keypairs as a source of randomness for the nonce to avoid mucking
+  // with any crypto dependencies. Note that this just has to be random and
+  // unique, not cryptographically secure, so it's fine.
+  const kp = Keypair.random().rawPublicKey();
+  const nonce = new xdr.Int64(...kp.buffer().subarray(0, 8));
+
+  const networkId = hash(Buffer.from(networkPassphrase));
+  const envelope = new xdr.HashIdPreimageSorobanAuthorization({
+    networkId,
+    invocation,
+    nonce,
+    signatureExpirationLedger: validUntil
+  });
+  const preimage = hash(
+    xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(envelope).toXDR()
+  );
+
+  return new xdr.SorobanAuthorizationEntry({
+    credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
+      new xdr.SorobanAddressCredentials({
+        address: new Address(signer.publicKey()).toScAddress(),
+        nonce: envelope.nonce(),
+        signatureExpirationLedger: envelope.signatureExpirationLedger(),
+        signatureArgs: [
+          nativeToScVal(
+            {
+              public_key: signer.rawPublicKey(),
+              signature: signer.sign(preimage)
+            },
+            {
+              // force the keys to be interpreted as symbols (expected for
+              // Soroban [contracttype]s)
+              type: {
+                public_key: ['symbol', null],
+                signature: ['symbol', null]
+              }
+            }
+          )
+        ]
+      })
+    ),
+    rootInvocation: invocation
+  });
+}

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,9 +1,11 @@
-import { Address } from './address';
-import { Keypair } from './keypair';
-import { hash } from './signing';
-
-import { nativeToScVal } from './scval';
 import xdr from './xdr';
+
+import { StrKey } from './strkey';
+import { Keypair } from './keypair';
+import { hash } from './hashing';
+
+import { Address } from './address';
+import { nativeToScVal } from './scval';
 
 /**
  * This builds an authorization entry that indicates to
@@ -42,7 +44,7 @@ export function authorizeInvocation(
   const preimage = buildAuthEnvelope(networkPassphrase, validUntil, invocation);
   const input = hash(preimage.toXDR());
   const signature = signer.sign(input);
-  return buildAuthEntry(preimage, signature, publicKey);
+  return buildAuthEntry(preimage, signature, signer.publicKey());
 }
 
 /**
@@ -121,7 +123,7 @@ export function buildAuthEntry(envelope, signature, publicKey) {
   }
 
   return new xdr.SorobanAuthorizationEntry({
-    rootInvocation: invocation,
+    rootInvocation: envelope.sorobanAuthorization().invocation(),
     credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
       new xdr.SorobanAddressCredentials({
         address: new Address(publicKey).toScAddress(),

--- a/src/auth.js
+++ b/src/auth.js
@@ -50,8 +50,8 @@ export function authorizeInvocation(
 /**
  * An asynchronous callback to sign an input buffer.
  *
+ * @async
  * @callback signingCallback
- *
  * @param {Uint8Array} input  the raw buffer to sign
  * @returns {Uint8Array} the signature on the input buffer
  */
@@ -67,10 +67,11 @@ export function authorizeInvocation(
  *
  * @param {string} publicKey    the public identity that is authorizing this
  *    invocation via its signature
- * @param {signingCallback} signingMethod  a function which takes a single
- *    bytearray parameter (i.e. `Uint8Array`) and returns a bytearray
- *    representing the signature of that input via the private key corresponding
- *    to the `publicKey` parameter
+ * @param {function(Buffer): Buffer} signingMethod  a function which takes
+ *    an input bytearray and returns its signature as signed by the private key
+ *    corresponding to the `publicKey` parameter
+ * @param {string}  networkPassphrase   the network passphrase is incorprated
+ *    into the signature (see {@link Networks} for options)
  * @param {number} validUntil   the (exclusive) future ledger sequence number
  *    until which this authorization entry should be valid (if
  *    `currentLedgerSeq==validUntil`, this is expired))
@@ -79,13 +80,13 @@ export function authorizeInvocation(
  *
  * @param {xdr.SorobanAuthorizedInvocation} invocation
  *
- * @returns {xdr.SorobanAuthorizationEntry}
+ * @returns {Promise<xdr.SorobanAuthorizationEntry>}
  * @see authorizeInvocation
  */
-
 export async function authorizeInvocationCallback(
   publicKey,
   signingMethod,
+  networkPassphrase,
   validUntil,
   invocation
 ) {

--- a/src/auth.js
+++ b/src/auth.js
@@ -155,5 +155,5 @@ export function buildAuthEntry(envelope, signature, publicKey) {
 
 function bytesToInt64(bytes) {
   // eslint-disable-next-line no-bitwise
-  return bytes.subarray(0, 8).reduce((accum, b) => ((accum << 8) | b), 0);
+  return bytes.subarray(0, 8).reduce((accum, b) => (accum << 8) | b, 0);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -55,5 +55,6 @@ export * from './numbers';
 export * from './scval';
 export * from './events';
 export * from './sorobandata_builder';
+export * from './auth';
 
 export default module.exports;

--- a/src/numbers/xdr_large_int.js
+++ b/src/numbers/xdr_large_int.js
@@ -18,7 +18,7 @@ import xdr from '../xdr';
  * @param {string}  type - force a specific data type. the type choices
  *    are: 'i64', 'u64', 'i128', 'u128', 'i256', and 'u256' (default: the
  *    smallest one that fits the `value`)
- * @param {number|bigint|string|ScInt|Array<number|bigint|string|ScInt>} values
+ * @param {number|bigint|string|XdrLargeInt|ScInt|Array<number|bigint|string|XdrLargeInt|ScInt>} values
  *    - a list of integer-like values interpreted in big-endian order
  */
 export class XdrLargeInt {

--- a/test/unit/auth_test.js
+++ b/test/unit/auth_test.js
@@ -27,8 +27,8 @@ describe('building authorization entries', function () {
       invocation
     );
 
-    const cred = entry.credentials().address();
-    const args = cred.signatureArgs().map((v) => StellarBase.scValToNative(v));
+    let cred = entry.credentials().address();
+    let args = cred.signatureArgs().map((v) => StellarBase.scValToNative(v));
 
     expect(cred.signatureExpirationLedger()).to.equal(123);
     expect(args.length).to.equal(1);
@@ -36,6 +36,8 @@ describe('building authorization entries', function () {
       StellarBase.StrKey.encodeEd25519PublicKey(args[0]['public_key'])
     ).to.equal(kp.publicKey());
     expect(entry.rootInvocation()).to.eql(invocation);
+
+    // TODO: Validate the signature using the XDR structure.
 
     const nextEntry = StellarBase.authorizeInvocation(
       kp,
@@ -46,5 +48,24 @@ describe('building authorization entries', function () {
     const nextCred = nextEntry.credentials().address();
 
     expect(cred.nonce()).to.not.equal(nextCred.nonce());
+
+    const thirdEntry = StellarBase.authorizeInvocationCallback(
+      (input) => { return kp.sign(input); },
+      kp.publicKey(),
+      StellarBase.Networks.FUTURENET,
+      123,
+      invocation,
+    );
+
+    cred = thirdEntry.credentials().address();
+    args = cred.signatureArgs().map((v) => StellarBase.scValToNative(v));
+
+    expect(cred.signatureExpirationLedger()).to.equal(123);
+    expect(args.length).to.equal(1);
+    expect(
+      StellarBase.StrKey.encodeEd25519PublicKey(args[0]['public_key'])
+    ).to.equal(kp.publicKey());
+    expect(entry.rootInvocation()).to.eql(invocation);
+
   });
 });

--- a/test/unit/auth_test.js
+++ b/test/unit/auth_test.js
@@ -1,0 +1,50 @@
+const xdr = StellarBase.xdr;
+
+describe('building authorization entries', function () {
+  const contractId = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+  const kp = StellarBase.Keypair.random();
+  const invocation = new xdr.SorobanAuthorizedInvocation({
+    function:
+      xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+        new xdr.SorobanAuthorizedContractFunction({
+          contractAddress: new StellarBase.Address(contractId).toScAddress(),
+          functionName: 'hello',
+          args: [StellarBase.nativeToScVal('world!')]
+        })
+      ),
+    subInvocations: []
+  });
+
+  it('built an mock invocation correctly', function () {
+    invocation.toXDR();
+  });
+
+  it('works with keypairs', function () {
+    const entry = StellarBase.authorizeInvocation(
+      kp,
+      StellarBase.Networks.FUTURENET,
+      123,
+      invocation
+    );
+
+    const cred = entry.credentials().address();
+    const args = cred.signatureArgs().map((v) => StellarBase.scValToNative(v));
+
+    expect(cred.signatureExpirationLedger()).to.equal(123);
+    expect(args.length).to.equal(1);
+    expect(
+      StellarBase.StrKey.encodeEd25519PublicKey(args[0]['public_key'])
+    ).to.equal(kp.publicKey());
+    expect(entry.rootInvocation()).to.eql(invocation);
+
+    const nextEntry = StellarBase.authorizeInvocation(
+      kp,
+      StellarBase.Networks.FUTURENET,
+      123,
+      invocation
+    );
+    const nextCred = nextEntry.credentials().address();
+
+    expect(cred.nonce()).to.not.equal(nextCred.nonce());
+  });
+});

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -1,4 +1,4 @@
-const NULL_ADDRESS = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM'
+const NULL_ADDRESS = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
 
 describe('Contract', function () {
   describe('constructor', function () {
@@ -13,7 +13,7 @@ describe('Contract', function () {
       expect(() => {
         new StellarBase.Contract('0'.repeat(63) + '1');
       }).to.throw();
-    })
+    });
 
     it('throws on invalid ids', function () {
       expect(() => {
@@ -25,9 +25,7 @@ describe('Contract', function () {
   describe('address', function () {
     it('returns the contract address', function () {
       let contract = new StellarBase.Contract(NULL_ADDRESS);
-      expect(contract.address().toString()).to.equal(
-        NULL_ADDRESS
-      );
+      expect(contract.address().toString()).to.equal(NULL_ADDRESS);
     });
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1132,7 +1132,7 @@ export function humanizeEvents(
 ): SorobanEvent[];
 
 export class SorobanDataBuilder {
-  constructor(data?: string | xdr.SorobanTransactionData | null);
+  constructor(data?: string | xdr.SorobanTransactionData);
 
   setRefundableFee(fee: IntLike): SorobanDataBuilder;
   setResources(
@@ -1152,3 +1152,10 @@ export class SorobanDataBuilder {
 
   build(): xdr.SorobanTransactionData;
 }
+
+export function authorizeInvocation(
+  signer: Keypair,
+  networkPassphrase: string,
+  validUntil: number,
+  invocation: xdr.SorobanAuthorizedInvocation
+): xdr.SorobanAuthorizationEntry;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1159,3 +1159,15 @@ export function authorizeInvocation(
   validUntil: number,
   invocation: xdr.SorobanAuthorizedInvocation
 ): xdr.SorobanAuthorizationEntry;
+
+export function buildAuthEnvelope(
+  networkPassphrase: string,
+  validUntil: number,
+  invocation: xdr.SorobanAuthorizedInvocation
+): xdr.HashIdPreimage;
+
+export function buildAuthEntry(
+  envelope: xdr.HashIdPreimage,
+  signature: Buffer | Uint8Array,
+  publicKey: string
+): xdr.SorobanAuthorizationEntry;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1161,8 +1161,8 @@ export function authorizeInvocation(
 ): xdr.SorobanAuthorizationEntry;
 
 export function authorizeInvocationCallback(
-  signingMethod: (input: Uint8Array) => Uint8Array,
   publicKey: string,
+  signingMethod: (input: Buffer) => Buffer,
   networkPassphrase: string,
   validUntil: number,
   invocation: xdr.SorobanAuthorizedInvocation

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1160,6 +1160,14 @@ export function authorizeInvocation(
   invocation: xdr.SorobanAuthorizedInvocation
 ): xdr.SorobanAuthorizationEntry;
 
+export function authorizeInvocationCallback(
+  signingMethod: (input: Uint8Array) => Uint8Array,
+  publicKey: string,
+  networkPassphrase: string,
+  validUntil: number,
+  invocation: xdr.SorobanAuthorizedInvocation
+): xdr.SorobanAuthorizationEntry;
+
 export function buildAuthEnvelope(
   networkPassphrase: string,
   validUntil: number,


### PR DESCRIPTION
Replaces #632 in an attempt to tackle #575. This adds three helpers (see the jsdocs for details):

```typescript
function authorizeInvocation(
  signer: Keypair,
  networkPassphrase: string,
  validUntil: number,
  invocation: xdr.SorobanAuthorizedInvocation
): xdr.SorobanAuthorizationEntry;

function buildAuthEnvelope(
  networkPassphrase: string,
  validUntil: number,
  invocation: xdr.SorobanAuthorizedInvocation
): xdr.HashIdPreimage;

function buildAuthEntry(
  envelope: xdr.HashIdPreimage,
  signature: Buffer | Uint8Array,
  publicKey: string
): xdr.SorobanAuthorizationEntry;
```