### PR TITLE
Fix asset class contractId missing argument

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -79,7 +79,7 @@ export class Asset {
   toXDRObject(): xdr.Asset;
   toChangeTrustXDRObject(): xdr.ChangeTrustAsset;
   toTrustLineXDRObject(): xdr.TrustLineAsset;
-  contractId(): string;
+  contractId(networkPassphrase: string): string;
 
   code: string;
   issuer: string;


### PR DESCRIPTION
This commit addressed the issue reported in https://github.com/stellar/js-stellar-base/issues/717

### **What:**
When using js-stellar-base and js-stellar-sdk to manage assets, the method `contractId()` always returns an error.

### **Why**
By looking at the source code, we can see the method expects an argument that is not present in the exported type.

- **Method**:
https://github.com/stellar/js-stellar-base/blob/cf370f4e627e2b0e296ceceaebd0164dede396bd/src/asset.js#L111

- **Exported type**:
https://github.com/stellar/js-stellar-base/blob/cf370f4e627e2b0e296ceceaebd0164dede396bd/types/index.d.ts#L82C3-L82C13

Forcing typescript to ignore the error and providing the network passphrase as an argument overcomes the issue. It is necessary to update the type to reflect the need for an argument.
