### PR TITLE
Automatically sort maps to match Soroban environment expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Improve the efficiency and portability of asset type retrieval ([#758](https://github.com/stellar/js-stellar-base/pull/758)).
+* `nativeToScVal` will now automatically sort maps lexicographically based on the keys to match what the Soroban environment expects ([#759](https://github.com/stellar/js-stellar-base/pull/759)).
 
 
 ## [`v12.0.1`](https://github.com/stellar/js-stellar-base/compare/v12.0.0...v12.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 * Improve the efficiency and portability of asset type retrieval ([#758](https://github.com/stellar/js-stellar-base/pull/758)).
-* `nativeToScVal` will now automatically sort maps lexicographically based on the keys to match what the Soroban environment expects ([#759](https://github.com/stellar/js-stellar-base/pull/759)).
+* `nativeToScVal` now correctly sorts maps lexicographically based on the keys to match what the Soroban environment expects ([#759](https://github.com/stellar/js-stellar-base/pull/759)).
 
 
 ## [`v12.0.1`](https://github.com/stellar/js-stellar-base/compare/v12.0.0...v12.0.1)

--- a/src/scval.js
+++ b/src/scval.js
@@ -138,7 +138,7 @@ import { ScInt, XdrLargeInt, scValToBigInt } from './numbers/index';
  */
 export function nativeToScVal(val, opts = {}) {
   switch (typeof val) {
-    case 'object':
+    case 'object': {
       if (val === null) {
         return xdr.ScVal.scvVoid();
       }
@@ -190,8 +190,14 @@ export function nativeToScVal(val, opts = {}) {
         );
       }
 
+      // The Soroban runtime expects maps to have their keys in sorted order, so
+      // let's do that here as part of the conversion to prevent confusing error
+      // messages on execution.
+      const entries = Object.entries(val);
+      entries.sort((entry1, entry2) => entry1[0].localeCompare(entry2[0]));
+
       return xdr.ScVal.scvMap(
-        Object.entries(val).map(([k, v]) => {
+        entries.map(([k, v]) => {
           // the type can be specified with an entry for the key and the value,
           // e.g. val = { 'hello': 1 } and opts.type = { hello: [ 'symbol',
           // 'u128' ]} or you can use `null` for the default interpretation
@@ -205,6 +211,7 @@ export function nativeToScVal(val, opts = {}) {
           });
         })
       );
+    }
 
     case 'number':
     case 'bigint':

--- a/src/scval.js
+++ b/src/scval.js
@@ -190,26 +190,25 @@ export function nativeToScVal(val, opts = {}) {
         );
       }
 
-      // The Soroban runtime expects maps to have their keys in sorted order, so
-      // let's do that here as part of the conversion to prevent confusing error
-      // messages on execution.
-      const entries = Object.entries(val);
-      entries.sort((entry1, entry2) => entry1[0].localeCompare(entry2[0]));
-
       return xdr.ScVal.scvMap(
-        entries.map(([k, v]) => {
-          // the type can be specified with an entry for the key and the value,
-          // e.g. val = { 'hello': 1 } and opts.type = { hello: [ 'symbol',
-          // 'u128' ]} or you can use `null` for the default interpretation
-          const [keyType, valType] = (opts?.type ?? {})[k] ?? [null, null];
-          const keyOpts = keyType ? { type: keyType } : {};
-          const valOpts = valType ? { type: valType } : {};
+        Object.entries(val)
+          // The Soroban runtime expects maps to have their keys in sorted
+          // order, so let's do that here as part of the conversion to prevent
+          // confusing error messages on execution.
+          .sort((entry1, entry2) => entry1[0].localeCompare(entry2[0]))
+          .map(([k, v]) => {
+            // the type can be specified with an entry for the key and the value,
+            // e.g. val = { 'hello': 1 } and opts.type = { hello: [ 'symbol',
+            // 'u128' ]} or you can use `null` for the default interpretation
+            const [keyType, valType] = (opts?.type ?? {})[k] ?? [null, null];
+            const keyOpts = keyType ? { type: keyType } : {};
+            const valOpts = valType ? { type: valType } : {};
 
-          return new xdr.ScMapEntry({
-            key: nativeToScVal(k, keyOpts),
-            val: nativeToScVal(v, valOpts)
-          });
-        })
+            return new xdr.ScMapEntry({
+              key: nativeToScVal(k, keyOpts),
+              val: nativeToScVal(v, valOpts)
+            });
+          })
       );
     }
 

--- a/src/scval.js
+++ b/src/scval.js
@@ -195,7 +195,7 @@ export function nativeToScVal(val, opts = {}) {
           // The Soroban runtime expects maps to have their keys in sorted
           // order, so let's do that here as part of the conversion to prevent
           // confusing error messages on execution.
-          .sort((entry1, entry2) => entry1[0].localeCompare(entry2[0]))
+          .sort(([key1], [key2]) => key1.localeCompare(key2))
           .map(([k, v]) => {
             // the type can be specified with an entry for the key and the value,
             // e.g. val = { 'hello': 1 } and opts.type = { hello: [ 'symbol',

--- a/test/unit/scval_test.js
+++ b/test/unit/scval_test.js
@@ -50,7 +50,7 @@ describe('parsing and building ScVals', function () {
           new xdr.ScMapEntry({
             key: xdr.ScVal.scvString('nested'),
             val: xdr.ScVal.scvString('values')
-          }),
+          })
         ])
       ],
       ['u128', new ScInt(1, { type: 'u128' }).toScVal()],
@@ -61,7 +61,7 @@ describe('parsing and building ScVals', function () {
         'vec',
         xdr.ScVal.scvVec(['same', 'type', 'list'].map(xdr.ScVal.scvString))
       ],
-      ['void', xdr.ScVal.scvVoid()],
+      ['void', xdr.ScVal.scvVoid()]
     ].map(([type, scv]) => {
       return new xdr.ScMapEntry({
         key: new xdr.ScVal.scvString(type),

--- a/test/unit/scval_test.js
+++ b/test/unit/scval_test.js
@@ -32,15 +32,10 @@ describe('parsing and building ScVals', function () {
   const targetScv = xdr.ScVal.scvMap(
     [
       ['bool', xdr.ScVal.scvBool(true)],
-      ['void', xdr.ScVal.scvVoid()],
-      ['u32', xdr.ScVal.scvU32(1)],
-      ['i32', xdr.ScVal.scvI32(1)],
-      ['u64', xdr.ScVal.scvU64(new xdr.Uint64(1))],
-      ['i64', xdr.ScVal.scvI64(new xdr.Int64(-1))],
-      ['u128', new ScInt(1, { type: 'u128' }).toScVal()],
       ['i128', new ScInt(1, { type: 'i128' }).toScVal()],
-      ['u256', new ScInt(1, { type: 'u256' }).toScVal()],
       ['i256', new ScInt(1, { type: 'i256' }).toScVal()],
+      ['i32', xdr.ScVal.scvI32(1)],
+      ['i64', xdr.ScVal.scvI64(new xdr.Int64(-1))],
       [
         'map',
         xdr.ScVal.scvMap([
@@ -49,19 +44,24 @@ describe('parsing and building ScVals', function () {
             val: xdr.ScVal.scvU64(new xdr.Uint64(1))
           }),
           new xdr.ScMapEntry({
+            key: xdr.ScVal.scvString('etc'),
+            val: xdr.ScVal.scvBool(false)
+          }),
+          new xdr.ScMapEntry({
             key: xdr.ScVal.scvString('nested'),
             val: xdr.ScVal.scvString('values')
           }),
-          new xdr.ScMapEntry({
-            key: xdr.ScVal.scvString('etc'),
-            val: xdr.ScVal.scvBool(false)
-          })
         ])
       ],
+      ['u128', new ScInt(1, { type: 'u128' }).toScVal()],
+      ['u256', new ScInt(1, { type: 'u256' }).toScVal()],
+      ['u32', xdr.ScVal.scvU32(1)],
+      ['u64', xdr.ScVal.scvU64(new xdr.Uint64(1))],
       [
         'vec',
         xdr.ScVal.scvVec(['same', 'type', 'list'].map(xdr.ScVal.scvString))
-      ]
+      ],
+      ['void', xdr.ScVal.scvVoid()],
     ].map(([type, scv]) => {
       return new xdr.ScMapEntry({
         key: new xdr.ScVal.scvString(type),
@@ -182,12 +182,12 @@ describe('parsing and building ScVals', function () {
     scv = nativeToScVal(
       {
         hello: 'world',
-        goodbye: [1, 2, 3]
+        there: [1, 2, 3]
       },
       {
         type: {
           hello: ['symbol', null],
-          goodbye: [null, 'i32']
+          there: [null, 'i32']
         }
       }
     );


### PR DESCRIPTION
Closes stellar/js-stellar-sdk#996 and stellar/js-stellar-sdk#966.

Note that test changes just involve changing the order of the map fields to be sorted accordingly in the "expected output" portion of the test.

Also, the diff is simpler if you [turn whitespace off](https://github.com/stellar/js-stellar-base/pull/759/files?diff=unified&w=1).