### PR TITLE
Support signed payload revoke signer sponsorship

### DIFF
--- a/src/operation.js
+++ b/src/operation.js
@@ -632,6 +632,12 @@ function convertXDRSignerKeyToObject(signerKey) {
       attrs.sha256Hash = signerKey.hashX().toString('hex');
       break;
     }
+    case xdr.SignerKeyType.signerKeyTypeEd25519SignedPayload().name: {
+      attrs.ed25519SignedPayload = StrKey.encodeSignedPayload(
+        signerKey.ed25519SignedPayload().toXDR()
+      );
+      break;
+    }
     default: {
       throw new Error(`Unknown signerKey: ${signerKey.switch().name}`);
     }

--- a/src/operations/revoke_sponsorship.js
+++ b/src/operations/revoke_sponsorship.js
@@ -248,6 +248,7 @@ export function revokeLiquidityPoolSponsorship(opts = {}) {
  * @param {string} [opts.signer.ed25519PublicKey] - The ed25519 public key of the signer.
  * @param {Buffer|string} [opts.signer.sha256Hash] - sha256 hash (Buffer or hex string).
  * @param {Buffer|string} [opts.signer.preAuthTx] - Hash (Buffer or hex string) of transaction.
+ * @param {string} [opts.signer.ed25519SignedPayload] - Signed payload signer (ed25519 public key + raw payload).
  * @param {string} [opts.source] - The source account for the operation. Defaults to the transaction's source account.
  * @returns {xdr.Operation} xdr operation
  *
@@ -298,6 +299,15 @@ export function revokeSignerSponsorship(opts = {}) {
     }
 
     key = new xdr.SignerKey.signerKeyTypeHashX(buffer);
+  } else if (opts.signer.ed25519SignedPayload) {
+    if (!StrKey.isValidSignedPayload(opts.signer.ed25519SignedPayload)) {
+      throw new Error('signer.ed25519SignedPayload is invalid.');
+    }
+    const rawKey = StrKey.decodeSignedPayload(opts.signer.ed25519SignedPayload);
+    const signedPayloadXdr =
+      xdr.SignerKeyEd25519SignedPayload.fromXDR(rawKey);
+
+    key = xdr.SignerKey.signerKeyTypeEd25519SignedPayload(signedPayloadXdr);
   } else {
     throw new Error('signer is invalid');
   }

--- a/test/unit/operations/classic_ops_test.js
+++ b/test/unit/operations/classic_ops_test.js
@@ -2256,6 +2256,32 @@ describe('Operation', function () {
       expect(obj.type).to.be.equal('revokeSignerSponsorship');
       expect(obj.account).to.be.equal(account);
       expect(obj.signer.sha256Hash).to.be.equal(signer.sha256Hash);
+
+      // ed25519SignedPayload signer
+      const signedPayload = new StellarBase.xdr.SignerKeyEd25519SignedPayload({
+        ed25519: StellarBase.StrKey.decodeEd25519PublicKey(account),
+        payload: Buffer.from('test')
+      });
+      const xdrSignerKey =
+        StellarBase.xdr.SignerKey.signerKeyTypeEd25519SignedPayload(
+          signedPayload
+        );
+      signer = {
+        ed25519SignedPayload: StellarBase.SignerKey.encodeSignerKey(
+          xdrSignerKey
+        )
+      };
+      op = StellarBase.Operation.revokeSignerSponsorship({
+        account,
+        signer
+      });
+      operation = StellarBase.xdr.Operation.fromXDR(op.toXDR('hex'), 'hex');
+      obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(obj.type).to.be.equal('revokeSignerSponsorship');
+      expect(obj.account).to.be.equal(account);
+      expect(obj.signer.ed25519SignedPayload).to.be.equal(
+        signer.ed25519SignedPayload
+      );
     });
     it('throws an error when account is invalid', function () {
       const signer = {


### PR DESCRIPTION
## Summary
- Adds `signerKeyTypeEd25519SignedPayload` parsing in `convertXDRSignerKeyToObject`.
- Allows `Operation.revokeSignerSponsorship` to build revoke-signer sponsorship ops for P-address signers.
- Adds a round-trip test covering build, XDR decode, and `Operation.fromXDRObject` output.

Fixes #966.

## Verification
- `corepack yarn install --ignore-scripts`
- `corepack yarn mocha test/unit/operations/classic_ops_test.js --grep "signed payload signer|revokeSignerSponsorship" --require @babel/register --require ./test/test-helper.js`
- `corepack yarn eslint -c ./config/.eslintrc.js src/operation.js src/operations/revoke_sponsorship.js`
- `node --check src/operation.js`
- `node --check src/operations/revoke_sponsorship.js`
- `node --check test/unit/operations/classic_ops_test.js`
- `git diff --check`

## Note
- Running ESLint over the full `test/unit/operations/classic_ops_test.js` file reports existing style violations unrelated to this change, so source files were linted directly and the changed test path was verified with the focused mocha run and syntax check.