### PR TITLE
Actually omit the 'contractId' field from humanized events when it's empty

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -29,10 +29,9 @@ export function humanizeEvents(events) {
 
 function extractEvent(event) {
   return {
-    contractId:
-      event.contractId() === null
-        ? ''
-        : StrKey.encodeContract(event.contractId()),
+    ...(event.contractId() != null && {
+      contractId: StrKey.encodeContract(event.contractId())
+    }),
     type: event.type().name,
     topics: event
       .body()

--- a/test/unit/events_test.js
+++ b/test/unit/events_test.js
@@ -14,9 +14,10 @@ describe('humanizing raw events', function () {
   // workaround for xdr.ContractEventBody.0(...) being invalid lol
   const cloneAndSet = (newBody) => {
     const clone = new xdr.ContractEventBody(
-      0, new xdr.ContractEventV0({
+      0,
+      new xdr.ContractEventV0({
         topics: [],
-        data: xdr.ScVal.scvVoid(),
+        data: xdr.ScVal.scvVoid()
       })
     );
     clone.v0().topics(newBody.topics);

--- a/test/unit/events_test.js
+++ b/test/unit/events_test.js
@@ -12,9 +12,13 @@ describe('humanizing raw events', function () {
   const data1 = nativeToScVal({ hello: 'world' });
 
   // workaround for xdr.ContractEventBody.0(...) being invalid lol
-  const bodyModel = xdr.ContractEventBody.fromXDR('AAAAAAAAAAAAAAAB', 'base64');
   const cloneAndSet = (newBody) => {
-    const clone = xdr.ContractEventBody.fromXDR(bodyModel.toXDR());
+    const clone = new xdr.ContractEventBody(
+      0, new xdr.ContractEventV0({
+        topics: [],
+        data: xdr.ScVal.scvVoid(),
+      })
+    );
     clone.v0().topics(newBody.topics);
     clone.v0().data(newBody.data);
     return clone;

--- a/test/unit/events_test.js
+++ b/test/unit/events_test.js
@@ -37,6 +37,17 @@ describe('humanizing raw events', function () {
           data: data1
         })
       })
+    }),
+    new xdr.DiagnosticEvent({
+      inSuccessfulContractCall: true,
+      event: new xdr.ContractEvent({
+        ext: new xdr.ExtensionPoint(0),
+        type: xdr.ContractEventType.contract(),
+        body: cloneAndSet({
+          topics: topics1,
+          data: data1
+        })
+      })
     })
   ];
 
@@ -52,6 +63,11 @@ describe('humanizing raw events', function () {
     expect(readable[0]).to.eql({
       type: 'contract',
       contractId: contractId,
+      topics: topics1.map(scValToNative),
+      data: scValToNative(data1)
+    });
+    expect(readable[1]).to.eql({
+      type: 'contract',
       topics: topics1.map(scValToNative),
       data: scValToNative(data1)
     });


### PR DESCRIPTION
Both the documentation and the TypeScript definitions outline it as being omitted when the field is not present in the event (in case of system events), so this is a bugfix rather than a breaking change.