### PR TITLE
Drop incorrect key entry for contract footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,7 @@
   - `xdr.SorobanTransactionData.refundableFee` is now `resourceFee`
   - In turn, `SorobanDataBuilder.setRefundableFee` is now `setResourceFee`
   - This new fee encompasses the entirety of the Soroban-related resource fees. Note that this is distinct from the "network-inclusion" fee that you would set on your transaction (i.e. `TransactionBuilder(..., { fee: ... })`).
-
-### Breaking Changes
-- `Contract.getFootprint()` now only returns a single result: the ledger key of the deployed instance for the given ID, because the key for the code entry was incorrect (it should not be the ID but rather the WASM hash, which is not calculatable w/o network access) ([#TODO](https://github.com/stellar/js-stellar-base/pull/TODO)).
+- `Contract.getFootprint()` now only returns a single result: the ledger key of the deployed instance for the given ID, because the key for the code entry was incorrect (it should not be the ID but rather the WASM hash, which is not calculatable w/o network access) ([#709](https://github.com/stellar/js-stellar-base/pull/709)).
 
 
 ## [`v10.0.0-beta.3`](https://github.com/stellar/js-stellar-base/compare/v10.0.0-beta.2...v10.0.0-beta.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Fixed
 - The type definition for `Memo.hash` now allows `Buffer`s ([#698](https://github.com/stellar/js-stellar-base/pull/698)).
 
+### Breaking Changes
+- `Contract.getFootprint()` now only returns a single result: the ledger key of the deployed instance for the given ID, because the key for the code entry was incorrect (it should not be the ID but rather the WASM hash, which is not calculatable w/o network access) ([#TODO](https://github.com/stellar/js-stellar-base/pull/TODO)).
+
 
 ## [`v10.0.0-beta.3`](https://github.com/stellar/js-stellar-base/compare/v10.0.0-beta.2...v10.0.0-beta.3)
 

--- a/src/contract.js
+++ b/src/contract.js
@@ -69,24 +69,18 @@ export class Contract {
 
   /**
    * Returns the read-only footprint entries necessary for any invocations to
-   * this contract, for convenience when adding it to your transaction's overall
-   * footprint or doing bump/restore operations.
+   * this contract, for convenience when manually adding it to your
+   * transaction's overall footprint or doing bump/restore operations.
    *
-   * @returns {xdr.LedgerKey[]} the ledger keys containing the contract's code
-   *    (first) and its deployed contract instance (second)
+   * @returns {xdr.LedgerKey} the ledger key for the deployed contract instance
    */
   getFootprint() {
-    return [
-      xdr.LedgerKey.contractCode(
-        new xdr.LedgerKeyContractCode({ hash: this._id })
-      ),
-      xdr.LedgerKey.contractData(
-        new xdr.LedgerKeyContractData({
-          contract: this.address().toScAddress(),
-          key: xdr.ScVal.scvLedgerKeyContractInstance(),
-          durability: xdr.ContractDataDurability.persistent()
-        })
-      )
-    ];
+    return xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        contract: this.address().toScAddress(),
+        key: xdr.ScVal.scvLedgerKeyContractInstance(),
+        durability: xdr.ContractDataDurability.persistent()
+      })
+    );
   }
 }

--- a/test/unit/contract_test.js
+++ b/test/unit/contract_test.js
@@ -35,20 +35,13 @@ describe('Contract', function () {
       expect(contract.contractId()).to.equal(NULL_ADDRESS);
 
       const actual = contract.getFootprint();
-      const expected = [
-        new xdr.LedgerKey.contractCode(
-          new xdr.LedgerKeyContractCode({
-            hash: StellarBase.StrKey.decodeContract(contract.contractId())
-          })
-        ),
-        new xdr.LedgerKey.contractData(
-          new xdr.LedgerKeyContractData({
-            contract: contract.address().toScAddress(),
-            key: xdr.ScVal.scvLedgerKeyContractInstance(),
-            durability: xdr.ContractDataDurability.persistent()
-          })
-        )
-      ];
+      const expected = new xdr.LedgerKey.contractData(
+        new xdr.LedgerKeyContractData({
+          contract: contract.address().toScAddress(),
+          key: xdr.ScVal.scvLedgerKeyContractInstance(),
+          durability: xdr.ContractDataDurability.persistent()
+        })
+      );
 
       expect(actual).to.eql(expected);
     });

--- a/test/unit/sorobandata_builder_test.js
+++ b/test/unit/sorobandata_builder_test.js
@@ -6,17 +6,17 @@ describe('SorobanTransactionData can be built', function () {
   const c = new StellarBase.Contract(contractId);
 
   const sentinel = new xdr.SorobanTransactionData({
+    ext: new xdr.ExtensionPoint(0),
     resources: new xdr.SorobanResources({
       footprint: new xdr.LedgerFootprint({ readOnly: [], readWrite: [] }),
       instructions: 1,
       readBytes: 2,
       writeBytes: 3
     }),
-    ext: new xdr.ExtensionPoint(0),
     resourceFee: new xdr.Int64(5)
   });
 
-  const key = c.getFootprint()[0];
+  const key = c.getFootprint(); // arbitrary key for testing
 
   it('constructs from xdr, base64, and nothing', function () {
     new dataBuilder();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,7 +30,7 @@ export class Contract {
   call(method: string, ...params: xdr.ScVal[]): xdr.Operation<Operation.InvokeHostFunction>;
   contractId(): string;
   address(): Address;
-  getFootprint(): xdr.LedgerKey[];
+  getFootprint(): xdr.LedgerKey;
 
   toString(): string;
 }


### PR DESCRIPTION
Context: The work done in was https://github.com/stellar/js-stellar-base/pull/662 simply incorrect: the hash in the code key should correspond to the hash of the WASM code, not the contract ID.