### PR TITLE
Allow omitting setTimeout() on builder if setLedgerbounds is called

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -592,14 +592,24 @@ export class TransactionBuilder {
       memo: this.memo ? this.memo.toXDRObject() : null
     };
 
+    // Allow building without explicit timebounds if ledgerbounds with maxLedger is set,
+    // since that provides an alternative upper bound on transaction validity.
+    const hasValidLedgerBounds =
+      this.ledgerbounds !== null && this.ledgerbounds.maxLedger > 0;
+
     if (
       this.timebounds === null ||
       typeof this.timebounds.minTime === 'undefined' ||
       typeof this.timebounds.maxTime === 'undefined'
     ) {
-      throw new Error(
-        'TimeBounds has to be set or you must call setTimeout(TimeoutInfinite).'
-      );
+      if (hasValidLedgerBounds) {
+        // Default to infinite timebounds when ledger bounds provide the constraint
+        this.timebounds = { minTime: 0, maxTime: 0 };
+      } else {
+        throw new Error(
+          'TimeBounds has to be set or you must call setTimeout(TimeoutInfinite).'
+        );
+      }
     }
 
     if (isValidDate(this.timebounds.minTime)) {


### PR DESCRIPTION
TransactionBuilder requires a call to `setTimeout()` even if a call to `setLedgerbounds()` was made.

This PR updates the `build()` method to check for a max ledger and if it is present, allow a max time of 0.