### PR TITLE
Add revoke sponsorship operation type literals

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -363,6 +363,13 @@ export namespace OperationType {
   type BeginSponsoringFutureReserves = 'beginSponsoringFutureReserves';
   type EndSponsoringFutureReserves = 'endSponsoringFutureReserves';
   type RevokeSponsorship = 'revokeSponsorship';
+  type RevokeAccountSponsorship = 'revokeAccountSponsorship';
+  type RevokeTrustlineSponsorship = 'revokeTrustlineSponsorship';
+  type RevokeOfferSponsorship = 'revokeOfferSponsorship';
+  type RevokeDataSponsorship = 'revokeDataSponsorship';
+  type RevokeClaimableBalanceSponsorship = 'revokeClaimableBalanceSponsorship';
+  type RevokeLiquidityPoolSponsorship = 'revokeLiquidityPoolSponsorship';
+  type RevokeSignerSponsorship = 'revokeSignerSponsorship';
   type Clawback = 'clawback';
   type ClawbackClaimableBalance = 'clawbackClaimableBalance';
   type SetTrustLineFlags = 'setTrustLineFlags';
@@ -392,6 +399,13 @@ export type OperationType =
   | OperationType.BeginSponsoringFutureReserves
   | OperationType.EndSponsoringFutureReserves
   | OperationType.RevokeSponsorship
+  | OperationType.RevokeAccountSponsorship
+  | OperationType.RevokeTrustlineSponsorship
+  | OperationType.RevokeOfferSponsorship
+  | OperationType.RevokeDataSponsorship
+  | OperationType.RevokeClaimableBalanceSponsorship
+  | OperationType.RevokeLiquidityPoolSponsorship
+  | OperationType.RevokeSignerSponsorship
   | OperationType.Clawback
   | OperationType.ClawbackClaimableBalance
   | OperationType.SetTrustLineFlags
@@ -793,14 +807,14 @@ export namespace Operation {
     options: OperationOptions.BaseOptions
   ): xdr.Operation<EndSponsoringFutureReserves>;
 
-  interface RevokeAccountSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+  interface RevokeAccountSponsorship extends BaseOperation<OperationType.RevokeAccountSponsorship> {
     account: string;
   }
   function revokeAccountSponsorship(
     options: OperationOptions.RevokeAccountSponsorship
   ): xdr.Operation<RevokeAccountSponsorship>;
 
-  interface RevokeTrustlineSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+  interface RevokeTrustlineSponsorship extends BaseOperation<OperationType.RevokeTrustlineSponsorship> {
     account: string;
     asset: Asset | LiquidityPoolId;
   }
@@ -808,7 +822,7 @@ export namespace Operation {
     options: OperationOptions.RevokeTrustlineSponsorship
   ): xdr.Operation<RevokeTrustlineSponsorship>;
 
-  interface RevokeOfferSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+  interface RevokeOfferSponsorship extends BaseOperation<OperationType.RevokeOfferSponsorship> {
     seller: string;
     offerId: string;
   }
@@ -816,7 +830,7 @@ export namespace Operation {
     options: OperationOptions.RevokeOfferSponsorship
   ): xdr.Operation<RevokeOfferSponsorship>;
 
-  interface RevokeDataSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+  interface RevokeDataSponsorship extends BaseOperation<OperationType.RevokeDataSponsorship> {
     account: string;
     name: string;
   }
@@ -824,21 +838,21 @@ export namespace Operation {
     options: OperationOptions.RevokeDataSponsorship
   ): xdr.Operation<RevokeDataSponsorship>;
 
-  interface RevokeClaimableBalanceSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+  interface RevokeClaimableBalanceSponsorship extends BaseOperation<OperationType.RevokeClaimableBalanceSponsorship> {
     balanceId: string;
   }
   function revokeClaimableBalanceSponsorship(
     options: OperationOptions.RevokeClaimableBalanceSponsorship
   ): xdr.Operation<RevokeClaimableBalanceSponsorship>;
 
-  interface RevokeLiquidityPoolSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+  interface RevokeLiquidityPoolSponsorship extends BaseOperation<OperationType.RevokeLiquidityPoolSponsorship> {
     liquidityPoolId: string;
   }
   function revokeLiquidityPoolSponsorship(
     options: OperationOptions.RevokeLiquidityPoolSponsorship
   ): xdr.Operation<RevokeLiquidityPoolSponsorship>;
 
-  interface RevokeSignerSponsorship extends BaseOperation<OperationType.RevokeSponsorship> {
+  interface RevokeSignerSponsorship extends BaseOperation<OperationType.RevokeSignerSponsorship> {
     account: string;
     signer: SignerKeyOptions;
   }

--- a/types/test.ts
+++ b/types/test.ts
@@ -151,6 +151,61 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
   .setExtraSigners([sourceKey.publicKey()])
   .build(); // $ExpectType () => Transaction<Memo<MemoType>, Operation[]>
 
+const revokeAccountSponsorship = StellarSdk.Operation.fromXDRObject(
+  StellarSdk.Operation.revokeAccountSponsorship({
+    account: account.accountId(),
+  })
+);
+revokeAccountSponsorship.type; // $ExpectType "revokeAccountSponsorship"
+
+const revokeTrustlineSponsorship = StellarSdk.Operation.fromXDRObject(
+  StellarSdk.Operation.revokeTrustlineSponsorship({
+    account: account.accountId(),
+    asset: usd,
+  })
+);
+revokeTrustlineSponsorship.type; // $ExpectType "revokeTrustlineSponsorship"
+
+const revokeOfferSponsorship = StellarSdk.Operation.fromXDRObject(
+  StellarSdk.Operation.revokeOfferSponsorship({
+    seller: account.accountId(),
+    offerId: "12345",
+  })
+);
+revokeOfferSponsorship.type; // $ExpectType "revokeOfferSponsorship"
+
+const revokeDataSponsorship = StellarSdk.Operation.fromXDRObject(
+  StellarSdk.Operation.revokeDataSponsorship({
+    account: account.accountId(),
+    name: "foo",
+  })
+);
+revokeDataSponsorship.type; // $ExpectType "revokeDataSponsorship"
+
+const revokeClaimableBalanceSponsorship = StellarSdk.Operation.fromXDRObject(
+  StellarSdk.Operation.revokeClaimableBalanceSponsorship({
+    balanceId: "00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be",
+  })
+);
+revokeClaimableBalanceSponsorship.type; // $ExpectType "revokeClaimableBalanceSponsorship"
+
+const revokeLiquidityPoolSponsorship = StellarSdk.Operation.fromXDRObject(
+  StellarSdk.Operation.revokeLiquidityPoolSponsorship({
+    liquidityPoolId: "dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7",
+  })
+);
+revokeLiquidityPoolSponsorship.type; // $ExpectType "revokeLiquidityPoolSponsorship"
+
+const revokeSignerSponsorship = StellarSdk.Operation.fromXDRObject(
+  StellarSdk.Operation.revokeSignerSponsorship({
+    account: account.accountId(),
+    signer: {
+      ed25519PublicKey: sourceKey.publicKey()
+    }
+  })
+);
+revokeSignerSponsorship.type; // $ExpectType "revokeSignerSponsorship"
+
 const transactionFromXDR = new StellarSdk.Transaction(transaction.toEnvelope(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]>
 
 transactionFromXDR.networkPassphrase; // $ExpectType string


### PR DESCRIPTION
## Summary
- Adds TypeScript operation type literals for each revoke sponsorship subtype.
- Updates revoke sponsorship operation interfaces to use their runtime `operation.type` names instead of the generic `revokeSponsorship` literal.
- Adds dtslint expectations covering all revoke sponsorship subtype names returned through `Operation.fromXDRObject`.

Fixes #728.

## Verification
- `corepack yarn dtslint --localTs node_modules/typescript/lib types/`
- `node --check types/test.ts`
- `git diff --check`