### PR TITLE
Auth Entry helpers - Adds arg for passing credential address nonce

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -46,7 +46,7 @@ export function authorizeInvocation(
   const preimage = buildAuthEnvelope(networkPassphrase, validUntil, invocation, credentialAddressNonce);
   const input = hash(preimage.toXDR());
   const signature = signer.sign(input);
-  return buildAuthEntry(preimage, signature, signer.publicKey(), credentialAddressNonce);
+  return buildAuthEntry(preimage, signature, signer.publicKey());
 }
 
 /**
@@ -86,7 +86,7 @@ export async function authorizeInvocationCallback(
   const preimage = buildAuthEnvelope(networkPassphrase, validUntil, invocation, credentialAddressNonce);
   const input = hash(preimage.toXDR());
   const signature = await signingMethod(input);
-  return buildAuthEntry(preimage, signature, publicKey, credentialAddressNonce);
+  return buildAuthEntry(preimage, signature, publicKey);
 }
 
 /**
@@ -137,7 +137,6 @@ export function buildAuthEnvelope(networkPassphrase, validUntil, invocation, cre
  *    envelope by the private key corresponding to `publicKey` (in other words,
  *    `signature = sign(hash(envelope))`)
  * @param {string} publicKey  the public identity that signed this envelope
- * @param {string} credentialAddressNonce  the nonce from the corresponding credential address
  *
  * @returns {xdr.SorobanAuthorizationEntry}
  *
@@ -146,7 +145,7 @@ export function buildAuthEnvelope(networkPassphrase, validUntil, invocation, cre
  * @throws {TypeError} if the envelope does not hold an
  *    {@link xdr.HashIdPreimageSorobanAuthorization} instance
  */
-export function buildAuthEntry(envelope, signature, publicKey, credentialAddressNonce) {
+export function buildAuthEntry(envelope, signature, publicKey) {
   // ensure this identity signed this envelope correctly
   if (
     !Keypair.fromPublicKey(publicKey).verify(hash(envelope.toXDR()), signature)
@@ -168,7 +167,7 @@ export function buildAuthEntry(envelope, signature, publicKey, credentialAddress
     credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
       new xdr.SorobanAddressCredentials({
         address: new Address(publicKey).toScAddress(),
-        nonce: credentialAddressNonce,
+        nonce: auth.nonce(),
         signatureExpirationLedger: auth.signatureExpirationLedger(),
         signatureArgs: [
           nativeToScVal(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1162,25 +1162,29 @@ export function authorizeInvocation(
   signer: Keypair,
   networkPassphrase: string,
   validUntil: number,
-  invocation: xdr.SorobanAuthorizedInvocation
+  invocation: xdr.SorobanAuthorizedInvocation,
+  credentialAddressNonce: xdr.Int64
 ): xdr.SorobanAuthorizationEntry;
 
 export function authorizeInvocationCallback(
   publicKey: string,
-  signingMethod: (input: Buffer) => Buffer,
+  signingMethod: (input: Buffer) => Promise<Buffer>,
   networkPassphrase: string,
   validUntil: number,
-  invocation: xdr.SorobanAuthorizedInvocation
+  invocation: xdr.SorobanAuthorizedInvocation,
+  credentialAddressNonce: xdr.Int64
 ): xdr.SorobanAuthorizationEntry;
 
 export function buildAuthEnvelope(
   networkPassphrase: string,
   validUntil: number,
-  invocation: xdr.SorobanAuthorizedInvocation
+  invocation: xdr.SorobanAuthorizedInvocation,
+  credentialAddressNonce: xdr.Int64
 ): xdr.HashIdPreimage;
 
 export function buildAuthEntry(
   envelope: xdr.HashIdPreimage,
   signature: Buffer | Uint8Array,
-  publicKey: string
+  publicKey: string,
+  credentialAddressNonce: xdr.Int64
 ): xdr.SorobanAuthorizationEntry;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1185,6 +1185,5 @@ export function buildAuthEnvelope(
 export function buildAuthEntry(
   envelope: xdr.HashIdPreimage,
   signature: Buffer | Uint8Array,
-  publicKey: string,
-  credentialAddressNonce: xdr.Int64
+  publicKey: string
 ): xdr.SorobanAuthorizationEntry;


### PR DESCRIPTION
After trying to use the new helpers in [this branch of the swap dapp](https://github.com/stellar/soroban-react-atomic-swap/compare/feature/soroban-sdk-v0.10.0?expand=1#). I found that the nonce required in both `buildAuthEntry` and `buildAuthEnvelope` should be the nonce from the original auth entries credential address,[ like you see here](https://github.com/stellar/soroban-react-atomic-swap/blob/main/src/helpers/soroban.ts#L217).

This adds `credentialAddressNonce` to all of the helpers, updates tests/types.
Fixes the return type for `authorizeInvocationCallback` signing method arg, Buffer -> Promise<<Buffer>>.