### PR TITLE
Correctly build operations via `Contract.call()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
  * `nativeToScVal` now allows anything to be passed to the `opts.type` specifier. Previously, it was only integer types ([#691](https://github.com/stellar/js-stellar-base/pull/691)).
- * `Contract.call()` now produces valid `Operation` XDR ([#TODO](https://github.com/stellar/js-stellar-base/pull/TODO)).
+ * `Contract.call()` now produces valid `Operation` XDR ([#692](https://github.com/stellar/js-stellar-base/pull/692)).
 
 
 ## [`v10.0.0-beta.0`](https://github.com/stellar/js-stellar-base/compare/v9.0.0...v10.0.0-beta.0): Protocol 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
  * `nativeToScVal` now allows anything to be passed to the `opts.type` specifier. Previously, it was only integer types ([#691](https://github.com/stellar/js-stellar-base/pull/691)).
+ * `Contract.call()` now produces valid `Operation` XDR ([#TODO](https://github.com/stellar/js-stellar-base/pull/TODO)).
 
 
 ## [`v10.0.0-beta.0`](https://github.com/stellar/js-stellar-base/compare/v9.0.0...v10.0.0-beta.0): Protocol 20

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "10.0.0-beta.0",
+  "version": "10.0.0-beta.1",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
   "browser": {

--- a/src/contract.js
+++ b/src/contract.js
@@ -59,7 +59,7 @@ export class Contract {
       func: xdr.HostFunction.hostFunctionTypeInvokeContract(
         new xdr.InvokeContractArgs({
           contractAddress: this.address().toScAddress(),
-          functionName: xdr.ScVal.scvSymbol(method),
+          functionName: method,
           args: params
         })
       ),

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -83,7 +83,7 @@ describe('Contract', function () {
     });
 
     it('passes the method name as the second arg', function () {
-      expect(args.functionName()).to.deep.equal(xdr.ScVal.scvSymbol('method'));
+      expect(args.functionName()).to.deep.equal('method');
     });
 
     it('passes all params after that', function () {

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -4,10 +4,13 @@ const NULL_ADDRESS = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
 describe('Contract', function () {
   describe('constructor', function () {
     it('parses strkeys', function () {
-      let contractId =
-        'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
-      let contract = new Contract(contractId);
-      expect(contract.contractId('strkey')).to.equal(contractId);
+      [
+        NULL_ADDRESS,
+        'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE'
+      ].forEach((cid) => {
+        const contract = new Contract(cid);
+        expect(contract.contractId()).to.equal(cid);
+      });
     });
 
     it('throws on obsolete hex ids', function () {
@@ -59,7 +62,11 @@ describe('Contract', function () {
       StellarBase.nativeToScVal(2, { type: 'i32' })
     );
 
-    xit('builds valid XDR', function () {
+    it('works with no parameters', function () {
+      contract.call('empty').toXDR();
+    });
+
+    it('builds valid XDR', function () {
       call.toXDR();
     });
 
@@ -84,10 +91,6 @@ describe('Contract', function () {
         xdr.ScVal.scvString('arg!'),
         xdr.ScVal.scvI32(2)
       ]);
-    });
-
-    xit('works with no parameters', function () {
-      contract.call('empty').toXDR();
     });
   });
 });


### PR DESCRIPTION
The type of `InvokeContractArgs.functionName` is supposed to be a `string` now, not an `ScSymbol` like before.

This **should** have been caught by testing but they were being skipped with `xit` by mistake :facepalm: 