### PR TITLE
Fix type definition for `Memo.hash` to allow buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## Unreleased
 
+### Fixed
+- The type definition for `Memo.hash` now allows `Buffer`s ([#698](https://github.com/stellar/js-stellar-base/pull/698)).
+
 
 ## [`v10.0.0-beta.2`](https://github.com/stellar/js-stellar-base/compare/v10.0.0-beta.1...v10.0.0-beta.2)
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -211,7 +211,7 @@ export type MemoValue = null | string | Buffer;
 
 export class Memo<T extends MemoType = MemoType> {
   static fromXDRObject(memo: xdr.Memo): Memo;
-  static hash(hash: string): Memo<MemoType.Hash>;
+  static hash(hash: string | Buffer): Memo<MemoType.Hash>;
   static id(id: string): Memo<MemoType.ID>;
   static none(): Memo<MemoType.None>;
   static return(hash: string): Memo<MemoType.Return>;


### PR DESCRIPTION
Closes https://github.com/stellar/js-stellar-base/issues/695.