### PR TITLE
Support constructors in contract creation via `Operation.createCustomContract`

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Code Formatting
 
 on:
   push:
@@ -8,32 +8,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        node-version: [18, 20, 21]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20
 
       # Workaround for some `yarn` nonsense, see:
       # https://github.com/yarnpkg/yarn/issues/6312#issuecomment-429685210
       - name: Install Dependencies
         run: yarn install --network-concurrency 1
 
-      - name: Build All
-        run: yarn build:prod
-
-      - name: Run Node Tests
-        run: yarn test:node
-
-      - name: Run Browser Tests
-        run: yarn test:browser
+      - name: Run Linter Checks
+        run: yarn fmt && yarn lint && (git diff-index --quiet HEAD; git diff)

--- a/src/operation.js
+++ b/src/operation.js
@@ -91,7 +91,13 @@ export const AuthClawbackEnabledFlag = 1 << 3;
  * * `{@link Operation.setTrustLineFlags}`
  * * `{@link Operation.liquidityPoolDeposit}`
  * * `{@link Operation.liquidityPoolWithdraw}`
- * * `{@link Operation.invokeHostFunction}`
+ * * `{@link Operation.invokeHostFunction}`, which has the following additional
+ *   "pseudo-operations" that make building host functions easier:
+ *   - `{@link Operation.createStellarAssetContract}`
+ *   - `{@link Operation.invokeContractFunction}`
+ *   - `{@link Operation.createCustomContract}`
+ *   - `{@link Operation.createConstructableContract}`
+ *   - `{@link Operation.uploadContractWasm}`
  * * `{@link Operation.extendFootprintTtlOp}`
  * * `{@link Operation.restoreFootprint}`
  *
@@ -680,4 +686,5 @@ Operation.restoreFootprint = ops.restoreFootprint;
 Operation.createStellarAssetContract = ops.createStellarAssetContract;
 Operation.invokeContractFunction = ops.invokeContractFunction;
 Operation.createCustomContract = ops.createCustomContract;
+Operation.createConstructableContract = ops.createConstructableContract;
 Operation.uploadContractWasm = ops.uploadContractWasm;

--- a/src/operation.js
+++ b/src/operation.js
@@ -96,7 +96,6 @@ export const AuthClawbackEnabledFlag = 1 << 3;
  *   - `{@link Operation.createStellarAssetContract}`
  *   - `{@link Operation.invokeContractFunction}`
  *   - `{@link Operation.createCustomContract}`
- *   - `{@link Operation.createConstructableContract}`
  *   - `{@link Operation.uploadContractWasm}`
  * * `{@link Operation.extendFootprintTtlOp}`
  * * `{@link Operation.restoreFootprint}`
@@ -686,5 +685,4 @@ Operation.restoreFootprint = ops.restoreFootprint;
 Operation.createStellarAssetContract = ops.createStellarAssetContract;
 Operation.invokeContractFunction = ops.invokeContractFunction;
 Operation.createCustomContract = ops.createCustomContract;
-Operation.createConstructableContract = ops.createConstructableContract;
 Operation.uploadContractWasm = ops.uploadContractWasm;

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -35,6 +35,7 @@ export {
   invokeContractFunction,
   createStellarAssetContract,
   createCustomContract,
+  createConstructableContract,
   uploadContractWasm
 } from './invoke_host_function';
 export { extendFootprintTtl } from './extend_footprint_ttl';

--- a/src/operations/index.js
+++ b/src/operations/index.js
@@ -35,7 +35,6 @@ export {
   invokeContractFunction,
   createStellarAssetContract,
   createCustomContract,
-  createConstructableContract,
   uploadContractWasm
 } from './invoke_host_function';
 export { extendFootprintTtl } from './extend_footprint_ttl';

--- a/src/operations/invoke_host_function.js
+++ b/src/operations/invoke_host_function.js
@@ -238,7 +238,7 @@ export function uploadContractWasm(opts) {
  * @param {Uint8Array|Buffer}  opts.wasmHash - the SHA-256 hash of the contract
  *    WASM you're uploading (see {@link hash} and
  *    {@link Operation.uploadContractWasm})
