### PR TITLE
Fixes a type comparison bug in authorization helpers.

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -100,10 +100,10 @@ export async function authorizeEntry(
   validUntilLedgerSeq,
   networkPassphrase = Networks.FUTURENET
 ) {
-  // no-op
+  // no-op if it's source account auth
   if (
-    entry.credentials().switch() !==
-    xdr.SorobanCredentialsType.sorobanCredentialsAddress()
+    entry.credentials().switch().value !==
+    xdr.SorobanCredentialsType.sorobanCredentialsAddress().value
   ) {
     return entry;
   }
@@ -169,8 +169,7 @@ export async function authorizeEntry(
  *     {@link Networks})
  *   - until a particular ledger sequence is reached.
  *
- * This is in contrast to {@link authorizeEntry}, which signs an existing entry
- * "in place".
+ * This is in contrast to {@link authorizeEntry}, which signs an existing entry.
  *
  * @param {Keypair | SigningCallback} signer  either a {@link Keypair} instance
  *    (or anything with a `.sign(buf): Buffer-like` method) or a function which


### PR DESCRIPTION
For some reason, !== on the object does not work in some envs. 
Note that it works fine in the unit tests.
This is a faster check, anyway.

Reported by @tyvdh on Discord [here](https://discord.com/channels/897514728459468821/1138959805218836510/1161061470289789038).