### PR TITLE
Support amount alias for manageBuyOffer

### DIFF
--- a/src/operation.js
+++ b/src/operation.js
@@ -253,6 +253,7 @@ export class Operation {
         result.selling = Asset.fromOperation(attrs.selling());
         result.buying = Asset.fromOperation(attrs.buying());
         result.buyAmount = this._fromXDRAmount(attrs.buyAmount());
+        result.amount = result.buyAmount;
         result.price = this._fromXDRPrice(attrs.price());
         result.offerId = attrs.offerId().toString();
         break;

--- a/src/operations/manage_buy_offer.js
+++ b/src/operations/manage_buy_offer.js
@@ -9,6 +9,7 @@ import xdr from '../xdr';
  * @param {Asset} opts.selling - What you're selling.
  * @param {Asset} opts.buying - What you're buying.
  * @param {string} opts.buyAmount - The total amount you're buying. If 0, deletes the offer.
+ * @param {string} opts.amount - Alias for `buyAmount`.
  * @param {number|string|BigNumber|Object} opts.price - Price of 1 unit of `buying` in terms of `selling`.
  * @param {number} opts.price.n - If `opts.price` is an object: the price numerator
  * @param {number} opts.price.d - If `opts.price` is an object: the price denominator
@@ -21,10 +22,12 @@ export function manageBuyOffer(opts) {
   const attributes = {};
   attributes.selling = opts.selling.toXDRObject();
   attributes.buying = opts.buying.toXDRObject();
-  if (!this.isValidAmount(opts.buyAmount, true)) {
-    throw new TypeError(this.constructAmountRequirementsError('buyAmount'));
+  const buyAmount = opts.buyAmount !== undefined ? opts.buyAmount : opts.amount;
+  const amountArg = opts.buyAmount !== undefined ? 'buyAmount' : 'amount';
+  if (!this.isValidAmount(buyAmount, true)) {
+    throw new TypeError(this.constructAmountRequirementsError(amountArg));
   }
-  attributes.buyAmount = this._toXDRAmount(opts.buyAmount);
+  attributes.buyAmount = this._toXDRAmount(buyAmount);
   if (opts.price === undefined) {
     throw new TypeError('price argument is required');
   }

--- a/test/unit/operations/classic_ops_test.js
+++ b/test/unit/operations/classic_ops_test.js
@@ -1216,8 +1216,35 @@ describe('Operation', function () {
         '31234560'
       );
       expect(obj.buyAmount).to.be.equal(opts.buyAmount);
+      expect(obj.amount).to.be.equal(opts.buyAmount);
       expect(obj.price).to.be.equal(opts.price);
       expect(obj.offerId).to.be.equal(opts.offerId);
+    });
+
+    it('creates a manageBuyOfferOp with amount alias', function () {
+      var opts = {};
+      opts.selling = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      opts.buying = new StellarBase.Asset(
+        'USD',
+        'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+      );
+      opts.amount = '4.2500000';
+      opts.price = '8.141592';
+      opts.offerId = '1';
+      let op = StellarBase.Operation.manageBuyOffer(opts);
+      var xdr = op.toXDR('hex');
+      var operation = StellarBase.xdr.Operation.fromXDR(
+        Buffer.from(xdr, 'hex')
+      );
+      var obj = StellarBase.Operation.fromXDRObject(operation);
+      expect(operation.body().value().buyAmount().toString()).to.be.equal(
+        '42500000'
+      );
+      expect(obj.buyAmount).to.be.equal(opts.amount);
+      expect(obj.amount).to.be.equal(opts.amount);
     });
 
     it('creates a manageBuyOfferOp (price fraction)', function () {
@@ -1386,6 +1413,24 @@ describe('Operation', function () {
       };
       expect(() => StellarBase.Operation.manageBuyOffer(opts)).to.throw(
         /buyAmount argument must be of type String/
+      );
+    });
+
+    it('fails to create manageBuyOffer operation with an invalid amount alias', function () {
+      let opts = {
+        amount: 20,
+        price: '10',
+        selling: new StellarBase.Asset(
+          'USD',
+          'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        ),
+        buying: new StellarBase.Asset(
+          'USD',
+          'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
+        )
+      };
+      expect(() => StellarBase.Operation.manageBuyOffer(opts)).to.throw(
+        /amount argument must be of type String/
       );
     });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -430,13 +430,17 @@ export namespace OperationOptions {
   interface ManageSellOffer extends CreatePassiveSellOffer {
     offerId?: number | string;
   }
-  interface ManageBuyOffer extends BaseOptions {
+  interface ManageBuyOfferBase extends BaseOptions {
     selling: Asset;
     buying: Asset;
-    buyAmount: string;
     price: number | string | object /* bignumber.js */;
     offerId?: number | string;
   }
+  type ManageBuyOffer = ManageBuyOfferBase &
+    (
+      | { buyAmount: string; amount?: string }
+      | { amount: string; buyAmount?: string }
+    );
   // tslint:disable-next-line
   interface Inflation extends BaseOptions {
     // tslint:disable-line
@@ -693,6 +697,7 @@ export namespace Operation {
     selling: Asset;
     buying: Asset;
     buyAmount: string;
+    amount: string;
     price: string;
     offerId: string;
   }

--- a/types/test.ts
+++ b/types/test.ts
@@ -27,6 +27,13 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
       asset: usd,
     })
   ).addOperation(
+    StellarSdk.Operation.manageBuyOffer({
+      selling: StellarSdk.Asset.native(),
+      buying: usd,
+      amount: "100",
+      price: "0.25",
+    })
+  ).addOperation(
     StellarSdk.Operation.createClaimableBalance({
       amount: "10",
       asset: StellarSdk.Asset.native(),


### PR DESCRIPTION
## Summary
- add non-breaking amount input support for Operation.manageBuyOffer
- keep the existing buyAmount field for compatibility
- expose amount alongside buyAmount when parsing manage buy offers from XDR
- cover the alias in runtime and TypeScript declaration tests

Fixes #200.

## Verification
- node --check src/operations/manage_buy_offer.js
- node --check src/operation.js
- node --check test/unit/operations/classic_ops_test.js
- corepack yarn mocha test/unit/operations/classic_ops_test.js --grep manageBuyOffer --require @babel/register --require ./test/test-helper.js
- corepack yarn dtslint --localTs node_modules/typescript/lib types/
- corepack yarn eslint -c ./config/.eslintrc.js src/operation.js src/operations/manage_buy_offer.js
- git diff --check