- * @param {xdr.ScVal[]} opts.ctorArgs - the parameters to pass to the
+ * @param {xdr.ScVal[]} opts.constructorArgs - the parameters to pass to the
  *    constructor of this contract (see {@link nativeToScVal} for ways to easily
  *    create these parameters from native JS values)
  *
@@ -284,7 +284,7 @@ export function createConstructableContract(opts) {
               salt
             })
           ),
-        constructorArgs: opts.ctorArgs ?? []
+        constructorArgs: opts.constructorArgs ?? []
       })
     )
   });

--- a/src/operations/invoke_host_function.js
+++ b/src/operations/invoke_host_function.js
@@ -24,7 +24,6 @@ import { Asset } from '../asset';
  * @see Operation.invokeContractFunction
  * @see Operation.createCustomContract
  * @see Operation.createStellarAssetContract
- * @see Operation.createConstructableContract
  * @see Operation.uploadContractWasm
  * @see Contract.call
  */
@@ -91,7 +90,8 @@ export function invokeContractFunction(opts) {
 }
 
 /**
- * Returns an operation that creates a custom WASM contract.
+ * Returns an operation that creates a custom WASM contract and atomically
+ * invokes its constructor.
  *
  * @function
  * @alias Operation.createCustomContract
@@ -101,6 +101,9 @@ export function invokeContractFunction(opts) {
  * @param {Uint8Array|Buffer}  opts.wasmHash - the SHA-256 hash of the contract
  *    WASM you're uploading (see {@link hash} and
  *    {@link Operation.uploadContractWasm})
+ * @param {xdr.ScVal[]} [opts.constructorArgs] - the optional parameters to pass
+ *    to the constructor of this contract (see {@link nativeToScVal} for ways to
+ *    easily create these parameters from native JS values)
  * @param {Uint8Array|Buffer} [opts.salt] - an optional, 32-byte salt to
  *    distinguish deployment instances of the same wasm from the same user (if
  *    omitted, one will be generated for you)
@@ -113,8 +116,6 @@ export function invokeContractFunction(opts) {
  *
  * @see
  * https://soroban.stellar.org/docs/fundamentals-and-concepts/invoking-contracts-with-transactions#function
- * @deprecated Please use {@link Operation.createConstructableContract} which
- *    supports contracts with constructors.
  */
 export function createCustomContract(opts) {
   const salt = Buffer.from(opts.salt || getSalty());
@@ -133,8 +134,8 @@ export function createCustomContract(opts) {
   return this.invokeHostFunction({
     source: opts.source,
     auth: opts.auth,
-    func: xdr.HostFunction.hostFunctionTypeCreateContract(
-      new xdr.CreateContractArgs({
+    func: xdr.HostFunction.hostFunctionTypeCreateContractV2(
+      new xdr.CreateContractArgsV2({
         executable: xdr.ContractExecutable.contractExecutableWasm(
           Buffer.from(opts.wasmHash)
         ),
@@ -144,7 +145,8 @@ export function createCustomContract(opts) {
               address: opts.address.toScAddress(),
               salt
             })
-          )
+          ),
+        constructorArgs: opts.constructorArgs ?? []
       })
     )
   });
@@ -222,70 +224,6 @@ export function uploadContractWasm(opts) {
     auth: opts.auth,
     func: xdr.HostFunction.hostFunctionTypeUploadContractWasm(
       Buffer.from(opts.wasm) // coalesce so we can drop `Buffer` someday
-    )
-  });
-}
-
-/**
- * Returns an operation that creates a custom WASM contract and atomically
- * invokes its constructor.
- *
- * @function
- * @alias Operation.createConstructableContract
- *
- * @param {any}     opts - the set of parameters
- * @param {Address} opts.address - the contract uploader address
- * @param {Uint8Array|Buffer}  opts.wasmHash - the SHA-256 hash of the contract
- *    WASM you're uploading (see {@link hash} and
- *    {@link Operation.uploadContractWasm})
- * @param {xdr.ScVal[]} opts.constructorArgs - the parameters to pass to the
- *    constructor of this contract (see {@link nativeToScVal} for ways to easily
- *    create these parameters from native JS values)
- *
- * @param {Uint8Array|Buffer} [opts.salt] - an optional, 32-byte salt to
- *    distinguish deployment instances of the same wasm from the same user (if
- *    omitted, one will be generated for you)
- * @param {xdr.SorobanAuthorizationEntry[]} [opts.auth] - an optional list
- *    outlining the tree of authorizations required for the call
- * @param {string} [opts.source] - an optional source account
- *
- * @returns {xdr.Operation} an Invoke Host Function operation
- *    (xdr.InvokeHostFunctionOp)
- *
- * @see
- * https://soroban.stellar.org/docs/fundamentals-and-concepts/invoking-contracts-with-transactions#function
- */
-export function createConstructableContract(opts) {
-  const salt = Buffer.from(opts.salt || getSalty());
-
-  if (!opts.wasmHash || opts.wasmHash.length !== 32) {
-    throw new TypeError(
-      `expected hash(contract WASM) in 'opts.wasmHash', got ${opts.wasmHash}`
-    );
-  }
-  if (salt.length !== 32) {
-    throw new TypeError(
-      `expected 32-byte salt in 'opts.salt', got ${opts.wasmHash}`
-    );
-  }
-
-  return this.invokeHostFunction({
-    source: opts.source,
-    auth: opts.auth,
-    func: xdr.HostFunction.hostFunctionTypeCreateContractV2(
-      new xdr.CreateContractArgsV2({
-        executable: xdr.ContractExecutable.contractExecutableWasm(
-          Buffer.from(opts.wasmHash)
-        ),
-        contractIdPreimage:
-          xdr.ContractIdPreimage.contractIdPreimageFromAddress(
-            new xdr.ContractIdPreimageFromAddress({
-              address: opts.address.toScAddress(),
-              salt
-            })
-          ),
-        constructorArgs: opts.constructorArgs ?? []
-      })
     )
   });
 }

