### PR TITLE
Allow specifying mixed types for vectors in `nativeToScVal`

### DIFF
--- a/docs/reference/base-examples.md
+++ b/docs/reference/base-examples.md
@@ -10,8 +10,8 @@ title: Transaction Examples
 
 ## Creating an account
 
-In the example below a new account is created by the source account with secret 
-`SA3W53XXG64ITFFIYQSBIJDG26LMXYRIMEVMNQMFAQJOYCZACCYBA34L`. The source account 
+In the example below a new account is created by the source account with secret
+`SA3W53XXG64ITFFIYQSBIJDG26LMXYRIMEVMNQMFAQJOYCZACCYBA34L`. The source account
 is giving the new account 25 XLM as its initial balance.
 
 
@@ -126,7 +126,7 @@ In each example, we'll use the root account.
 
 
 ```js
-var rootKeypair = StellarSdk.Keypair.fromSecret("SBQWY3DNPFWGSZTFNV4WQZLBOJ2GQYLTMJSWK3TTMVQXEY3INFXGO52X")
+var rootKeypair = StellarSdk.Keypair.fromSecret("SBQW...")
 var account = new StellarSdk.Account(rootkeypair.publicKey(), "46316927324160");
 
 var secondaryAddress = "GC6HHHS7SH7KNUAOBKVGT2QZIQLRB5UA7QAGLA3IROWPH4TN65UKNJPK";
@@ -166,11 +166,9 @@ var transaction = new StellarSdk.TransactionBuilder(account, {
     .setTimeout(30)
     .build();
 
-var secondKeypair = StellarSdk.Keypair.fromSecret("SAMZUAAPLRUH62HH3XE7NVD6ZSMTWPWGM6DS4X47HLVRHEBKP4U2H5E7");
+var secondKeypair = StellarSdk.Keypair.fromSecret("SAMZ...");
 
 // now we need to sign the transaction with both the root and the secondaryAddress
 transaction.sign(rootKeypair);
 transaction.sign(secondKeypair);
 ```
-
-

--- a/docs/reference/building-transactions.md
+++ b/docs/reference/building-transactions.md
@@ -143,8 +143,8 @@ var keypair = Keypair.random();
 
 
 ```js
-var key1 = Keypair.fromSecret('SBK2VIYYSVG76E7VC3QHYARNFLY2EAQXDHRC7BMXBBGIFG74ARPRMNQM');
-var key2 = Keypair.fromSecret('SAMZUAAPLRUH62HH3XE7NVD6ZSMTWPWGM6DS4X47HLVRHEBKP4U2H5E7');
+var key1 = Keypair.fromSecret('SBK2...');
+var key2 = Keypair.fromSecret('SAMZ...');
 
 // Create an Account object from an address and sequence number.
 var account=new StellarBase.Account("GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD","2319149195853854");
@@ -165,5 +165,3 @@ transaction.sign(key1);
 transaction.sign(key2);
 // submit tx to Horizon...
 ```
-
-

