### PR TITLE
added clearing and adding operations at a specified index

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -226,14 +226,39 @@ export class TransactionBuilder {
   addOperation(operation) {
     this.operations.push(operation);
     return this;
+  }	
+  
+  /**
+  * Adds an operation to the transaction at a specific index.
+  *
+  * @param {xdr.Operation} operation - The xdr operation object to add, use {@link Operation} static methods.
+  * @param {number} index - The index at which to insert the operation.
+  *
+  * @returns {TransactionBuilder} - The TransactionBuilder instance for method chaining.
+  */
+  addOperationAtIndex(operation, index) {
+    this.operations.splice(index, 0, operation);
+    return this;
   }
 
   /**
-   * Removes the operations from the builder (useful when cloning).
-   * @returns {TransactionBuilder} this builder instance
-   */
+  * Removes the operations from the builder (useful when cloning).
+  * @returns {TransactionBuilder} this builder instance
+  */
   clearOperations() {
     this.operations = [];
+    return this;
+  }
+
+  /**
+  * Removes the operation at the specified index from the transaction.
+  *
+  * @param {number} index - The index of the operation to remove.
+  *
+  * @returns {TransactionBuilder} The TransactionBuilder instance for method chaining.
+  */
+  clearOperationAtIndex(index) {
+    this.operations.splice(index, 1);
     return this;
   }
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -229,34 +229,34 @@ export class TransactionBuilder {
   }	
   
   /**
-  * Adds an operation to the transaction at a specific index.
-  *
-  * @param {xdr.Operation} operation - The xdr operation object to add, use {@link Operation} static methods.
-  * @param {number} index - The index at which to insert the operation.
-  *
-  * @returns {TransactionBuilder} - The TransactionBuilder instance for method chaining.
-  */
+   * Adds an operation to the transaction at a specific index.
+   *
+   * @param {xdr.Operation} operation - The xdr operation object to add, use {@link Operation} static methods.
+   * @param {number} index - The index at which to insert the operation.
+   *
+   * @returns {TransactionBuilder} - The TransactionBuilder instance for method chaining.
+   */
   addOperationAtIndex(operation, index) {
     this.operations.splice(index, 0, operation);
     return this;
   }
 
   /**
-  * Removes the operations from the builder (useful when cloning).
-  * @returns {TransactionBuilder} this builder instance
-  */
+   * Removes the operations from the builder (useful when cloning).
+   * @returns {TransactionBuilder} this builder instance
+   */
   clearOperations() {
     this.operations = [];
     return this;
   }
 
   /**
-  * Removes the operation at the specified index from the transaction.
-  *
-  * @param {number} index - The index of the operation to remove.
-  *
-  * @returns {TransactionBuilder} The TransactionBuilder instance for method chaining.
-  */
+   * Removes the operation at the specified index from the transaction.
+   *
+   * @param {number} index - The index of the operation to remove.
+   *
+   * @returns {TransactionBuilder} The TransactionBuilder instance for method chaining.
+   */
   clearOperationAtIndex(index) {
     this.operations.splice(index, 1);
     return this;

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -236,7 +236,7 @@ export class TransactionBuilder {
    *
    * @returns {TransactionBuilder} - The TransactionBuilder instance for method chaining.
    */
-  addOperationAtIndex(operation, index) {
+  addOperationAt(operation, index) {
     this.operations.splice(index, 0, operation);
     return this;
   }
@@ -257,7 +257,7 @@ export class TransactionBuilder {
    *
    * @returns {TransactionBuilder} The TransactionBuilder instance for method chaining.
    */
-  clearOperationAtIndex(index) {
+  clearOperationAt(index) {
     this.operations.splice(index, 1);
     return this;
   }

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -954,5 +954,53 @@ describe('TransactionBuilder', function () {
         .build();
       expect(cloneTx.operations).to.be.empty;
     });
+
+    it('adds operations at a specific index', function () {
+        const builder = new StellarBase.TransactionBuilder(source, {
+          fee: '100',
+          timebounds: { minTime: 0, maxTime: 0 },
+          memo: new StellarBase.Memo(StellarBase.MemoText, 'Testing adding op at index'),
+          networkPassphrase
+        });
+
+        builder.addOperationAt(StellarBase.Operation.payment({
+          source: source.accountId(),
+          destination: destination,
+          amount: '1',
+          asset: asset
+        }), 0);
+
+        builder.addOperationAt(StellarBase.Operation.payment({
+          source: source.accountId(),
+          destination: destination,
+          amount: '2',
+          asset: asset
+        }), 1);
+
+        const tx = builder.build();
+        // Assert operations
+        expect(tx.operations.length).to.equal(2);
+        expect(tx.operations[0].source).to.equal(source.accountId());
+        expect(parseInt(tx.operations[0].amount)).to.equal(1);
+        expect(tx.operations[1].source).to.equal(source.accountId());
+        expect(parseInt(tx.operations[1].amount)).to.equal(2);
+
+        const clonedTx = StellarBase.TransactionBuilder.cloneFrom(tx)
+        clonedTx.clearOperationAt(0);
+        const newOperation = StellarBase.Operation.payment({
+          source: source.accountId(),
+          destination: destination,
+          amount: '3',
+          asset: asset
+        })
+        clonedTx.addOperationAt(newOperation, 0);
+        const newTx = clonedTx.build()
+        // Assert that the operations are the same, but the first one is updated
+        expect(newTx.operations.length).to.equal(2);
+        expect(newTx.operations[0].source).to.equal(source.accountId());
+        expect(parseInt(newTx.operations[0].amount)).to.equal(3);
+        expect(newTx.operations[1].source).to.equal(source.accountId());
+        expect(parseInt(newTx.operations[1].amount)).to.equal(2);
+    });
   });
 });


### PR DESCRIPTION
# Summary of changes

- Added two methods: `addOperationAtIndex` and `clearOperationAtIndex` in the `TransactionBuilder` class 

# Use Case

I wanted to add them because I was trying to change the amount of one operations after cloning and realized it would that much easier if I could just clear an operation at a specified index and then add it add the updated operation at the same index again.