### PR TITLE
Mention max int64 in amount validation errors

### DIFF
--- a/src/operation.js
+++ b/src/operation.js
@@ -449,7 +449,7 @@ export class Operation {
   }
 
   static constructAmountRequirementsError(arg) {
-    return `${arg} argument must be of type String, represent a positive number and have at most 7 digits after the decimal`;
+    return `${arg} argument must be of type String, represent a positive number, have at most 7 digits after the decimal, and not exceed the maximum 64-bit signed integer value`;
   }
 
   /**

--- a/test/unit/operations/classic_ops_test.js
+++ b/test/unit/operations/classic_ops_test.js
@@ -438,6 +438,22 @@ describe('Operation', function () {
         /destMin argument must be of type String/
       );
     });
+
+    it('fails to create path payment operation when destMin exceeds MAX_INT64', function () {
+      const opts = {
+        destination: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ',
+        sendAmount: '20',
+        destMin: '922337203685.4775808',
+        sendAsset: StellarBase.Asset.native(),
+        destAsset: new StellarBase.Asset(
+          'USD',
+          'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        )
+      };
+      expect(() => StellarBase.Operation.pathPaymentStrictSend(opts)).to.throw(
+        /destMin argument.*maximum 64-bit signed integer value/
+      );
+    });
   });
 
   describe('.changeTrust()', function () {


### PR DESCRIPTION
## Summary
- Updates amount validation errors to mention the maximum 64-bit signed integer limit.
- Adds a path payment strict send regression test for `destMin` exceeding the max amount.

Fixes #789.

## Verification
- `corepack yarn mocha test/unit/operations/classic_ops_test.js --grep "pathPaymentStrictSend" --require @babel/register --require ./test/test-helper.js`
- `corepack yarn eslint -c ./config/.eslintrc.js src/operation.js`
- `node --check src/operation.js`
- `node --check test/unit/operations/classic_ops_test.js`
- `git diff --check`