### PR TITLE
add 'formatTokenAmount' and 'parseTokenAmount'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,48 +1,49 @@
 /* eslint-disable import/no-import-module-exports */
-import BigNumber from 'bignumber.js';
-import xdr from './xdr';
+import BigNumber from "bignumber.js";
+import xdr from "./xdr";
 
 BigNumber.DEBUG = true; // gives us exceptions on bad constructor values
 
 export { xdr };
-export { hash } from './hashing';
-export { sign, verify, FastSigning } from './signing';
+export { hash } from "./hashing";
+export { sign, verify, FastSigning } from "./signing";
 export {
   getLiquidityPoolId,
-  LiquidityPoolFeeV18
-} from './get_liquidity_pool_id';
-export { Keypair } from './keypair';
-export { UnsignedHyper, Hyper } from 'js-xdr';
-export { TransactionBase } from './transaction_base';
-export { Transaction } from './transaction';
-export { FeeBumpTransaction } from './fee_bump_transaction';
+  LiquidityPoolFeeV18,
+} from "./get_liquidity_pool_id";
+export { Keypair } from "./keypair";
+export { UnsignedHyper, Hyper } from "js-xdr";
+export { TransactionBase } from "./transaction_base";
+export { Transaction } from "./transaction";
+export { FeeBumpTransaction } from "./fee_bump_transaction";
 export {
   TransactionBuilder,
   TimeoutInfinite,
-  BASE_FEE
-} from './transaction_builder';
-export { Asset } from './asset';
-export { LiquidityPoolAsset } from './liquidity_pool_asset';
-export { LiquidityPoolId } from './liquidity_pool_id';
+  BASE_FEE,
+} from "./transaction_builder";
+export { Asset } from "./asset";
+export { LiquidityPoolAsset } from "./liquidity_pool_asset";
+export { LiquidityPoolId } from "./liquidity_pool_id";
 export {
   Operation,
   AuthRequiredFlag,
   AuthRevocableFlag,
   AuthImmutableFlag,
-  AuthClawbackEnabledFlag
-} from './operation';
-export * from './memo';
-export { Account } from './account';
-export { MuxedAccount } from './muxed_account';
-export { Claimant } from './claimant';
-export { Networks } from './network';
-export { StrKey } from './strkey';
-export { SignerKey } from './signerkey';
+  AuthClawbackEnabledFlag,
+} from "./operation";
+export * from "./memo";
+export { Account } from "./account";
+export { MuxedAccount } from "./muxed_account";
+export { Claimant } from "./claimant";
+export { Networks } from "./network";
+export { StrKey } from "./strkey";
+export { SignerKey } from "./signerkey";
+export { Soroban } from "./soroban";
 export {
   decodeAddressToMuxedAccount,
   encodeMuxedAccountToAddress,
   extractBaseAddress,
-  encodeMuxedAccount
-} from './util/decode_encode_muxed_account';
+  encodeMuxedAccount,
+} from "./util/decode_encode_muxed_account";
 
 export default module.exports;

--- a/src/soroban.js
+++ b/src/soroban.js
@@ -1,0 +1,74 @@
+import BigNumber from "bignumber.js";
+
+/**
+ * Soroban helper class
+ * formatting, parsing, and etc
+ * @class Soroban
+ */
+export class Soroban {
+  /**
+   * format token amount to its ideal specific number of decimals
+   *
+   * @param {BigNumber} amount - the token amount you want to display
+   * @param {number} decimals
+   * @returns {string}
+   */
+  static formatTokenAmount(amount, decimals) {
+    let formatted = amount.toString();
+
+    if (decimals > 0) {
+      formatted = amount.shiftedBy(-decimals).toFixed(decimals).toString();
+
+      // Trim trailing zeros
+      while (formatted[formatted.length - 1] === "0") {
+        formatted = formatted.substring(0, formatted.length - 1);
+      }
+
+      if (formatted.endsWith(".")) {
+        formatted = formatted.substring(0, formatted.length - 1);
+      }
+    }
+
+    return formatted;
+  }
+
+  /**
+   * parse token amount to use it on smart contract
+   *
+   * @param {string} value - the token amount you want to use it on smart contract
+   * @param {number} decimals
+   * @returns {string}
+   */
+  static parseTokenAmount(value, decimals) {
+    const comps = value.split(".");
+
+    let whole = comps[0];
+    let fraction = comps[1];
+    if (!whole) {
+      whole = "0";
+    }
+    if (!fraction) {
+      fraction = "0";
+    }
+
+    // Trim trailing zeros
+    while (fraction[fraction.length - 1] === "0") {
+      fraction = fraction.substring(0, fraction.length - 1);
+    }
+
+    // If decimals is 0, we have an empty string for fraction
+    if (fraction === "") {
+      fraction = "0";
+    }
+
+    // Fully pad the string with zeros to get to value
+    while (fraction.length < decimals) {
+      fraction += "0";
+    }
+
+    const wholeValue = new BigNumber(whole);
+    const fractionValue = new BigNumber(fraction);
+
+    return wholeValue.shiftedBy(decimals).plus(fractionValue);
+  }
+}

--- a/test/unit/soroban_test.js
+++ b/test/unit/soroban_test.js
@@ -1,0 +1,38 @@
+import BigNumber from "bignumber.js";
+
+describe("Soroban", function () {
+  describe("formatTokenAmount", function () {
+    it("returns '100.0000001' for '1000000001' of a token set to 7 decimals", function () {
+      const amount = new BigNumber(1000000001);
+
+      expect(StellarBase.Soroban.formatTokenAmount(amount, 7)).to.equal(
+        "100.0000001",
+      );
+    });
+
+    it("returns '100000.0001' for '10000000010' of a token set to 5 decimals", function () {
+      const amount = new BigNumber(10000000010);
+
+      expect(StellarBase.Soroban.formatTokenAmount(amount, 5)).to.equal(
+        "100000.0001",
+      );
+    });
+
+    it("returns '10000.00001' for '1000000001.'.' of a token set to 5 decimals", function () {
+      const amount = new BigNumber("1000000001.");
+
+      expect(StellarBase.Soroban.formatTokenAmount(amount, 5)).to.equal(
+        "10000.00001",
+      );
+    });
+  });
+
+  describe("parseTokenAmount", function () {
+    it("returns '10000' for '100' of a token set to 2 decimals", function () {
+      const amount = "100";
+      const parsedAmount = StellarBase.Soroban.parseTokenAmount(amount, 2);
+
+      expect(parsedAmount.toNumber()).to.equal(10000);
+    });
+  });
+});


### PR DESCRIPTION
**Summary:** 
- adding soroban token display formatter and parser from 
- moving the commonly used functions [parseTokenAmount](https://github.com/stellar/soroban-react-payment/blob/904ecebbccb0ec05587999117e28f46bf0b9c0db/src/helpers/soroban.ts#L58) and [formatTokenAmount](https://github.com/stellar/soroban-react-payment/blob/904ecebbccb0ec05587999117e28f46bf0b9c0db/src/helpers/format.ts#L27) from `soroban-react-payment`