### PR TITLE
build: move typescript to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "taffydb": "^2.7.3",
     "terser-webpack-plugin": "^5.3.10",
     "ts-node": "^10.9.2",
+    "typescript": "^5.3.3",
     "webpack": "^5.90.1",
     "webpack-cli": "^5.1.1"
   },
@@ -124,8 +125,7 @@
     "bignumber.js": "^9.1.2",
     "buffer": "^6.0.3",
     "sha.js": "^2.3.6",
-    "tweetnacl": "^1.0.3",
-    "typescript": "^5.3.3"
+    "tweetnacl": "^1.0.3"
   },
   "optionalDependencies": {
     "sodium-native": "^4.0.8"


### PR DESCRIPTION
Reduces bundle size by 95%.

Before, as measured by [bundle-phobia-cli](https://github.com/AdrieanKhisbe/bundle-phobia-cli):

```
$ bundle-phobia -p ./package.json
ℹ @stellar/js-xdr (3.1.0) has 0 dependencies for a weight of 43.86KB (12.32KB gzipped)
ℹ base32.js (0.1.0) has 0 dependencies for a weight of 2.24KB (877B gzipped)
ℹ bignumber.js (9.1.2) has 0 dependencies for a weight of 18.19KB (8.15KB gzipped)
ℹ buffer (6.0.3) has 2 dependencies for a weight of 26.83KB (7.95KB gzipped)
ℹ sha.js (2.4.11) has 2 dependencies for a weight of 12.04KB (4.18KB gzipped)
ℹ tweetnacl (1.0.3) has 0 dependencies for a weight of 31.51KB (10.46KB gzipped)
ℹ typescript (5.3.3) has 0 dependencies for a weight of 3.15MB (890.61KB gzipped)

ℹ total (7 packages) has 4 dependencies for a weight of 3.28MB (934.53KB gzipped)
```

After:

```
$ bundle-phobia -p ./package.json
ℹ @stellar/js-xdr (3.1.0) has 0 dependencies for a weight of 43.86KB (12.32KB gzipped)
ℹ base32.js (0.1.0) has 0 dependencies for a weight of 2.24KB (877B gzipped)
ℹ bignumber.js (9.1.2) has 0 dependencies for a weight of 18.19KB (8.15KB gzipped)
ℹ buffer (6.0.3) has 2 dependencies for a weight of 26.83KB (7.95KB gzipped)
ℹ sha.js (2.4.11) has 2 dependencies for a weight of 12.04KB (4.18KB gzipped)
ℹ tweetnacl (1.0.3) has 0 dependencies for a weight of 31.51KB (10.46KB gzipped)

ℹ total (6 packages) has 4 dependencies for a weight of 134.68KB (43.92KB gzipped)
```