### PR TITLE
Remove `MuxedAccount.parseBaseAddress` from TypeScript definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+* Remove `MuxedAccount.parseBaseAddress` from TypeScript definitions ([#797](https://github.com/stellar/js-stellar-base/pull/797)).
+
 ## [`v13.1.0`](https://github.com/stellar/js-stellar-base/compare/v13.0.1...v13.1.0)
 
 ### Added

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,7 +38,6 @@ export class Contract {
 export class MuxedAccount {
   constructor(account: Account, sequence: string);
   static fromAddress(mAddress: string, sequenceNum: string): MuxedAccount;
-  static parseBaseAddress(mAddress: string): string;
 
   /* Modeled after Account, above */
   accountId(): string;


### PR DESCRIPTION
This function does not exist in [`MuxedAccount`](https://github.com/stellar/js-stellar-base/blob/087e2d651a59b5cbed01386b4b8c45862d358259/src/muxed_account.js#L48), so we should remove it. Or should we add this function as an alias for [`extractBaseAddress`](https://github.com/stellar/js-stellar-base/blob/087e2d651a59b5cbed01386b4b8c45862d358259/src/muxed_account.js#L74)?