### PR TITLE
Cover signing with raw secret seed

### DIFF
--- a/src/keypair.js
+++ b/src/keypair.js
@@ -191,7 +191,7 @@ export class Keypair {
   }
 
   /**
-   * Returns raw secret key.
+   * Returns the raw 32-byte secret seed.
    * @returns {Buffer}
    */
   rawSecretKey() {

--- a/test/unit/signing_test.js
+++ b/test/unit/signing_test.js
@@ -30,6 +30,16 @@ describe('StellarBase#sign', function () {
     let actualSig = StellarBase.sign(data, secretKey).toString('hex');
     expect(actualSig).to.eql(expectedSig);
   });
+
+  it('can sign with a Keypair raw secret seed', function () {
+    let data = Buffer.from('hello world', 'utf8');
+    let keypair = StellarBase.Keypair.fromRawEd25519Seed(seed);
+    let actualSig = StellarBase.sign(data, keypair.rawSecretKey());
+
+    expect(actualSig.toString('hex')).to.eql(expectedSig);
+    expect(StellarBase.verify(data, actualSig, keypair.rawPublicKey())).to.be
+      .ok;
+  });
 });
 
 describe('StellarBase#verify', function () {


### PR DESCRIPTION
## Summary
- add regression coverage for signing with Keypair.rawSecretKey()
- verify the resulting signature with the matching raw public key
- clarify that rawSecretKey() returns the raw 32-byte secret seed

Fixes #281.

## Verification
- node --check src/keypair.js
- node --check test/unit/signing_test.js
- corepack yarn mocha test/unit/signing_test.js --require @babel/register --require ./test/test-helper.js
- corepack yarn eslint -c ./config/.eslintrc.js src/keypair.js src/signing.js
- git diff --check