### PR TITLE
Prepare v13.0.0-beta.1 (Protocol 22) for release.

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -24,9 +24,9 @@ jobs:
 
       - name: Publish npm package to both places
         run: |
-          yarn publish --access public --tag beta
+          yarn publish --access public --tag protocol-22-beta
           sed -i -e 's#"@stellar/stellar-base"#"stellar-base"#' package.json
-          yarn publish --tag beta
+          yarn publish --tag protocol-22-beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -24,9 +24,9 @@ jobs:
 
       - name: Publish npm package to both places
         run: |
-          yarn publish --access public
+          yarn publish --access public --tag beta
           sed -i -e 's#"@stellar/stellar-base"#"stellar-base"#' package.json
-          yarn publish
+          yarn publish --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## Unreleased
 
 
+## [`v13.0.0-beta.0`](https://github.com/stellar/js-stellar-base/compare/v12.1.1...v13.0.0-beta.1)
+
+**This is the first release that supports Protocol 22.** While the network has not upgraded yet, you can start integrating the new features into your codebase if you want a head start. Keep in mind that while the binary XDR is backwards-compatible, the naming and layout of structures is not. In other words, this build will continue to work on Protocol 21, but you may have to update code that references XDR directly.
+
+### Breaking Changes
+* XDR definitions have been upgraded to Protocol 22 ([#777](https://github.com/stellar/js-stellar-base/pull/777)).
+
+### Added
+* You can create contracts with constructors a new, optional parameter of `Operation.createCustomContract`, `constructorArgs: xdr.ScVal[]` ([#770](https://github.com/stellar/js-stellar-base/pull/770)).
+
+
 ## [`v12.1.1`](https://github.com/stellar/js-stellar-base/compare/v12.1.0...v12.1.1)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 
-## [`v13.0.0-beta.0`](https://github.com/stellar/js-stellar-base/compare/v12.1.1...v13.0.0-beta.1)
+## [`v13.0.0-beta.1`](https://github.com/stellar/js-stellar-base/compare/v12.1.1...v13.0.0-beta.1)
 
 **This is the first release that supports Protocol 22.** While the network has not upgraded yet, you can start integrating the new features into your codebase if you want a head start. Keep in mind that while the binary XDR is backwards-compatible, the naming and layout of structures is not. In other words, this build will continue to work on Protocol 21, but you may have to update code that references XDR directly.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/stellar-base",
-  "version": "12.1.1",
+  "version": "13.0.0-beta.1",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
   "browser": {


### PR DESCRIPTION
In order to keep `master` clean for bugfixes during the transition period, we should release from the Protocol 22 branch which has a well-defined set of already-approved and merged PRs (see lucky https://github.com/stellar/js-stellar-base/pull/777).

This PR tags off the version, publishes under the `beta` tag on NPM, and updates the changelog.

Note that this is tagged as a `beta` instead of an `rc` so that we can properly handle any anticipated changes to core that occur throughout the release process (e.g. patch fixes after `v22.0.0` that require XDR structure or behavior changes), as was the case with Protocol 20.