### PR TITLE
Fix type definition of optional parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
  * `nativeToScVal` now allows anything to be passed to the `opts.type` specifier (previously, it was only integer types, [#691](https://github.com/stellar/js-stellar-base/pull/691)).
 
+
 ## [`v10.0.0-beta.0`](https://github.com/stellar/js-stellar-base/compare/v9.0.0...v10.0.0-beta.0): Protocol 20
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+### Fixed
+ * `nativeToScVal` now allows anything to be passed to the `opts.type` specifier (previously, it was only integer types, [#691](https://github.com/stellar/js-stellar-base/pull/691)).
 
 ## [`v10.0.0-beta.0`](https://github.com/stellar/js-stellar-base/compare/v9.0.0...v10.0.0-beta.0): Protocol 20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## Unreleased
 
 ### Fixed
- * `nativeToScVal` now allows anything to be passed to the `opts.type` specifier (previously, it was only integer types, [#691](https://github.com/stellar/js-stellar-base/pull/691)).
+ * `nativeToScVal` now allows anything to be passed to the `opts.type` specifier. Previously, it was only integer types ([#691](https://github.com/stellar/js-stellar-base/pull/691)).
 
 
 ## [`v10.0.0-beta.0`](https://github.com/stellar/js-stellar-base/compare/v9.0.0...v10.0.0-beta.0): Protocol 20

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1126,7 +1126,7 @@ export class ScInt extends XdrLargeInt {
 }
 
 export function scValToBigInt(scv: xdr.ScVal): bigint;
-export function nativeToScVal(val: any, opts?: { type: ScIntType }): xdr.ScVal;
+export function nativeToScVal(val: any, opts?: { type: any }): xdr.ScVal;
 export function scValToNative(scv: xdr.ScVal): any;
 
 interface SorobanEvent {


### PR DESCRIPTION
This bug prevented all non-integer types from being passed via `{ type: '...' }` (such as `'symbol'` or `'address'`) when used from TypeScript without casting `as any`.