### PR TITLE
Add ability to clear out operations from the transaction builder

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -228,6 +228,12 @@ export class TransactionBuilder {
     return this;
   }
 
+  /** Removes the operations from the builder (useful when cloning). */
+  clearOperations() {
+    this.operations = [];
+    return this;
+  }
+
   /**
    * Adds a memo to the transaction.
    * @param {Memo} memo {@link Memo} object

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -947,6 +947,11 @@ describe('TransactionBuilder', function () {
         fee: '10000'
       }).build();
       expect(cloneTx.fee).to.equal('20000'); // double because two ops
+
+      cloneTx = StellarBase.TransactionBuilder.cloneFrom(tx)
+        .clearOperations()
+        .build();
+      expect(cloneTx.operations).to.be.empty;
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1017,6 +1017,7 @@ export class TransactionBuilder {
     options?: TransactionBuilder.TransactionBuilderOptions
   );
   addOperation(operation: xdr.Operation): this;
+  clearOperations(): this;
   addMemo(memo: Memo): this;
   setTimeout(timeoutInSeconds: number): this;
   setTimebounds(min: Date | number, max: Date | number): this;


### PR DESCRIPTION
This suggestion comes from @sreuland after #656 to clear out operations from a builder to allow them to be built separately. This is particularly key for Soroban operations in configuring auth.