### PR TITLE
Fixes muxed account handling in `Address` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Fixed
+* Fixes muxed account handling in `Address` class ([#814](https://github.com/stellar/js-stellar-base/pull/814)).
 
 ## [`v14.0.0-rc.2`](https://github.com/stellar/js-stellar-base/compare/v13.1.0...v14.0.0-rc.2)
 

--- a/src/address.js
+++ b/src/address.js
@@ -118,8 +118,13 @@ export class Address {
         return Address.account(scAddress.accountId().ed25519());
       case xdr.ScAddressType.scAddressTypeContract().value:
         return Address.contract(scAddress.contractId());
-      case xdr.ScAddressType.scAddressTypeMuxedAccount().value:
-        return Address.muxedAccount(scAddress.muxedAccount());
+      case xdr.ScAddressType.scAddressTypeMuxedAccount().value: {
+        const raw = Buffer.concat([
+          scAddress.muxedAccount().ed25519(),
+          scAddress.muxedAccount().id().toXDR('raw')
+        ]);
+        return Address.muxedAccount(raw);
+      }
       case xdr.ScAddressType.scAddressTypeClaimableBalance().value:
         return Address.claimableBalance(scAddress.claimableBalanceId());
       case xdr.ScAddressType.scAddressTypeLiquidityPool().value:
@@ -186,7 +191,10 @@ export class Address {
 
       case 'muxedAccount':
         return xdr.ScAddress.scAddressTypeMuxedAccount(
-          xdr.MuxedEd25519Account.fromXDR(this._key)
+          new xdr.MuxedEd25519Account({
+            ed25519: this._key.subarray(0, 32),
+            id: xdr.Uint64.fromXDR(this._key.subarray(32, 40), 'raw')
+          })
         );
 
       default:

--- a/test/unit/address_test.js
+++ b/test/unit/address_test.js
@@ -3,6 +3,9 @@ describe('Address', function () {
   const CONTRACT = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
   const MUXED_ADDRESS =
     'MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK';
+  const MUXED_ADDRESS_ID = '9223372036854775808';
+  const MUXED_ADDRESS_BASE =
+    'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ';
 
   const MUXED_ZERO = StellarBase.StrKey.encodeMed25519PublicKey(
     Buffer.alloc(40)
@@ -91,7 +94,11 @@ describe('Address', function () {
 
       it('parses muxed-account addresses', function () {
         const sc = StellarBase.xdr.ScAddress.scAddressTypeMuxedAccount(
-          StellarBase.StrKey.decodeMed25519PublicKey(MUXED_ADDRESS)
+          new StellarBase.xdr.MuxedEd25519Account({
+            id: new StellarBase.xdr.Uint64(MUXED_ADDRESS_ID),
+            ed25519:
+              StellarBase.StrKey.decodeEd25519PublicKey(MUXED_ADDRESS_BASE)
+          })
         );
         const m = StellarBase.Address.fromScAddress(sc);
         expect(m.toString()).to.equal(MUXED_ADDRESS);
@@ -140,7 +147,11 @@ describe('Address', function () {
       it('parses muxed-account ScVals', function () {
         const scVal = StellarBase.xdr.ScVal.scvAddress(
           StellarBase.xdr.ScAddress.scAddressTypeMuxedAccount(
-            StellarBase.StrKey.decodeMed25519PublicKey(MUXED_ADDRESS)
+            new StellarBase.xdr.MuxedEd25519Account({
+              id: new StellarBase.xdr.Uint64(MUXED_ADDRESS_ID),
+              ed25519:
+                StellarBase.StrKey.decodeEd25519PublicKey(MUXED_ADDRESS_BASE)
+            })
           )
         );
         const m = StellarBase.Address.fromScVal(scVal);
@@ -193,6 +204,10 @@ describe('Address', function () {
       expect(s.switch()).to.equal(
         StellarBase.xdr.ScAddressType.scAddressTypeMuxedAccount()
       );
+      expect(s.muxedAccount().ed25519()).to.deep.equal(
+        StellarBase.StrKey.decodeEd25519PublicKey(MUXED_ADDRESS_BASE)
+      );
+      expect(s.muxedAccount().id().toString()).to.equal(MUXED_ADDRESS_ID);
       expect(StellarBase.xdr.ScAddress.fromXDR(s.toXDR())).to.eql(s);
     });
 


### PR DESCRIPTION
The encoding of muxed accounts in XDR is different from that in StrKey; XDR uses an 8-byte ID + 32-byte key, while StrKey uses a 32-byte key + 8-byte ID.