### PR TITLE
Add support for `nativeToScVal` to convert strings to all number sizes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 * Improve the efficiency and portability of asset type retrieval ([#758](https://github.com/stellar/js-stellar-base/pull/758)).
 * `nativeToScVal` now correctly sorts maps lexicographically based on the keys to match what the Soroban environment expects ([#759](https://github.com/stellar/js-stellar-base/pull/759)).
+* `nativeToScVal` now allows all integer types to come from strings ([#763](https://github.com/stellar/js-stellar-base/pull/763)).
 
 
 ## [`v12.0.1`](https://github.com/stellar/js-stellar-base/compare/v12.0.0...v12.0.1)

--- a/src/scval.js
+++ b/src/scval.js
@@ -239,6 +239,12 @@ export function nativeToScVal(val, opts = {}) {
         case 'address':
           return new Address(val).toScVal();
 
+        case 'u32':
+          return xdr.ScVal.scvU32(parseInt(val));
+
+        case 'i32':
+          return xdr.ScVal.scvI32(parseInt(val));
+
         default:
           if (XdrLargeInt.isType(optType)) {
             return new XdrLargeInt(optType, val).toScVal();

--- a/src/scval.js
+++ b/src/scval.js
@@ -240,10 +240,10 @@ export function nativeToScVal(val, opts = {}) {
           return new Address(val).toScVal();
 
         case 'u32':
-          return xdr.ScVal.scvU32(parseInt(val));
+          return xdr.ScVal.scvU32(parseInt(val, 10));
 
         case 'i32':
-          return xdr.ScVal.scvI32(parseInt(val));
+          return xdr.ScVal.scvI32(parseInt(val, 10));
 
         default:
           if (XdrLargeInt.isType(optType)) {

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -226,8 +226,8 @@ export class TransactionBuilder {
   addOperation(operation) {
     this.operations.push(operation);
     return this;
-  }	
-  
+  }
+
   /**
    * Adds an operation to the transaction at a specific index.
    *

--- a/test/unit/scval_test.js
+++ b/test/unit/scval_test.js
@@ -214,11 +214,9 @@ describe('parsing and building ScVals', function () {
   it('lets strings be small integer ScVals', function () {
     ['i32', 'u32'].forEach((type) => {
       const scv = nativeToScVal('12345', { type });
-      if (type === 'u32') {
-        expect(scv.switch()).to.eql(xdr.ScValType.scvU32());
-      } else {
-        expect(scv.switch()).to.eql(xdr.ScValType.scvI32());
-      }
+      expect(scv.switch()).to.eql(
+        type === 'u32' ? xdr.ScValType.scvU32() : xdr.ScValType.scvI32()
+      );
       expect(scv.value()).to.eql(12345);
     });
   });

--- a/test/unit/scval_test.js
+++ b/test/unit/scval_test.js
@@ -211,6 +211,18 @@ describe('parsing and building ScVals', function () {
     expect(() => nativeToScVal([1, 'a', false])).to.throw(/same type/i);
   });
 
+  it('lets strings be small integer ScVals', function () {
+    ['i32', 'u32'].forEach((type) => {
+      const scv = nativeToScVal('12345', { type });
+      if (type === 'u32') {
+        expect(scv.switch()).to.eql(xdr.ScValType.scvU32());
+      } else {
+        expect(scv.switch()).to.eql(xdr.ScValType.scvI32());
+      }
+      expect(scv.value()).to.eql(12345);
+    });
+  });
+
   it('lets strings be large integer ScVals', function () {
     ['i64', 'i128', 'i256', 'u64', 'u128', 'u256'].forEach((type) => {
       const scv = nativeToScVal('12345', { type });
@@ -220,7 +232,6 @@ describe('parsing and building ScVals', function () {
 
     expect(() => nativeToScVal('not a number', { type: 'i128' })).to.throw();
     expect(() => nativeToScVal('12345', { type: 'notnumeric' })).to.throw();
-    expect(() => nativeToScVal('use a Number', { type: 'i32' })).to.throw();
   });
 
   it('lets strings be addresses', function () {

--- a/test/unit/transaction_builder_test.js
+++ b/test/unit/transaction_builder_test.js
@@ -956,51 +956,60 @@ describe('TransactionBuilder', function () {
     });
 
     it('adds operations at a specific index', function () {
-        const builder = new StellarBase.TransactionBuilder(source, {
-          fee: '100',
-          timebounds: { minTime: 0, maxTime: 0 },
-          memo: new StellarBase.Memo(StellarBase.MemoText, 'Testing adding op at index'),
-          networkPassphrase
-        });
+      const builder = new StellarBase.TransactionBuilder(source, {
+        fee: '100',
+        timebounds: { minTime: 0, maxTime: 0 },
+        memo: new StellarBase.Memo(
+          StellarBase.MemoText,
+          'Testing adding op at index'
+        ),
+        networkPassphrase
+      });
 
-        builder.addOperationAt(StellarBase.Operation.payment({
+      builder.addOperationAt(
+        StellarBase.Operation.payment({
           source: source.accountId(),
           destination: destination,
           amount: '1',
           asset: asset
-        }), 0);
+        }),
+        0
+      );
 
-        builder.addOperationAt(StellarBase.Operation.payment({
+      builder.addOperationAt(
+        StellarBase.Operation.payment({
           source: source.accountId(),
           destination: destination,
           amount: '2',
           asset: asset
-        }), 1);
+        }),
+        1
+      );
 
-        const tx = builder.build();
-        // Assert operations
-        expect(tx.operations.length).to.equal(2);
-        expect(tx.operations[0].source).to.equal(source.accountId());
-        expect(parseInt(tx.operations[0].amount)).to.equal(1);
-        expect(tx.operations[1].source).to.equal(source.accountId());
-        expect(parseInt(tx.operations[1].amount)).to.equal(2);
+      const tx = builder.build();
+      // Assert operations
+      expect(tx.operations.length).to.equal(2);
+      expect(tx.operations[0].source).to.equal(source.accountId());
+      expect(parseInt(tx.operations[0].amount)).to.equal(1);
+      expect(tx.operations[1].source).to.equal(source.accountId());
+      expect(parseInt(tx.operations[1].amount)).to.equal(2);
 
-        const clonedTx = StellarBase.TransactionBuilder.cloneFrom(tx)
-        clonedTx.clearOperationAt(0);
-        const newOperation = StellarBase.Operation.payment({
-          source: source.accountId(),
-          destination: destination,
-          amount: '3',
-          asset: asset
-        })
-        clonedTx.addOperationAt(newOperation, 0);
-        const newTx = clonedTx.build()
-        // Assert that the operations are the same, but the first one is updated
-        expect(newTx.operations.length).to.equal(2);
-        expect(newTx.operations[0].source).to.equal(source.accountId());
-        expect(parseInt(newTx.operations[0].amount)).to.equal(3);
-        expect(newTx.operations[1].source).to.equal(source.accountId());
-        expect(parseInt(newTx.operations[1].amount)).to.equal(2);
+      const clonedTx = StellarBase.TransactionBuilder.cloneFrom(tx);
+      clonedTx.clearOperationAt(0);
+      const newOperation = StellarBase.Operation.payment({
+        source: source.accountId(),
+        destination: destination,
+        amount: '3',
+        asset: asset
+      });
+      clonedTx.addOperationAt(newOperation, 0);
+      const newTx = clonedTx.build();
+      // Assert that the operations are the same, but the first one is updated
+      expect(newTx.operations.length).to.equal(2);
+      expect(newTx.operations[0].source).to.equal(source.accountId());
+      expect(parseInt(newTx.operations[0].amount)).to.equal(3);
+      expect(newTx.operations[1].source).to.equal(source.accountId());
+      expect(parseInt(newTx.operations[1].amount)).to.equal(2);
     });
   });
 });


### PR DESCRIPTION
Previously, `i32` and `u32` could not automatically come from string values when using `nativeToScVal`. Namely, `nativeToScVal("4", { type: "i32" })` was explicitly forbidden. This was my design: the rationale was that if it's a 32-bit integer, it should be passed as a `Number`. 

However, this logic does not hold true for maps, because in JavaScript, all map keys are strings. Therefore, creating an `ScVal` representing an integer-to-integer map is impossible via `nativeToScVal`, e.g., a function signature like this one:

```rust
fn spin(env: Env, pairs: Map<u32, u64>) -> boolean;
```

cannot be executed by 
```js
nativeToScVal(
  { 1234: 5678 }, 
  { 
    type: { 
      "1234": [ "u32, "u64" ],
      "5678": [ "u32, "u64" ],
    }
);
```

because `1234` would be interpreted as a string, and thus could not be automatically converted to a `number` for a `u32` inference.