--- a/src/keypair.js
+++ b/src/keypair.js
@@ -61,7 +61,7 @@ export class Keypair {
   /**
    * Creates a new `Keypair` instance from secret. This can either be secret key or secret seed depending
    * on underlying public-key signature system. Currently `Keypair` only supports ed25519.
-   * @param {string} secret secret key (ex. `SDAKFNYEIAORZKKCYRILFQKLLOCNPL5SWJ3YY5NM3ZH6GJSZGXHZEPQS`)
+   * @param {string} secret secret key (ex. `SDAK....`)
    * @returns {Keypair}
    */
   static fromSecret(secret) {

--- a/src/numbers/xdr_large_int.js
+++ b/src/numbers/xdr_large_int.js
@@ -15,9 +15,9 @@ import xdr from '../xdr';
  * the type / width / size in bits of the integer you're targeting, regardless
  * of the input value(s) you provide.
  *
- * @param {string}  type - force a specific data type. the type choices are:
- *    'i64', 'u64', 'i128', 'u128', 'i256', and 'u256' (default: the smallest
- *    one that fits the `value`) (see {@link XdrLargeInt.isType})
+ * @param {string}  type - specifices a data type to use to represent the, one
+ *    of: 'i64', 'u64', 'i128', 'u128', 'i256', and 'u256' (see
+ *    {@link XdrLargeInt.isType})
  * @param {number|bigint|string|Array<number|bigint|string>} values   a list of
  *    integer-like values interpreted in big-endian order
  */
@@ -39,7 +39,7 @@ export class XdrLargeInt {
       if (typeof i === 'bigint') {
         return i;
       }
-      if (i instanceof XdrLargeInt) {
+      if (typeof i.toBigInt === 'function') {
         return i.toBigInt();
       }
       return BigInt(i);

--- a/src/numbers/xdr_large_int.js
+++ b/src/numbers/xdr_large_int.js
@@ -15,7 +15,7 @@ import xdr from '../xdr';
  * the type / width / size in bits of the integer you're targeting, regardless
  * of the input value(s) you provide.
  *
- * @param {string}  type - specifices a data type to use to represent the, one
+ * @param {string}  type - specifies a data type to use to represent the, one
  *    of: 'i64', 'u64', 'i128', 'u128', 'i256', and 'u256' (see
  *    {@link XdrLargeInt.isType})
  * @param {number|bigint|string|Array<number|bigint|string>} values   a list of

--- a/src/operations/invoke_host_function.js
+++ b/src/operations/invoke_host_function.js
@@ -228,7 +228,7 @@ export function uploadContractWasm(opts) {
   });
 }
 
-/** @returns {Buffer} a random 256-bit "salt" value. */
+/* Returns a random 256-bit "salt" value. */
 function getSalty() {
   return Keypair.random().xdrPublicKey().value(); // ed25519 is 256 bits, too
 }

--- a/src/scval.js
+++ b/src/scval.js
@@ -92,6 +92,8 @@ import { ScInt, XdrLargeInt, scValToBigInt } from './numbers/index';
  * nativeToScVal([1, 2, 3]);                    // gives scvVec with each element as scvU64
  * nativeToScVal([1, 2, 3], { type: 'i128' });  // scvVec<scvI128>
  * nativeToScVal([1, '2'], { type: ['i128', 'symbol'] });  // scvVec with diff types
+ * nativeToScVal([1, '2', 3], { type: ['i128', 'symbol'] });
+ *    // scvVec with diff types, using the default when omitted
  * nativeToScVal({ 'hello': 1, 'world': [ true, false ] }, {
  *   type: {
  *     'hello': [ 'symbol', 'i128' ],

--- a/test/unit/scval_test.js
+++ b/test/unit/scval_test.js
@@ -209,6 +209,18 @@ describe('parsing and building ScVals', function () {
   it('doesnt throw on arrays with mixed types', function () {
     expect(nativeToScVal([1, 'a', false]).switch().name).to.equal('scvVec');
   });
+  it('allows type specifications across an array', function () {
+    const scv = nativeToScVal([1, 'a', false, 'b'], {
+      type: ['i128', 'symbol']
+    });
+    expect(scv.switch().name).to.equal('scvVec');
+    expect(scv.value().length).to.equal(4);
+    ['scvI128', 'scvSymbol', 'scvBool', 'scvString'].forEach(
+      (expectedType, idx) => {
+        expect(scv.value()[idx].switch().name).to.equal(expectedType);
+      }
+    );
+  });
 
   it('lets strings be small integer ScVals', function () {
     ['i32', 'u32'].forEach((type) => {


### PR DESCRIPTION
Previously, you could only specify a single type or use defaults:

```js
nativeToScVal([1, 2, 3], { type: 'i128' }); // Vec<I128>
nativeToScVal([1, "2", 3], { type: 'i128' }); // error
nativeToScVal([1, "2", 3]); // Vec<u32, string, u32>
```

but now you can specify types for each element in the array

```js
nativeToScVal([1, "2", 3], { type: ['i128', 'string', 'i128'] }); // Vec<I128, String, I128>
```

This is super helpful because contracts are just `Vec<Val>` so they can be anything and unnamed enums also require this format.