--- a/test/unit/operations/invoke_host_function_test.js
+++ b/test/unit/operations/invoke_host_function_test.js
@@ -170,7 +170,7 @@ describe('Operation', function () {
         // check deep inner field to ensure ctor args match
         const ctorArgs = decodedOp.func.createContractV2().constructorArgs();
         expect(ctorArgs).to.eql(
-          args,
+          constructorArgs,
           `constructor parameters don't match: ${JSON.stringify(
             ctorArgs,
             null,

--- a/test/unit/operations/invoke_host_function_test.js
+++ b/test/unit/operations/invoke_host_function_test.js
@@ -132,10 +132,7 @@ describe('Operation', function () {
       it('lets you create contracts with a constructor', function () {
         const h = hash(Buffer.from('random stuff'));
         const constructorArgs = [
-          // note: using a string here doesn't work because once the operation
-          // is encoded/decoded it will be a Buffer internally and it'd be a
-          // mild pain in the ass to check equivalence
-          nativeToScVal(Buffer.from('admin name')),
+          nativeToScVal('admin name'),
           nativeToScVal(1234, { type: 'i128' })
         ];
 
@@ -169,15 +166,14 @@ describe('Operation', function () {
 
         // check deep inner field to ensure ctor args match
         const ctorArgs = decodedOp.func.createContractV2().constructorArgs();
-        expect(ctorArgs).to.eql(
-          constructorArgs,
-          `constructor parameters don't match: ${JSON.stringify(
-            ctorArgs,
-            null,
-            2
-          )} vs. ${JSON.stringify(constructorArgs, null, 2)}`
-        );
+
+        expect(ctorArgs).to.have.lengthOf(2);
+        expect(ctorArgs[1]).to.eql(constructorArgs[1]);
         expect(decodedOp.auth).to.be.empty;
+        // note: we used a string initially but once the operation is
+        // encoded/decoded it will be a Buffer internally, so we need to
+        // compare that way instead.
+        expect(ctorArgs[0].str().toString()).to.eql(constructorArgs[0].str());
       });
     });
   });

--- a/test/unit/operations/invoke_host_function_test.js
+++ b/test/unit/operations/invoke_host_function_test.js
@@ -1,4 +1,4 @@
-const { Asset, Contract, Operation, hash } = StellarBase;
+const { Asset, Contract, Operation, hash, nativeToScVal } = StellarBase;
 
 describe('Operation', function () {
   describe('.invokeHostFunction()', function () {
@@ -15,7 +15,7 @@ describe('Operation', function () {
           new StellarBase.xdr.InvokeContractArgs({
             contractAddress: this.c.address().toScAddress(),
             functionName: 'hello',
-            args: [StellarBase.nativeToScVal('world')]
+            args: [nativeToScVal('world')]
           })
         )
       });
@@ -32,7 +32,7 @@ describe('Operation', function () {
         Operation.invokeContractFunction({
           contract: this.contractId,
           function: 'hello',
-          args: [StellarBase.nativeToScVal('world')]
+          args: [nativeToScVal('world')]
         }).toXDR('hex')
       ).to.eql(xdr);
     });
@@ -126,6 +126,57 @@ describe('Operation', function () {
           'hostFunctionTypeUploadContractWasm'
         );
         expect(decodedOp.func.wasm()).to.eql(wasm);
+        expect(decodedOp.auth).to.be.empty;
+      });
+
+      it('lets you create contracts with a constructor', function () {
+        const h = hash(Buffer.from('random stuff'));
+        const args = [
+          // note: using a string here doesn't work because once the operation
+          // is encoded/decoded it will be a Buffer internally and it'd be a
+          // mild pain in the ass to check equivalence
+          nativeToScVal(Buffer.from('admin name')),
+          nativeToScVal(1234, { type: 'i128' })
+        ];
+
+        const op = Operation.createConstructableContract({
+          address: this.c.address(),
+          ctorArgs: args,
+          wasmHash: h,
+          salt: h
+        });
+        expect(op.body().switch().name).to.equal('invokeHostFunction');
+
+        // round trip back
+
+        const xdr = op.toXDR('hex');
+        const xdrOp = StellarBase.xdr.Operation.fromXDR(xdr, 'hex');
+        const decodedOp = Operation.fromXDRObject(xdrOp, 'hex');
+
+        expect(decodedOp.type).to.equal('invokeHostFunction');
+        expect(decodedOp.func.switch().name).to.equal(
+          'hostFunctionTypeCreateContractV2'
+        );
+
+        // check deep inner field to ensure RT
+        expect(
+          decodedOp.func
+            .createContractV2()
+            .contractIdPreimage()
+            .fromAddress()
+            .salt()
+        ).to.eql(h, "hashes don't match");
+
+        // check deep inner field to ensure ctor args match
+        const ctorArgs = decodedOp.func.createContractV2().constructorArgs();
+        expect(ctorArgs).to.eql(
+          args,
+          `constructor parameters don't match: ${JSON.stringify(
+            ctorArgs,
+            null,
+            2
+          )} vs. ${JSON.stringify(args, null, 2)}`
+        );
         expect(decodedOp.auth).to.be.empty;
       });
     });

--- a/test/unit/operations/invoke_host_function_test.js
+++ b/test/unit/operations/invoke_host_function_test.js
@@ -131,7 +131,7 @@ describe('Operation', function () {
 
       it('lets you create contracts with a constructor', function () {
         const h = hash(Buffer.from('random stuff'));
-        const args = [
+        const constructorArgs = [
           // note: using a string here doesn't work because once the operation
           // is encoded/decoded it will be a Buffer internally and it'd be a
           // mild pain in the ass to check equivalence
@@ -141,7 +141,7 @@ describe('Operation', function () {
 
         const op = Operation.createConstructableContract({
           address: this.c.address(),
-          ctorArgs: args,
+          constructorArgs,
           wasmHash: h,
           salt: h
         });
@@ -175,7 +175,7 @@ describe('Operation', function () {
             ctorArgs,
             null,
             2
-          )} vs. ${JSON.stringify(args, null, 2)}`
+          )} vs. ${JSON.stringify(constructorArgs, null, 2)}`
         );
         expect(decodedOp.auth).to.be.empty;
       });

--- a/test/unit/operations/invoke_host_function_test.js
+++ b/test/unit/operations/invoke_host_function_test.js
@@ -63,12 +63,12 @@ describe('Operation', function () {
 
         expect(decodedOp.type).to.equal('invokeHostFunction');
         expect(decodedOp.func.switch().name).to.equal(
-          'hostFunctionTypeCreateContract'
+          'hostFunctionTypeCreateContractV2'
         );
         expect(
           // check deep inner field to ensure RT
           decodedOp.func
-            .createContract()
+            .createContractV2()
             .contractIdPreimage()
             .fromAddress()
             .salt()
@@ -139,7 +139,7 @@ describe('Operation', function () {
           nativeToScVal(1234, { type: 'i128' })
         ];
 
-        const op = Operation.createConstructableContract({
+        const op = Operation.createCustomContract({
           address: this.c.address(),
           constructorArgs,
           wasmHash: h,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -561,12 +561,7 @@ export namespace OperationOptions {
   interface CreateCustomContract extends BaseInvocationOptions {
     address: Address;
     wasmHash: Buffer | Uint8Array;
-    salt?: Buffer | Uint8Array;
-  }
-  interface CreateConstructableContract extends BaseInvocationOptions {
-    address: Address;
-    wasmHash: Buffer | Uint8Array;
-    constructorArgs: xdr.ScVal[];
+    constructorArgs?: xdr.ScVal[];
     salt?: Buffer | Uint8Array;
   }
   interface CreateStellarAssetContract extends BaseOptions {
@@ -615,7 +610,6 @@ export type OperationOptions =
   | OperationOptions.ExtendFootprintTTL
   | OperationOptions.RestoreFootprint
   | OperationOptions.CreateCustomContract
-  | OperationOptions.CreateConstructableContract
   | OperationOptions.CreateStellarAssetContract
   | OperationOptions.InvokeContractFunction
   | OperationOptions.UploadContractWasm;
@@ -920,9 +914,6 @@ export namespace Operation {
 
   function createCustomContract(
     opts: OperationOptions.CreateCustomContract
-  ): xdr.Operation<InvokeHostFunction>;
-  function createConstructableContract(
-    opts: OperationOptions.CreateConstructableContract
   ): xdr.Operation<InvokeHostFunction>;
   function createStellarAssetContract(
     opts: OperationOptions.CreateStellarAssetContract

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -563,6 +563,12 @@ export namespace OperationOptions {
     wasmHash: Buffer | Uint8Array;
     salt?: Buffer | Uint8Array;
   }
+  interface CreateConstructableContract extends BaseInvocationOptions {
+    address: Address;
+    wasmHash: Buffer | Uint8Array;
+    ctorArgs: xdr.ScVal[];
+    salt?: Buffer | Uint8Array;
+  }
   interface CreateStellarAssetContract extends BaseOptions {
     asset: Asset | string;
   }
@@ -609,6 +615,7 @@ export type OperationOptions =
   | OperationOptions.ExtendFootprintTTL
   | OperationOptions.RestoreFootprint
   | OperationOptions.CreateCustomContract
+  | OperationOptions.CreateConstructableContract
   | OperationOptions.CreateStellarAssetContract
   | OperationOptions.InvokeContractFunction
   | OperationOptions.UploadContractWasm;
@@ -913,6 +920,9 @@ export namespace Operation {
 
   function createCustomContract(
     opts: OperationOptions.CreateCustomContract
+  ): xdr.Operation<InvokeHostFunction>;
+  function createConstructableContract(
+    opts: OperationOptions.CreateConstructableContract
   ): xdr.Operation<InvokeHostFunction>;
   function createStellarAssetContract(
     opts: OperationOptions.CreateStellarAssetContract

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -566,7 +566,7 @@ export namespace OperationOptions {
   interface CreateConstructableContract extends BaseInvocationOptions {
     address: Address;
     wasmHash: Buffer | Uint8Array;
-    ctorArgs: xdr.ScVal[];
+    constructorArgs: xdr.ScVal[];
     salt?: Buffer | Uint8Array;
   }
   interface CreateStellarAssetContract extends BaseOptions {


### PR DESCRIPTION
Upgrade the `createCustomContract` abstraction to accept a new, optional parameter:

```diff
class Operation {
  // ...
  createCustomContract(
    address: Address,
    wasmHash: Buffer | Uint8Array,
+   constructorArgs?: xdr.ScVal[],
    salt?: Buffer | Uint8Array,
...
```

and upgrade the internals to use the `CreateContractV2` host function.

This closes #768.