### PR TITLE
Allow bitwise setOptions flag types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -263,7 +263,9 @@ export type AuthFlag =
   | AuthFlag.required
   | AuthFlag.immutable
   | AuthFlag.revocable
-  | AuthFlag.clawbackEnabled;
+  | AuthFlag.clawbackEnabled
+  | number;
+export type AuthFlagInput = AuthFlag | string;
 
 export namespace TrustLineFlag {
   type deauthorize = 0;
@@ -468,8 +470,8 @@ export namespace OperationOptions {
   }
   interface SetOptions<T extends SignerOptions = never> extends BaseOptions {
     inflationDest?: string;
-    clearFlags?: AuthFlag;
-    setFlags?: AuthFlag;
+    clearFlags?: AuthFlagInput;
+    setFlags?: AuthFlagInput;
     masterWeight?: number | string;
     lowThreshold?: number | string;
     medThreshold?: number | string;

--- a/types/test.ts
+++ b/types/test.ts
@@ -136,8 +136,8 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
     })
   ).addOperationAt(
     StellarSdk.Operation.setOptions({
-      setFlags:   (StellarSdk.AuthImmutableFlag | StellarSdk.AuthRequiredFlag) as StellarSdk.AuthFlag,
-      clearFlags: (StellarSdk.AuthRevocableFlag | StellarSdk.AuthClawbackEnabledFlag) as StellarSdk.AuthFlag,
+      setFlags:   StellarSdk.AuthImmutableFlag | StellarSdk.AuthRequiredFlag,
+      clearFlags: StellarSdk.AuthRevocableFlag | StellarSdk.AuthClawbackEnabledFlag,
     }),
     0
   ).clearOperationAt(2
@@ -152,6 +152,12 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
   .build(); // $ExpectType () => Transaction<Memo<MemoType>, Operation[]>
 
 const transactionFromXDR = new StellarSdk.Transaction(transaction.toEnvelope(), StellarSdk.Networks.TESTNET); // $ExpectType Transaction<Memo<MemoType>, Operation[]>
+
+const stringFlagSetOptions = StellarSdk.Operation.setOptions({
+  clearFlags: "4",
+  setFlags: "8",
+});
+stringFlagSetOptions.toXDR("hex");
 
 transactionFromXDR.networkPassphrase; // $ExpectType string
 transactionFromXDR.networkPassphrase = "SDF";


### PR DESCRIPTION
## Summary
- Allows `setOptions` `setFlags` and `clearFlags` inputs to accept bitwise bitmap values without TypeScript casts.
- Adds `AuthFlagInput` for user-provided numeric/string flag values while keeping operation output flags numeric.
- Updates the dtslint coverage to use bitwise flag expressions directly and cover string flag inputs.

Fixes #347.

## Verification
- `corepack yarn dtslint --localTs node_modules/typescript/lib types/`
- `node --check types/test.ts`
- `git diff --check`