### PR TITLE
Improves `SorobanDataBuilder` construction and adds a getter

### DIFF
--- a/test/unit/sorobandata_builder_test.js
+++ b/test/unit/sorobandata_builder_test.js
@@ -34,6 +34,12 @@ describe('SorobanTransactionData can be built', function () {
 
     expect(fromRaw).to.eql(sentinel);
     expect(fromStr).to.eql(sentinel);
+
+    const baseline = new dataBuilder().build();
+    [null, '', 0].forEach((falsy) => {
+      const db = new dataBuilder(falsy).build();
+      expect(db).to.eql(baseline);
+    });
   });
 
   it('sets properties as expected', function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1163,6 +1163,7 @@ export class SorobanDataBuilder {
   setReadOnly(keys: xdr.LedgerKey[]): SorobanDataBuilder;
   setReadWrite(keys: xdr.LedgerKey[]): SorobanDataBuilder;
 
+  getFootprint(): xdr.LedgerFootprint;
   getReadOnly(): xdr.LedgerKey[];
   getReadWrite(): xdr.LedgerKey[];
 


### PR DESCRIPTION
This does two things:

 * **change:** the default structure will kick in on **any** "falsy" parameter, now (before, it considered string/buffer first, but this meant empty strings, e.g. from Soroban RPC, were interpreted incorrectly)
 * **add:** `getFootprint()` to easily get both read-only and read-write pieces