### PR TITLE
Add SEP-53 arbitrary message signing support

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -163,6 +163,8 @@ export class Keypair {
   signPayloadDecorated(data: Buffer): xdr.DecoratedSignature;
   signatureHint(): Buffer;
   verify(data: Buffer, signature: Buffer): boolean;
+  signMessage(message: string | Buffer): Buffer;
+  verifyMessage(message: string | Buffer, signature: Buffer): boolean;
 
   xdrAccountId(): xdr.AccountId;
   xdrPublicKey(): xdr.PublicKey;


### PR DESCRIPTION
## Summary

Implements [SEP-53](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0053.md) (Stellar Arbitrary Message Signing) by adding two new methods to the `Keypair` class:

- **`signMessage(message)`**: Signs an arbitrary message by prepending the SEP-53 prefix `"Stellar Signed Message:\n"`, hashing with SHA-256, and signing with the ed25519 key.

- **`verifyMessage(message, signature)`**: Verifies a SEP-53 signature by recomputing the hash and verifying against the public key.

Both methods accept `string` or `Buffer` inputs.

### Use Cases
- Proving account ownership without on-chain transactions
- Off-chain attestations
- Application-specific authentication
- Wallet verification ("Connect Wallet" flows)

### Implementation Details
- Uses the existing `hash()` function from `hashing.js` for SHA-256
- Uses the existing `sign()` and `verify()` primitives from `signing.js`
- Compatible with SEP-53 implementations in other SDKs (Python, Java, Freighter)

### Example Usage
```javascript
import { Keypair } from '@stellar/stellar-base';

// Sign a message
const kp = Keypair.fromSecret('SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW');
const signature = kp.signMessage('Hello, World!');

// Verify a signature
const publicKp = Keypair.fromPublicKey('GBXFXNDLV4LSWA4VB7YIL5GBD7BVNR22SGBTDKMO2SBZZHDXSKZYCP7L');
const isValid = publicKp.verifyMessage('Hello, World!', signature);
```

Closes stellar/js-stellar-sdk#1492

## Test plan

- [x] Added comprehensive tests for `signMessage` and `verifyMessage`
- [x] Verified against SEP-53 test vectors from the specification
- [x] Tests cover edge cases: empty messages, unicode, long messages, binary data
- [x] Tests verify rejection of invalid signatures and wrong signers
- [x] All 1132 tests pass (Node.js + browser environments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)