### PR TITLE
fixed lint warn on jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "10.0.0-soroban.6",
+  "version": "10.0.0-soroban.7",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
   "browser": {

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -228,7 +228,10 @@ export class TransactionBuilder {
     return this;
   }
 
-  /** Removes the operations from the builder (useful when cloning). */
+  /** Removes the operations from the builder (useful when cloning). 
+   * 
+   * @returns {TransactionBuilder}
+   */ 
   clearOperations() {
     this.operations = [];
     return this;


### PR DESCRIPTION
noticed the npm publish step was failing on prior commits to `soroban` due to a lint warning:

[build: src/transaction_builder.js#L231](https://github.com/stellar/js-stellar-base/commit/6d3a5d5958830673fea6ba8a007bcc9a8857be3a#annotation_13300108768)
Missing JSDoc @returns for function

and increased base's version to `10.0.0-soroban.7` as the `soroban` branch has been updated with latest interim xdr updates, and this will enable getting npm published?