### PR TITLE
correct the return type to 'string'

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1229,5 +1229,5 @@ export function walkInvocationTree(
 
 export namespace Soroban {
   function formatTokenAmount(address: string, decimals: number): string;
-  function parseTokenAmount(value: string, decimals: number): Address;
+  function parseTokenAmount(value: string, decimals: number): string;
 }


### PR DESCRIPTION
It's supposed to be `string` not `Address`