### PR TITLE
Fix handling `ScError` types in `scValToNative`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Fixed
+* `scValToNative` would fail when the values contained error codes because the parsing routine hadn't been updated to the new error schemas. Errors are now converted to the following format:
+
+```typescript
+interface Error {
+  type: "contract" | "soroban";
+  code: number;
+  value?: string; // only present for type === 'soroban'
+}
+```
+
+You can refer to the [XDR documentation](https://github.com/stellar/stellar-xdr/blob/70180d5e8d9caee9e8645ed8a38c36a8cf403cd9/Stellar-contract.x#L76-L115) for additional explanations for each error code.
+
 
 ## [`v12.0.0`](https://github.com/stellar/js-stellar-base/compare/v11.0.1...v12.0.0)
 

--- a/src/scval.js
+++ b/src/scval.js
@@ -354,12 +354,12 @@ export function scValToNative(scv) {
     case xdr.ScValType.scvError().value:
       // Distinguish errors from the user contract.
       if (scv.error().switch() === xdr.ScErrorType.sceContract().value) {
-        return { "type": "contract", "code": scv.error().contractCode() };
+        return { type: 'contract', code: scv.error().contractCode() };
       }
       return {
-        "type": "soroban",
-        "code": scv.error().code().value,
-        "value": scv.error().code().name,
+        type: 'soroban',
+        code: scv.error().code().value,
+        value: scv.error().code().name
       };
 
     // in the fallthrough case, just return the underlying value directly

--- a/src/scval.js
+++ b/src/scval.js
@@ -352,15 +352,19 @@ export function scValToNative(scv) {
       return new xdr.Uint64(scv.value()).toBigInt();
 
     case xdr.ScValType.scvError().value:
-      // Distinguish errors from the user contract.
-      if (scv.error().switch() === xdr.ScErrorType.sceContract().value) {
-        return { type: 'contract', code: scv.error().contractCode() };
+      switch (scv.error().switch().value) {
+        // Distinguish errors from the user contract.
+        case xdr.ScErrorType.sceContract().value:
+          return { type: 'contract', code: scv.error().contractCode() };
+        default: {
+          const err = scv.error();
+          return {
+            type: 'system',
+            code: err.code().value,
+            value: err.code().name
+          };
+        }
       }
-      return {
-        type: 'soroban',
-        code: scv.error().code().value,
-        value: scv.error().code().name
-      };
 
     // in the fallthrough case, just return the underlying value directly
     default:

--- a/src/scval.js
+++ b/src/scval.js
@@ -351,22 +351,16 @@ export function scValToNative(scv) {
     case xdr.ScValType.scvDuration().value:
       return new xdr.Uint64(scv.value()).toBigInt();
 
-    case xdr.ScValType.scvStatus().value:
-      // TODO: Convert each status type into a human-readable error string?
-      switch (scv.value().switch()) {
-        case xdr.ScStatusType.sstOk().value:
-        case xdr.ScStatusType.sstUnknownError().value:
-        case xdr.ScStatusType.sstHostValueError().value:
-        case xdr.ScStatusType.sstHostObjectError().value:
-        case xdr.ScStatusType.sstHostFunctionError().value:
-        case xdr.ScStatusType.sstHostStorageError().value:
-        case xdr.ScStatusType.sstHostContextError().value:
-        case xdr.ScStatusType.sstVmError().value:
-        case xdr.ScStatusType.sstContractError().value:
-        case xdr.ScStatusType.sstHostAuthError().value:
-        default:
-          break;
+    case xdr.ScValType.scvError().value:
+      // Distinguish errors from the user contract.
+      if (scv.error().switch() === xdr.ScErrorType.sceContract().value) {
+        return { "type": "contract", "code": scv.error().contractCode() };
       }
+      return {
+        "type": "soroban",
+        "code": scv.error().code().value,
+        "value": scv.error().code().name,
+      };
 
     // in the fallthrough case, just return the underlying value directly
     default:

--- a/test/unit/scval_test.js
+++ b/test/unit/scval_test.js
@@ -237,4 +237,22 @@ describe('parsing and building ScVals', function () {
       expect(scv).to.deep.equal(equiv);
     });
   });
+
+  it('parses errors', function () {
+    const userErr = xdr.ScVal.scvError(xdr.ScError.sceContract(1234));
+    const systemErr = xdr.ScVal.scvError(
+      xdr.ScError.sceWasmVm(xdr.ScErrorCode.scecInvalidInput())
+    );
+
+    const native = scValToNative(xdr.ScVal.scvVec([userErr, systemErr]));
+
+    expect(native).to.deep.equal([
+      { type: 'contract', code: 1234 },
+      {
+        type: 'system',
+        code: systemErr.error().code().value,
+        value: systemErr.error().code().name
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
Errors were updated, but converting them to native objects wasn't. Errors are now converted to the following format:

```typescript
interface Error {
  type: "contract" | "system";
  code: number;
  value?: string; // only present for type === 'system'
}
```