### PR TITLE
Re-generates the current Futurenet XDR with latest xdrgen commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ XDR_FILES_NEXT= \
 	Stellar-contract-config-setting.x
 XDR_FILES_LOCAL_NEXT=$(addprefix xdr/next/,$(XDR_FILES_NEXT))
 
-XDRGEN_COMMIT=8d303b1
+XDRGEN_COMMIT=master
 DTSXDR_COMMIT=master
 
 all: generate
@@ -58,7 +58,6 @@ types/curr.d.ts: src/generated/curr_generated.js
 		yarn install --network-concurrency 1 && \
 		OUT=/wd/$@ npx jscodeshift -t src/transform.js /wd/$< && \
 		cd /wd && \
-		yarn run prettier --write /wd/$@ \
 		'
 
 types/next.d.ts: src/generated/next_generated.js
@@ -69,7 +68,6 @@ types/next.d.ts: src/generated/next_generated.js
 		yarn install --network-concurrency 1 && \
 		OUT=/wd/$@ npx jscodeshift -t src/transform.js /wd/$< && \
 		cd /wd && \
-		yarn run prettier --write /wd/$@ \
 		'
 
 clean:
@@ -77,11 +75,11 @@ clean:
 
 $(XDR_FILES_LOCAL_CURR):
 	mkdir -p $(dir $@)
-	curl -L -o $@ $(XDR_BASE_URL_CURR)/$(notdir $@)
+	curl -s -L -o $@ $(XDR_BASE_URL_CURR)/$(notdir $@)
 
 $(XDR_FILES_LOCAL_NEXT):
 	mkdir -p $(dir $@)
