### PR TITLE
Add Buffer.from checkSum to fix buffer concat could fail

### DIFF
--- a/src/strkey.js
+++ b/src/strkey.js
@@ -343,7 +343,7 @@ export function encodeCheck(versionByteName, data) {
 
   const versionBuffer = Buffer.from([versionByte]);
   const payload = Buffer.concat([versionBuffer, data]);
-  const checksum = calculateChecksum(payload);
+  const checksum = Buffer.from(calculateChecksum(payload));
   const unencoded = Buffer.concat([payload, checksum]);
 
   return base32.encode(unencoded);


### PR DESCRIPTION
Hi team, we are running stellar code in a [sandbox](https://www.npmjs.com/package/vm2), and in our production env we are prohibit to inject any additional modules into this sandbox. 

In following code you can see we try to get `.publicKey()` from a keypair, this will throw an error 
`Failed to execute script. TypeError [ERR_INVALID_ARG_TYPE]: The "list[1]" argument must be an instance of Buffer or Uint8Array. Received an instance of Object`, this is due to in sandbox env could not identify Unit8Array so it been treated as an object here. 

```js

const {NodeVM, VMScript} = require('vm2');
const {Keypair} = require('@stellar/stellar-base')

const vm = new NodeVM({
    require: {
        builtin: ['crypto'],
        external: true,
        context: 'sandbox',
        resolve: (moduleName) => {
            return require.resolve(moduleName, {paths: ['./']});
        },
    },
    wrapper: 'commonjs',
    sourceExtensions: ['js', 'cjs'],
});

try {
    vm.run(`
        const {Keypair} = require('@stellar/stellar-base')
        const sourceKeypair = Keypair.fromSecret(
            "SCQN3XGRO65BHNSWLSHYIR4B65AHLDUQ7YLHGIWQ4677AZFRS77TCZRB"
        );
        console.log(sourceKeypair.publicKey())
    `);
} catch (err) {
    console.error('Failed to execute script.', err);
}
```

We require minimal change within this pr, so it could still concat with Buffer. Thank you ~
