### PR TITLE
Add an `xdr.scvMapSorted` constructor to automagically sort map `ScVal`s.

### DIFF
--- a/src/scval.js
+++ b/src/scval.js
@@ -379,14 +379,14 @@ export function scValToNative(scv) {
 
 /// Inject a sortable map builder into the xdr module.
 xdr.scvSortedMap = (items) => {
-  let sorted = Array.from(items).sort((a, b) => {
+  const sorted = Array.from(items).sort((a, b) => {
     // Both a and b are `ScMapEntry`s, so we need to sort by underlying key.
     //
     // We couldn't possibly handle every combination of keys since Soroban
     // maps don't enforce consistent types, so we do a best-effort and try
     // sorting by "number-like" or "string-like."
-    let nativeA = scValToNative(a.key()),
-      nativeB = scValToNative(b.key());
+    const nativeA = scValToNative(a.key());
+    const nativeB = scValToNative(b.key());
 
     switch (typeof nativeA) {
       case 'number':

--- a/src/scval.js
+++ b/src/scval.js
@@ -376,3 +376,27 @@ export function scValToNative(scv) {
       return scv.value();
   }
 }
+
+/// Inject a sortable map builder into the xdr module.
+xdr.scvSortedMap = (items) => {
+  let sorted = Array.from(items).sort((a, b) => {
+    // Both a and b are `ScMapEntry`s, so we need to sort by underlying key.
+    //
+    // We couldn't possibly handle every combination of keys since Soroban
+    // maps don't enforce consistent types, so we do a best-effort and try
+    // sorting by "number-like" or "string-like."
+    let nativeA = scValToNative(a.key()),
+      nativeB = scValToNative(b.key());
+
+    switch (typeof nativeA) {
+      case 'number':
+      case 'bigint':
+        return nativeA < nativeB ? -1 : 1;
+
+      default:
+        return nativeA.toString().localeCompare(nativeB.toString());
+    }
+  });
+
+  return xdr.ScVal.scvMap(sorted);
+};

--- a/src/scval.js
+++ b/src/scval.js
@@ -172,13 +172,6 @@ export function nativeToScVal(val, opts = {}) {
       }
 
       if (Array.isArray(val)) {
-        if (val.length > 0 && val.some((v) => typeof v !== typeof val[0])) {
-          throw new TypeError(
-            `array values (${val}) must have the same type (types: ${val
-              .map((v) => typeof v)
-              .join(',')})`
-          );
-        }
         return xdr.ScVal.scvVec(val.map((v) => nativeToScVal(v, opts)));
       }
 

--- a/src/xdr.js
+++ b/src/xdr.js
@@ -2,24 +2,26 @@ import xdr from './generated/curr_generated';
 import { scValToNative } from './scval';
 
 xdr.scvMapSorted = (items) => {
-    return xdr.ScVal.scvMap(items.sort((a, b) => {
-        // Both a and b are `ScMapEntry`s, so we need to sort by underlying key.
-        //
-        // We couldn't possibly handle every combination of keys since Soroban
-        // maps don't enforce consistent types, so we do a best-effort and try
-        // sorting by "number-like" or "string-like."
-        let nativeA = scValToNative(a.key()),
-            nativeB = scValToNative(b.key());
+  let sorted = Array.from(items).sort((a, b) => {
+    // Both a and b are `ScMapEntry`s, so we need to sort by underlying key.
+    //
+    // We couldn't possibly handle every combination of keys since Soroban
+    // maps don't enforce consistent types, so we do a best-effort and try
+    // sorting by "number-like" or "string-like."
+    let nativeA = scValToNative(a.key()),
+      nativeB = scValToNative(b.key());
 
-        switch (typeof nativeA) {
-            case "number":
-            case "bigint":
-                return nativeA < nativeB;
+    switch (typeof nativeA) {
+      case 'number':
+      case 'bigint':
+        return nativeA < nativeB ? -1 : 1;
 
-            default:
-                return nativeA.toString().localeCompare(nativeB.toString());
-        }
-    }));
-}
+      default:
+        return nativeA.toString().localeCompare(nativeB.toString());
+    }
+  });
+
+  return xdr.ScVal.scvMap(sorted);
+};
 
 export default xdr;

--- a/src/xdr.js
+++ b/src/xdr.js
@@ -1,27 +1,3 @@
 import xdr from './generated/curr_generated';
-import { scValToNative } from './scval';
-
-xdr.scvMapSorted = (items) => {
-  let sorted = Array.from(items).sort((a, b) => {
-    // Both a and b are `ScMapEntry`s, so we need to sort by underlying key.
-    //
-    // We couldn't possibly handle every combination of keys since Soroban
-    // maps don't enforce consistent types, so we do a best-effort and try
-    // sorting by "number-like" or "string-like."
-    let nativeA = scValToNative(a.key()),
-      nativeB = scValToNative(b.key());
-
-    switch (typeof nativeA) {
-      case 'number':
-      case 'bigint':
-        return nativeA < nativeB ? -1 : 1;
-
-      default:
-        return nativeA.toString().localeCompare(nativeB.toString());
-    }
-  });
-
-  return xdr.ScVal.scvMap(sorted);
-};
 
 export default xdr;

--- a/src/xdr.js
+++ b/src/xdr.js
@@ -1,3 +1,25 @@
 import xdr from './generated/curr_generated';
+import { scValToNative } from './scval';
+
+xdr.scvMapSorted = (items) => {
+    return xdr.ScVal.scvMap(items.sort((a, b) => {
+        // Both a and b are `ScMapEntry`s, so we need to sort by underlying key.
+        //
+        // We couldn't possibly handle every combination of keys since Soroban
+        // maps don't enforce consistent types, so we do a best-effort and try
+        // sorting by "number-like" or "string-like."
+        let nativeA = scValToNative(a.key()),
+            nativeB = scValToNative(b.key());
+
+        switch (typeof nativeA) {
+            case "number":
+            case "bigint":
+                return nativeA < nativeB;
+
+            default:
+                return nativeA.toString().localeCompare(nativeB.toString());
+        }
+    }));
+}
 
 export default xdr;

--- a/test/unit/scval_test.js
+++ b/test/unit/scval_test.js
@@ -288,7 +288,7 @@ describe('parsing and building ScVals', function () {
       expect(sample.value()[idx].key().value()).to.equal(val);
     });
 
-    const sorted = xdr.scvMapSorted(sample.value());
+    const sorted = xdr.scvSortedMap(sample.value());
     expect(sorted.switch().name).to.equal('scvMap');
     ['a', 'b', 'c'].forEach((val, idx) => {
       expect(sorted.value()[idx].key().value()).to.equal(val);
@@ -323,7 +323,7 @@ describe('parsing and building ScVals', function () {
       expect(sample.value()[idx].key().value().toBigInt()).to.equal(val);
     });
 
-    const sorted = xdr.scvMapSorted(sample.value());
+    const sorted = xdr.scvSortedMap(sample.value());
     expect(sorted.switch().name).to.equal('scvMap');
     [1n, 2n, 3n].forEach((val, idx) => {
       expect(sorted.value()[idx].key().value().toBigInt()).to.equal(val);

--- a/test/unit/scval_test.js
+++ b/test/unit/scval_test.js
@@ -81,8 +81,6 @@ describe('parsing and building ScVals', function () {
     // iterate for granular errors on failures
     targetScv.value().forEach((entry, idx) => {
       const actual = scv.value()[idx];
-      // console.log(idx, 'exp:', JSON.stringify(entry));
-      // console.log(idx, 'act:', JSON.stringify(actual));
       expect(entry).to.deep.equal(actual, `item ${idx} doesn't match`);
     });
 
@@ -207,8 +205,8 @@ describe('parsing and building ScVals', function () {
     );
   });
 
-  it('throws on arrays with mixed types', function () {
-    expect(() => nativeToScVal([1, 'a', false])).to.throw(/same type/i);
+  it('doesnt throw on arrays with mixed types', function () {
+    expect(nativeToScVal([1, 'a', false]).switch().name).to.equal('scvVec');
   });
 
   it('lets strings be small integer ScVals', function () {
@@ -263,5 +261,72 @@ describe('parsing and building ScVals', function () {
         value: systemErr.error().code().name
       }
     ]);
+  });
+
+  it('can sort maps by string', function () {
+    const sample = nativeToScVal(
+      { a: 1, b: 2, c: 3 },
+      {
+        type: {
+          a: ['symbol'],
+          b: ['symbol'],
+          c: ['symbol']
+        }
+      }
+    );
+    ['a', 'b', 'c'].forEach((val, idx) => {
+      expect(sample.value()[idx].key().value()).to.equal(val);
+    });
+
+    // nativeToScVal will sort, so we need to "unsort" to make sure it works.
+    // We'll do this by swapping 0 (a) and 2 (c).
+    let tmp = sample.value()[0];
+    sample.value()[0] = sample.value()[2];
+    sample.value()[2] = tmp;
+
+    ['c', 'b', 'a'].forEach((val, idx) => {
+      expect(sample.value()[idx].key().value()).to.equal(val);
+    });
+
+    const sorted = xdr.scvMapSorted(sample.value());
+    expect(sorted.switch().name).to.equal('scvMap');
+    ['a', 'b', 'c'].forEach((val, idx) => {
+      expect(sorted.value()[idx].key().value()).to.equal(val);
+    });
+  });
+
+  it('can sort number-like maps', function () {
+    const sample = nativeToScVal(
+      { 1: 'a', 2: 'b', 3: 'c' },
+      {
+        type: {
+          1: ['i64', 'symbol'],
+          2: ['i64', 'symbol'],
+          3: ['i64', 'symbol']
+        }
+      }
+    );
+    expect(sample.value()[0].key().switch().name).to.equal('scvI64');
+
+    [1n, 2n, 3n].forEach((val, idx) => {
+      let underlyingKey = sample.value()[idx].key().value();
+      expect(underlyingKey.toBigInt()).to.equal(val);
+    });
+
+    // nativeToScVal will sort, so we need to "unsort" to make sure it works.
+    // We'll do this by swapping 0th (1n) and 2nd (3n).
+    let tmp = sample.value()[0];
+    sample.value()[0] = sample.value()[2];
+    sample.value()[2] = tmp;
+
+    [3n, 2n, 1n].forEach((val, idx) => {
+      expect(sample.value()[idx].key().value().toBigInt()).to.equal(val);
+    });
+
+    const sorted = xdr.scvMapSorted(sample.value());
+    expect(sorted.switch().name).to.equal('scvMap');
+    [1n, 2n, 3n].forEach((val, idx) => {
+      expect(sorted.value()[idx].key().value().toBigInt()).to.equal(val);
+    });
   });
 });

--- a/types/curr.d.ts
+++ b/types/curr.d.ts
@@ -44,6 +44,16 @@ export namespace xdr {
 
   type Hash = Opaque[]; // workaround, cause unknown
 
+  /**
+   * Returns an {@link ScVal} with a map type and sorted entries.
+   *
+   * @param items the key-value pairs to sort.
+   *
+   * @warning This only performs "best-effort" sorting, working best when the
+   * keys are all either numeric or string-like.
+   */
+  function scvSortedMap(items: ScMapEntry[]): ScVal;
+
   interface SignedInt {
     readonly MAX_VALUE: 2147483647;
     readonly MIN_VALUE: -2147483648;


### PR DESCRIPTION
Injects an `scvMapSorted` constructor into the `xdr` module so that people can created maps with sorted entries from raw `ScMapEntry` instances.

Closes stellar/js-stellar-sdk#1131.