### PR TITLE
fix: Address.fromScAddress fails for claimable balance from decoded XDR

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -125,8 +125,12 @@ export class Address {
         ]);
         return Address.muxedAccount(raw);
       }
-      case xdr.ScAddressType.scAddressTypeClaimableBalance().value:
-        return Address.claimableBalance(scAddress.claimableBalanceId());
+      case xdr.ScAddressType.scAddressTypeClaimableBalance().value: {
+        const cbi = scAddress.claimableBalanceId();
+        return Address.claimableBalance(
+          Buffer.concat([Buffer.from([cbi.switch().value]), cbi.v0()])
+        );
+      }
       case xdr.ScAddressType.scAddressTypeLiquidityPool().value:
         return Address.liquidityPool(scAddress.liquidityPoolId());
       default:

--- a/test/unit/address_test.js
+++ b/test/unit/address_test.js
@@ -106,10 +106,24 @@ describe('Address', function () {
 
       it('parses claimable-balance addresses', function () {
         const sc = StellarBase.xdr.ScAddress.scAddressTypeClaimableBalance(
-          Buffer.alloc(33)
+          new StellarBase.xdr.ClaimableBalanceId(
+            'claimableBalanceIdTypeV0',
+            Buffer.alloc(32)
+          )
         );
         const cb = StellarBase.Address.fromScAddress(sc);
         expect(cb.toString()).to.equal(CLAIMABLE_BALANCE_ZERO);
+      });
+
+      it('parses claimable-balance from decoded XDR', function () {
+        // XDR: ScVal containing claimable balance address
+        const xdrBase64 =
+          'AAAAEgAAAAMAAAAAGZ8agta/ETY/tCE7KG10xWweJ9IBmnhmy0alCNG6gOE=';
+        const scVal = StellarBase.xdr.ScVal.fromXDR(xdrBase64, 'base64');
+        const addr = StellarBase.Address.fromScVal(scVal);
+        expect(addr.toString()).to.equal(
+          'BAABTHY2QLLL6EJWH62CCOZINV2MK3A6E7JADGTYM3FUNJII2G5IBYM2TU'
+        );
       });
 
       it('parses liquidity-pool addresses', function () {
@@ -161,7 +175,10 @@ describe('Address', function () {
       it('parses claimable-balance ScVals', function () {
         const scVal = StellarBase.xdr.ScVal.scvAddress(
           StellarBase.xdr.ScAddress.scAddressTypeClaimableBalance(
-            Buffer.alloc(33)
+            new StellarBase.xdr.ClaimableBalanceId(
+              'claimableBalanceIdTypeV0',
+              Buffer.alloc(32)
+            )
           )
         );
         const cb = StellarBase.Address.fromScVal(scVal);


### PR DESCRIPTION
When XDR is decoded from base64, claimableBalanceId() returns a ClaimableBalanceId union object, not raw bytes. The previous code passed this union directly to StrKey.encodeClaimableBalance(), which called Buffer.from() on it, causing a TypeError.

Fix: Extract the discriminant byte and hash from the union to construct the 33-byte buffer that StrKey expects.

Also updated tests to use proper ClaimableBalanceId XDR construction instead of raw Buffer, matching real-world decoded XDR behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)