### PR TITLE
Fix bug with signing auth entries in multisig scenarios

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -136,7 +136,7 @@ export async function authorizeEntry(
   } else {
     signature = Buffer.from(signer.sign(payload));
   }
-  const publicKey = Address.fromScAddress(addrAuth.address()).toString();
+  const publicKey = signer.publicKey();
 
   if (!Keypair.fromPublicKey(publicKey).verify(payload, signature)) {
     throw new Error(`signature doesn't match payload`);


### PR DESCRIPTION
Not every auth entry will be signing for itself, in the case of a multisig account where the master is GAA and the sub is GBB the auth entry will be GAA but we need to sign and check for GBB. We need to check the payload against the key that actually did the signing.

Context: https://discord.com/channels/897514728459468821/1281628550008406078