### PR TITLE
Republish package under @stellar/ scope

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -32,6 +32,6 @@ jobs:
 
       - name: Deprecate the old package
         run: |
-          npm deprecate stellar-base "⚠️ This package has moved to @stellar/stellar-base! 🚚"
+          npm deprecate stellar-base@latest "⚠️ This package has moved to @stellar/stellar-base! 🚚"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -22,7 +22,16 @@ jobs:
       - name: Test & Build
         run: yarn preversion
 
-      - name: Publish release npm package
-        run: yarn publish --tag beta
+      - name: Publish npm package to both places
+        run: |
+          yarn publish --tag beta --access public
+          sed -i -e 's#"@stellar/stellar-base"#"stellar-base"#' package.json
+          yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Deprecate the old package
+        run: |
+          npm deprecate stellar-base "⚠️ This package has moved to @stellar/stellar-base! 🚚"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stellar-base",
+  "name": "@stellar/stellar-base",
   "version": "10.0.0-beta.3",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
@@ -123,7 +123,7 @@
     "base32.js": "^0.1.0",
     "bignumber.js": "^9.1.2",
     "buffer": "^6.0.3",
-    "js-xdr": "^3.0.0",
+    "@stellar/js-xdr": "^3.0.1",
     "sha.js": "^2.3.6",
     "tweetnacl": "^1.0.3"
   },

--- a/src/generated/curr_generated.js
+++ b/src/generated/curr_generated.js
@@ -4,7 +4,7 @@
 /* jshint maxstatements:2147483647  */
 /* jshint esnext:true  */
 
