### PR TITLE
Add `Asset.contractId()` helper to predict contract IDs

### DIFF
--- a/src/asset.js
+++ b/src/asset.js
@@ -106,9 +106,7 @@ export class Asset {
    *
    * @returns {string}  the strkey-encoded (`C...`) contract ID for this asset
    *
-   * @warning This makes no guarantee that this contract actually exists, but
-   *    rather just returns what the predictable contract ID *should* be for
-   *    this asset.
+   * @warning This makes no guarantee that this contract actually *exists*.
    */
   contractId(networkPassphrase) {
     const networkId = hash(Buffer.from(networkPassphrase));

--- a/src/asset.js
+++ b/src/asset.js
@@ -2,6 +2,7 @@ import { trimEnd } from './util/util';
 import xdr from './xdr';
 import { Keypair } from './keypair';
 import { StrKey } from './strkey';
+import { hash } from './hashing';
 
 /**
  * Asset class represents an asset, either the native asset (`XLM`)
@@ -93,6 +94,34 @@ export class Asset {
    */
   toTrustLineXDRObject() {
     return this._toXDRObject(xdr.TrustLineAsset);
+  }
+
+  /**
+   * Returns the would-be contract ID (`C...` format) for this asset on a given
+   * network.
+   *
+   * @param {string}    networkPassphrase   indicates which network the contract
+   *    ID should refer to, since every network will have a unique ID for the
+   *    same contract (see {@link Networks} for options)
+   *
+   * @returns {string}  the strkey-encoded (`C...`) contract ID for this asset
+   *
+   * @warning This makes no guarantee that this contract actually exists, but
+   *    rather just returns what the predictable contract ID *should* be for
+   *    this asset.
+   */
+  contractId(networkPassphrase) {
+    const networkId = hash(Buffer.from(networkPassphrase));
+    const preimage = xdr.HashIdPreimage.envelopeTypeContractId(
+      new xdr.HashIdPreimageContractId({
+        networkId,
+        contractIdPreimage: xdr.ContractIdPreimage.contractIdPreimageFromAsset(
+          this.toXDRObject()
+        )
+      })
+    );
+
+    return StrKey.encodeContract(hash(preimage.toXDR()));
   }
 
   /**

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -1,29 +1,29 @@
+const { Asset } = StellarBase;
+
 describe('Asset', function () {
   describe('constructor', function () {
     it("throws an error when there's no issuer for non XLM type asset", function () {
-      expect(() => new StellarBase.Asset('USD')).to.throw(
-        /Issuer cannot be null/
-      );
+      expect(() => new Asset('USD')).to.throw(/Issuer cannot be null/);
     });
 
     it('throws an error when code is invalid', function () {
       expect(
         () =>
-          new StellarBase.Asset(
+          new Asset(
             '',
             'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
           )
       ).to.throw(/Asset code is invalid/);
       expect(
         () =>
-          new StellarBase.Asset(
+          new Asset(
             '1234567890123',
             'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
           )
       ).to.throw(/Asset code is invalid/);
       expect(
         () =>
-          new StellarBase.Asset(
+          new Asset(
             'ab_',
             'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
           )
@@ -31,20 +31,18 @@ describe('Asset', function () {
     });
 
     it('throws an error when issuer is invalid', function () {
-      expect(() => new StellarBase.Asset('USD', 'GCEZWKCA5')).to.throw(
-        /Issuer is invalid/
-      );
+      expect(() => new Asset('USD', 'GCEZWKCA5')).to.throw(/Issuer is invalid/);
     });
   });
 
   describe('getCode()', function () {
     it('returns a code for a native asset object', function () {
-      var asset = new StellarBase.Asset.native();
+      var asset = new Asset.native();
       expect(asset.getCode()).to.be.equal('XLM');
     });
 
     it('returns a code for a non-native asset', function () {
-      var asset = new StellarBase.Asset(
+      var asset = new Asset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -54,12 +52,12 @@ describe('Asset', function () {
 
   describe('getIssuer()', function () {
     it('returns a code for a native asset object', function () {
-      var asset = new StellarBase.Asset.native();
+      var asset = new Asset.native();
       expect(asset.getIssuer()).to.be.undefined;
     });
 
     it('returns a code for a non-native asset', function () {
-      var asset = new StellarBase.Asset(
+      var asset = new Asset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -71,12 +69,12 @@ describe('Asset', function () {
 
   describe('getAssetType()', function () {
     it('returns native for native assets', function () {
-      var asset = StellarBase.Asset.native();
+      var asset = Asset.native();
       expect(asset.getAssetType()).to.eq('native');
     });
 
     it('returns credit_alphanum4 if the asset code length is between 1 and 4', function () {
-      var asset = new StellarBase.Asset(
+      var asset = new Asset(
         'ABCD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -84,7 +82,7 @@ describe('Asset', function () {
     });
 
     it('returns credit_alphanum12 if the asset code length is between 5 and 12', function () {
-      var asset = new StellarBase.Asset(
+      var asset = new Asset(
         'ABCDEF',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -94,7 +92,7 @@ describe('Asset', function () {
 
   describe('toXDRObject(), toChangeTrustXDRObject(), toTrustLineXDRObject', function () {
     it('parses a native asset object', function () {
-      const asset = new StellarBase.Asset.native();
+      const asset = new Asset.native();
 
       let xdr = asset.toXDRObject();
       expect(xdr).to.be.instanceof(StellarBase.xdr.Asset);
@@ -116,7 +114,7 @@ describe('Asset', function () {
     });
 
     it('parses a 3-alphanum asset object', function () {
-      const asset = new StellarBase.Asset(
+      const asset = new Asset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -141,7 +139,7 @@ describe('Asset', function () {
     });
 
     it('parses a 4-alphanum asset object', function () {
-      const asset = new StellarBase.Asset(
+      const asset = new Asset(
         'BART',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -165,7 +163,7 @@ describe('Asset', function () {
     });
 
     it('parses a 5-alphanum asset object', function () {
-      const asset = new StellarBase.Asset(
+      const asset = new Asset(
         '12345',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -189,7 +187,7 @@ describe('Asset', function () {
     });
 
     it('parses a 12-alphanum asset object', function () {
-      const asset = new StellarBase.Asset(
+      const asset = new Asset(
         '123456789012',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -216,9 +214,9 @@ describe('Asset', function () {
   describe('fromOperation()', function () {
     it('parses a native asset XDR', function () {
       var xdr = new StellarBase.xdr.Asset.assetTypeNative();
-      var asset = StellarBase.Asset.fromOperation(xdr);
+      var asset = Asset.fromOperation(xdr);
 
-      expect(asset).to.be.instanceof(StellarBase.Asset);
+      expect(asset).to.be.instanceof(Asset);
       expect(asset.isNative()).to.equal(true);
     });
 
@@ -234,9 +232,9 @@ describe('Asset', function () {
         assetType
       );
 
-      var asset = StellarBase.Asset.fromOperation(xdr);
+      var asset = Asset.fromOperation(xdr);
 
-      expect(asset).to.be.instanceof(StellarBase.Asset);
+      expect(asset).to.be.instanceof(Asset);
       expect(asset.getCode()).to.equal(assetCode);
       expect(asset.getIssuer()).to.equal(issuer);
     });
@@ -253,9 +251,9 @@ describe('Asset', function () {
         assetType
       );
 
-      var asset = StellarBase.Asset.fromOperation(xdr);
+      var asset = Asset.fromOperation(xdr);
 
-      expect(asset).to.be.instanceof(StellarBase.Asset);
+      expect(asset).to.be.instanceof(Asset);
       expect(asset.getCode()).to.equal(assetCode);
       expect(asset.getIssuer()).to.equal(issuer);
     });
@@ -263,12 +261,12 @@ describe('Asset', function () {
 
   describe('toString()', function () {
     it("returns 'native' for native asset", function () {
-      var asset = StellarBase.Asset.native();
+      var asset = Asset.native();
       expect(asset.toString()).to.be.equal('native');
     });
 
     it("returns 'code:issuer' for non-native asset", function () {
-      var asset = new StellarBase.Asset(
+      var asset = new Asset(
         'USD',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
@@ -279,104 +277,119 @@ describe('Asset', function () {
   });
 
   describe('compare()', function () {
-    const assetA = new StellarBase.Asset(
+    const assetA = new Asset(
       'ARST',
       'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
     );
-    const assetB = new StellarBase.Asset(
+    const assetB = new Asset(
       'USD',
       'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
     );
 
     it('throws an error if the input assets are invalid', function () {
-      expect(() => StellarBase.Asset.compare()).to.throw(/assetA is invalid/);
+      expect(() => Asset.compare()).to.throw(/assetA is invalid/);
 
-      expect(() => StellarBase.Asset.compare(assetA)).to.throw(
-        /assetB is invalid/
-      );
+      expect(() => Asset.compare(assetA)).to.throw(/assetB is invalid/);
 
-      expect(() => StellarBase.Asset.compare(assetA, assetB)).to.not.throw;
+      expect(() => Asset.compare(assetA, assetB)).to.not.throw;
     });
 
     it('returns false if assets are equal', function () {
-      const XLM = new StellarBase.Asset.native();
-      expect(StellarBase.Asset.compare(XLM, XLM)).to.eq(0);
-      expect(StellarBase.Asset.compare(assetA, assetA)).to.eq(0);
-      expect(StellarBase.Asset.compare(assetB, assetB)).to.eq(0);
+      const XLM = new Asset.native();
+      expect(Asset.compare(XLM, XLM)).to.eq(0);
+      expect(Asset.compare(assetA, assetA)).to.eq(0);
+      expect(Asset.compare(assetB, assetB)).to.eq(0);
     });
 
     it('test if asset types are being validated as native < anum4 < anum12', function () {
-      const XLM = new StellarBase.Asset.native();
-      const anum4 = new StellarBase.Asset(
+      const XLM = new Asset.native();
+      const anum4 = new Asset(
         'ARST',
         'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
       );
-      const anum12 = new StellarBase.Asset(
+      const anum12 = new Asset(
         'ARSTANUM12',
         'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
       );
 
-      expect(StellarBase.Asset.compare(XLM, XLM)).to.eq(0);
-      expect(StellarBase.Asset.compare(XLM, anum4)).to.eq(-1);
-      expect(StellarBase.Asset.compare(XLM, anum12)).to.eq(-1);
+      expect(Asset.compare(XLM, XLM)).to.eq(0);
+      expect(Asset.compare(XLM, anum4)).to.eq(-1);
+      expect(Asset.compare(XLM, anum12)).to.eq(-1);
 
-      expect(StellarBase.Asset.compare(anum4, XLM)).to.eq(1);
-      expect(StellarBase.Asset.compare(anum4, anum4)).to.eq(0);
-      expect(StellarBase.Asset.compare(anum4, anum12)).to.eq(-1);
+      expect(Asset.compare(anum4, XLM)).to.eq(1);
+      expect(Asset.compare(anum4, anum4)).to.eq(0);
+      expect(Asset.compare(anum4, anum12)).to.eq(-1);
 
-      expect(StellarBase.Asset.compare(anum12, XLM)).to.eq(1);
-      expect(StellarBase.Asset.compare(anum12, anum4)).to.eq(1);
-      expect(StellarBase.Asset.compare(anum12, anum12)).to.eq(0);
+      expect(Asset.compare(anum12, XLM)).to.eq(1);
+      expect(Asset.compare(anum12, anum4)).to.eq(1);
+      expect(Asset.compare(anum12, anum12)).to.eq(0);
     });
 
     it('test if asset codes are being validated as assetCodeA < assetCodeB', function () {
-      const assetARST = new StellarBase.Asset(
+      const assetARST = new Asset(
         'ARST',
         'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
       );
-      const assetUSDX = new StellarBase.Asset('USDA', assetARST.getIssuer());
+      const assetUSDX = new Asset('USDA', assetARST.getIssuer());
 
-      expect(StellarBase.Asset.compare(assetARST, assetARST)).to.eq(0);
-      expect(StellarBase.Asset.compare(assetARST, assetUSDX)).to.eq(-1);
+      expect(Asset.compare(assetARST, assetARST)).to.eq(0);
+      expect(Asset.compare(assetARST, assetUSDX)).to.eq(-1);
 
-      expect(StellarBase.Asset.compare(assetUSDX, assetARST)).to.eq(1);
-      expect(StellarBase.Asset.compare(assetUSDX, assetUSDX)).to.eq(0);
+      expect(Asset.compare(assetUSDX, assetARST)).to.eq(1);
+      expect(Asset.compare(assetUSDX, assetUSDX)).to.eq(0);
 
       // uppercase should be smaller
-      const assetLower = new StellarBase.Asset('aRST', assetARST.getIssuer());
-      expect(StellarBase.Asset.compare(assetARST, assetLower)).to.eq(-1);
-      expect(StellarBase.Asset.compare(assetLower, assetA)).to.eq(1);
+      const assetLower = new Asset('aRST', assetARST.getIssuer());
+      expect(Asset.compare(assetARST, assetLower)).to.eq(-1);
+      expect(Asset.compare(assetLower, assetA)).to.eq(1);
     });
 
     it('test if asset issuers are being validated as assetIssuerA < assetIssuerB', function () {
-      const assetIssuerA = new StellarBase.Asset(
+      const assetIssuerA = new Asset(
         'ARST',
         'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
       );
-      const assetIssuerB = new StellarBase.Asset(
+      const assetIssuerB = new Asset(
         'ARST',
         'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
       );
 
-      expect(StellarBase.Asset.compare(assetIssuerA, assetIssuerB)).to.eq(-1);
-      expect(StellarBase.Asset.compare(assetIssuerA, assetIssuerA)).to.eq(0);
+      expect(Asset.compare(assetIssuerA, assetIssuerB)).to.eq(-1);
+      expect(Asset.compare(assetIssuerA, assetIssuerA)).to.eq(0);
 
-      expect(StellarBase.Asset.compare(assetIssuerB, assetIssuerA)).to.eq(1);
-      expect(StellarBase.Asset.compare(assetIssuerB, assetIssuerB)).to.eq(0);
+      expect(Asset.compare(assetIssuerB, assetIssuerA)).to.eq(1);
+      expect(Asset.compare(assetIssuerB, assetIssuerB)).to.eq(0);
     });
 
     it('test if codes with upper-case letters are sorted before lower-case letters', function () {
       // All upper-case letters should come before any lower-case ones
-      const assetA = new StellarBase.Asset(
+      const assetA = new Asset(
         'B',
         'GA7NLOF4EHWMJF6DBXXV2H6AYI7IHYWNFZR6R52BYBLY7TE5Q74AIDRA'
       );
-      const assetB = new StellarBase.Asset(
+      const assetB = new Asset(
         'a',
         'GA7NLOF4EHWMJF6DBXXV2H6AYI7IHYWNFZR6R52BYBLY7TE5Q74AIDRA'
       );
 
-      expect(StellarBase.Asset.compare(assetA, assetB)).to.eq(-1);
+      expect(Asset.compare(assetA, assetB)).to.eq(-1);
+    });
+  });
+
+  describe('contractId()', function () {
+    it('creates the correct contract IDs', function () {
+      [
+        [
+          Asset.native(),
+          '-CB64D3G7SM2RTH6JSGG34DDTFTQ5CFDKVDZJZSODMCX4NJ2HV2KN7OHT'
+        ]
+      ].forEach(([asset, contractId]) => {
+        console.log('wtf');
+        expect(asset.contractId(StellarBase.Networks.FUTURENET)).to.equal(
+          contractId,
+          `the asset was: ${asset.toString()}`
+        );
+      });
     });
   });
 });

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -381,8 +381,9 @@ describe('Asset', function () {
       [
         [
           Asset.native(),
-          '-CB64D3G7SM2RTH6JSGG34DDTFTQ5CFDKVDZJZSODMCX4NJ2HV2KN7OHT'
+          'CB64D3G7SM2RTH6JSGG34DDTFTQ5CFDKVDZJZSODMCX4NJ2HV2KN7OHT'
         ]
+        // TODO: Add more
       ].forEach(([asset, contractId]) => {
         console.log('wtf');
         expect(asset.contractId(StellarBase.Networks.FUTURENET)).to.equal(
@@ -390,6 +391,8 @@ describe('Asset', function () {
           `the asset was: ${asset.toString()}`
         );
       });
+
+      expect(false).to.be.true('add more tests!');
     });
   });
 });

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -385,7 +385,6 @@ describe('Asset', function () {
         ]
         // TODO: Add more
       ].forEach(([asset, contractId]) => {
-        console.log('wtf');
         expect(asset.contractId(StellarBase.Networks.FUTURENET)).to.equal(
           contractId,
           `the asset was: ${asset.toString()}`

--- a/test/unit/asset_test.js
+++ b/test/unit/asset_test.js
@@ -382,16 +382,20 @@ describe('Asset', function () {
         [
           Asset.native(),
           'CB64D3G7SM2RTH6JSGG34DDTFTQ5CFDKVDZJZSODMCX4NJ2HV2KN7OHT'
+        ],
+        [
+          new Asset(
+            'USD',
+            'GCP2QKBFLLEEWYVKAIXIJIJNCZ6XEBIE4PCDB6BF3GUB6FGE2RQ3HDVP'
+          ),
+          'CCWNZPARJG7KQ6N4BGZ5OBWKSSK4AVQ5URLDRXB4ZJXKGEJQTIIRPAHN'
         ]
-        // TODO: Add more
       ].forEach(([asset, contractId]) => {
         expect(asset.contractId(StellarBase.Networks.FUTURENET)).to.equal(
           contractId,
           `the asset was: ${asset.toString()}`
         );
       });
-
-      expect(false).to.be.true('add more tests!');
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -79,6 +79,7 @@ export class Asset {
   toXDRObject(): xdr.Asset;
   toChangeTrustXDRObject(): xdr.ChangeTrustAsset;
   toTrustLineXDRObject(): xdr.TrustLineAsset;
+  contractId(): string;
 
   code: string;
   issuer: string;


### PR DESCRIPTION
This just needs a few more test cases before it's ready to merge, cc @orbitlens.