### PR TITLE
Correctly encode claimable balances and muxed accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 
+## [`v14.0.0-rc.2`](https://github.com/stellar/js-stellar-base/compare/v13.1.0...v14.0.0-rc.2)
+
+### Fixed
+* Fixes a bug in `Address.toScAddress()` that would prevent claimable balances and muxed accounts from being encoded correctly.
+
+
 ## [`v14.0.0-rc.1`](https://github.com/stellar/js-stellar-base/compare/v13.1.0...v14.0.0-rc.1): Protocol 23
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/stellar-base",
-  "version": "14.0.0-rc.1",
+  "version": "14.0.0-rc.2",
   "description": "Low-level support library for the Stellar network.",
   "main": "./lib/index.js",
   "browser": {
@@ -15,7 +15,7 @@
     "build:browser:prod": "cross-env NODE_ENV=production yarn build:browser",
     "build:prod": "cross-env NODE_ENV=production yarn build",
     "test": "yarn build && yarn test:node && yarn test:browser",
-    "test:node": "NODE_OPTIONS=$(test ! $(node -v | awk -F'.' '{printf substr($1,2)}') = '18' && echo '--no-experimental-detect-module') yarn _nyc mocha",
+    "test:node": "NODE_OPTIONS=--no-experimental-detect-module yarn _nyc mocha",
     "test:browser": "karma start ./config/karma.conf.js",
     "docs": "jsdoc -c ./config/.jsdoc.json --verbose",
     "lint": "eslint -c ./config/.eslintrc.js src/ && dtslint --localTs node_modules/typescript/lib types/",

--- a/src/address.js
+++ b/src/address.js
@@ -173,12 +173,26 @@ export class Address {
         );
       case 'contract':
         return xdr.ScAddress.scAddressTypeContract(this._key);
-      case 'claimableBalance':
-        return xdr.ScAddress.scAddressTypeClaimableBalance(this._key);
       case 'liquidityPool':
         return xdr.ScAddress.scAddressTypeLiquidityPool(this._key);
+
+      case 'claimableBalance':
+        const idType = this._key.at(0);
+        if (idType !== 0) {
+          throw new TypeError(
+            `expected claimable balance type 0, got type ${idType}`
+          );
+        }
+
+        return xdr.ScAddress.scAddressTypeClaimableBalance(
+          xdr.ClaimableBalanceId.claimableBalanceIdTypeV0(this._key.subarray(1))
+        );
+
       case 'muxedAccount':
-        return xdr.ScAddress.scAddressTypeMuxedAccount(this._key);
+        return xdr.ScAddress.scAddressTypeMuxedAccount(
+          xdr.MuxedEd25519Account.fromXDR(this._key)
+        );
+
       default:
         throw new Error(`Unsupported address type: ${this._type}`);
     }

--- a/test/unit/address_test.js
+++ b/test/unit/address_test.js
@@ -174,6 +174,7 @@ describe('Address', function () {
       expect(s.switch()).to.equal(
         StellarBase.xdr.ScAddressType.scAddressTypeAccount()
       );
+      expect(StellarBase.xdr.ScAddress.fromXDR(s.toXDR())).to.eql(s);
     });
 
     it('converts contracts', function () {
@@ -182,6 +183,7 @@ describe('Address', function () {
       expect(s.switch()).to.equal(
         StellarBase.xdr.ScAddressType.scAddressTypeContract()
       );
+      expect(StellarBase.xdr.ScAddress.fromXDR(s.toXDR())).to.eql(s);
     });
 
     it('converts muxed accounts', function () {
@@ -191,6 +193,7 @@ describe('Address', function () {
       expect(s.switch()).to.equal(
         StellarBase.xdr.ScAddressType.scAddressTypeMuxedAccount()
       );
+      expect(StellarBase.xdr.ScAddress.fromXDR(s.toXDR())).to.eql(s);
     });
 
     it('converts claimable balances', function () {
@@ -199,6 +202,7 @@ describe('Address', function () {
       expect(s.switch()).to.equal(
         StellarBase.xdr.ScAddressType.scAddressTypeClaimableBalance()
       );
+      expect(StellarBase.xdr.ScAddress.fromXDR(s.toXDR())).to.eql(s);
     });
 
     it('converts liquidity pools', function () {
@@ -207,6 +211,7 @@ describe('Address', function () {
       expect(s.switch()).to.equal(
         StellarBase.xdr.ScAddressType.scAddressTypeLiquidityPool()
       );
+      expect(StellarBase.xdr.ScAddress.fromXDR(s.toXDR())).to.eql(s);
     });
   });
 


### PR DESCRIPTION
The internal `_key` does not always represent the raw data that can be handed to encode an `ScAddress`. In the case of claimable balances, the object must be built manually from the hash, and in the case of muxed accounts, the object must be built by actually decoding the raw data.

Closes #807.