-import * as XDR from "js-xdr";
+import * as XDR from "@stellar/js-xdr";
 
 var types = XDR.config((xdr) => {
   // Workaround for https://github.com/stellar/xdrgen/issues/152

--- a/src/generated/next_generated.js
+++ b/src/generated/next_generated.js
@@ -4,7 +4,7 @@
 /* jshint maxstatements:2147483647  */
 /* jshint esnext:true  */
 
-import * as XDR from "js-xdr";
+import * as XDR from "@stellar/js-xdr";
 
 var types = XDR.config((xdr) => {
   // Workaround for https://github.com/stellar/xdrgen/issues/152

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export {
   LiquidityPoolFeeV18
 } from './get_liquidity_pool_id';
 export { Keypair } from './keypair';
-export { UnsignedHyper, Hyper } from 'js-xdr';
+export { UnsignedHyper, Hyper } from '@stellar/js-xdr';
 export { TransactionBase } from './transaction_base';
 export { Transaction } from './transaction';
 export { FeeBumpTransaction } from './fee_bump_transaction';

--- a/src/memo.js
+++ b/src/memo.js
@@ -1,4 +1,4 @@
-import { UnsignedHyper } from 'js-xdr';
+import { UnsignedHyper } from '@stellar/js-xdr';
 import BigNumber from 'bignumber.js';
 import xdr from './xdr';
 

--- a/src/numbers/int128.js
+++ b/src/numbers/int128.js
@@ -1,4 +1,4 @@
-import { LargeInt } from 'js-xdr';
+import { LargeInt } from '@stellar/js-xdr';
 
 export class Int128 extends LargeInt {
   /**

--- a/src/numbers/int256.js
+++ b/src/numbers/int256.js
@@ -1,4 +1,4 @@
-import { LargeInt } from 'js-xdr';
+import { LargeInt } from '@stellar/js-xdr';
 
 export class Int256 extends LargeInt {
   /**

--- a/src/numbers/uint128.js
+++ b/src/numbers/uint128.js
@@ -1,4 +1,4 @@
-import { LargeInt } from 'js-xdr';
+import { LargeInt } from '@stellar/js-xdr';
 
 export class Uint128 extends LargeInt {
   /**

--- a/src/numbers/uint256.js
+++ b/src/numbers/uint256.js
@@ -1,4 +1,4 @@
-import { LargeInt } from 'js-xdr';
+import { LargeInt } from '@stellar/js-xdr';
 
 export class Uint256 extends LargeInt {
   /**

--- a/src/numbers/xdr_large_int.js
+++ b/src/numbers/xdr_large_int.js
@@ -22,14 +22,10 @@ import xdr from '../xdr';
  *    integer-like values interpreted in big-endian order
  */
 export class XdrLargeInt {
-  /**
-   * @type {xdr.LargeInt}
-   */
+  /** @type {xdr.LargeInt} */
   int; // child class of a jsXdr.LargeInt
 
-  /**
-   * @type {string}   one of 'i64', 'u64', 'i128', 'u128', 'i256', or 'u256'
-   */
+  /** @type {string} */
   type;
 
   constructor(type, values) {

--- a/src/numbers/xdr_large_int.js
+++ b/src/numbers/xdr_large_int.js
@@ -1,5 +1,5 @@
 /* eslint no-bitwise: ["error", {"allow": [">>"]}] */
-import { Hyper, UnsignedHyper } from 'js-xdr';
+import { Hyper, UnsignedHyper } from '@stellar/js-xdr';
 
 import { Uint128 } from './uint128';
 import { Uint256 } from './uint256';

--- a/src/operation.js
+++ b/src/operation.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-bitwise */
 
-import { Hyper } from 'js-xdr';
+import { Hyper } from '@stellar/js-xdr';
 import BigNumber from 'bignumber.js';
 import { trimEnd } from './util/util';
 import { best_r } from './util/continued_fraction';

--- a/src/operations/bump_sequence.js
+++ b/src/operations/bump_sequence.js
@@ -1,4 +1,4 @@
-import { Hyper } from 'js-xdr';
+import { Hyper } from '@stellar/js-xdr';
 import BigNumber from 'bignumber.js';
 import xdr from '../xdr';
 

--- a/src/operations/change_trust.js
+++ b/src/operations/change_trust.js
@@ -1,4 +1,4 @@
-import { Hyper } from 'js-xdr';
+import { Hyper } from '@stellar/js-xdr';
 import BigNumber from 'bignumber.js';
 import xdr from '../xdr';
 import { Asset } from '../asset';

--- a/src/operations/manage_buy_offer.js
+++ b/src/operations/manage_buy_offer.js
@@ -1,4 +1,4 @@
-import { Hyper } from 'js-xdr';
+import { Hyper } from '@stellar/js-xdr';
 import xdr from '../xdr';
 /**
  * Returns a XDR ManageBuyOfferOp. A "manage buy offer" operation creates, updates, or

--- a/src/operations/manage_sell_offer.js
+++ b/src/operations/manage_sell_offer.js
@@ -1,4 +1,4 @@
-import { Hyper } from 'js-xdr';
+import { Hyper } from '@stellar/js-xdr';
 import xdr from '../xdr';
 /**
  * Returns a XDR ManageSellOfferOp. A "manage sell offer" operation creates, updates, or

--- a/src/soroban.js
+++ b/src/soroban.js
@@ -1,4 +1,4 @@
-/** Soroban helper class to assist with formatting and parsing token amounts. */
+/* Helper class to assist with formatting and parsing token amounts. */
 export class Soroban {
   /**
    * Given a whole number smart contract amount of a token and an amount of

--- a/src/soroban.js
+++ b/src/soroban.js
@@ -1,7 +1,4 @@
-/**
- * @class Soroban
- * Soroban helper class to assist with formatting and parsing token amounts.
- */
+/** Soroban helper class to assist with formatting and parsing token amounts. */
 export class Soroban {
   /**
    * Given a whole number smart contract amount of a token and an amount of

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -154,8 +154,9 @@ export class Transaction extends TransactionBase {
   }
 
   /**
-   * @type {string} 64 bit account sequence
+   * 64 bit account sequence
    * @readonly
+   * @type {string}
    */
   get minAccountSequence() {
     return this._minAccountSequence;
@@ -165,7 +166,8 @@ export class Transaction extends TransactionBase {
   }
 
   /**
-   * @type {number} 64 bit number of seconds
+   * 64 bit number of seconds
+   * @type {number}
    * @readonly
    */
   get minAccountSequenceAge() {
@@ -176,7 +178,8 @@ export class Transaction extends TransactionBase {
   }
 
   /**
-   * @type {number} 32 bit number of ledgers
+   * 32 bit number of ledgers
+   * @type {number}
    * @readonly
    */
   get minAccountSequenceLedgerGap() {
@@ -187,7 +190,8 @@ export class Transaction extends TransactionBase {
   }
 
   /**
-   * @type {string[]}   array of extra signers (@{link StrKey}s)
+   * array of extra signers ({@link StrKey}s)
+   * @type {string[]}
    * @readonly
    */
   get extraSigners() {
@@ -204,7 +208,6 @@ export class Transaction extends TransactionBase {
   get sequence() {
     return this._sequence;
   }
-
   set sequence(value) {
     throw new Error('Transaction is immutable');
   }
@@ -216,7 +219,6 @@ export class Transaction extends TransactionBase {
   get source() {
     return this._source;
   }
-
   set source(value) {
     throw new Error('Transaction is immutable');
   }
@@ -228,7 +230,6 @@ export class Transaction extends TransactionBase {
   get operations() {
     return this._operations;
   }
-
   set operations(value) {
     throw new Error('Transaction is immutable');
   }
@@ -240,7 +241,6 @@ export class Transaction extends TransactionBase {
   get memo() {
     return Memo.fromXDRObject(this._memo);
   }
-
   set memo(value) {
     throw new Error('Transaction is immutable');
   }

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -1,4 +1,4 @@
-import { UnsignedHyper } from 'js-xdr';
+import { UnsignedHyper } from '@stellar/js-xdr';
 import BigNumber from 'bignumber.js';
 
 import xdr from './xdr';

--- a/test/unit/i256_test.js
+++ b/test/unit/i256_test.js
@@ -1,4 +1,4 @@
-// import { XdrWriter, XdrReader } from 'js-xdr';
+// import { XdrWriter, XdrReader } from '@stellar/js-xdr';
 const I256 = StellarBase.Int256; // shorthand
 
 describe('I256.isValid', function () {

--- a/test/unit/soroban_test.js
+++ b/test/unit/soroban_test.js
@@ -13,12 +13,12 @@ describe('Soroban', function () {
       {
         amount: '1000000001.1',
         decimals: 7,
-        expected: /No decimal is allowed/
+        expected: /No decimals are allowed/
       },
       {
         amount: '10000.00001.1',
         decimals: 4,
-        expected: /No decimal is allowed/
+        expected: /No decimals are allowed/
       }
     ];
 

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -1,4 +1,4 @@
-import { UnsignedHyper } from 'js-xdr';
+import { UnsignedHyper } from '@stellar/js-xdr';
 import randomBytes from 'randombytes';
 
 describe('Transaction', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,6 +1315,11 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
+"@stellar/js-xdr@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@stellar/js-xdr/-/js-xdr-3.0.1.tgz#d500f1e1332210cd56e0ef95e44c54506d9f48f3"
+  integrity sha512-dp5Eh7Nr1YjiIeqpdkj2cQYxfoPudDAH3ck8MWggp48Htw66Z/hUssNYUQG/OftLjEmHT90Z/dtey2Y77DOxIw==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
@@ -4557,11 +4562,6 @@ js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
-js-xdr@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-3.0.0.tgz#fb74275de0ed3cec61269721140a576edf6fca7e"
-  integrity sha512-tSt6UKJ2L7t+yaQURGkHo9kop9qnVbChTlCu62zNiDbDZQoZb/YjUj2iFJ3lgelhfg9p5bhO2o/QX+g36TPsSQ==
 
 js-yaml@4.1.0, js-yaml@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Notice that this is targeting the `stable` branch: we will only include this rename as part of the stable package release.

See stellar/js-xdr#111, stellar/js-xdr#112, and stellar/js-xdr#113 for what was needed in that package to accomplish this.

This also moves the code to use `@stellar/js-xdr` instead of `js-xdr`.

Related: stellar/js-stellar-sdk#851.