-	curl -L -o $@ $(XDR_BASE_URL_NEXT)/$(notdir $@)
+	curl -s -L -o $@ $(XDR_BASE_URL_NEXT)/$(notdir $@)
 
 reset-xdr:
 	rm -f xdr/*/*.x
@@ -89,3 +87,6 @@ reset-xdr:
 	rm -f types/curr.d.ts
 	rm -f types/next.d.ts
 	$(MAKE) generate
+	yarn run prettier --config config/prettier.config.json --write \
+		types/{curr,next}.d.ts \
+		src/generated/*.js

--- a/config/prettier.config.js
+++ b/config/prettier.config.js
@@ -5,9 +5,9 @@ module.exports = {
   printWidth: 80,
   proseWrap: 'always',
   semi: true,
-  singleQuote: true,
+  singleQuote: false,
   tabWidth: 2,
   parser: 'babel',
-  trailingComma: 'none',
+  trailingComma: 'es5',
   useTabs: false
 };

--- a/config/prettier.config.js
+++ b/config/prettier.config.js
@@ -5,9 +5,9 @@ module.exports = {
   printWidth: 80,
   proseWrap: 'always',
   semi: true,
-  singleQuote: false,
+  singleQuote: true,
   tabWidth: 2,
   parser: 'babel',
-  trailingComma: 'es5',
+  trailingComma: 'none',
   useTabs: false
 };

--- a/src/generated/next_generated.js
+++ b/src/generated/next_generated.js
@@ -598,8 +598,8 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, xdr.void()],
-      [3, "v3"],
+      ["_0", xdr.void()],
+      ["_3", "v3"],
     ],
     arms: {
       v3: xdr.lookup("AccountEntryExtensionV3"),
@@ -653,8 +653,8 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, xdr.void()],
-      [2, "v2"],
+      ["_0", xdr.void()],
+      ["_2", "v2"],
     ],
     arms: {
       v2: xdr.lookup("AccountEntryExtensionV2"),
@@ -698,8 +698,8 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, xdr.void()],
-      [1, "v1"],
+      ["_0", xdr.void()],
+      ["_1", "v1"],
     ],
     arms: {
       v1: xdr.lookup("AccountEntryExtensionV1"),
@@ -853,7 +853,7 @@ var types = XDR.config((xdr) => {
   xdr.union("TrustLineEntryExtensionV2Ext", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -892,8 +892,8 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, xdr.void()],
-      [2, "v2"],
+      ["_0", xdr.void()],
+      ["_2", "v2"],
     ],
     arms: {
       v2: xdr.lookup("TrustLineEntryExtensionV2"),
@@ -949,8 +949,8 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, xdr.void()],
-      [1, "v1"],
+      ["_0", xdr.void()],
+      ["_1", "v1"],
     ],
     arms: {
       v1: xdr.lookup("TrustLineEntryV1"),
@@ -1035,7 +1035,7 @@ var types = XDR.config((xdr) => {
   xdr.union("OfferEntryExt", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -1090,7 +1090,7 @@ var types = XDR.config((xdr) => {
   xdr.union("DataEntryExt", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -1292,7 +1292,7 @@ var types = XDR.config((xdr) => {
   xdr.union("ClaimableBalanceEntryExtensionV1Ext", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -1331,8 +1331,8 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, xdr.void()],
-      [1, "v1"],
+      ["_0", xdr.void()],
+      ["_1", "v1"],
     ],
     arms: {
       v1: xdr.lookup("ClaimableBalanceEntryExtensionV1"),
@@ -1647,7 +1647,7 @@ var types = XDR.config((xdr) => {
   xdr.union("LedgerEntryExtensionV1Ext", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -1738,8 +1738,8 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, xdr.void()],
-      [1, "v1"],
+      ["_0", xdr.void()],
+      ["_1", "v1"],
     ],
     arms: {
       v1: xdr.lookup("LedgerEntryExtensionV1"),
@@ -2100,9 +2100,9 @@ var types = XDR.config((xdr) => {
   //       TimePoint closeTime; // network close time
   //
   //       // upgrades to apply to the previous ledger (usually empty)
-  //       // this is a vector of encoded "LedgerUpgrade" so that nodes can drop
+  //       // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
   //       // unknown steps during consensus if needed.
-  //       // see notes below on "LedgerUpgrade" for more detail
+  //       // see notes below on 'LedgerUpgrade' for more detail
   //       // max size is dictated by number of upgrade types (+ room for future)
   //       UpgradeType upgrades<6>;
   //
@@ -2168,7 +2168,7 @@ var types = XDR.config((xdr) => {
   xdr.union("LedgerHeaderExtensionV1Ext", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -2207,8 +2207,8 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, xdr.void()],
-      [1, "v1"],
+      ["_0", xdr.void()],
+      ["_1", "v1"],
     ],
     arms: {
       v1: xdr.lookup("LedgerHeaderExtensionV1"),
@@ -2397,7 +2397,7 @@ var types = XDR.config((xdr) => {
   xdr.union("BucketMetadataExt", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -2516,7 +2516,7 @@ var types = XDR.config((xdr) => {
   xdr.union("TransactionPhase", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, "v0Components"]],
+    switches: [["_0", "v0Components"]],
     arms: {
       v0Components: xdr.varArray(xdr.lookup("TxSetComponent"), 2147483647),
     },
@@ -2563,7 +2563,7 @@ var types = XDR.config((xdr) => {
   xdr.union("GeneralizedTransactionSet", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[1, "v1TxSet"]],
+    switches: [["_1", "v1TxSet"]],
     arms: {
       v1TxSet: xdr.lookup("TransactionSetV1"),
     },
@@ -2610,8 +2610,8 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, xdr.void()],
-      [1, "generalizedTxSet"],
+      ["_0", xdr.void()],
+      ["_1", "generalizedTxSet"],
     ],
     arms: {
       generalizedTxSet: xdr.lookup("GeneralizedTransactionSet"),
@@ -2655,7 +2655,7 @@ var types = XDR.config((xdr) => {
   xdr.union("TransactionHistoryResultEntryExt", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -2694,7 +2694,7 @@ var types = XDR.config((xdr) => {
   xdr.union("LedgerHeaderHistoryEntryExt", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -2761,7 +2761,7 @@ var types = XDR.config((xdr) => {
   xdr.union("ScpHistoryEntry", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, "v0"]],
+    switches: [["_0", "v0"]],
     arms: {
       v0: xdr.lookup("ScpHistoryEntryV0"),
     },
@@ -2915,7 +2915,7 @@ var types = XDR.config((xdr) => {
   xdr.union("ContractEventBody", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, "v0"]],
+    switches: [["_0", "v0"]],
     arms: {
       v0: xdr.lookup("ContractEventV0"),
     },
@@ -3050,10 +3050,10 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, "operations"],
-      [1, "v1"],
-      [2, "v2"],
-      [3, "v3"],
+      ["_0", "operations"],
+      ["_1", "v1"],
+      ["_2", "v2"],
+      ["_3", "v3"],
     ],
     arms: {
       operations: xdr.varArray(xdr.lookup("OperationMeta"), 2147483647),
@@ -3240,9 +3240,9 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, "v0"],
-      [1, "v1"],
-      [2, "v2"],
+      ["_0", "v0"],
+      ["_1", "v1"],
+      ["_2", "v2"],
     ],
     arms: {
       v0: xdr.lookup("LedgerCloseMetaV0"),
@@ -3911,7 +3911,7 @@ var types = XDR.config((xdr) => {
   xdr.union("AuthenticatedMessage", {
     switchOn: xdr.lookup("Uint32"),
     switchName: "v",
-    switches: [[0, "v0"]],
+    switches: [["_0", "v0"]],
     arms: {
       v0: xdr.lookup("AuthenticatedMessageV0"),
     },
@@ -5384,7 +5384,7 @@ var types = XDR.config((xdr) => {
   xdr.union("TransactionV0Ext", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -5451,8 +5451,8 @@ var types = XDR.config((xdr) => {
     switchOn: xdr.int(),
     switchName: "v",
     switches: [
-      [0, xdr.void()],
-      [1, "sorobanData"],
+      ["_0", xdr.void()],
+      ["_1", "sorobanData"],
     ],
     arms: {
       sorobanData: xdr.lookup("SorobanTransactionData"),
@@ -5550,7 +5550,7 @@ var types = XDR.config((xdr) => {
   xdr.union("FeeBumpTransactionExt", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -7836,7 +7836,7 @@ var types = XDR.config((xdr) => {
   xdr.union("InnerTransactionResultExt", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -7975,7 +7975,7 @@ var types = XDR.config((xdr) => {
   xdr.union("TransactionResultExt", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 
@@ -8097,7 +8097,7 @@ var types = XDR.config((xdr) => {
   xdr.union("ExtensionPoint", {
     switchOn: xdr.int(),
     switchName: "v",
-    switches: [[0, xdr.void()]],
+    switches: [["_0", xdr.void()]],
     arms: {},
   });
 

--- a/types/next.d.ts
+++ b/types/next.d.ts
@@ -1,4 +1,4 @@
-// Automatically generated on 2023-08-10T13:29:00-08:00
+// Automatically generated on 2023-08-16T14:23:00-08:00
 import { Operation } from './index';
 
 export {};
@@ -9340,9 +9340,9 @@ export namespace xdr {
 
     v3(value?: AccountEntryExtensionV3): AccountEntryExtensionV3;
 
-    static 0(): AccountEntryExtensionV2Ext;
+    static _0(): AccountEntryExtensionV2Ext;
 
-    static 3(value: AccountEntryExtensionV3): AccountEntryExtensionV2Ext;
+    static _3(value: AccountEntryExtensionV3): AccountEntryExtensionV2Ext;
 
     value(): AccountEntryExtensionV3 | void;
 
@@ -9375,9 +9375,9 @@ export namespace xdr {
 
     v2(value?: AccountEntryExtensionV2): AccountEntryExtensionV2;
 
-    static 0(): AccountEntryExtensionV1Ext;
+    static _0(): AccountEntryExtensionV1Ext;
 
-    static 2(value: AccountEntryExtensionV2): AccountEntryExtensionV1Ext;
+    static _2(value: AccountEntryExtensionV2): AccountEntryExtensionV1Ext;
 
     value(): AccountEntryExtensionV2 | void;
 
@@ -9410,9 +9410,9 @@ export namespace xdr {
 
     v1(value?: AccountEntryExtensionV1): AccountEntryExtensionV1;
 
-    static 0(): AccountEntryExt;
+    static _0(): AccountEntryExt;
 
-    static 1(value: AccountEntryExtensionV1): AccountEntryExt;
+    static _1(value: AccountEntryExtensionV1): AccountEntryExt;
 
     value(): AccountEntryExtensionV1 | void;
 
@@ -9480,7 +9480,7 @@ export namespace xdr {
   class TrustLineEntryExtensionV2Ext {
     switch(): number;
 
-    static 0(): TrustLineEntryExtensionV2Ext;
+    static _0(): TrustLineEntryExtensionV2Ext;
 
     value(): void;
 
@@ -9513,9 +9513,9 @@ export namespace xdr {
 
     v2(value?: TrustLineEntryExtensionV2): TrustLineEntryExtensionV2;
 
-    static 0(): TrustLineEntryV1Ext;
+    static _0(): TrustLineEntryV1Ext;
 
-    static 2(value: TrustLineEntryExtensionV2): TrustLineEntryV1Ext;
+    static _2(value: TrustLineEntryExtensionV2): TrustLineEntryV1Ext;
 
     value(): TrustLineEntryExtensionV2 | void;
 
@@ -9548,9 +9548,9 @@ export namespace xdr {
 
     v1(value?: TrustLineEntryV1): TrustLineEntryV1;
 
-    static 0(): TrustLineEntryExt;
+    static _0(): TrustLineEntryExt;
 
-    static 1(value: TrustLineEntryV1): TrustLineEntryExt;
+    static _1(value: TrustLineEntryV1): TrustLineEntryExt;
 
     value(): TrustLineEntryV1 | void;
 
@@ -9578,7 +9578,7 @@ export namespace xdr {
   class OfferEntryExt {
     switch(): number;
 
-    static 0(): OfferEntryExt;
+    static _0(): OfferEntryExt;
 
     value(): void;
 
@@ -9606,7 +9606,7 @@ export namespace xdr {
   class DataEntryExt {
     switch(): number;
 
-    static 0(): DataEntryExt;
+    static _0(): DataEntryExt;
 
     value(): void;
 
@@ -9749,7 +9749,7 @@ export namespace xdr {
   class ClaimableBalanceEntryExtensionV1Ext {
     switch(): number;
 
-    static 0(): ClaimableBalanceEntryExtensionV1Ext;
+    static _0(): ClaimableBalanceEntryExtensionV1Ext;
 
     value(): void;
 
@@ -9787,9 +9787,11 @@ export namespace xdr {
       value?: ClaimableBalanceEntryExtensionV1,
     ): ClaimableBalanceEntryExtensionV1;
 
-    static 0(): ClaimableBalanceEntryExt;
+    static _0(): ClaimableBalanceEntryExt;
 
-    static 1(value: ClaimableBalanceEntryExtensionV1): ClaimableBalanceEntryExt;
+    static _1(
+      value: ClaimableBalanceEntryExtensionV1,
+    ): ClaimableBalanceEntryExt;
 
     value(): ClaimableBalanceEntryExtensionV1 | void;
 
@@ -9927,7 +9929,7 @@ export namespace xdr {
   class LedgerEntryExtensionV1Ext {
     switch(): number;
 
-    static 0(): LedgerEntryExtensionV1Ext;
+    static _0(): LedgerEntryExtensionV1Ext;
 
     value(): void;
 
@@ -10031,9 +10033,9 @@ export namespace xdr {
 
     v1(value?: LedgerEntryExtensionV1): LedgerEntryExtensionV1;
 
-    static 0(): LedgerEntryExt;
+    static _0(): LedgerEntryExt;
 
-    static 1(value: LedgerEntryExtensionV1): LedgerEntryExt;
+    static _1(value: LedgerEntryExtensionV1): LedgerEntryExt;
 
     value(): LedgerEntryExtensionV1 | void;
 
@@ -10170,7 +10172,7 @@ export namespace xdr {
   class LedgerHeaderExtensionV1Ext {
     switch(): number;
 
-    static 0(): LedgerHeaderExtensionV1Ext;
+    static _0(): LedgerHeaderExtensionV1Ext;
 
     value(): void;
 
@@ -10203,9 +10205,9 @@ export namespace xdr {
 
     v1(value?: LedgerHeaderExtensionV1): LedgerHeaderExtensionV1;
 
-    static 0(): LedgerHeaderExt;
+    static _0(): LedgerHeaderExt;
 
-    static 1(value: LedgerHeaderExtensionV1): LedgerHeaderExt;
+    static _1(value: LedgerHeaderExtensionV1): LedgerHeaderExt;
 
     value(): LedgerHeaderExtensionV1 | void;
 
@@ -10283,7 +10285,7 @@ export namespace xdr {
   class BucketMetadataExt {
     switch(): number;
 
-    static 0(): BucketMetadataExt;
+    static _0(): BucketMetadataExt;
 
     value(): void;
 
@@ -10387,7 +10389,7 @@ export namespace xdr {
 
     v0Components(value?: TxSetComponent[]): TxSetComponent[];
 
-    static 0(value: TxSetComponent[]): TransactionPhase;
+    static _0(value: TxSetComponent[]): TransactionPhase;
 
     value(): TxSetComponent[];
 
@@ -10417,7 +10419,7 @@ export namespace xdr {
 
     v1TxSet(value?: TransactionSetV1): TransactionSetV1;
 
-    static 1(value: TransactionSetV1): GeneralizedTransactionSet;
+    static _1(value: TransactionSetV1): GeneralizedTransactionSet;
 
     value(): TransactionSetV1;
 
@@ -10452,9 +10454,9 @@ export namespace xdr {
       value?: GeneralizedTransactionSet,
     ): GeneralizedTransactionSet;
 
-    static 0(): TransactionHistoryEntryExt;
+    static _0(): TransactionHistoryEntryExt;
 
-    static 1(value: GeneralizedTransactionSet): TransactionHistoryEntryExt;
+    static _1(value: GeneralizedTransactionSet): TransactionHistoryEntryExt;
 
     value(): GeneralizedTransactionSet | void;
 
@@ -10485,7 +10487,7 @@ export namespace xdr {
   class TransactionHistoryResultEntryExt {
     switch(): number;
 
-    static 0(): TransactionHistoryResultEntryExt;
+    static _0(): TransactionHistoryResultEntryExt;
 
     value(): void;
 
@@ -10519,7 +10521,7 @@ export namespace xdr {
   class LedgerHeaderHistoryEntryExt {
     switch(): number;
 
-    static 0(): LedgerHeaderHistoryEntryExt;
+    static _0(): LedgerHeaderHistoryEntryExt;
 
     value(): void;
 
@@ -10552,7 +10554,7 @@ export namespace xdr {
 
     v0(value?: ScpHistoryEntryV0): ScpHistoryEntryV0;
 
-    static 0(value: ScpHistoryEntryV0): ScpHistoryEntry;
+    static _0(value: ScpHistoryEntryV0): ScpHistoryEntry;
 
     value(): ScpHistoryEntryV0;
 
@@ -10624,7 +10626,7 @@ export namespace xdr {
 
     v0(value?: ContractEventV0): ContractEventV0;
 
-    static 0(value: ContractEventV0): ContractEventBody;
+    static _0(value: ContractEventV0): ContractEventBody;
 
     value(): ContractEventV0;
 
@@ -10660,13 +10662,13 @@ export namespace xdr {
 
     v3(value?: TransactionMetaV3): TransactionMetaV3;
 
-    static 0(value: OperationMeta[]): TransactionMeta;
+    static _0(value: OperationMeta[]): TransactionMeta;
 
-    static 1(value: TransactionMetaV1): TransactionMeta;
+    static _1(value: TransactionMetaV1): TransactionMeta;
 
-    static 2(value: TransactionMetaV2): TransactionMeta;
+    static _2(value: TransactionMetaV2): TransactionMeta;
 
-    static 3(value: TransactionMetaV3): TransactionMeta;
+    static _3(value: TransactionMetaV3): TransactionMeta;
 
     value():
       | OperationMeta[]
@@ -10704,11 +10706,11 @@ export namespace xdr {
 
     v2(value?: LedgerCloseMetaV2): LedgerCloseMetaV2;
 
-    static 0(value: LedgerCloseMetaV0): LedgerCloseMeta;
+    static _0(value: LedgerCloseMetaV0): LedgerCloseMeta;
 
-    static 1(value: LedgerCloseMetaV1): LedgerCloseMeta;
+    static _1(value: LedgerCloseMetaV1): LedgerCloseMeta;
 
-    static 2(value: LedgerCloseMetaV2): LedgerCloseMeta;
+    static _2(value: LedgerCloseMetaV2): LedgerCloseMeta;
 
     value(): LedgerCloseMetaV0 | LedgerCloseMetaV1 | LedgerCloseMetaV2;
 
@@ -10944,7 +10946,7 @@ export namespace xdr {
 
     v0(value?: AuthenticatedMessageV0): AuthenticatedMessageV0;
 
-    static 0(value: AuthenticatedMessageV0): AuthenticatedMessage;
+    static _0(value: AuthenticatedMessageV0): AuthenticatedMessage;
 
     value(): AuthenticatedMessageV0;
 
@@ -11602,7 +11604,7 @@ export namespace xdr {
   class TransactionV0Ext {
     switch(): number;
 
-    static 0(): TransactionV0Ext;
+    static _0(): TransactionV0Ext;
 
     value(): void;
 
@@ -11632,9 +11634,9 @@ export namespace xdr {
 
     sorobanData(value?: SorobanTransactionData): SorobanTransactionData;
 
-    static 0(): TransactionExt;
+    static _0(): TransactionExt;
 
-    static 1(value: SorobanTransactionData): TransactionExt;
+    static _1(value: SorobanTransactionData): TransactionExt;
 
     value(): SorobanTransactionData | void;
 
@@ -11697,7 +11699,7 @@ export namespace xdr {
   class FeeBumpTransactionExt {
     switch(): number;
 
-    static 0(): FeeBumpTransactionExt;
+    static _0(): FeeBumpTransactionExt;
 
     value(): void;
 
@@ -13351,7 +13353,7 @@ export namespace xdr {
   class InnerTransactionResultExt {
     switch(): number;
 
-    static 0(): InnerTransactionResultExt;
+    static _0(): InnerTransactionResultExt;
 
     value(): void;
 
@@ -13459,7 +13461,7 @@ export namespace xdr {
   class TransactionResultExt {
     switch(): number;
 
-    static 0(): TransactionResultExt;
+    static _0(): TransactionResultExt;
 
     value(): void;
 
@@ -13490,7 +13492,7 @@ export namespace xdr {
   class ExtensionPoint {
     switch(): number;
 
-    static 0(): ExtensionPoint;
+    static _0(): ExtensionPoint;
 
     value(): void;
 


### PR DESCRIPTION
Specifically, this lets you construct unions with numeric arms, e.g. `xdr.ExtensionPoint._0()`. This is necessary for certain bits of downstream work, so we're generating this on current futurenet XDR to continue that.