### PR TITLE
Account: allow negative sequence number

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -45,10 +45,6 @@ export class Account {
       throw new Error("sequence is not a valid number");
     }
 
-    if (parsed.isNegative()) {
-      throw new Error("sequence must be a non-negative number");
-    }
-
     this._accountId = accountId;
     this.sequence = parsed;
   }

--- a/test/unit/account.test.ts
+++ b/test/unit/account.test.ts
@@ -11,6 +11,7 @@ describe("Account.constructor", () => {
   });
 
   it("fails to create Account object from an invalid sequence number", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
     expect(() => new Account(ACCOUNT, 100 as any)).toThrow(
       /sequence must be of type string/,
     );
@@ -22,12 +23,6 @@ describe("Account.constructor", () => {
   it("fails to create Account object from an empty string sequence", () => {
     expect(() => new Account(ACCOUNT, "")).toThrow(
       /sequence is not a valid number/,
-    );
-  });
-
-  it("fails to create Account object from a negative sequence number", () => {
-    expect(() => new Account(ACCOUNT, "-1")).toThrow(
-      /sequence must be a non-negative number/,
     );
   });
 


### PR DESCRIPTION
There is a use case for a negative sequence number. For example, we use it in `WebAuth.buildChallengeTx` ([code](https://github.com/stellar/js-stellar-sdk/blob/master/src/webauth/challenge_transaction.ts#L77)). 

> [!NOTE]
> This was introduced during migration. This check does not exist in the current version.