### PR TITLE
Accept 32-byte claimable balance StrKeys

### DIFF
--- a/src/strkey.js
+++ b/src/strkey.js
@@ -302,7 +302,7 @@ function isValid(versionByteName, encoded) {
       break;
 
     case 'claimableBalance':
-      if (encoded.length !== 58) {
+      if (encoded.length !== 56 && encoded.length !== 58) {
         return false;
       }
       break;
@@ -341,7 +341,10 @@ function isValid(versionByteName, encoded) {
       return decoded.length === 32;
 
     case 'claimableBalance':
-      return decoded.length === 32 + 1; // +1 byte for discriminant
+      return (
+        decoded.length === 32 ||
+        (decoded.length === 32 + 1 && decoded[0] === 0)
+      );
 
     case 'med25519PublicKey':
       return decoded.length === 40; // +8 bytes for the ID

--- a/test/unit/strkey_test.js
+++ b/test/unit/strkey_test.js
@@ -429,6 +429,20 @@ describe('StrKey', function () {
   });
 
   describe('#claimableBalances', function () {
+    it('valid w/ 32-byte strkey', function () {
+      const strkey =
+        'BA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJV5AS';
+      const asHex =
+        '3f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a';
+      expect(StellarBase.StrKey.isValidClaimableBalance(strkey)).to.be.true;
+      expect(
+        StellarBase.StrKey.decodeClaimableBalance(strkey).toString('hex')
+      ).to.equal(asHex);
+      expect(
+        StellarBase.StrKey.encodeClaimableBalance(Buffer.from(asHex, 'hex'))
+      ).to.equal(strkey);
+    });
+
     it('valid w/ 33-byte strkey', function () {
       const strkey =
         'BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU';
@@ -441,6 +455,15 @@ describe('StrKey', function () {
       expect(
         StellarBase.StrKey.encodeClaimableBalance(Buffer.from(asHex, 'hex'))
       ).to.equal(strkey);
+    });
+
+    it('rejects a 33-byte strkey with a non-v0 discriminant', function () {
+      const asHex =
+        '013f0c34bf93ad0d9971d04ccc90f705511c838aad9734a4a2fb0d7a03fc7fe89a';
+      const strkey = StellarBase.StrKey.encodeClaimableBalance(
+        Buffer.from(asHex, 'hex')
+      );
+      expect(StellarBase.StrKey.isValidClaimableBalance(strkey)).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Summary
- accept standard 56-character / 32-byte claimable balance B-addresses in StrKey validation
- keep existing 58-character / 33-byte v0 claimable balance validation for compatibility
- reject 33-byte claimable balance payloads with a non-v0 discriminant
- add focused StrKey tests for both accepted forms and the invalid discriminant case

Fixes stellar/js-stellar-sdk#1489.

## Verification
- node --check src/strkey.js
- node --check test/unit/strkey_test.js
- corepack yarn mocha test/unit/strkey_test.js --grep claimableBalances --require @babel/register --require ./test/test-helper.js
- corepack yarn mocha test/unit/strkey_test.js --require @babel/register --require ./test/test-helper.js
- corepack yarn eslint -c ./config/.eslintrc.js src/strkey.js
- git diff --check

Note: linting the whole legacy strkey_test.js file reports pre-existing style violations, so the source lint check was scoped to src/strkey.js while the full strkey test file was verified with mocha.