### PR TITLE
Compare assets by integer rather than by object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+* Improve the efficiency and portability of asset type retrieval ([#758](https://github.com/stellar/js-stellar-base/pull/758)).
+
 
 ## [`v12.0.1`](https://github.com/stellar/js-stellar-base/compare/v12.0.0...v12.0.1)
 

--- a/src/asset.js
+++ b/src/asset.js
@@ -185,12 +185,12 @@ export class Asset {
    *  - `unknown` as the error case (which should never occur)
    */
   getAssetType() {
-    switch (this.getRawAssetType()) {
-      case xdr.AssetType.assetTypeNative():
+    switch (this.getRawAssetType().value) {
+      case xdr.AssetType.assetTypeNative().value:
         return 'native';
-      case xdr.AssetType.assetTypeCreditAlphanum4():
+      case xdr.AssetType.assetTypeCreditAlphanum4().value:
         return 'credit_alphanum4';
-      case xdr.AssetType.assetTypeCreditAlphanum12():
+      case xdr.AssetType.assetTypeCreditAlphanum12().value:
         return 'credit_alphanum12';
       default:
         return 'unknown';

--- a/test/unit/soroban_test.js
+++ b/test/unit/soroban_test.js
@@ -1,7 +1,6 @@
 describe('Soroban', function () {
   it('should have XDR serialization', function () {
     expect(StellarBase.cereal).not.to.be.undefined;
-    console.log(StellarBase.cereal);
   });
 
   describe('formatTokenAmount', function () {


### PR DESCRIPTION
This increases cross-compatibility across different instances of `stellar-base` by comparing integers rather than objects (which will be `!=` given two different `base`s).