### PR TITLE
Release beta.4 with a sequence number bugfix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## [`v10.0.0-beta.4`](https://github.com/stellar/js-stellar-base/compare/v10.0.0-beta.3...v10.0.0-beta.4)
 ### Fixed
-- You can now correctly clone transactions (`TransactionBuilder.cloneFrom`) with large sequence numbers ([TODO]()).
+- You can now correctly clone transactions (`TransactionBuilder.cloneFrom`) with large sequence numbers ([#711](https://github.com/stellar/js-stellar-base/pull/711)).
 
 
 ## [`v10.0.0-beta.3`](https://github.com/stellar/js-stellar-base/compare/v10.0.0-beta.2...v10.0.0-beta.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 
 ## Unreleased
 
+
+## [`v10.0.0-beta.4`](https://github.com/stellar/js-stellar-base/compare/v10.0.0-beta.3...v10.0.0-beta.4)
 ### Fixed
-- The type definition for `Memo.hash` now allows `Buffer`s ([#698](https://github.com/stellar/js-stellar-base/pull/698)).
+- You can now correctly clone transactions (`TransactionBuilder.cloneFrom`) with large sequence numbers ([TODO]()).
 
 
 ## [`v10.0.0-beta.3`](https://github.com/stellar/js-stellar-base/compare/v10.0.0-beta.2...v10.0.0-beta.3)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-base",
-  "version": "10.0.0-beta.3",
+  "version": "10.0.0-beta.4",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
   "browser": {

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -181,7 +181,7 @@ export class TransactionBuilder {
       throw new TypeError(`expected a 'Transaction', got: ${tx}`);
     }
 
-    const sequenceNum = `${parseInt(tx.sequence, 10) - 1}`;
+    const sequenceNum = (BigNumber(tx.sequence) - 1n).toString();
 
     let source;
     // rebuild the source account based on the strkey

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -181,7 +181,7 @@ export class TransactionBuilder {
       throw new TypeError(`expected a 'Transaction', got: ${tx}`);
     }
 
-    const sequenceNum = (BigNumber(tx.sequence) - 1n).toString();
+    const sequenceNum = (BigInt(tx.sequence) - 1n).toString();
 
     let source;
     // rebuild the source account based on the strkey


### PR DESCRIPTION
### Fixed
- You can now correctly clone transactions (`TransactionBuilder.cloneFrom`) with large sequence numbers.