### PR TITLE
Remove setting `BigNumber.DEBUG` to `true` to avoid global impact.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Breaking Changes
+* Starting from **v10.0.0-beta.0**, we set [`BigNumber.DEBUG`](https://mikemcl.github.io/bignumber.js/#debug) in `bignumber.js` to `true`, which would affect all code using `BigNumber`. In this release, we have removed the relevant setting, meaning that `BigNumber.DEBUG` will remain at its default setting, which is not enabling DEBUG mode. ([#729](https://github.com/stellar/js-stellar-base/pull/729)).
 
 ## [`v10.0.2`](https://github.com/stellar/js-stellar-base/compare/v10.0.1...v10.0.2)
 

--- a/src/account.js
+++ b/src/account.js
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from './util/bignumber';
 
 import { StrKey } from './strkey';
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,5 @@
 /* eslint-disable import/no-import-module-exports */
-import BigNumber from 'bignumber.js';
 import xdr from './xdr';
-
-BigNumber.DEBUG = true; // gives us exceptions on bad constructor values
 
 export { xdr };
 export { hash } from './hashing';

--- a/src/memo.js
+++ b/src/memo.js
@@ -1,5 +1,5 @@
 import { UnsignedHyper } from '@stellar/js-xdr';
-import BigNumber from 'bignumber.js';
+import BigNumber from './util/bignumber';
 import xdr from './xdr';
 
 /**

--- a/src/operation.js
+++ b/src/operation.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 
 import { Hyper } from '@stellar/js-xdr';
-import BigNumber from 'bignumber.js';
+import BigNumber from './util/bignumber';
 import { trimEnd } from './util/util';
 import { best_r } from './util/continued_fraction';
 import { Asset } from './asset';

--- a/src/operations/bump_sequence.js
+++ b/src/operations/bump_sequence.js
@@ -1,5 +1,5 @@
 import { Hyper } from '@stellar/js-xdr';
-import BigNumber from 'bignumber.js';
+import BigNumber from '../util/bignumber';
 import xdr from '../xdr';
 
 /**

--- a/src/operations/change_trust.js
+++ b/src/operations/change_trust.js
@@ -1,5 +1,5 @@
 import { Hyper } from '@stellar/js-xdr';
-import BigNumber from 'bignumber.js';
+import BigNumber from '../util/bignumber';
 import xdr from '../xdr';
 import { Asset } from '../asset';
 import { LiquidityPoolAsset } from '../liquidity_pool_asset';

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -1,5 +1,5 @@
 import { UnsignedHyper } from '@stellar/js-xdr';
-import BigNumber from 'bignumber.js';
+import BigNumber from './util/bignumber';
 
 import xdr from './xdr';
 

--- a/src/util/bignumber.js
+++ b/src/util/bignumber.js
@@ -1,0 +1,7 @@
+import OriginBigNumber from 'bignumber.js';
+
+const BigNumber = OriginBigNumber.clone();
+
+BigNumber.DEBUG = true; // gives us exceptions on bad constructor values
+
+export default BigNumber;

--- a/src/util/continued_fraction.js
+++ b/src/util/continued_fraction.js
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from './bignumber';
 
 // eslint-disable-next-line no-bitwise
 const MAX_INT = ((1 << 31) >>> 0) - 1;

--- a/test/unit/util/bignumber_test.js
+++ b/test/unit/util/bignumber_test.js
@@ -1,0 +1,12 @@
+import BigNumber from 'bignumber.js';
+import SDKBigNumber from '../../../src/util/bignumber';
+
+describe('bignumber', function () {
+  it('Debug mode has been enabled in the cloned bignumber.', function () {
+    expect(SDKBigNumber.DEBUG).to.be.true;
+  });
+
+  it('Debug mode has been disabled (default setting) in the original bignumber.', function () {
+    expect(BigNumber.DEBUG).to.be.undefined;
+  });
+});


### PR DESCRIPTION
Closes #727 